### PR TITLE
Make paperless-ng able to be run as a rootless container (support for podman)

### DIFF
--- a/docker/compose/docker-compose.env
+++ b/docker/compose/docker-compose.env
@@ -1,6 +1,7 @@
 # The UID and GID of the user used to run paperless in the container. Set this
 # to your UID and GID on the host so that you have write access to the
 # consumption directory.
+# Note: this setting is ignored when run as a rootless container (podman).
 #USERMAP_UID=1000
 #USERMAP_GID=1000
 

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -95,7 +95,7 @@ initialize
 
 if [[ "$1" != "/"* ]]; then
 	echo Executing management command "$@"
-	exec ${SUDO_CMD} python3 manage.py "$@"
+	exec "${SUDO_CMD}" python3 manage.py "$@"
 else
 	echo Executing "$@"
 	exec "$@"

--- a/docker/supervisord-rootless.conf
+++ b/docker/supervisord-rootless.conf
@@ -1,0 +1,32 @@
+[supervisord]
+nodaemon=true               ; start in foreground if true; default false
+logfile=/var/log/supervisord/supervisord.log ; main log file; default $CWD/supervisord.log
+pidfile=/var/run/supervisord/supervisord.pid ; supervisord pidfile; default supervisord.pid
+logfile_maxbytes=50MB        ; max main logfile bytes b4 rotation; default 50MB
+logfile_backups=10           ; # of main logfile backups; 0 means none, default 10
+loglevel=info                ; log level; default info; others: debug,warn,trace
+user=root
+
+[program:gunicorn]
+command=gunicorn -c /usr/src/paperless/gunicorn.conf.py paperless.asgi:application
+
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+[program:consumer]
+command=python3 manage.py document_consumer
+
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+[program:scheduler]
+command=python3 manage.py qcluster
+
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0


### PR DESCRIPTION

This pull request has been imported from jonaswinkler/paperless-ng#900 and was originally opened by gillesgagniard on 2021-04-12 12:36:51.

---

When using `podman` instead of Docker, it is possible to run containers in a rootless mode, ie. containers are directly created by the user and not by `root` through the Docker daemon.

A key difference of rootless containers is that they run in a different user namespace, where the `root` user inside the container (uid 1) is mapped to the user creating the container outside on the host, and other users inside the container get alternative user id in a different namespace than the host user namespace.

As a consequence, running paperless-ng webserver as `root` inside the rootless container is actually what we want: the paperless processes are then run by the user from the host point-of-view, and thus are able to read/write to the consume and export directories.

The current trick of forcing the paperless uid/gid to match the host user doesn't easily work for rootless containers, as uid/gid are remapped.

This proposed patch adds a new build argument `ROOTLESS` in Dockerfile for creating a rootless container image:
- No creation of paperless user and file ownership changes
- Different supervisord configuration file to run everything as root
- Export a `PAPERLESS_ROOTLESS` environment variable so that docker-entry.sh runs everything as root at container start time

It can be invoked like this:

    docker build . -t docker.io/jonaswinkler/paperless-ng:rootless --build-arg ROOTLESS=1
