### PR TITLE
Enable non-root port 80 via systemd

### DIFF
--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -411,9 +411,8 @@ writing. Windows is not and will never be supported.
 
 		The ``socket`` script enables ``gunicorn`` to run on port 80 without
 		root privileges. For this you need to uncomment the ``Require=paperless-webserver.socket``
-		in the ``webserver`` script and configure ``gunicorn`` to listen on port 80 (see 
+		in the ``webserver`` script and configure ``gunicorn`` to listen on port 80 (see ``paperless/gunicorn.conf.py``).
 
-``paperless/gunicorn.conf.py``).
     You may need to adjust the path to the ``gunicorn`` executable. This
     will be installed as part of the python dependencies, and is either located
     in the ``bin`` folder of your virtual environment, or in ``~/.local/bin/`` if

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -408,7 +408,11 @@ writing. Windows is not and will never be supported.
     Paperless needs the ``webserver`` script to run the webserver, the
     ``consumer`` script to watch the input folder, and the ``scheduler``
     script to run tasks such as email checking and document consumption.
-
+		
+		The ``socket`` script enables ``gunicorn`` to run on port 80 without
+		root privileges. For this you need to uncomment the ``Require=paperless-webserver.socket``
+		in the ``webserver`` script and configure ``gunicorn`` to listen on port 80 (see ``paperless/gunicorn.conf.py``).
+		
     You may need to adjust the path to the ``gunicorn`` executable. This
     will be installed as part of the python dependencies, and is either located
     in the ``bin`` folder of your virtual environment, or in ``~/.local/bin/`` if

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -408,9 +408,12 @@ writing. Windows is not and will never be supported.
     Paperless needs the ``webserver`` script to run the webserver, the
     ``consumer`` script to watch the input folder, and the ``scheduler``
     script to run tasks such as email checking and document consumption.
+
 		The ``socket`` script enables ``gunicorn`` to run on port 80 without
 		root privileges. For this you need to uncomment the ``Require=paperless-webserver.socket``
-		in the ``webserver`` script and configure ``gunicorn`` to listen on port 80 (see ``paperless/gunicorn.conf.py``).
+		in the ``webserver`` script and configure ``gunicorn`` to listen on port 80 (see 
+
+``paperless/gunicorn.conf.py``).
     You may need to adjust the path to the ``gunicorn`` executable. This
     will be installed as part of the python dependencies, and is either located
     in the ``bin`` folder of your virtual environment, or in ``~/.local/bin/`` if

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -408,11 +408,9 @@ writing. Windows is not and will never be supported.
     Paperless needs the ``webserver`` script to run the webserver, the
     ``consumer`` script to watch the input folder, and the ``scheduler``
     script to run tasks such as email checking and document consumption.
-		
 		The ``socket`` script enables ``gunicorn`` to run on port 80 without
 		root privileges. For this you need to uncomment the ``Require=paperless-webserver.socket``
 		in the ``webserver`` script and configure ``gunicorn`` to listen on port 80 (see ``paperless/gunicorn.conf.py``).
-		
     You may need to adjust the path to the ``gunicorn`` executable. This
     will be installed as part of the python dependencies, and is either located
     in the ``bin`` folder of your virtual environment, or in ``~/.local/bin/`` if

--- a/scripts/paperless-webserver.service
+++ b/scripts/paperless-webserver.service
@@ -3,6 +3,7 @@ Description=Paperless webserver
 After=network.target
 Wants=network.target
 Requires=redis.service
+#Requires=paperless-webserver.socket
 
 [Service]
 User=paperless

--- a/scripts/paperless-webserver.socket
+++ b/scripts/paperless-webserver.socket
@@ -1,0 +1,9 @@
+[Unit]
+Description=Paperless Webserver Socket
+
+[Socket]
+ListenStream=80
+NoDelay=true
+
+[Install]
+WantedBy=sockets.target


### PR DESCRIPTION

This pull request has been imported from jonaswinkler/paperless-ng#1120 and was originally opened by benjaminfrank on 2021-06-16 20:58:05.

---

Add a systemd socket unit to enable running paperless on port 80 without root.

To enable running on port 80 one needs to
- copy `scripts/paperless-webserver.socket` to `/etc/systemd/system/`
- uncomment  `#Requires=paperless-webserver.socket` from `scripts/paperless-webserver.service`
- configure gunicorn to listen on port 80 in `paperless/gunicorn.conf.py`

I updated the documentation but somehow the result renders funny in GitHub and I don't know what I am doing wrong 🤷 
