### PR TITLE
Add arm64 compatible docker-compose for sqlite-tika

### DIFF
--- a/docker/compose/docker-compose.postgres-tika.yml
+++ b/docker/compose/docker-compose.postgres-tika.yml
@@ -1,6 +1,7 @@
 # docker-compose file for running paperless from the Docker Hub.
 # This file contains everything paperless needs to run.
-# Paperless supports amd64, arm and arm64 hardware.
+# Paperless supports amd64, arm and arm64 hardware. The apache/tika image
+# does not support arm or arm64, however.
 #
 # All compose files of paperless configure paperless in the following way:
 #

--- a/docker/compose/docker-compose.sqlite-tika.arm.yml
+++ b/docker/compose/docker-compose.sqlite-tika.arm.yml
@@ -12,6 +12,9 @@
 #
 # SQLite is used as the database. The SQLite file is stored in the data volume.
 #
+# iwishiwasaneagle/apache-tika-arm docker image is used to enable arm64 arch
+# which apache/tika does not currently support.
+#
 # In addition to that, this docker-compose file adds the following optional
 # configurations:
 #

--- a/docker/compose/docker-compose.sqlite-tika.arm.yml
+++ b/docker/compose/docker-compose.sqlite-tika.arm.yml
@@ -1,0 +1,78 @@
+# docker-compose file for running paperless from the Docker Hub.
+# This file contains everything paperless needs to run.
+# Paperless supports amd64, arm and arm64 hardware.
+#
+# All compose files of paperless configure paperless in the following way:
+#
+# - Paperless is (re)started on system boot, if it was running before shutdown.
+# - Docker volumes for storing data are managed by Docker.
+# - Folders for importing and exporting files are created in the same directory
+#   as this file and mounted to the correct folders inside the container.
+# - Paperless listens on port 8000.
+#
+# SQLite is used as the database. The SQLite file is stored in the data volume.
+#
+# In addition to that, this docker-compose file adds the following optional
+# configurations:
+#
+# - Apache Tika and Gotenberg servers are started with paperless and paperless
+#   is configured to use these services. These provide support for consuming
+#   Office documents (Word, Excel, Power Point and their LibreOffice counter-
+#   parts.
+#
+# To install and update paperless with this file, do the following:
+#
+# - Copy this file as 'docker-compose.yml' and the files 'docker-compose.env'
+#   and '.env' into a folder.
+# - Run 'docker-compose pull'.
+# - Run 'docker-compose run --rm webserver createsuperuser' to create a user.
+# - Run 'docker-compose up -d'.
+#
+# For more extensive installation and update instructions, refer to the
+# documentation.
+
+version: "3.4"
+services:
+  broker:
+    image: redis:6.0
+    restart: unless-stopped
+
+  webserver:
+    image: jonaswinkler/paperless-ng:latest
+    restart: unless-stopped
+    depends_on:
+      - broker
+      - gotenberg
+      - tika
+    ports:
+      - 8000:8000
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+    volumes:
+      - data:/usr/src/paperless/data
+      - media:/usr/src/paperless/media
+      - ./export:/usr/src/paperless/export
+      - ./consume:/usr/src/paperless/consume
+    env_file: docker-compose.env
+    environment:
+      PAPERLESS_REDIS: redis://broker:6379
+      PAPERLESS_TIKA_ENABLED: 1
+      PAPERLESS_TIKA_GOTENBERG_ENDPOINT: http://gotenberg:3000
+      PAPERLESS_TIKA_ENDPOINT: http://tika:9998
+
+  gotenberg:
+    image: thecodingmachine/gotenberg
+    restart: unless-stopped
+    environment:
+      DISABLE_GOOGLE_CHROME: 1
+
+  tika:
+    image: iwishiwasaneagle/apache-tika-arm
+    restart: unless-stopped
+
+volumes:
+  data:
+  media:

--- a/docker/compose/docker-compose.sqlite-tika.yml
+++ b/docker/compose/docker-compose.sqlite-tika.yml
@@ -1,6 +1,7 @@
 # docker-compose file for running paperless from the Docker Hub.
 # This file contains everything paperless needs to run.
-# Paperless supports amd64, arm and arm64 hardware.
+# Paperless supports amd64, arm and arm64 hardware. The apache/tika image
+# does not support arm or arm64, however.
 #
 # All compose files of paperless configure paperless in the following way:
 #

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -807,6 +807,8 @@ configuring some options in paperless can help improve performance immensely:
     times. Thumbnails will be about 20% larger.
 *   If using docker, consider setting ``PAPERLESS_WEBSERVER_WORKERS`` to
     1. This will save some memory.
+*   Use the arm compatible docker-compose if you're wanting to use Tika on something like 
+		a raspberry pi. The official apache/tika image doesn not support the arm architecture.
 
 For details, refer to :ref:`configuration`.
 

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -807,7 +807,7 @@ configuring some options in paperless can help improve performance immensely:
     times. Thumbnails will be about 20% larger.
 *   If using docker, consider setting ``PAPERLESS_WEBSERVER_WORKERS`` to
     1. This will save some memory.
-*   Use the arm compatible docker-compose if you're wanting to use Tika on something like 
+*   Use the arm compatible docker-compose if you're wanting to use Tika on something like
 		a raspberry pi. The official apache/tika image doesn not support the arm architecture.
 
 For details, refer to :ref:`configuration`.


### PR DESCRIPTION

This pull request has been imported from jonaswinkler/paperless-ng#1354 and was originally opened by iwishiwasaneagle on 2021-09-30 13:57:57.

---

As per this discussion, https://github.com/jonaswinkler/paperless-ng/discussions/1256, the Tika docker-compose variants weren't working as apache/tika only supports `amd64` and not `arm64`. I forked the apache/tika-docker repo and build for both `amd64` and `arm64` https://github.com/iwishiwasaneagle/tika-docker. 

This PR just adds a docker-compose using the new `arm64` compatible Tika image + updates to the docs.
