### PR TITLE
Tell users about multiple OCR languages in the install script

### DIFF
--- a/install-paperless-ng.sh
+++ b/install-paperless-ng.sh
@@ -179,6 +179,7 @@ echo "Specify the default language that most of your documents are written in."
 echo "Use ISO 639-2, (T) variant language codes: "
 echo "https://www.loc.gov/standards/iso639-2/php/code_list.php"
 echo "Common values: eng (English) deu (German) nld (Dutch) fra (French)"
+echo "This can be a combination of multiple languages such as deu+eng"
 echo ""
 
 ask "OCR language" "eng"


### PR DESCRIPTION

This pull request has been imported from jonaswinkler/paperless-ng#1374 and was originally opened by denilsonsa on 2021-10-10 23:52:23.

---

This valuable piece of information was only mentioned in the docs: https://paperless-ng.readthedocs.io/en/latest/configuration.html#ocr-settings

It would be good to have it in the install script, because that's where/when the user is explicitly asked to choose a language.
