### PR TITLE
Clarifying documentation on filename placeholders

### DIFF
--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -221,14 +221,14 @@ Paperless provides the following placeholders withing filenames:
 * ``{document_type}``: The name of the document type, or "none".
 * ``{tag_list}``: A comma separated list of all tags assigned to the document.
 * ``{title}``: The title of the document.
-* ``{created}``: The full date and time the document was created.
+* ``{created}``: The full date (ISO format) the document was created.
 * ``{created_year}``: Year created only.
-* ``{created_month}``: Month created only (number 1-12).
-* ``{created_day}``: Day created only (number 1-31).
-* ``{added}``: The full date and time the document was added to paperless.
+* ``{created_month}``: Month created only (number 01-12).
+* ``{created_day}``: Day created only (number 01-31).
+* ``{added}``: The full date (ISO format) the document was added to paperless.
 * ``{added_year}``: Year added only.
-* ``{added_month}``: Month added only (number 1-12).
-* ``{added_day}``: Day added only (number 1-31).
+* ``{added_month}``: Month added only (number 01-12).
+* ``{added_day}``: Day added only (number 01-31).
 
 
 Paperless will try to conserve the information from your database as much as possible.


### PR DESCRIPTION

This pull request has been imported from jonaswinkler/paperless-ng#1391 and was originally opened by denilsonsa on 2021-10-15 13:14:17.

---

The documentation text now better describes what the code does. It is now clear that the time is not included, and that all date placeholders are either zero-padded or ISO-formatted.

https://github.com/jonaswinkler/paperless-ng/blob/05c36f91cfa5613bdea5b3c490774cc40b586eeb/src/documents/file_handling.py#L164-L171
