### PR TITLE
fix(gotenberg): use command flags

### DIFF
--- a/docker/compose/docker-compose.postgres-tika.yml
+++ b/docker/compose/docker-compose.postgres-tika.yml
@@ -77,8 +77,9 @@ services:
   gotenberg:
     image: gotenberg/gotenberg:7
     restart: unless-stopped
-    environment:
-      CHROMIUM_DISABLE_ROUTES: 1
+    command:
+      - "gotenberg"
+      - "--chromium-disable-routes=true"
 
   tika:
     image: apache/tika

--- a/docker/compose/docker-compose.sqlite-tika.yml
+++ b/docker/compose/docker-compose.sqlite-tika.yml
@@ -66,8 +66,9 @@ services:
   gotenberg:
     image: gotenberg/gotenberg:7
     restart: unless-stopped
-    environment:
-      CHROMIUM_DISABLE_ROUTES: 1
+    command:
+      - "gotenberg"
+      - "--chromium-disable-routes=true"
 
   tika:
     image: apache/tika

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -446,8 +446,9 @@ requires are as follows:
         gotenberg:
             image: gotenberg/gotenberg:7
             restart: unless-stopped
-            environment:
-                CHROMIUM_DISABLE_ROUTES: 1
+            command:
+                - "gotenberg"
+                - "--chromium-disable-routes=true"
 
         tika:
             image: apache/tika

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -106,7 +106,7 @@ You may experience these errors when using the optional TIKA integration:
 Gotenberg is a server that converts Office documents into PDF documents and has a default timeout of 30 seconds.
 When conversion takes longer, Gotenberg raises this error.
 
-You can increase the timeout by configuring an environment variable for Gotenberg (see also `here <https://gotenberg.dev/docs/modules/api#properties>`__).
+You can increase the timeout by configuring a command flag for Gotenberg (see also `here <https://gotenberg.dev/docs/modules/api#properties>`__).
 If using docker-compose, this is achieved by the following configuration change in the ``docker-compose.yml`` file:
 
 .. code:: yaml
@@ -114,9 +114,10 @@ If using docker-compose, this is achieved by the following configuration change 
     gotenberg:
         image: gotenberg/gotenberg:7
         restart: unless-stopped
-        environment:
-            CHROMIUM_DISABLE_ROUTES: 1
-            API_PROCESS_TIMEOUT: 60
+        command:
+            - "gotenberg"
+            - "--chromium-disable-routes=true"
+            - "--api-timeout=60"
 
 Permission denied errors in the consumption directory
 #####################################################


### PR DESCRIPTION

This pull request has been imported from jonaswinkler/paperless-ng#1438 and was originally opened by Tooa on 2021-11-15 09:22:48.

---

# Description

Gotenberg v7 does not use environment variables anymore, but command's flags. See: https://gotenberg.dev/docs/get-started/docker-compose#modules-properties. Thanks to @ gulien for bringing this to my attention [here](https://github.com/jonaswinkler/paperless-ng/pull/1262#issuecomment-915232891). I'm sorry it took so long.

@ jonaswinkler Let me know if you need more information or request a change.

# Addresses Issues

* Follow-up of #1250

# Conducted Tests

```bash
$ cd docker/compose
$ docker-compose -f docker-compose.sqlite-tika.yml
$ docker-compose -f docker-compose.sqlite-tika.yml run --rm webserver createsuperuser
$ docker-compose -f docker-compose.sqlite-tika.yml up -d
$ cp test.pdf ./consume
```
![paperless](https://user-images.githubusercontent.com/5375334/141755651-0ff48e11-b9e5-432f-9e2e-61ce499d35df.png)


[Logs](https://pastebin.com/FG4XFh21)
