### PR TITLE
Update setup.rst

### DIFF
--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -222,7 +222,7 @@ Install Paperless from Docker Hub
 
     .. code-block:: shell-session
 
-        $ docker-compose run --rm webserver createsuperuser
+        $ docker exec -it webserver python manage.py createsuperuser
 
     This will prompt you to set a username, an optional e-mail address and
     finally a password (at least 8 characters).


### PR DESCRIPTION

This pull request has been imported from jonaswinkler/paperless-ng#1590 and was originally opened by a-waider on 2022-01-31 09:10:33.

---

In my installation environment the setup didn't work. I think running `docker exec` instead of `docker-compose run` is more error free. Or is there any specific reason why `docker-compose run` is used?
