### PR TITLE
Merging Non-Trivial PRs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 If you feel like contributing to the project, please do! Bug fixes and improvements are always welcome.
 
-If you want to implement something big: 
+If you want to implement something big:
 
 * Please start a discussion about that in the issues! Maybe something similar is already in development and we can make it happen together.
 * When making additions to the project, consider if the majority of users will benefit from your change. If not, you're probably better of forking the project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ Our community review process for `non-trivial` prs is the following:
 1. Must pass usual automated code tests and formatting checks.
 2. The PR will be assigned and pinged to the appropriately experienced team (i.e. @paperless-ngx/backend for backend changes).
 3. Development team will check and test code manually (possibly over several days).
-   - You may be asked to make changes or rebase. 
+   - You may be asked to make changes or rebase.
    - The team may ask for additional testing done by @paperless-ngx/test
 4. **Two or three** members of the team will approve and finally merge the request into `dev` 🎉.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 # Contributing
 
-There's still lots of things to be done, just have a look at that issue log. If you feel like contributing to the project, please do! Bug fixes and improvements to the front end (I just can't seem to get some of these CSS things right) are always welcome.
+If you feel like contributing to the project, please do! Bug fixes and improvements are always welcome.
 
-If you want to implement something big: Please start a discussion about that in the issues! Maybe I've already had something similar in mind and we can make it happen together.
+If you want to implement something big: Please start a discussion about that in the issues! Maybe something similar is already in development and we can make it happen together.
 
 * When making additions to the project, consider if the majority of users will benefit from your change. If not, you're probably better of forking the project.
 * Also consider if your change will get in the way of other users. A good change is a change that enhances the experience of some users who want that change and does not affect users who do not care about the change.
@@ -13,17 +13,17 @@ Paperless supports python 3.6, 3.7, 3.8 and 3.9.
 
 ## Branches
 
-master always reflects the latest release. Apart from changes to the documentation or readme, absolutely no functional changes on this branch in between releases.
+`master` always reflects the latest release. Apart from changes to the documentation or readme, absolutely no functional changes on this branch in between releases.
 
-dev contains all changes that will be part of the next release. Use this branch to start making your changes.
+`dev` contains all changes that will be part of the next release. Use this branch to start making your changes.
 
-feature-X branches is for experimental stuff that will eventually be merged into dev, and then released as part of the next release.
+`feature-X` branches are for experimental stuff that will eventually be merged into dev.
 
 ## Testing:
 
-I'm trying to get most of paperless tested, so please do the same for your code! I know its a hassle, but it makes sure that your code works now and will allow us to detect regressions easily.
+Please test your code! I know its a hassle, but it makes sure that your code works now and will allow us to detect regressions easily.
 
-To test your code, execute `pytest` in the src/ directory. Executing that in the project root is no good. This also generates a html coverage report, which you can use to see if you missed anything important during testing.
+To test your code, execute `pytest` in the src/ directory. This also generates a html coverage report, which you can use to see if you missed anything important during testing.
 
 ## More info:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 There's still lots of things to be done, just have a look at that issue log. If you feel like contributing to the project, please do! Bug fixes and improvements to the front end (I just can't seem to get some of these CSS things right) are always welcome.
 
-If you want to implement something big: Please start a discussion about that in the issues! Maybe I've already had something similar in mind and we can make it happen together. However, keep in mind that the general roadmap is to make the existing features stable and get them tested. See the roadmap in the readme.
+If you want to implement something big: Please start a discussion about that in the issues! Maybe I've already had something similar in mind and we can make it happen together.
 
 * When making additions to the project, consider if the majority of users will benefit from your change. If not, you're probably better of forking the project.
 * Also consider if your change will get in the way of other users. A good change is a change that enhances the experience of some users who want that change and does not affect users who do not care about the change.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-There's still lots of things to be done, just have a look at that issue log. If you feel like conctributing to the project, please do! Bug fixes and improvements to the front end (I just can't seem to get some of these CSS things right) are always welcome.
+There's still lots of things to be done, just have a look at that issue log. If you feel like contributing to the project, please do! Bug fixes and improvements to the front end (I just can't seem to get some of these CSS things right) are always welcome.
 
 If you want to implement something big: Please start a discussion about that in the issues! Maybe I've already had something similar in mind and we can make it happen together. However, keep in mind that the general roadmap is to make the existing features stable and get them tested. See the roadmap in the readme.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,10 +2,12 @@
 
 If you feel like contributing to the project, please do! Bug fixes and improvements are always welcome.
 
-If you want to implement something big: Please start a discussion about that in the issues! Maybe something similar is already in development and we can make it happen together.
+If you want to implement something big: 
 
+* Please start a discussion about that in the issues! Maybe something similar is already in development and we can make it happen together.
 * When making additions to the project, consider if the majority of users will benefit from your change. If not, you're probably better of forking the project.
 * Also consider if your change will get in the way of other users. A good change is a change that enhances the experience of some users who want that change and does not affect users who do not care about the change.
+* Please see the [paperless-ngx merge process](#merging-non-trivial-prs) below.
 
 ## Python
 
@@ -28,3 +30,28 @@ To test your code, execute `pytest` in the src/ directory. This also generates a
 ## More info:
 
 ... is available in the documentation. https://paperless-ng.readthedocs.io/en/latest/extending.html
+
+# Merging PRs
+
+Once you have submitted a **P**ull **R**equest it will be reviewed, approved, and merged by one or more community members of any team. Automated code tests and formatting checks must be passed.
+
+## Non-Trivial Requests
+
+PRs deemed `non-trivial` will go through a stricter review process before being merged into `dev`. This is to ensure code quality and complete functionality (free of side effects).
+
+Examples of `non-trivial` PRs might include:
+
+* Additional features
+* Large changes to many distinct files
+* Breaking or depreciation of existing features
+
+Our community review process for `non-trivial` prs is the following:
+
+1. Must pass usual automated code tests and formatting checks.
+2. The PR will be assigned and pinged to the appropriately experienced team (i.e. @paperless-ngx/backend for backend changes).
+3. Development team will check and test code manually (possibly over several days).
+   - You may be asked to make changes or rebase. 
+   - The team may ask for additional testing done by @paperless-ngx/test
+4. **Two or three** members of the team will approve and finally merge the request into `dev` 🎉.
+
+This process might be slow as community members have different schedules and time to dedicate to the Paperless project. However it ensures community code reviews are as brilliantly thorough as they once were with @jonaswinkler.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Paperless supports python 3.6, 3.7, 3.8 and 3.9.
 
 ## Testing:
 
-Please test your code! I know its a hassle, but it makes sure that your code works now and will allow us to detect regressions easily.
+Please test your code! I know it's a hassle, but it makes sure that your code works now and will allow us to detect regressions easily.
 
 To test your code, execute `pytest` in the src/ directory. This also generates a html coverage report, which you can use to see if you missed anything important during testing.
 
@@ -45,13 +45,13 @@ Examples of `non-trivial` PRs might include:
 * Large changes to many distinct files
 * Breaking or depreciation of existing features
 
-Our community review process for `non-trivial` prs is the following:
+Our community review process for `non-trivial` PRs is the following:
 
 1. Must pass usual automated code tests and formatting checks.
 2. The PR will be assigned and pinged to the appropriately experienced team (i.e. @paperless-ngx/backend for backend changes).
 3. Development team will check and test code manually (possibly over several days).
    - You may be asked to make changes or rebase.
    - The team may ask for additional testing done by @paperless-ngx/test
-4. **Two or three** members of the team will approve and finally merge the request into `dev` 🎉.
+4. **At least two** members of the team will approve and finally merge the request into `dev` 🎉.
 
 This process might be slow as community members have different schedules and time to dedicate to the Paperless project. However it ensures community code reviews are as brilliantly thorough as they once were with @jonaswinkler.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ If you want to implement something big:
 * Please start a discussion about that in the issues! Maybe something similar is already in development and we can make it happen together.
 * When making additions to the project, consider if the majority of users will benefit from your change. If not, you're probably better of forking the project.
 * Also consider if your change will get in the way of other users. A good change is a change that enhances the experience of some users who want that change and does not affect users who do not care about the change.
-* Please see the [paperless-ngx merge process](#merging-non-trivial-prs) below.
+* Please see the [paperless-ngx merge process](#merging-prs) below.
 
 ## Python
 


### PR DESCRIPTION
## Why

Our community/organization process for reviewing and merging PRs should be documented. Both for people submitting changes and those reviewing them. This ensures a standard is met for Paperless and that several members can attest to that quality. 

## Future updates

This updates `CONTRIBUTING.md`, but other contribution instructions are also found in [contributing.rst](https://github.com/paperless-ngx/paperless-ngx/blob/dev/docs/contributing.rst) and [extending.rst](https://github.com/paperless-ngx/paperless-ngx/blob/dev/docs/extending.rst). Maybe all 3 should be consolidated?

## Feedback

See here for the manifesto: https://github.com/paperless-ngx/paperless-ngx/blob/de9fbd48df1274c907b816914342764dbcb4291b/CONTRIBUTING.md?plain=1#L34-L57

Are there any steps to add/modify?