### PR TITLE
Add docs note on python version for development

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -21,6 +21,9 @@ indent_style = space
 [*.yml]
 indent_style = space
 
+[*.rst]
+indent_style = space
+
 # Tests don't get a line width restriction.  It's still a good idea to follow
 # the 79 character rule, but in the interests of clarity, tests often need to
 # violate it.

--- a/docs/extending.rst
+++ b/docs/extending.rst
@@ -54,10 +54,11 @@ To do the setup you need to perform the steps from the following chapters in a c
             docker run -d -p 6379:6379 -restart unless-stopped redis:latest
 
 6.  Install the python dependencies by performing in the src/ directory.
-
     .. code:: shell-session
 
         pipenv install --dev
+
+  * Make sure you're using python 3.9.x or lower. Otherwise you might get issues with building dependencies. You can use `pyenv <https://github.com/pyenv/pyenv>`_ to install a specific python version.
 
 7.  Generate the static UI so you can perform a login to get session that is required for frontend development (this needs to be done one time only). From root folder:
 


### PR DESCRIPTION
Should address the issues with installing dependencies if python 3.10 is used.