### PR TITLE
CI: Ansible Test fix

### DIFF
--- a/ansible/tasks/install-source.yml
+++ b/ansible/tasks/install-source.yml
@@ -26,7 +26,7 @@
 
     - name: pull paperless-ng
       git:
-        repo: https://github.com/jonaswinkler/paperless-ng.git
+        repo: https://github.com/paperless-ngx/paperless-ngx.git
         dest: "{{ gitdir.path }}"
         version: "{{ paperlessng_version }}"
         refspec: "+refs/pull/*:refs/pull/*"


### PR DESCRIPTION
Minor update, just changing the repo to ngx in the Ansible CI check.

This does **not** solve #12, I haven't tested if the Ansible role actually works. Goal for me now is to fix broken CI notification spam.

Last fixed run: https://github.com/paperless-ngx/paperless-ngx/actions/runs/1855444482