### PR TITLE
Sort languages

### DIFF
--- a/src-ui/angular.json
+++ b/src-ui/angular.json
@@ -17,19 +17,19 @@
 				"sourceLocale": "en-US",
 				"locales": {
 					"de-DE": "src/locale/messages.de_DE.xlf",
-					"nl-NL": "src/locale/messages.nl_NL.xlf",
-					"fr-FR": "src/locale/messages.fr_FR.xlf",
 					"en-GB": "src/locale/messages.en_GB.xlf",
+					"es-ES": "src/locale/messages.es_ES.xlf",
+					"fr-FR": "src/locale/messages.fr_FR.xlf",
+					"it-IT": "src/locale/messages.it_IT.xlf",
+					"lb-LU": "src/locale/messages.lb_LU.xlf",
+					"nl-NL": "src/locale/messages.nl_NL.xlf",
+					"pl-PL": "src/locale/messages.pl_PL.xlf",
 					"pt-BR": "src/locale/messages.pt_BR.xlf",
 					"pt-PT": "src/locale/messages.pt_PT.xlf",
-					"it-IT": "src/locale/messages.it_IT.xlf",
 					"ro-RO": "src/locale/messages.ro_RO.xlf",
 					"ru-RU": "src/locale/messages.ru_RU.xlf",
-					"es-ES": "src/locale/messages.es_ES.xlf",
-					"pl-PL": "src/locale/messages.pl_PL.xlf",
-					"sv-SE": "src/locale/messages.sv_SE.xlf",
-					"lb-LU": "src/locale/messages.lb_LU.xlf"
-				}
+					"sv-SE": "src/locale/messages.sv_SE.xlf"
+        }
 			},
 			"architect": {
 				"build": {

--- a/src-ui/src/app/services/settings.service.ts
+++ b/src-ui/src/app/services/settings.service.ts
@@ -86,7 +86,7 @@ export class SettingsService {
   }
 
   getLanguageOptions(): LanguageOption[] {
-    return [
+    const languages = [
       {code: "en-us", name: $localize`English (US)`, englishName: "English (US)", dateInputFormat: "mm/dd/yyyy"},
       {code: "de-de", name: $localize`German`, englishName: "German", dateInputFormat: "dd.mm.yyyy"},
       {code: "en-gb", name: $localize`English (GB)`, englishName: "English (GB)", dateInputFormat: "dd/mm/yyyy"},
@@ -102,6 +102,11 @@ export class SettingsService {
       {code: "ru-ru", name: $localize`Russian`, englishName: "Russian", dateInputFormat: "dd.mm.yyyy"},
       {code: "sv-se", name: $localize`Swedish`, englishName: "Swedish", dateInputFormat: "yyyy-mm-dd"}
     ]
+
+    // Sort languages by localized name at runtime
+    languages.sort((a, b) => { return a.name < b.name ? -1 : 1 })
+
+    return languages
   }
 
   getDateLocaleOptions(): LanguageOption[] {

--- a/src-ui/src/app/services/settings.service.ts
+++ b/src-ui/src/app/services/settings.service.ts
@@ -88,19 +88,19 @@ export class SettingsService {
   getLanguageOptions(): LanguageOption[] {
     return [
       {code: "en-us", name: $localize`English (US)`, englishName: "English (US)", dateInputFormat: "mm/dd/yyyy"},
-      {code: "en-gb", name: $localize`English (GB)`, englishName: "English (GB)", dateInputFormat: "dd/mm/yyyy"},
       {code: "de-de", name: $localize`German`, englishName: "German", dateInputFormat: "dd.mm.yyyy"},
-      {code: "nl-nl", name: $localize`Dutch`, englishName: "Dutch", dateInputFormat: "dd-mm-yyyy"},
+      {code: "en-gb", name: $localize`English (GB)`, englishName: "English (GB)", dateInputFormat: "dd/mm/yyyy"},
+      {code: "es-es", name: $localize`Spanish`, englishName: "Spanish", dateInputFormat: "dd/mm/yyyy"},
       {code: "fr-fr", name: $localize`French`, englishName: "French", dateInputFormat: "dd/mm/yyyy"},
-      {code: "pt-pt", name: $localize`Portuguese`, englishName: "Portuguese", dateInputFormat: "dd/mm/yyyy"},
-      {code: "pt-br", name: $localize`Portuguese (Brazil)`, englishName: "Portuguese (Brazil)", dateInputFormat: "dd/mm/yyyy"},
       {code: "it-it", name: $localize`Italian`, englishName: "Italian", dateInputFormat: "dd/mm/yyyy"},
+      {code: "lb-lu", name: $localize`Luxembourgish`, englishName: "Luxembourgish", dateInputFormat: "dd.mm.yyyy"},
+      {code: "nl-nl", name: $localize`Dutch`, englishName: "Dutch", dateInputFormat: "dd-mm-yyyy"},
+      {code: "pl-pl", name: $localize`Polish`, englishName: "Polish", dateInputFormat: "dd.mm.yyyy"},
+      {code: "pt-br", name: $localize`Portuguese (Brazil)`, englishName: "Portuguese (Brazil)", dateInputFormat: "dd/mm/yyyy"},
+      {code: "pt-pt", name: $localize`Portuguese`, englishName: "Portuguese", dateInputFormat: "dd/mm/yyyy"},
       {code: "ro-ro", name: $localize`Romanian`, englishName: "Romanian", dateInputFormat: "dd.mm.yyyy"},
       {code: "ru-ru", name: $localize`Russian`, englishName: "Russian", dateInputFormat: "dd.mm.yyyy"},
-      {code: "es-es", name: $localize`Spanish`, englishName: "Spanish", dateInputFormat: "dd/mm/yyyy"},
-      {code: "pl-pl", name: $localize`Polish`, englishName: "Polish", dateInputFormat: "dd.mm.yyyy"},
-      {code: "sv-se", name: $localize`Swedish`, englishName: "Swedish", dateInputFormat: "yyyy-mm-dd"},
-      {code: "lb-lu", name: $localize`Luxembourgish`, englishName: "Luxembourgish", dateInputFormat: "dd.mm.yyyy"}
+      {code: "sv-se", name: $localize`Swedish`, englishName: "Swedish", dateInputFormat: "yyyy-mm-dd"}
     ]
   }
 

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -301,20 +301,20 @@ DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 LANGUAGE_CODE = 'en-us'
 
 LANGUAGES = [
-    ("en-us", _("English (US)")),
-    ("en-gb", _("English (GB)")),
+    ("en-us", _("English (US)")), # needs to be first to act as fallback language
     ("de-de", _("German")),
-    ("nl-nl", _("Dutch")),
+    ("en-gb", _("English (GB)")),
+    ("es-es", _("Spanish")),
     ("fr-fr", _("French")),
+    ("it-it", _("Italian")),
+    ("lb-lu", _("Luxembourgish")),
+    ("nl-nl", _("Dutch")),
+    ("pl-pl", _("Polish")),
     ("pt-br", _("Portuguese (Brazil)")),
     ("pt-pt", _("Portuguese")),
-    ("it-it", _("Italian")),
     ("ro-ro", _("Romanian")),
     ("ru-ru", _("Russian")),
-    ("es-es", _("Spanish")),
-    ("pl-pl", _("Polish")),
     ("sv-se", _("Swedish")),
-    ("lb-lu", _("Luxembourgish")),
 ]
 
 LOCALE_PATHS = [


### PR DESCRIPTION
Currently, languages are listed in a more or less random order (presumably the order they were added in). With this patch, the languages are sorted alphabetically by locale in the source code for the purpose of making the code a bit cleaner.

In the UI, they are sorted alphabetically by localized name at runtime (second commit).

Example with English locale:
![image](https://user-images.githubusercontent.com/362092/154520860-8af47bf5-eaf7-4b53-9a9b-83ae2221e4a1.png)

Example with German locale:
![image](https://user-images.githubusercontent.com/362092/154521101-da9316d8-54bf-411f-b5e2-9bec887ec33f.png)
