### PR TITLE
Enabled the Danish (da-dk) translations

### DIFF
--- a/src-ui/angular.json
+++ b/src-ui/angular.json
@@ -16,6 +16,7 @@
 			"i18n": {
 				"sourceLocale": "en-US",
 				"locales": {
+					"da-DK": "src/locale/messages.da_DK.xlf",
 					"de-DE": "src/locale/messages.de_DE.xlf",
 					"en-GB": "src/locale/messages.en_GB.xlf",
 					"es-ES": "src/locale/messages.es_ES.xlf",

--- a/src-ui/src/app/services/settings.service.ts
+++ b/src-ui/src/app/services/settings.service.ts
@@ -88,6 +88,7 @@ export class SettingsService {
   getLanguageOptions(): LanguageOption[] {
     const languages = [
       {code: "en-us", name: $localize`English (US)`, englishName: "English (US)", dateInputFormat: "mm/dd/yyyy"},
+      {code: "da-dk", name: $localize`Danish`, englishName: "Danish", dateInputFormat: "dd.mm.yyyy"},
       {code: "de-de", name: $localize`German`, englishName: "German", dateInputFormat: "dd.mm.yyyy"},
       {code: "en-gb", name: $localize`English (GB)`, englishName: "English (GB)", dateInputFormat: "dd/mm/yyyy"},
       {code: "es-es", name: $localize`Spanish`, englishName: "Spanish", dateInputFormat: "dd/mm/yyyy"},

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -302,6 +302,7 @@ LANGUAGE_CODE = 'en-us'
 
 LANGUAGES = [
     ("en-us", _("English (US)")), # needs to be first to act as fallback language
+    ("da-dk", _("Danish")),
     ("de-de", _("German")),
     ("en-gb", _("English (GB)")),
     ("es-es", _("Spanish")),


### PR DESCRIPTION
The language is currently 100% translated on Crowdin, but wasn't enabled in the source code yet.
For the date format, I used information from Wikipedia: https://en.wikipedia.org/wiki/Date_and_time_notation_in_Denmark
I used the "traditional" notation which seems to be more widely used.

Again, as with #83, I'm not familiar with the language.