### PR TITLE
Revert "CI: Build and tag container on PRs"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,9 +278,9 @@ jobs:
           asset_name: paperless-ng-${{ steps.get_version.outputs.version }}.tar.xz
           asset_content_type: application/x-xz
 
-  # build and push image to ghcr.
+  # build and push image to docker hub.
   build-docker-image:
-    if: startsWith(github.ref, 'refs/heads/feature-') || github.ref == 'refs/heads/dev' || startsWith(github.ref, 'refs/tags/ng-') || startsWith(github.ref, 'refs/pull/')
+    if: github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/feature-') || github.ref == 'refs/heads/dev' || startsWith(github.ref, 'refs/tags/ng-'))
     runs-on: ubuntu-latest
     needs: [frontend, tests, whitespace, codestyle]
     steps:
@@ -294,9 +294,6 @@ jobs:
             INSPECT_TAG=${IMAGE_NAME}:latest
           elif [[ $GITHUB_REF == refs/heads/* ]]; then
             TAGS=${IMAGE_NAME}:${GITHUB_REF#refs/heads/}
-            INSPECT_TAG=${TAGS}
-          elif [[ $GITHUB_REF == refs/pull/* ]]; then
-            TAGS=${IMAGE_NAME}:pr-${{ github.event.number }}
             INSPECT_TAG=${TAGS}
           else
             exit 1


### PR DESCRIPTION
Reverts paperless-ngx/paperless-ngx#79

This is failing in many different ways I didn't expect and needs to be revisited. 

1. Write permissions are not given to outside forks ([for security](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)) failed [here
](https://github.com/paperless-ngx/paperless-ngx/runs/5256509587?check_suite_focus=true)
2. Whatever is going on [here...](https://github.com/paperless-ngx/paperless-ngx/runs/5259904053?check_suite_focus=true)

Anyway, it's creating unnecessarily failed checks and is annoying. I'll retest and get some input from the CI team this week.