### PR TITLE
Increase default timeout of `pip install`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,8 +63,8 @@ RUN apt-get update \
 		build-essential \
 		libpq-dev \
 		libqpdf-dev \
-	&& python3 -m pip install --upgrade --no-cache-dir supervisor \
-  && python3 -m pip install --no-cache-dir -r ../requirements.txt \
+	&& python3 -m pip install --default-timeout=1000 --upgrade --no-cache-dir supervisor \
+  && python3 -m pip install --default-timeout=1000 --no-cache-dir -r ../requirements.txt \
 	&& apt-get -y purge build-essential libqpdf-dev \
 	&& apt-get -y autoremove --purge \
 	&& rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Attempt to fix the sporadic `ConnectionResetError` seen [here](https://github.com/paperless-ngx/paperless-ngx/runs/5275984654?check_suite_focus=true) and [here](https://github.com/paperless-ngx/paperless-ngx/runs/5259904053?check_suite_focus=true).

Found this fix from [tensorflow/addons](https://github.com/tensorflow/addons/pull/1857)