### PR TITLE
Allow specifying port through PAPERLESS_PORT environment variable

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -700,8 +700,13 @@ PAPERLESS_WEBSERVER_WORKERS=<num>
     Defaults to 2.
 
 PAPERLESS_PORT=<port>
-    The port number the webserver will listen on. Change the port if it collides
-    with other services in your setup.
+    The port number the webserver will listen on inside the container. There are
+    special setups where you may need this to avoid collisions with other
+    services (like using podman with multiple containers in one pod).
+
+    Don't change this when using Docker. To change the port the webserver is
+    reachable outside of the container, instead refer to the "ports" key in
+    ``docker-compose.yml``.
 
     Defaults to 8000.
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -699,6 +699,12 @@ PAPERLESS_WEBSERVER_WORKERS=<num>
 
     Defaults to 2.
 
+PAPERLESS_PORT=<port>
+    The port number the webserver will listen on. Change the port if it collides
+    with other services in your setup.
+
+    Defaults to 8000.
+
 USERMAP_UID=<uid>
     The ID of the paperless user in the container. Set this to your actual user ID on the
     host system, which you can get by executing

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,6 +1,6 @@
 import os
 
-bind = '0.0.0.0:8000'
+bind = f'0.0.0.0:{os.getenv("PAPERLESS_PORT", 8000)}'
 workers = int(os.getenv("PAPERLESS_WEBSERVER_WORKERS", 2))
 worker_class = 'paperless.workers.ConfigurableWorker'
 timeout = 120


### PR DESCRIPTION
Supersedes #25 and adresses the issue mentioned in https://github.com/jonaswinkler/paperless-ng/pull/1285#discussion_r706390519.