### PR TITLE
Use a named volume for broker

### DIFF
--- a/docker/compose/docker-compose.portainer.yml
+++ b/docker/compose/docker-compose.portainer.yml
@@ -35,6 +35,7 @@ services:
     restart: unless-stopped
     volumes:
       - redisdata:/data
+
   db:
     image: postgres:13
     restart: unless-stopped

--- a/docker/compose/docker-compose.portainer.yml
+++ b/docker/compose/docker-compose.portainer.yml
@@ -33,7 +33,8 @@ services:
   broker:
     image: redis:6.0
     restart: unless-stopped
-
+    volumes:
+      - redisdata:/data
   db:
     image: postgres:13
     restart: unless-stopped
@@ -92,3 +93,4 @@ volumes:
   data:
   media:
   pgdata:
+  redisdata:

--- a/docker/compose/docker-compose.postgres-tika.yml
+++ b/docker/compose/docker-compose.postgres-tika.yml
@@ -35,7 +35,8 @@ services:
   broker:
     image: redis:6.0
     restart: unless-stopped
-
+    volumes:
+      - redisdata:/data
   db:
     image: postgres:13
     restart: unless-stopped
@@ -88,3 +89,4 @@ volumes:
   data:
   media:
   pgdata:
+  redisdata:

--- a/docker/compose/docker-compose.postgres-tika.yml
+++ b/docker/compose/docker-compose.postgres-tika.yml
@@ -37,6 +37,7 @@ services:
     restart: unless-stopped
     volumes:
       - redisdata:/data
+
   db:
     image: postgres:13
     restart: unless-stopped

--- a/docker/compose/docker-compose.postgres.yml
+++ b/docker/compose/docker-compose.postgres.yml
@@ -31,7 +31,8 @@ services:
   broker:
     image: redis:6.0
     restart: unless-stopped
-
+    volumes:
+      - redisdata:/data
   db:
     image: postgres:13
     restart: unless-stopped
@@ -70,3 +71,4 @@ volumes:
   data:
   media:
   pgdata:
+  redisdata:

--- a/docker/compose/docker-compose.postgres.yml
+++ b/docker/compose/docker-compose.postgres.yml
@@ -33,6 +33,7 @@ services:
     restart: unless-stopped
     volumes:
       - redisdata:/data
+
   db:
     image: postgres:13
     restart: unless-stopped

--- a/docker/compose/docker-compose.sqlite-tika.yml
+++ b/docker/compose/docker-compose.sqlite-tika.yml
@@ -36,7 +36,8 @@ services:
   broker:
     image: redis:6.0
     restart: unless-stopped
-
+    volumes:
+      - redisdata:/data
   webserver:
     image: jonaswinkler/paperless-ng:latest
     restart: unless-stopped
@@ -76,3 +77,4 @@ services:
 volumes:
   data:
   media:
+  redisdata:

--- a/docker/compose/docker-compose.sqlite-tika.yml
+++ b/docker/compose/docker-compose.sqlite-tika.yml
@@ -38,6 +38,7 @@ services:
     restart: unless-stopped
     volumes:
       - redisdata:/data
+
   webserver:
     image: jonaswinkler/paperless-ng:latest
     restart: unless-stopped

--- a/docker/compose/docker-compose.sqlite.yml
+++ b/docker/compose/docker-compose.sqlite.yml
@@ -30,6 +30,7 @@ services:
     restart: unless-stopped
     volumes:
       - redisdata:/data
+
   webserver:
     image: jonaswinkler/paperless-ng:latest
     restart: unless-stopped

--- a/docker/compose/docker-compose.sqlite.yml
+++ b/docker/compose/docker-compose.sqlite.yml
@@ -28,7 +28,8 @@ services:
   broker:
     image: redis:6.0
     restart: unless-stopped
-
+    volumes:
+      - redisdata:/data
   webserver:
     image: jonaswinkler/paperless-ng:latest
     restart: unless-stopped
@@ -54,3 +55,4 @@ services:
 volumes:
   data:
   media:
+  redisdata:


### PR DESCRIPTION
`docker-compose` automatically creates an anonymous [volume for redis](https://github.com/docker-library/redis/blob/5800387c04b3a07957e578258e0438187dd9e5d2/6.0/Dockerfile#L113). This names it as `redisdata` (ultimately `paperless_redisdata`) instead of the default sha.

Closes #112.