### PR TITLE
Remove alpha layer from PNG files for img2pdf

### DIFF
--- a/src/paperless_tesseract/parsers.py
+++ b/src/paperless_tesseract/parsers.py
@@ -67,14 +67,8 @@ class RasterisedDocumentParser(DocumentParser):
         ]
 
     def has_alpha(self, image):
-        try:
-            with Image.open(image) as im:
-                return im.mode in ('RGBA', 'LA')
-        except Exception as e:
-            self.log(
-                'warning',
-                f"Error while check for alpha channel in image {image}: {e}")
-            return None
+        with Image.open(image) as im:
+            return im.mode in ('RGBA', 'LA')
 
     def get_dpi(self, image):
         try:

--- a/src/paperless_tesseract/parsers.py
+++ b/src/paperless_tesseract/parsers.py
@@ -196,7 +196,8 @@ class RasterisedDocumentParser(DocumentParser):
             if self.has_alpha(input_file):
                 self.log(
                     "info",
-                    f"Removing alpha layer from {input_file} for compatibility with img2pdf"
+                    f"Removing alpha layer from {input_file} "
+                    "for compatibility with img2pdf"
                 )
                 with Image.open(input_file) as im:
                     background = Image.new('RGBA', im.size, (255, 255, 255))

--- a/src/paperless_tesseract/tests/test_parser.py
+++ b/src/paperless_tesseract/tests/test_parser.py
@@ -181,13 +181,14 @@ class TestParser(DirectoriesMixin, TestCase):
 
         self.assertContainsStrings(parser.get_text(), ["This is a test document."])
 
-    def test_image_simple_alpha_fail(self):
+    def test_image_simple_alpha(self):
         parser = RasterisedDocumentParser(None)
 
-        def f():
-            parser.parse(os.path.join(self.SAMPLE_FILES, "simple-alpha.png"), "image/png")
+        parser.parse(os.path.join(self.SAMPLE_FILES, "simple-alpha.png"), "image/png")
 
-        self.assertRaises(ParseError, f)
+        self.assertTrue(os.path.isfile(parser.archive_path))
+
+        self.assertContainsStrings(parser.get_text(), ["This is a test document."])
 
     def test_image_calc_a4_dpi(self):
         parser = RasterisedDocumentParser(None)


### PR DESCRIPTION
Resubmitting from jonaswinkler/paperless-ng#1663:

If a PNG file with an alpha layer is loaded in paperless-ng, the upload fails with an UnsupportedImageFormatError() although PNG files are generally supported. The error comes from OCRmyPDF (line 76 in src/ocrmypdf/_pipeline.py) which in turn tries to fulfill the requirements for img2pdf.

img2pdf states that it is meant for lossless conversion and thus does not want alter the input images (e.g. by removing the alpha layer) for conversion.

This PR checks if input images have an alpha layer and removes it by blending it with a white background. This enables support for images with alpha layers and fixes issue #1254.
