### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9']
+        python-version: ['3.8', '3.9']
       fail-fast: false
     steps:
       -

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,6 +11,6 @@ sphinx:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
+  version: "3.8"
   install:
     - requirements: docs/requirements.txt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ If you want to implement something big:
 
 ## Python
 
-Paperless supports python 3.6, 3.7, 3.8 and 3.9.
+Paperless supports python 3.8 and 3.9.
 
 ## Branches
 

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -282,7 +282,7 @@ writing. Windows is not and will never be supported.
 
 1.  Install dependencies. Paperless requires the following packages.
 
-    *   ``python3`` 3.6, 3.7, 3.8, 3.9
+    *   ``python3`` 3.8, 3.9
     *   ``python3-pip``
     *   ``python3-dev``
 


### PR DESCRIPTION
Since support for Python 3.7 stops us from upgrading some dependencies, we should remove it.

Closes: #114