### PR TITLE
Make CI build from tags starting with ngx-

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: ci
 
 on:
   push:
-    tags: ng-*
+    tags: ngx-*
     branches-ignore:
       - 'translations**'
   pull_request:
@@ -240,7 +240,7 @@ jobs:
   publish-release:
     runs-on: ubuntu-latest
     needs: build-release
-    if: contains(github.ref, 'refs/tags/ng-')
+    if: contains(github.ref, 'refs/tags/ngx-')
     steps:
       -
         name: Download release artifact


### PR DESCRIPTION
Currently, the CI will only publish new releases if the tag starts with ng- (e.g. `ng-1.5.0`). We should probably name our tags something like `ngx-1.6.0`.