### PR TITLE
Fix `build-docker-image` CI step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,6 +188,7 @@ jobs:
         run: |
           sudo apt-get update -qq
           sudo apt-get install -qq --no-install-recommends gettext liblept5
+          pip3 install --upgrade pip setuptools wheel
           pip3 install -r requirements.txt
       -
         name: Download frontend artifact

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,7 @@ RUN apt-get update \
 		build-essential \
 		libpq-dev \
 		libqpdf-dev \
+	&& python3 -m pip install --upgrade pip setuptools wheel \
 	&& python3 -m pip install --default-timeout=1000 --upgrade --no-cache-dir supervisor \
   && python3 -m pip install --default-timeout=1000 --no-cache-dir -r ../requirements.txt \
 	&& apt-get -y purge build-essential libqpdf-dev \


### PR DESCRIPTION
Currently the `build-docker-image` build step fails on:

```
#47 739.3   ERROR: Failed building wheel for pikepdf
#47 739.4 ERROR: Could not build wheels for pikepdf which use PEP 517 and cannot be installed directly
#47 739.4 Failed to build pikepdf
#47 741.2 WARNING: You are using pip version 21.2.4; however, version 22.0.3 is available.
#47 741.2 You should consider upgrading via the '/usr/local/bin/python3 -m pip install --upgrade pip' command.
#47 ERROR: process "/bin/sh -c apt-get update   && apt-get -y --no-install-recommends install \t\tbuild-essential \t\tlibpq-dev \t\tlibqpdf-dev \t&& python3 -m pip install --default-timeout=1000 --upgrade --no-cache-dir supervisor   && python3 -m pip install --default-timeout=1000 --no-cache-dir -r ../requirements.txt \t&& apt-get -y purge build-essential libqpdf-dev \t&& apt-get -y autoremove --purge \t&& rm -rf /var/lib/apt/lists/*" did not complete successfully: exit code: 1
```

Since pikepdf provides [matching wheels](https://pypi.org/project/pikepdf/#files) for our environment, it's probably due to the outdated pip version. I also added a pip upgrade to the "build release" workflow.