### PR TITLE
Restructure `README.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,9 +56,20 @@ Our community review process for `non-trivial` PRs is the following:
 
 This process might be slow as community members have different schedules and time to dedicate to the Paperless project. However it ensures community code reviews are as brilliantly thorough as they once were with @jonaswinkler.
 
-# Adding a new language
+# Translating Paperless-ngx
 
-This section describes how new languages can be added to the code.
+Some notes about translation:
+
+- There are two resources:
+  - `src-ui/messages.xlf` contains the translation strings for the front end. This is the most important.
+  - `django.po` contains strings for the administration section of paperless, which is nice to have translated.
+- Most of the front-end strings are used on buttons, menu items, etc., so ideally the translated string should not be much longer than the English original.
+- Translation units may contain placeholders. These usually mean that there's a name of a tag or document or something in the string. You can click on the placeholders to copy them.
+- Translation units may contain plural expressions such as `{PLURAL_VAR, plural, =1 {one result} =0 {no results} other {<placeholder> results}}`. Copy these verbatim and translate only the content in the inner `{}` brackets. Example: `{PLURAL_VAR, plural, =1 {Ein Ergebnis} =0 {Keine Ergebnisse} other {<placeholder> Ergebnisse}}`
+- Changes to translations on Crowdin will get pushed into the repository automatically.
+
+## Adding new languages to the codebase
+
 If a language has already been added, and you would like to contribute new translations or change existing translations, please read the "Translation" section in the README.md file for further details on that.
 
 If you would like the project to be translated to another language, first head over to https://crwd.in/paperless-ngx to check if that language has already been enabled for translation.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Paperless-ngx forked from [paperless-ng](https://github.com/jonaswinkler/paperle
 [#1599](https://github.com/jonaswinkler/paperless-ng/issues/1599) and [#1632](https://github.com/jonaswinkler/paperless-ng/issues/1632).
 
 #### Demo
-A demo is available at [demo.paperless-ngx.com](http://demo.paperless-ngx.com) using login `demo` / `demo`. *Note: demo content is reset frequently and confidential information should not be uploaded.*
+A demo is available at [demo.paperless-ngx.com](https://demo.paperless-ngx.com) using login `demo` / `demo`. *Note: demo content is reset frequently and confidential information should not be uploaded.*
 
 
 - [Features](#features)

--- a/README.md
+++ b/README.md
@@ -3,49 +3,37 @@
 [![Documentation Status](https://readthedocs.org/projects/paperless-ngx/badge/?version=latest)](https://paperless-ngx.readthedocs.io/en/latest/?badge=latest)
 [![Coverage Status](https://coveralls.io/repos/github/paperless-ngx/paperless-ngx/badge.svg?branch=master)](https://coveralls.io/github/paperless-ngx/paperless-ngx?branch=master)
 
+![Paperless logo](https://github.com/paperless-ngx/paperless-ngx/raw/main/resources/logo/web/png/Black%20logo%20-%20no%20background.png#gh-light-mode-only)
+![Paperless logo](https://github.com/paperless-ngx/paperless-ngx/raw/main/resources/logo/web/png/White%20logo%20-%20no%20background.png#gh-dark-mode-only)
+
+<!-- omit in toc -->
 # Paperless-ngx
 
-[Paperless (click me)](https://github.com/the-paperless-project/paperless) is an application by Daniel Quinn and contributors that indexes your scanned documents and allows you to easily search for documents and store metadata alongside your documents.
+Paperless-ngx is a document management system that transforms your wieldy physical document binders into an searchable online archive.
 
-Paperless-ng is a fork of the original project, adding a new interface and many other changes under the hood. These key points should help you decide whether Paperless-ng is something you would prefer over Paperless:
+Paperless-ngx forked from [paperless-ng](https://github.com/jonaswinkler/paperless-ng) to continue the great work and distribute responsibility among a team of people. That discussion can be found in issues
+[#1599](https://github.com/jonaswinkler/paperless-ng/issues/1599)
+and [#1632](https://github.com/jonaswinkler/paperless-ng/issues/1632).
 
-* Interface: The new front end is the main interface for Paperless-ng, the old interface still exists but most customizations (such as thumbnails for the document list) have been removed.0
-* Encryption: Paperless-ng does not support GnuPG anymore, since storing your data on encrypted file systems (that you optionally mount on demand) achieves about the same result.
-* Resource usage: Paperless-ng does use a bit more resources than Paperless. Running the web server requires about 300MB of RAM or more, depending on the configuration. While adding documents, it requires about 300MB additional RAM, depending on the document. It still runs on Raspberry Pi (many users do that), but it has been generally geared to better use the resources of more powerful systems.
-* API changes: If you rely on the REST API of paperless, some of its functionality has been changed.
-
-For a detailed list of changes done in paperless-ng, have a look at the [change log](https://paperless-ng.readthedocs.io/en/latest/changelog.html) in the documentation, especially the section about the [0.9.0 release](https://paperless-ng.readthedocs.io/en/latest/changelog.html#paperless-ng-0-9-0).
-
-Paperless-ngx forked from paperless-ng to continue the great work already done and distribute responsibility among a team of people.
-
-Discussion around that can be found in the issues in the paperless-ng repository:
-[1599](https://github.com/jonaswinkler/paperless-ng/issues/1599)
-[1632](https://github.com/jonaswinkler/paperless-ng/issues/1632)
-## Get in Touch
-
-People interested in continuing the work on paperless-ng(x) and form the organisation connected here on github and created a
-[Matrix Room](https://matrix.to/#/#paperless:adnidor.de) for realtime communication.
-
-# How it Works
-
-Paperless does not control your scanner, it only helps you deal with what your scanner produces.
-
-1. Buy a document scanner that can write to a place on your network.  If you need some inspiration, have a look at the [scanner recommendations](https://paperless-ngx.readthedocs.io/en/latest/scanners.html) page. Set it up to "scan to FTP" or something similar. It should be able to push scanned images to a server without you having to do anything.  Of course if your scanner doesn't know how to automatically upload the file somewhere, you can always do that manually. Paperless doesn't care how the documents get into its local consumption directory.
-
-	- Alternatively, you can use any of the mobile scanning apps out there. We have an app that allows you to share documents with paperless, if you're on Android. See the section on affiliated projects below.
-
-2. Wait for paperless to process your files. OCR is expensive, and depending on the power of your machine, this might take a bit of time.
-3. Use the web frontend to sift through the database and find what you want.
-4. Download the PDF you need/want via the web interface and do whatever you like with it.  You can even print it and send it as if it's the original. In most cases, no one will care or notice.
-
-Here's what you get:
-
-![Dashboard](https://raw.githubusercontent.com/paperless-ngx/paperless-ngx/master/docs/_static/screenshots/dashboard.png)
-
-If you want to see paperless-ngx in action, [more screenshots are available in the documentation](https://paperless-ngx.readthedocs.io/en/latest/screenshots.html).
+- [Features](#features)
+- [Getting started](#getting-started)
+- [How it Works](#how-it-works)
+- [Paperless-ngx vs Paperless](#paperless-ngx-vs-paperless)
+	- [Migrating from Paperless to Paperless-ngx](#migrating-from-paperless-to-paperless-ngx)
+- [Contributing](#contributing)
+	- [Documentation](#documentation)
+	- [Translation](#translation)
+	- [Feature Requests](#feature-requests)
+	- [Questions? Something not working?](#questions-something-not-working)
+- [Get in Touch](#get-in-touch)
+- [Affiliated Projects](#affiliated-projects)
+- [Important Note](#important-note)
 
 # Features
 
+![Dashboard](https://raw.githubusercontent.com/paperless-ngx/paperless-ngx/master/docs/_static/screenshots/documents-largecards.png)
+
+* Organize and index your scanned documents with tags, correspondents, types, and more.
 * Performs OCR on your documents, adds selectable text to image only documents and adds tags, correspondents and document types to your documents.
 * Supports PDF documents, images, plain text files, and Office documents (Word, Excel, Powerpoint, and LibreOffice equivalents).
 	* Office document support is optional and provided by Apache Tika (see [configuration](https://paperless-ngx.readthedocs.io/en/latest/configuration.html#tika-settings))
@@ -69,45 +57,75 @@ If you want to see paperless-ngx in action, [more screenshots are available in t
 
 # Getting started
 
-The recommended way to deploy paperless is docker-compose. The files in the /docker/compose directory are configured to pull the image from Docker Hub.
+The recommended way to deploy paperless is docker-compose. The files in the `/docker/compose` directory are configured to pull the image from GHCR.io.
 
-Read the [documentation](https://paperless-ngx.readthedocs.io/en/latest/setup.html#installation) on how to get started.
+Please read the [documentation](https://paperless-ngx.readthedocs.io/en/latest/setup.html#installation) on how to get started.
 
-Alternatively, you can install the dependencies and setup apache and a database server yourself. The documenation has a step by step guide on how to do it.
+Alternatively, you can install the dependencies and setup apache and a database server yourself. The [documentation](https://paperless-ngx.readthedocs.io/en/latest/setup.html#installation) has a step by step guide on how to do it.
+# How it Works
 
-# Migrating from Paperless to Paperless-ngx
+Paperless does not control your scanner, it only helps you deal with what your scanner produces.
+
+1. Buy a document scanner that can write to a place on your network.  If you need some inspiration, have a look at the [scanner recommendations](https://paperless-ngx.readthedocs.io/en/latest/scanners.html) page. Set it up to "scan to FTP" or something similar. It should be able to push scanned images to a server without you having to do anything.  Of course if your scanner doesn't know how to automatically upload the file somewhere, you can always do that manually. Paperless doesn't care how the documents get into its local consumption directory.
+
+	- Alternatively, you can use any of the mobile scanning apps out there. We have an app that allows you to share documents with paperless, if you're on Android. See the section on affiliated projects below.
+
+2. Wait for paperless to process your files. OCR is expensive, and depending on the power of your machine, this might take a bit of time.
+3. Use the web frontend to sift through the database and find what you want.
+4. Download the PDF you need/want via the web interface and do whatever you like with it.  You can even print it and send it as if it's the original. In most cases, no one will care or notice.
+
+If you want to see paperless-ngx in action, [more screenshots are available in the documentation](https://paperless-ngx.readthedocs.io/en/latest/screenshots.html).
+
+# Paperless-ngx vs Paperless
+
+[Paperless](https://github.com/the-paperless-project/paperless) is an application by Daniel Quinn and contributors that indexes your scanned documents and allows you to easily search for documents and store metadata alongside your documents.
+
+Paperless-ng is a fork of the original project, adding a new interface and many other changes under the hood. These key points should help you decide whether Paperless-ng is something you would prefer over Paperless:
+
+* Interface: The new front end is the main interface for Paperless-ng, the old interface still exists but most customizations (such as thumbnails for the document list) have been removed.0
+* Encryption: Paperless-ng does not support GnuPG anymore, since storing your data on encrypted file systems (that you optionally mount on demand) achieves about the same result.
+* Resource usage: Paperless-ng does use a bit more resources than Paperless. Running the web server requires about 300MB of RAM or more, depending on the configuration. While adding documents, it requires about 300MB additional RAM, depending on the document. It still runs on Raspberry Pi (many users do that), but it has been generally geared to better use the resources of more powerful systems.
+* API changes: If you rely on the REST API of paperless, some of its functionality has been changed.
+
+For a detailed list of changes done in paperless-ng, have a look at the [change log](https://paperless-ng.readthedocs.io/en/latest/changelog.html) in the documentation, especially the section about the [0.9.0 release](https://paperless-ng.readthedocs.io/en/latest/changelog.html#paperless-ng-0-9-0).
+
+## Migrating from Paperless to Paperless-ngx
 
 Read the section about [migration](https://paperless-ngx.readthedocs.io/en/latest/setup.html#migration-to-paperless-ng) in the documentation. Its also entirely possible to go back to Paperless by reverting the database migrations.
 
-# Documentation
+# Contributing
+
+If you feel like contributing to the project, please do! Bug fixes and improvements to the front end (I just can't seem to get some of these CSS things right) are always welcome. The [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html) has some basic information on how to get started.
+
+If you want to implement something big: Please start a discussion about that! Maybe I've already had something similar in mind and we can make it happen together. However, keep in mind that the general roadmap is to make the existing features stable and get them tested.
+
+## Documentation
 
 The documentation for Paperless-ngx is available on [ReadTheDocs](https://paperless-ngx.readthedocs.io/).
 
-# Translation
+## Translation
 
 Paperless-ngx is available in many languages that are coordinated on Crowdin. If you want to help out by translating paperless-ngx into your language, please head over to https://crwd.in/paperless-ngx, and thank you! More details about adding new languages to the code can be found in [CONTRIBUTING.md](https://github.com/paperless-ngx/paperless-ngx/blob/master/CONTRIBUTING.md#adding-a-new-language). Some notes about translation:
 
 - There are two resources:
-  - "src-ui/messages.xlf" contains the translation strings for the front end. This is the most important.
-  - "django.po" contains strings for the administration section of paperless, which is nice to have translated.
+  - `src-ui/messages.xlf` contains the translation strings for the front end. This is the most important.
+  - `django.po` contains strings for the administration section of paperless, which is nice to have translated.
 - Most of the front-end strings are used on buttons, menu items, etc., so ideally the translated string should not be much longer than the English original.
 - Translation units may contain placeholders. These usually mean that there's a name of a tag or document or something in the string. You can click on the placeholders to copy them.
 - Translation units may contain plural expressions such as `{PLURAL_VAR, plural, =1 {one result} =0 {no results} other {<placeholder> results}}`. Copy these verbatim and translate only the content in the inner `{}` brackets. Example: `{PLURAL_VAR, plural, =1 {Ein Ergebnis} =0 {Keine Ergebnisse} other {<placeholder> Ergebnisse}}`
 - Changes to translations on Crowdin will get pushed into the repository automatically.
 
-# Feature Requests
+## Feature Requests
 
 Feature requests can be submitted via [GitHub Discussions](https://github.com/paperless-ngx/paperless-ngx/discussions/categories/feature-requests), you can search for existing ideas, add your own and vote for the ones you care about! Note that some older feature requests can also be found under [issues](https://github.com/paperless-ngx/paperless-ngx/issues).
 
-# Questions? Something not working?
+## Questions? Something not working?
 
 For bugs please [open an issue](https://github.com/paperless-ngx/paperless-ngx/issues) or [start a discussion](https://github.com/paperless-ngx/paperless-ngx/discussions) if you have questions.
 
-## Feel like helping out?
+# Get in Touch
 
-There's still lots of things to be done, just have a look at open issues & discussions. If you feel like contributing to the project, please do! Bug fixes and improvements to the front end (I just can't seem to get some of these CSS things right) are always welcome. The documentation has some basic information on how to get started.
-
-If you want to implement something big: Please start a discussion about that! Maybe I've already had something similar in mind and we can make it happen together. However, keep in mind that the general roadmap is to make the existing features stable and get them tested.
+People interested in continuing the work on paperless-ngx are connecting here on github and in a [Matrix Room](https://matrix.to/#/#paperless:adnidor.de) for realtime communication.
 
 # Affiliated Projects
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@
 [![Coverage Status](https://coveralls.io/repos/github/paperless-ngx/paperless-ngx/badge.svg?branch=master)](https://coveralls.io/github/paperless-ngx/paperless-ngx?branch=master)
 [![Chat on Matrix](https://matrix.to/img/matrix-badge.svg)](https://matrix.to/#/#paperless:adnidor.de)
 
-![Paperless logo](https://github.com/paperless-ngx/paperless-ngx/raw/main/resources/logo/web/png/Black%20logo%20-%20no%20background.png#gh-light-mode-only)
-![Paperless logo](https://github.com/paperless-ngx/paperless-ngx/raw/main/resources/logo/web/png/White%20logo%20-%20no%20background.png#gh-dark-mode-only)
-
+<p align="center">
+<img src="https://github.com/paperless-ngx/paperless-ngx/raw/main/resources/logo/web/png/Black%20logo%20-%20no%20background.png#gh-light-mode-only" width="50%" />
+<img src="https://github.com/paperless-ngx/paperless-ngx/raw/main/resources/logo/web/png/White%20logo%20-%20no%20background.png#gh-dark-mode-only" width="50%" />
+</p>
+	
 <!-- omit in toc -->
 # Paperless-ngx
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ The recommended way to deploy paperless is docker-compose. The files in the `/do
 Please read the [documentation](https://paperless-ngx.readthedocs.io/en/latest/setup.html#installation) on how to get started.
 
 Alternatively, you can install the dependencies and setup apache and a database server yourself. The [documentation](https://paperless-ngx.readthedocs.io/en/latest/setup.html#installation) has a step by step guide on how to do it.
+
 # How it Works
 
 Paperless does not control your scanner, it only helps you deal with what your scanner produces.

--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@ and [#1632](https://github.com/jonaswinkler/paperless-ng/issues/1632).
 - [Features](#features)
 - [Getting started](#getting-started)
 - [How it Works](#how-it-works)
-- [Paperless-ngx vs Paperless](#paperless-ngx-vs-paperless)
-	- [Migrating from Paperless to Paperless-ngx](#migrating-from-paperless-to-paperless-ngx)
 - [Contributing](#contributing)
 	- [Documentation](#documentation)
 	- [Translation](#translation)
@@ -77,23 +75,6 @@ Paperless does not control your scanner, it only helps you deal with what your s
 4. Download the PDF you need/want via the web interface and do whatever you like with it.  You can even print it and send it as if it's the original. In most cases, no one will care or notice.
 
 If you want to see paperless-ngx in action, [more screenshots are available in the documentation](https://paperless-ngx.readthedocs.io/en/latest/screenshots.html).
-
-# Paperless-ngx vs Paperless
-
-[Paperless](https://github.com/the-paperless-project/paperless) is an application by Daniel Quinn and contributors that indexes your scanned documents and allows you to easily search for documents and store metadata alongside your documents.
-
-Paperless-ngx is a fork of the original project, adding a new interface and many other changes under the hood, including:
-
-* Interface: The new front end is the main interface for Paperless-ng, the old interface still exists but most customizations (such as thumbnails for the document list) have been removed.
-* Encryption: Paperless-ng does not support GnuPG anymore, since storing your data on encrypted file systems (that you optionally mount on demand) achieves about the same result.
-* Resource usage: Paperless-ng does use a bit more resources than Paperless. Running the web server requires about 300MB of RAM or more, depending on the configuration. While adding documents, it requires about 300MB additional RAM, depending on the document. It still runs on Raspberry Pi (many users do that), but it has been generally geared to better use the resources of more powerful systems.
-* API changes: If you rely on the REST API of paperless, some of its functionality has been changed.
-
-For a detailed list of changes done in paperless-ng, have a look at the [change log](https://paperless-ng.readthedocs.io/en/latest/changelog.html) in the documentation, especially the section about the [0.9.0 release](https://paperless-ng.readthedocs.io/en/latest/changelog.html#paperless-ng-0-9-0).
-
-## Migrating from Paperless to Paperless-ngx
-
-Read the section about [migration](https://paperless-ngx.readthedocs.io/en/latest/setup.html#migration-to-paperless-ng) in the documentation. Its also entirely possible to go back to Paperless by reverting the database migrations.
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Crowdin](https://badges.crowdin.net/paperless-ngx/localized.svg)](https://crowdin.com/project/paperless-ngx)
 [![Documentation Status](https://readthedocs.org/projects/paperless-ngx/badge/?version=latest)](https://paperless-ngx.readthedocs.io/en/latest/?badge=latest)
 [![Coverage Status](https://coveralls.io/repos/github/paperless-ngx/paperless-ngx/badge.svg?branch=master)](https://coveralls.io/github/paperless-ngx/paperless-ngx?branch=master)
+[![Chat on Matrix](https://matrix.to/img/matrix-badge.svg)](https://matrix.to/#/#paperless:adnidor.de)
 
 ![Paperless logo](https://github.com/paperless-ngx/paperless-ngx/raw/main/resources/logo/web/png/Black%20logo%20-%20no%20background.png#gh-light-mode-only)
 ![Paperless logo](https://github.com/paperless-ngx/paperless-ngx/raw/main/resources/logo/web/png/White%20logo%20-%20no%20background.png#gh-dark-mode-only)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Paperless-ngx is a document management system that transforms your physical docu
 Paperless-ngx forked from [paperless-ng](https://github.com/jonaswinkler/paperless-ng) to continue the great work and distribute responsibility of supporting and advancing the project among a team of people. [Consider joining us!](#community-support) Discussion of this transition can be found in issues
 [#1599](https://github.com/jonaswinkler/paperless-ng/issues/1599) and [#1632](https://github.com/jonaswinkler/paperless-ng/issues/1632).
 
-#### Demo
 A demo is available at [demo.paperless-ngx.com](https://demo.paperless-ngx.com) using login `demo` / `demo`. *Note: demo content is reset frequently and confidential information should not be uploaded.*
 
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 <img src="https://github.com/paperless-ngx/paperless-ngx/raw/main/resources/logo/web/png/Black%20logo%20-%20no%20background.png#gh-light-mode-only" width="50%" />
 <img src="https://github.com/paperless-ngx/paperless-ngx/raw/main/resources/logo/web/png/White%20logo%20-%20no%20background.png#gh-dark-mode-only" width="50%" />
 </p>
-	
+
 <!-- omit in toc -->
 # Paperless-ngx
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Paperless-ngx forked from [paperless-ng](https://github.com/jonaswinkler/paperle
 and [#1632](https://github.com/jonaswinkler/paperless-ng/issues/1632).
 
 #### Demo
-A demo is available at [http://demo.paperless-ngx.com](http://demo.paperless-ngx.com) using login `demo` / `demo` (content is reset frequently).
+A demo is available at [demo.paperless-ngx.com](http://demo.paperless-ngx.com) using login `demo` / `demo` (content is reset frequently).
 
 
 - [Features](#features)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A demo is available at [demo.paperless-ngx.com](https://demo.paperless-ngx.com) 
 - [Contributing](#contributing)
 	- [Community Support](#community-support)
 	- [Translation](#translation)
-	- [Feature Requests](#feature-requests-issues)
+	- [Feature Requests](#feature-requests)
 	- [Bugs](#bugs)
 - [Affiliated Projects](#affiliated-projects)
 - [Important Note](#important-note)
@@ -65,6 +65,7 @@ The easiest way to deploy paperless is docker-compose. The files in the [`/docke
 
 Alternatively, you can install the dependencies and setup apache and a database server yourself. The [documentation](https://paperless-ngx.readthedocs.io/en/latest/setup.html#installation) has a step by step guide on how to do it.
 
+<!-- omit in toc -->
 ### Documentation
 
 The documentation for Paperless-ngx is available on [ReadTheDocs](https://paperless-ngx.readthedocs.io/).

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ A demo is available at [demo.paperless-ngx.com](https://demo.paperless-ngx.com) 
 
 # Getting started
 
-The easiest way to deploy paperless is docker-compose. The files in the [`/docker/compose` directory](https://github.com/paperless-ngx/paperless-ngx/tree/main/docker/compose) are configured to pull the image from GHCR.io.
+The easiest way to deploy paperless is docker-compose. The files in the [`/docker/compose` directory](https://github.com/paperless-ngx/paperless-ngx/tree/main/docker/compose) are configured to pull the image from Github Packages.
 
 Alternatively, you can install the dependencies and setup apache and a database server yourself. The [documentation](https://paperless-ngx.readthedocs.io/en/latest/setup.html#installation) has a step by step guide on how to do it.
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,8 @@
 
 Paperless-ngx is a document management system that transforms your physical documents into a searchable online archive so you can keep, well, *less paper*.
 
-Paperless-ngx forked from [paperless-ng](https://github.com/jonaswinkler/paperless-ng) to continue the great work and distribute responsibility among a team of people. That discussion can be found in issues
-[#1599](https://github.com/jonaswinkler/paperless-ng/issues/1599)
-and [#1632](https://github.com/jonaswinkler/paperless-ng/issues/1632).
+Paperless-ngx forked from [paperless-ng](https://github.com/jonaswinkler/paperless-ng) to continue the great work and distribute responsibility of supporting and advancing the project among a team of people. [Consider joining us!](#community-support) Discussion of this transition can be found in issues
+[#1599](https://github.com/jonaswinkler/paperless-ng/issues/1599) and [#1632](https://github.com/jonaswinkler/paperless-ng/issues/1632).
 
 #### Demo
 A demo is available at [demo.paperless-ngx.com](http://demo.paperless-ngx.com) using login `demo` / `demo`. *Note: demo content is reset frequently and confidential information should not be uploaded.*
@@ -25,10 +24,10 @@ A demo is available at [demo.paperless-ngx.com](http://demo.paperless-ngx.com) u
 - [Features](#features)
 - [Getting started](#getting-started)
 - [Contributing](#contributing)
+	- [Community Supported](#community-supported)
 	- [Translation](#translation)
-	- [Feature Requests](#feature-requests)
-	- [Questions? Something not working?](#questions-something-not-working)
-- [Get in Touch](#get-in-touch)
+	- [Feature Requests](#feature-requests-issues)
+	- [Bugs](#bugs)
 - [Affiliated Projects](#affiliated-projects)
 - [Important Note](#important-note)
 
@@ -62,7 +61,7 @@ A demo is available at [demo.paperless-ngx.com](http://demo.paperless-ngx.com) u
 
 # Getting started
 
-The recommended way to deploy paperless is docker-compose. The files in the `/docker/compose` directory are configured to pull the image from GHCR.io.
+The easiest way to deploy paperless is docker-compose. The files in the [`/docker/compose` directory](https://github.com/paperless-ngx/paperless-ngx/tree/main/docker/compose) are configured to pull the image from GHCR.io.
 
 Alternatively, you can install the dependencies and setup apache and a database server yourself. The [documentation](https://paperless-ngx.readthedocs.io/en/latest/setup.html#installation) has a step by step guide on how to do it.
 
@@ -74,33 +73,25 @@ The documentation for Paperless-ngx is available on [ReadTheDocs](https://paperl
 
 If you feel like contributing to the project, please do! Bug fixes, enhancements, visual fixes etc. are always welcome. If you want to implement something big: Please start a discussion about that! The [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html) has some basic information on how to get started.
 
+## Community Supported
+
+People interested in continuing the work on paperless-ngx are encouraged to reach out here on github and in the [Matrix Room](https://matrix.to/#/#paperless:adnidor.de).
+
 ## Translation
 
-Paperless-ngx is available in many languages that are coordinated on Crowdin. If you want to help out by translating paperless-ngx into your language, please head over to https://crwd.in/paperless-ngx, and thank you! More details about adding new languages to the code can be found in [CONTRIBUTING.md](https://github.com/paperless-ngx/paperless-ngx/blob/master/CONTRIBUTING.md#adding-a-new-language). Some notes about translation:
-
-- There are two resources:
-  - `src-ui/messages.xlf` contains the translation strings for the front end. This is the most important.
-  - `django.po` contains strings for the administration section of paperless, which is nice to have translated.
-- Most of the front-end strings are used on buttons, menu items, etc., so ideally the translated string should not be much longer than the English original.
-- Translation units may contain placeholders. These usually mean that there's a name of a tag or document or something in the string. You can click on the placeholders to copy them.
-- Translation units may contain plural expressions such as `{PLURAL_VAR, plural, =1 {one result} =0 {no results} other {<placeholder> results}}`. Copy these verbatim and translate only the content in the inner `{}` brackets. Example: `{PLURAL_VAR, plural, =1 {Ein Ergebnis} =0 {Keine Ergebnisse} other {<placeholder> Ergebnisse}}`
-- Changes to translations on Crowdin will get pushed into the repository automatically.
+Paperless-ngx is available in many languages that are coordinated on Crowdin. If you want to help out by translating paperless-ngx into your language, please head over to https://crwd.in/paperless-ngx, and thank you! More details can be found in [CONTRIBUTING.md](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md#translating-paperless-ngx).
 
 ## Feature Requests
 
-Feature requests can be submitted via [GitHub Discussions](https://github.com/paperless-ngx/paperless-ngx/discussions/categories/feature-requests), you can search for existing ideas, add your own and vote for the ones you care about! Note that some older feature requests can also be found under [issues](https://github.com/paperless-ngx/paperless-ngx/issues).
+Feature requests can be submitted via [GitHub Discussions](https://github.com/paperless-ngx/paperless-ngx/discussions/categories/feature-requests), you can search for existing ideas, add your own and vote for the ones you care about.
 
-## Questions? Something not working?
+## Bugs
 
 For bugs please [open an issue](https://github.com/paperless-ngx/paperless-ngx/issues) or [start a discussion](https://github.com/paperless-ngx/paperless-ngx/discussions) if you have questions.
 
-# Get in Touch
-
-People interested in continuing the work on paperless-ngx are connecting here on github and in a [Matrix Room](https://matrix.to/#/#paperless:adnidor.de) for realtime communication.
-
 # Affiliated Projects
 
-Paperless has been around a while now, and people are starting to build stuff on top of it.  If you're one of those people, we can add your project to this list:
+Paperless has been around a while now, and people are starting to build stuff on top of it. If you're one of those people, we can add your project to this list:
 
 * [Paperless App](https://github.com/bauerj/paperless_app): An Android/iOS app for Paperless-ngx. Also works with the original Paperless and Paperless-ng.
 * [Paperless Share](https://github.com/qcasey/paperless_share). Share any files from your Android application with paperless. Very simple, but works with all of the mobile scanning apps out there that allow you to share scanned documents.
@@ -112,9 +103,9 @@ These projects also exist, but their status and compatibility with paperless-ngx
 
 This project also exists, but needs updates to be compatible with paperless-ngx.
 
-* [Paperless Desktop](https://github.com/thomasbrueggemann/paperless-desktop): A desktop UI for your Paperless installation.  Runs on Mac, Linux, and Windows.
+* [Paperless Desktop](https://github.com/thomasbrueggemann/paperless-desktop): A desktop UI for your Paperless installation. Runs on Mac, Linux, and Windows.
 	Known issues on Mac: (Could not load reminders and documents)
 
 # Important Note
 
-Document scanners are typically used to scan sensitive documents.  Things like your social insurance number, tax records, invoices, etc.  Everything is stored in the clear without encryption. This means that Paperless should never be run on an untrusted host.  Instead, I recommend that if you do want to use it, run it locally on a server in your own home.
+Document scanners are typically used to scan sensitive documents. Things like your social insurance number, tax records, invoices, etc. Everything is stored in the clear without encryption. This means that Paperless should never be run on an untrusted host. Instead, I recommend that if you do want to use it, run it locally on a server in your own home.

--- a/README.md
+++ b/README.md
@@ -16,11 +16,14 @@ Paperless-ngx forked from [paperless-ng](https://github.com/jonaswinkler/paperle
 [#1599](https://github.com/jonaswinkler/paperless-ng/issues/1599)
 and [#1632](https://github.com/jonaswinkler/paperless-ng/issues/1632).
 
+#### Demo
+A demo is available at [http://demo.paperless-ngx.com](http://demo.paperless-ngx.com) using login `demo` / `demo` (content is reset frequently).
+
+
 - [Features](#features)
 - [Getting started](#getting-started)
 - [How it Works](#how-it-works)
 - [Contributing](#contributing)
-	- [Documentation](#documentation)
 	- [Translation](#translation)
 	- [Feature Requests](#feature-requests)
 	- [Questions? Something not working?](#questions-something-not-working)
@@ -54,36 +57,21 @@ and [#1632](https://github.com/jonaswinkler/paperless-ng/issues/1632).
 	* Paperless learns from your documents and will be able to automatically assign tags, correspondents and types to documents once you've stored a few documents in paperless.
 * Optimized for multi core systems: Paperless-ng consumes multiple documents in parallel.
 * The integrated sanity checker makes sure that your document archive is in good health.
+* [More screenshots are available in the documentation](https://paperless-ngx.readthedocs.io/en/latest/screenshots.html).
 
 # Getting started
 
 The recommended way to deploy paperless is docker-compose. The files in the `/docker/compose` directory are configured to pull the image from GHCR.io.
 
-Please read the [documentation](https://paperless-ngx.readthedocs.io/en/latest/setup.html#installation) on how to get started.
-
 Alternatively, you can install the dependencies and setup apache and a database server yourself. The [documentation](https://paperless-ngx.readthedocs.io/en/latest/setup.html#installation) has a step by step guide on how to do it.
 
-# How it Works
+### Documentation
 
-Paperless does not control your scanner, it only helps you deal with what your scanner produces.
-
-1. Buy a document scanner that can write to a place on your network.  If you need some inspiration, have a look at the [scanner recommendations](https://paperless-ngx.readthedocs.io/en/latest/scanners.html) page. Set it up to "scan to FTP" or something similar. It should be able to push scanned images to a server without you having to do anything.  Of course if your scanner doesn't know how to automatically upload the file somewhere, you can always do that manually. Paperless doesn't care how the documents get into its local consumption directory.
-
-	- Alternatively, you can use any of the mobile scanning apps out there. We have an app that allows you to share documents with paperless, if you're on Android. See the section on affiliated projects below.
-
-2. Wait for paperless to process your files. OCR is expensive, and depending on the power of your machine, this might take a bit of time.
-3. Use the web frontend to sift through the database and find what you want.
-4. Download the PDF you need/want via the web interface and do whatever you like with it.  You can even print it and send it as if it's the original. In most cases, no one will care or notice.
-
-If you want to see paperless-ngx in action, [more screenshots are available in the documentation](https://paperless-ngx.readthedocs.io/en/latest/screenshots.html).
+The documentation for Paperless-ngx is available on [ReadTheDocs](https://paperless-ngx.readthedocs.io/).
 
 # Contributing
 
 If you feel like contributing to the project, please do! Bug fixes, enhancements, visual fixes etc. are always welcome. If you want to implement something big: Please start a discussion about that! The [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html) has some basic information on how to get started.
-
-## Documentation
-
-The documentation for Paperless-ngx is available on [ReadTheDocs](https://paperless-ngx.readthedocs.io/).
 
 ## Translation
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ A demo is available at [demo.paperless-ngx.com](https://demo.paperless-ngx.com) 
 
 The easiest way to deploy paperless is docker-compose. The files in the [`/docker/compose` directory](https://github.com/paperless-ngx/paperless-ngx/tree/main/docker/compose) are configured to pull the image from Github Packages.
 
+If you'd like to jump right in, you can configure a docker-compose environment with our install script:
+
+```bash
+bash -c "$(curl -L https://raw.githubusercontent.com/paperless-ngx/paperless-ngx/master/install-paperless-ng.sh)"
+```
+
 Alternatively, you can install the dependencies and setup apache and a database server yourself. The [documentation](https://paperless-ngx.readthedocs.io/en/latest/setup.html#installation) has a step by step guide on how to do it.
 
 <!-- omit in toc -->

--- a/README.md
+++ b/README.md
@@ -17,12 +17,11 @@ Paperless-ngx forked from [paperless-ng](https://github.com/jonaswinkler/paperle
 and [#1632](https://github.com/jonaswinkler/paperless-ng/issues/1632).
 
 #### Demo
-A demo is available at [demo.paperless-ngx.com](http://demo.paperless-ngx.com) using login `demo` / `demo` (content is reset frequently).
+A demo is available at [demo.paperless-ngx.com](http://demo.paperless-ngx.com) using login `demo` / `demo`. *Note: demo content is reset frequently and confidential information should not be uploaded.*
 
 
 - [Features](#features)
 - [Getting started](#getting-started)
-- [How it Works](#how-it-works)
 - [Contributing](#contributing)
 	- [Translation](#translation)
 	- [Feature Requests](#feature-requests)
@@ -54,7 +53,7 @@ A demo is available at [demo.paperless-ngx.com](http://demo.paperless-ngx.com) u
 	* Configure multiple accounts and filters for each account.
 	* When adding documents from mail, paperless can move these mail to a new folder, mark them as read, flag them as important or delete them.
 * Machine learning powered document matching.
-	* Paperless learns from your documents and will be able to automatically assign tags, correspondents and types to documents once you've stored a few documents in paperless.
+	* Paperless-ngx learns from your documents and will be able to automatically assign tags, correspondents and types to documents once you've stored a few documents in paperless.
 * Optimized for multi core systems: Paperless-ng consumes multiple documents in parallel.
 * The integrated sanity checker makes sure that your document archive is in good health.
 * [More screenshots are available in the documentation](https://paperless-ngx.readthedocs.io/en/latest/screenshots.html).

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 <!-- omit in toc -->
 # Paperless-ngx
 
-Paperless-ngx is a document management system that transforms your wieldy physical document binders into an searchable online archive.
+Paperless-ngx is a document management system that transforms your physical documents into a searchable online archive so you can keep, well, *less paper*.
 
 Paperless-ngx forked from [paperless-ng](https://github.com/jonaswinkler/paperless-ng) to continue the great work and distribute responsibility among a team of people. That discussion can be found in issues
 [#1599](https://github.com/jonaswinkler/paperless-ng/issues/1599)
@@ -82,9 +82,9 @@ If you want to see paperless-ngx in action, [more screenshots are available in t
 
 [Paperless](https://github.com/the-paperless-project/paperless) is an application by Daniel Quinn and contributors that indexes your scanned documents and allows you to easily search for documents and store metadata alongside your documents.
 
-Paperless-ng is a fork of the original project, adding a new interface and many other changes under the hood. These key points should help you decide whether Paperless-ng is something you would prefer over Paperless:
+Paperless-ngx is a fork of the original project, adding a new interface and many other changes under the hood, including:
 
-* Interface: The new front end is the main interface for Paperless-ng, the old interface still exists but most customizations (such as thumbnails for the document list) have been removed.0
+* Interface: The new front end is the main interface for Paperless-ng, the old interface still exists but most customizations (such as thumbnails for the document list) have been removed.
 * Encryption: Paperless-ng does not support GnuPG anymore, since storing your data on encrypted file systems (that you optionally mount on demand) achieves about the same result.
 * Resource usage: Paperless-ng does use a bit more resources than Paperless. Running the web server requires about 300MB of RAM or more, depending on the configuration. While adding documents, it requires about 300MB additional RAM, depending on the document. It still runs on Raspberry Pi (many users do that), but it has been generally geared to better use the resources of more powerful systems.
 * API changes: If you rely on the REST API of paperless, some of its functionality has been changed.
@@ -97,9 +97,7 @@ Read the section about [migration](https://paperless-ngx.readthedocs.io/en/lates
 
 # Contributing
 
-If you feel like contributing to the project, please do! Bug fixes and improvements to the front end (I just can't seem to get some of these CSS things right) are always welcome. The [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html) has some basic information on how to get started.
-
-If you want to implement something big: Please start a discussion about that! Maybe I've already had something similar in mind and we can make it happen together. However, keep in mind that the general roadmap is to make the existing features stable and get them tested.
+If you feel like contributing to the project, please do! Bug fixes, enhancements, visual fixes etc. are always welcome. If you want to implement something big: Please start a discussion about that! The [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html) has some basic information on how to get started.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A demo is available at [demo.paperless-ngx.com](http://demo.paperless-ngx.com) u
 - [Features](#features)
 - [Getting started](#getting-started)
 - [Contributing](#contributing)
-	- [Community Supported](#community-supported)
+	- [Community Support](#community-support)
 	- [Translation](#translation)
 	- [Feature Requests](#feature-requests-issues)
 	- [Bugs](#bugs)
@@ -73,9 +73,9 @@ The documentation for Paperless-ngx is available on [ReadTheDocs](https://paperl
 
 If you feel like contributing to the project, please do! Bug fixes, enhancements, visual fixes etc. are always welcome. If you want to implement something big: Please start a discussion about that! The [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html) has some basic information on how to get started.
 
-## Community Supported
+## Community Support
 
-People interested in continuing the work on paperless-ngx are encouraged to reach out here on github and in the [Matrix Room](https://matrix.to/#/#paperless:adnidor.de).
+People interested in continuing the work on paperless-ngx are encouraged to reach out here on github and in the [Matrix Room](https://matrix.to/#/#paperless:adnidor.de). If you would like to contribute to the project on an ongoing basis there are multiple [teams](https://github.com/orgs/paperless-ngx/people) (frontend, ci/cd, etc) that could use your help so please reach out!
 
 ## Translation
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ and [#1632](https://github.com/jonaswinkler/paperless-ng/issues/1632).
 
 # Features
 
-![Dashboard](https://raw.githubusercontent.com/paperless-ngx/paperless-ngx/master/docs/_static/screenshots/documents-largecards.png)
+![Dashboard](https://raw.githubusercontent.com/paperless-ngx/paperless-ngx/main/docs/_static/screenshots/documents-wchrome.png#gh-light-mode-only)
+![Dashboard](https://raw.githubusercontent.com/paperless-ngx/paperless-ngx/main/docs/_static/screenshots/documents-wchrome-dark.png#gh-dark-mode-only)
 
 * Organize and index your scanned documents with tags, correspondents, types, and more.
 * Performs OCR on your documents, adds selectable text to image only documents and adds tags, correspondents and document types to your documents.


### PR DESCRIPTION
I [mentioned](https://github.com/paperless-ngx/paperless-ngx/pull/55#issuecomment-1048045508) it'd be a good idea to restructure the README for clarity. 

These are the changes this PR makes ([View render on GH](https://github.com/paperless-ngx/paperless-ngx/tree/readme-ngx#readme)):

1. Adds Paperless logo to header area (thoughts? too big?).
2. Adds tagline (from docs) to :hook: hook those awesome-self-hosted skimmers.
3. Clarifies the paperless-ngx fork situation.
4. Adds table of contents.
5. Moves **Paperless-ngx vs Paperless** and **Migrating from Paperless to Paperless-ngx** further down.
6. Changes screenshot from dashboard to documents (more compelling IMO).
7. Typo and sentence structures fixes.

Of course, open to suggestions