### PR TITLE
Fix Armv7 Docker Build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,14 +317,6 @@ jobs:
         name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       -
-        name: Cache Docker layers
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-      -
         name: Login to Github Container Registry
         uses: docker/login-action@v1
         with:
@@ -340,8 +332,8 @@ jobs:
           platforms: linux/amd64,linux/arm/v7,linux/arm64
           push: true
           tags: ${{ steps.prepare.outputs.tags }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
       -
         name: Inspect image
         run: |


### PR DESCRIPTION
Another attempt at #145 😅

This time with help from @Schnuffle.

Upstream pikepdf provides binary wheels for amd64 and arm64 but not armv7. This means we have to compile it on that architecture. This also means that we have to compile its dependency qpdf manually.

This takes almost forever (two hours!) but with improved Docker caching, this should hopefully be not much of an issue.

Closes: #150