### PR TITLE
Fix whitespace issue in scanners.rst

### DIFF
--- a/docs/scanners.rst
+++ b/docs/scanners.rst
@@ -111,4 +111,4 @@ On Android, you can use these applications in combination with one of the :ref:`
 .. _OpenScan: https://github.com/Ethereal-Developers-Inc/OpenScan
 
 .. _hannahswain: https://github.com/hannahswain
-.. _benjaminfrank: https://github.com/benjaminfrank	
+.. _benjaminfrank: https://github.com/benjaminfrank


### PR DESCRIPTION
There was a trailing space hidden in #162. This makes the CI happy again.