### PR TITLE
Install: Ask for database folder mount when using postgres

### DIFF
--- a/install-paperless-ngx.sh
+++ b/install-paperless-ngx.sh
@@ -339,8 +339,8 @@ if [[ -n $POSTGRES_FOLDER ]] ; then
 	sed -i "s#- pgdata:/var/lib/postgresql/data#- $POSTGRES_FOLDER:/var/lib/postgresql/data#g" docker-compose.yml
 fi
 
-# docker-compose pull
+docker-compose pull
 
-# docker-compose run --rm -e DJANGO_SUPERUSER_PASSWORD="$PASSWORD" webserver createsuperuser --noinput --username "$USERNAME" --email "$EMAIL"
+docker-compose run --rm -e DJANGO_SUPERUSER_PASSWORD="$PASSWORD" webserver createsuperuser --noinput --username "$USERNAME" --email "$EMAIL"
 
-# docker-compose up -d
+docker-compose up -d

--- a/install-paperless-ngx.sh
+++ b/install-paperless-ngx.sh
@@ -189,7 +189,10 @@ MEDIA_FOLDER=$ask_result
 
 echo ""
 echo "The data folder is where paperless stores other data, such as your"
-echo "SQLite database (if used), the search index and other data."
+if [[ "$DATABASE_BACKEND" == "sqlite" ]]
+	echo -n "SQLite database, the "
+fi
+echo "search index and other data."
 echo "As with the media folder, leave empty to have this managed by docker."
 echo ""
 echo "CAUTION: If specified, you must specify an absolute path starting with /"

--- a/install-paperless-ngx.sh
+++ b/install-paperless-ngx.sh
@@ -85,58 +85,7 @@ echo ""
 echo "This script will download, configure and start paperless-ngx."
 
 echo ""
-echo "1. Folder configuration"
-echo "======================="
-echo ""
-echo "The target folder is used to store the configuration files of "
-echo "paperless. You can move this folder around after installing paperless."
-echo "You will need this folder whenever you want to start, stop, update or "
-echo "maintain your paperless instance."
-echo ""
-
-ask "Target folder" "$(pwd)/paperless-ngx"
-TARGET_FOLDER=$ask_result
-
-echo ""
-echo "The consume folder is where paperles will search for new documents."
-echo "Point this to a folder where your scanner is able to put your scanned"
-echo "documents."
-echo ""
-echo "CAUTION: You must specify an absolute path starting with / or a relative "
-echo "path starting with ./ here. Examples:"
-echo "  /mnt/consume"
-echo "  ./consume"
-echo ""
-
-ask_docker_folder "Consume folder" "$TARGET_FOLDER/consume"
-CONSUME_FOLDER=$ask_result
-
-echo ""
-echo "The media folder is where paperless stores your documents."
-echo "Leave empty and docker will manage this folder for you."
-echo "Docker usually stores managed folders in /var/lib/docker/volumes."
-echo ""
-echo "CAUTION: If specified, you must specify an absolute path starting with /"
-echo "or a relative path starting with ./ here."
-echo ""
-
-ask_docker_folder "Media folder" ""
-MEDIA_FOLDER=$ask_result
-
-echo ""
-echo "The data folder is where paperless stores other data, such as your"
-echo "SQLite database (if used), the search index and other data."
-echo "As with the media folder, leave empty to have this managed by docker."
-echo ""
-echo "CAUTION: If specified, you must specify an absolute path starting with /"
-echo "or a relative path starting with ./ here."
-echo ""
-
-ask_docker_folder "Data folder" ""
-DATA_FOLDER=$ask_result
-
-echo ""
-echo "2. Application configuration"
+echo "1. Application configuration"
 echo "============================"
 
 echo ""
@@ -198,6 +147,57 @@ USERMAP_UID=$ask_result
 
 ask "Group ID" "$(id -g)"
 USERMAP_GID=$ask_result
+
+echo ""
+echo "2. Folder configuration"
+echo "======================="
+echo ""
+echo "The target folder is used to store the configuration files of "
+echo "paperless. You can move this folder around after installing paperless."
+echo "You will need this folder whenever you want to start, stop, update or "
+echo "maintain your paperless instance."
+echo ""
+
+ask "Target folder" "$(pwd)/paperless-ngx"
+TARGET_FOLDER=$ask_result
+
+echo ""
+echo "The consume folder is where paperles will search for new documents."
+echo "Point this to a folder where your scanner is able to put your scanned"
+echo "documents."
+echo ""
+echo "CAUTION: You must specify an absolute path starting with / or a relative "
+echo "path starting with ./ here. Examples:"
+echo "  /mnt/consume"
+echo "  ./consume"
+echo ""
+
+ask_docker_folder "Consume folder" "$TARGET_FOLDER/consume"
+CONSUME_FOLDER=$ask_result
+
+echo ""
+echo "The media folder is where paperless stores your documents."
+echo "Leave empty and docker will manage this folder for you."
+echo "Docker usually stores managed folders in /var/lib/docker/volumes."
+echo ""
+echo "CAUTION: If specified, you must specify an absolute path starting with /"
+echo "or a relative path starting with ./ here."
+echo ""
+
+ask_docker_folder "Media folder" ""
+MEDIA_FOLDER=$ask_result
+
+echo ""
+echo "The data folder is where paperless stores other data, such as your"
+echo "SQLite database (if used), the search index and other data."
+echo "As with the media folder, leave empty to have this managed by docker."
+echo ""
+echo "CAUTION: If specified, you must specify an absolute path starting with /"
+echo "or a relative path starting with ./ here."
+echo ""
+
+ask_docker_folder "Data folder" ""
+DATA_FOLDER=$ask_result
 
 echo ""
 echo "3. Login credentials"


### PR DESCRIPTION
Closes #153 

In the install script when a user chooses (the default option) postgres, it would use a docker volume for the database without asking the user. This leads to situations like #153 where the user assumes they have specified all data directories Paperless uses, which is not true.

This PR asks the user to provide a directory to use for postgres, just like `data` and `media`. That change also requires asking the **Application configuration** questions first.