### PR TITLE
Switched to `flag()`

### DIFF
--- a/src/paperless_mail/mail.py
+++ b/src/paperless_mail/mail.py
@@ -44,7 +44,7 @@ class MarkReadMailAction(BaseMailAction):
         return {"seen": False}
 
     def post_consume(self, M, message_uids, parameter):
-        M.seen(message_uids, True)
+        M.flag(message_uids, [MailMessageFlags.SEEN], True)
 
 
 class MoveMailAction(BaseMailAction):

--- a/src/paperless_mail/tests/test_mail.py
+++ b/src/paperless_mail/tests/test_mail.py
@@ -68,11 +68,6 @@ class BogusMailBox(ContextManager):
 
         return list(msg)
 
-    def seen(self, uid_list, seen_val):
-        for message in self.messages:
-            if message.uid in uid_list:
-                message.seen = seen_val
-
     def delete(self, uid_list):
         self.messages = list(filter(lambda m: m.uid not in uid_list, self.messages))
 
@@ -82,6 +77,8 @@ class BogusMailBox(ContextManager):
                 for flag in flag_set:
                     if flag == MailMessageFlags.FLAGGED:
                         message.flagged = value
+                    if flag == MailMessageFlags.SEEN:
+                        message.seen = value
 
     def move(self, uid_list, folder):
         if folder == "spam":


### PR DESCRIPTION
Newer versions of imap_tools moved away from `seen()` in favour of
`flag()` and deprecated the former.

This fixes https://github.com/jonaswinkler/paperless-ng/issues/1672