### PR TITLE
add instructions to install pytest-xdist and pytest-cov 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,8 +27,7 @@ Please format and test your code! I know it's a hassle, but it makes sure that y
 
 To test your code, execute `pytest` in the src/ directory. This also generates a html coverage report, which you can use to see if you missed anything important during testing.
 
-Before you can run `pytest`, ensure to run `pipenv install`
-and `pipenv install --dev` so all python dependencies are installed.
+Before you can run `pytest`, ensure to [properly set up your local environment](https://paperless-ngx.readthedocs.io/en/latest/extending.html#initial-setup-and-first-start).
 
 ## More info:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,8 @@ Please format and test your code! I know it's a hassle, but it makes sure that y
 
 To test your code, execute `pytest` in the src/ directory. This also generates a html coverage report, which you can use to see if you missed anything important during testing.
 
-Before you can run `pytest`, ensure to install `pytest-xdist` and `pytest-cov` by running `pip3 install pytest-xdist pytest-cov`.
+Before you can run `pytest`, ensure to run `pipenv install`
+and `pipenv install --dev` so all python dependencies are installed.
 
 ## More info:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,8 @@ Please format and test your code! I know it's a hassle, but it makes sure that y
 
 To test your code, execute `pytest` in the src/ directory. This also generates a html coverage report, which you can use to see if you missed anything important during testing.
 
+Before you can run `pytest`, ensure to install `pytest-xdist` and `pytest-cov` by running `pip3 install pytest-xdist pytest-cov`.
+
 ## More info:
 
 ... is available in the documentation. https://paperless-ngx.readthedocs.io/en/latest/extending.html


### PR DESCRIPTION
(imported https://github.com/jonaswinkler/paperless-ng/pull/1681)

I needed to research this, so I think it could help others to have it in the documentation.