### PR TITLE
Fix issue 225 management page filtering, add esc clearing of filter field

### DIFF
--- a/src-ui/src/app/components/manage/correspondent-list/correspondent-list.component.html
+++ b/src-ui/src/app/components/manage/correspondent-list/correspondent-list.component.html
@@ -6,7 +6,7 @@
   <div class="col-md mb-2 mb-xl-0">
     <div class="form-inline d-flex align-items-center">
       <label class="text-muted me-2 mb-0" i18n>Filter by:</label>
-      <input class="form-control form-control-sm flex-fill w-auto" type="text" [(ngModel)]="nameFilter" placeholder="Name" i18n-placeholder>
+      <input class="form-control form-control-sm flex-fill w-auto" type="text" autofocus [(ngModel)]="nameFilter" (keyup)="onNameFilterKeyUp($event)" placeholder="Name" i18n-placeholder>
     </div>
   </div>
 

--- a/src-ui/src/app/components/manage/document-type-list/document-type-list.component.html
+++ b/src-ui/src/app/components/manage/document-type-list/document-type-list.component.html
@@ -6,7 +6,7 @@
   <div class="col-md mb-2 mb-xl-0">
     <div class="form-inline d-flex align-items-center">
       <label class="text-muted me-2 mb-0" i18n>Filter by:</label>
-      <input class="form-control form-control-sm flex-fill w-auto" type="text" [(ngModel)]="nameFilter" placeholder="Name" i18n-placeholder>
+      <input class="form-control form-control-sm flex-fill w-auto" type="text" autofocus [(ngModel)]="nameFilter" (keyup)="onNameFilterKeyUp($event)" placeholder="Name" i18n-placeholder>
     </div>
   </div>
 

--- a/src-ui/src/app/components/manage/generic-list/generic-list.component.ts
+++ b/src-ui/src/app/components/manage/generic-list/generic-list.component.ts
@@ -61,6 +61,7 @@ export abstract class GenericListComponent<T extends ObjectWithId> implements On
       distinctUntilChanged()
     ).subscribe(title => {
       this._nameFilter = title
+      this.page = 1
       this.reloadData()
     })
   }

--- a/src-ui/src/app/components/manage/generic-list/generic-list.component.ts
+++ b/src-ui/src/app/components/manage/generic-list/generic-list.component.ts
@@ -125,4 +125,8 @@ export abstract class GenericListComponent<T extends ObjectWithId> implements On
   set nameFilter(nameFilter: string) {
     this.nameFilterDebounce.next(nameFilter)
   }
+  
+  onNameFilterKeyUp(event: KeyboardEvent) {
+    if (event.code == 'Escape') this.nameFilterDebounce.next(null)
+  }
 }

--- a/src-ui/src/app/components/manage/tag-list/tag-list.component.html
+++ b/src-ui/src/app/components/manage/tag-list/tag-list.component.html
@@ -6,7 +6,7 @@
   <div class="col-md mb-2 mb-xl-0">
     <div class="form-inline d-flex align-items-center">
       <label class="text-muted me-2 mb-0" i18n>Filter by:</label>
-      <input class="form-control form-control-sm flex-fill w-auto" type="text" [(ngModel)]="nameFilter" placeholder="Name" i18n-placeholder>
+      <input class="form-control form-control-sm flex-fill w-auto" type="text" autofocus [(ngModel)]="nameFilter" (keyup)="onNameFilterKeyUp($event)" placeholder="Name" i18n-placeholder>
     </div>
   </div>
 


### PR DESCRIPTION
This PR addresses a bug found in 1.6.0-rc1 (though likely pre-existing) where management pages (i.e. tags / correspondents / document types) cannot be filtered if not on page 1. I also added autofocus to the field and the ability to use the `ESC` key to clear it, because thats a nice thing.

Closes #225

Video for eyeballs.

https://user-images.githubusercontent.com/4887959/157089609-6e7c6a9d-9951-4296-be87-6e3c77a960f5.mov

