### PR TITLE
Reduce warnings in test suite

### DIFF
--- a/src/documents/management/commands/decrypt_documents.py
+++ b/src/documents/management/commands/decrypt_documents.py
@@ -59,8 +59,10 @@ class Command(BaseCommand):
 
             old_paths = [document.source_path, document.thumbnail_path]
 
-            raw_document = GnuPG.decrypted(document.source_file, passphrase)
-            raw_thumb = GnuPG.decrypted(document.thumbnail_file, passphrase)
+            with document.source_file as file_handle:
+                raw_document = GnuPG.decrypted(file_handle, passphrase)
+            with document.thumbnail_file as file_handle:
+                raw_thumb = GnuPG.decrypted(file_handle, passphrase)
 
             document.storage_type = Document.STORAGE_TYPE_UNENCRYPTED
 

--- a/src/documents/management/commands/document_exporter.py
+++ b/src/documents/management/commands/document_exporter.py
@@ -199,19 +199,22 @@ class Command(BaseCommand):
 
                 os.makedirs(os.path.dirname(original_target), exist_ok=True)
                 with open(original_target, "wb") as f:
-                    f.write(GnuPG.decrypted(document.source_file))
-                    os.utime(original_target, times=(t, t))
+                    with document.source_file as out_file:
+                        f.write(GnuPG.decrypted(out_file))
+                        os.utime(original_target, times=(t, t))
 
                 os.makedirs(os.path.dirname(thumbnail_target), exist_ok=True)
                 with open(thumbnail_target, "wb") as f:
-                    f.write(GnuPG.decrypted(document.thumbnail_file))
-                    os.utime(thumbnail_target, times=(t, t))
+                    with document.thumbnail_file as out_file:
+                        f.write(GnuPG.decrypted(out_file))
+                        os.utime(thumbnail_target, times=(t, t))
 
                 if archive_target:
                     os.makedirs(os.path.dirname(archive_target), exist_ok=True)
                     with open(archive_target, "wb") as f:
-                        f.write(GnuPG.decrypted(document.archive_path))
-                        os.utime(archive_target, times=(t, t))
+                        with document.archive_path as out_file:
+                            f.write(GnuPG.decrypted(out_file))
+                            os.utime(archive_target, times=(t, t))
             else:
                 self.check_and_copy(
                     document.source_path, document.checksum, original_target

--- a/src/documents/tests/test_admin.py
+++ b/src/documents/tests/test_admin.py
@@ -61,6 +61,6 @@ class TestDocumentAdmin(DirectoriesMixin, TestCase):
 
     def test_created(self):
         doc = Document.objects.create(
-            title="test", created=timezone.datetime(2020, 4, 12)
+            title="test", created=timezone.make_aware(timezone.datetime(2020, 4, 12))
         )
         self.assertEqual(self.doc_admin.created_(doc), "2020-04-12")

--- a/src/documents/tests/test_api.py
+++ b/src/documents/tests/test_api.py
@@ -10,6 +10,7 @@ from unittest import mock
 import pytest
 from django.conf import settings
 from django.contrib.auth.models import User
+from django.utils import timezone
 from django.test import override_settings
 from rest_framework.test import APITestCase
 from whoosh.writing import AsyncWriter
@@ -567,11 +568,15 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
         d3.tags.add(t)
         d3.tags.add(t2)
         d4 = Document.objects.create(
-            checksum="4", created=datetime.datetime(2020, 7, 13), content="test"
+            checksum="4",
+            created=timezone.datetime(2020, 7, 13),
+            content="test",
         )
         d4.tags.add(t2)
         d5 = Document.objects.create(
-            checksum="5", added=datetime.datetime(2020, 7, 13), content="test"
+            checksum="5",
+            added=timezone.datetime(2020, 7, 13),
+            content="test",
         )
         d6 = Document.objects.create(checksum="6", content="test2")
 

--- a/src/documents/tests/test_matchables.py
+++ b/src/documents/tests/test_matchables.py
@@ -162,7 +162,7 @@ class TestMatching(TestCase):
     def test_match_regex(self):
 
         self._test_matching(
-            "alpha\w+gamma",
+            r"alpha\w+gamma",
             "MATCH_REGEX",
             (
                 "I have alpha_and_gamma in me",
@@ -181,7 +181,7 @@ class TestMatching(TestCase):
         )
 
     def test_tach_invalid_regex(self):
-        self._test_matching("[[", "MATCH_REGEX", [], ["Don't match this"])
+        self._test_matching("[", "MATCH_REGEX", [], ["Don't match this"])
 
     def test_match_fuzzy(self):
 

--- a/src/paperless_tesseract/parsers.py
+++ b/src/paperless_tesseract/parsers.py
@@ -121,7 +121,7 @@ class RasterisedDocumentParser(DocumentParser):
             # TODO catch all for various issues with PDFminer.six.
             #  If PDFminer fails, fall back to OCR.
             self.log(
-                "warn",
+                "warning",
                 "Error while getting text from PDF document with " "pdfminer.six",
                 exc_info=True,
             )


### PR DESCRIPTION
This pull request reduces the number of warnings from the test suite by about 40.  They basically fell into categories:
- `DeprecationWarning` from using `logger.warn` instead of `logger.warning`
- `ResourceWarning` from unclosed file handles in the decrypt and export commands
- `RuntimeWarning` for a few places in the tests where Django got a naïve datetime (no timezone)
- `FutureWarning` for a `[[`, because that looks like a nested set, but we can create an invalid regex without it
- `DeprecationWarning` to fix the `\w+` in a regex, so Python treats it as a raw string

The biggest thing I didn't try to fix was the rest of Django's complaints about naïve datetime objects.  These mostly (maybe completely) stem from `Document` model, but I'm not confident enough with Django to fix them.

Most of the rest of the warnings are from libraries, like `pytest-sugar`, `redis` and `dateparser`, which hopefully will be fixed as dependencies are updated.