### PR TITLE
Fix #224: "Auto-detected date is day before receipt date"

### DIFF
--- a/src/documents/parsers.py
+++ b/src/documents/parsers.py
@@ -224,6 +224,7 @@ def parse_date(filename, text):
                 "DATE_ORDER": date_order,
                 "PREFER_DAY_OF_MONTH": "first",
                 "RETURN_AS_TIMEZONE_AWARE": True,
+                "TIMEZONE": settings.TIME_ZONE,
             },
         )
 

--- a/src/documents/tests/test_consumer.py
+++ b/src/documents/tests/test_consumer.py
@@ -316,6 +316,8 @@ class TestConsumer(DirectoriesMixin, TestCase):
 
         self._assert_first_last_send_progress()
 
+        self.assertEqual(document.created.tzinfo.zone, 'America/Chicago')
+
     @override_settings(PAPERLESS_FILENAME_FORMAT=None)
     def testDeleteMacFiles(self):
         # https://github.com/jonaswinkler/paperless-ng/discussions/1037

--- a/src/documents/tests/test_consumer.py
+++ b/src/documents/tests/test_consumer.py
@@ -288,7 +288,7 @@ class TestConsumer(DirectoriesMixin, TestCase):
         shutil.copy(src, dst)
         return dst
 
-    @override_settings(PAPERLESS_FILENAME_FORMAT=None)
+    @override_settings(PAPERLESS_FILENAME_FORMAT=None, TIME_ZONE="America/Chicago")
     def testNormalOperation(self):
 
         filename = self.get_test_file()

--- a/src/documents/tests/test_consumer.py
+++ b/src/documents/tests/test_consumer.py
@@ -316,7 +316,7 @@ class TestConsumer(DirectoriesMixin, TestCase):
 
         self._assert_first_last_send_progress()
 
-        self.assertEqual(document.created.tzinfo.zone, 'America/Chicago')
+        self.assertEqual(document.created.tzinfo.zone, "America/Chicago")
 
     @override_settings(PAPERLESS_FILENAME_FORMAT=None)
     def testDeleteMacFiles(self):


### PR DESCRIPTION
Fixing #224 by
1. Adding the timezone to the parsed date from the document
2. Adding corresponding assertion in consumption test
