### PR TITLE
Add Chinese localization

### DIFF
--- a/src-ui/angular.json
+++ b/src-ui/angular.json
@@ -31,7 +31,8 @@
 					"ro-RO": "src/locale/messages.ro_RO.xlf",
 					"ru-RU": "src/locale/messages.ru_RU.xlf",
 					"sl-SI": "src/locale/messages.sl_SI.xlf",
-					"sv-SE": "src/locale/messages.sv_SE.xlf"
+					"sv-SE": "src/locale/messages.sv_SE.xlf",
+					"zh-CN": "src/locale/messages.zh_CN.xlf"
         }
 			},
 			"architect": {

--- a/src-ui/src/app/app.module.ts
+++ b/src-ui/src/app/app.module.ts
@@ -1,6 +1,5 @@
 import { BrowserModule } from '@angular/platform-browser'
 import { NgModule } from '@angular/core'
-
 import { AppRoutingModule } from './app-routing.module'
 import { AppComponent } from './app.component'
 import {
@@ -84,6 +83,7 @@ import localeRo from '@angular/common/locales/ro'
 import localeRu from '@angular/common/locales/ru'
 import localeSl from '@angular/common/locales/sl'
 import localeSv from '@angular/common/locales/sv'
+import localeZh from '@angular/common/locales/zh'
 
 registerLocaleData(localeCs)
 registerLocaleData(localeDa)
@@ -101,6 +101,7 @@ registerLocaleData(localeRo)
 registerLocaleData(localeRu)
 registerLocaleData(localeSl)
 registerLocaleData(localeSv)
+registerLocaleData(localeZh)
 
 @NgModule({
   declarations: [

--- a/src-ui/src/app/services/settings.service.ts
+++ b/src-ui/src/app/services/settings.service.ts
@@ -264,6 +264,12 @@ export class SettingsService {
         englishName: 'Swedish',
         dateInputFormat: 'yyyy-mm-dd',
       },
+      {
+        code: "zh-cn",
+        name: $localize`Chinese Simplified`,
+        englishName: "Chinese Simplified",
+        dateInputFormat: "yyyy-mm-dd"
+      }
     ]
 
     // Sort languages by localized name at runtime

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -315,6 +315,7 @@ LANGUAGES = [
     ("ru-ru", _("Russian")),
     ("sl-si", _("Slovenian")),
     ("sv-se", _("Swedish")),
+    ("zh-cn", _("Chinese Simplified")),
 ]
 
 LOCALE_PATHS = [os.path.join(BASE_DIR, "locale")]


### PR DESCRIPTION
Addresses https://github.com/paperless-ngx/paperless-ngx/issues/134#issuecomment-1062950795

It looks like there have been some changes to Chinese Simplified locale string and other things so would be good if other(s) could test to make sure this is OK. Obviously I tested (screenshot) this, fyi I created a config like:

```json
"configurations": {
	"production": {
	...
		"zh": {
			"localize": ["en-US"]
		}
	}
}
...
"serve": {
	"configurations": {
	...
		"zh": {
			"browserTarget": "paperless-ui:build:zh"
		}
	}
}
```
<img width="1449" alt="Screen Shot 2022-03-10 at 9 58 04 AM" src="https://user-images.githubusercontent.com/4887959/157727012-3594d29b-7b4a-44b4-a091-58145ef8375b.png">

