### PR TITLE
Parse dates when entered without separators

### DIFF
--- a/src-ui/src/app/utils/ngb-date-parser-formatter.ts
+++ b/src-ui/src/app/utils/ngb-date-parser-formatter.ts
@@ -27,7 +27,67 @@ export class LocalizedDateParserFormatter extends NgbDateParserFormatter {
       )
   }
 
+  /**
+   * This adds date separators if none are entered. 
+   * It also adds the current year if it wasn't entered. 
+   * 
+   * This allows users to just enter 1003, 100322, 10032022 and 
+   * have it expanded to 10.03.2022, in the case of the German format.
+   * (All other formats are also supported)
+   * 
+   * It also replaces commas with the date separator. 
+   * This allows quick entry of the date on the numpad. 
+   */
+  private preformatDateInput(value: string): string {
+    let inputFormat = this.getDateInputFormat()
+    let dateSeparator = inputFormat.replace(/[dmy]/gi, '').charAt(0)
+
+    value = value.replace(/,/g, dateSeparator)
+
+    if (value.includes(dateSeparator)) { return value }
+
+    if (value.length == 4 && inputFormat.substring(0, 4) != 'yyyy') {
+      return value.substring(0, 2)
+        + dateSeparator
+        + value.substring(2, 4)
+        + dateSeparator
+        + new Date().getFullYear()
+    }
+    else if (value.length == 4 && inputFormat.substring(0, 4) == 'yyyy') {
+      return new Date().getFullYear()
+        + dateSeparator
+        + value.substring(0, 2)
+        + dateSeparator
+        + value.substring(2, 4)
+    }
+    else if (value.length == 6) {
+      return value.substring(0, 2)
+        + dateSeparator
+        + value.substring(2, 4)
+        + dateSeparator
+        + value.substring(4, 6)
+    }
+    else if (value.length == 8 && inputFormat.substring(0, 4) != 'yyyy') {
+      return value.substring(0, 2)
+        + dateSeparator
+        + value.substring(2, 4)
+        + dateSeparator
+        + value.substring(4, 8)
+    }
+    else if (value.length == 8 && inputFormat.substring(0, 4) == 'yyyy') {
+      return value.substring(0, 4)
+        + dateSeparator
+        + value.substring(4, 6)
+        + dateSeparator
+        + value.substring(6, 8)
+    }
+    else {
+      return value
+    }
+  }
+
   parse(value: string): NgbDateStruct | null {
+    value = this.preformatDateInput(value);
     let match = this.getDateParseRegex().exec(value)
     if (match) {
       let dateStruct = {


### PR DESCRIPTION
As referenced here, point 3: https://github.com/paperless-ngx/paperless-ngx/discussions/240

This change allows entering the date without the separator, regardless of locale.
E.g. 1003, 100322, 10032022 become 10.03.2022, or 10/03/2022.

If the date format has the year in front (e.g. yyyy-mm-dd), it would work like this: 0310, 220310, 20220310 --> 2022-03-10

The date can now also be entered with a comma instead of a dot (or slash or dash). This allows quick input with the numpad.

This is my first pull request ever, by the way =) 