### PR TITLE
Make dependabot labels consistent

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,9 @@ updates:
     # Check the npm registry for updates every week
     schedule:
       interval: "weekly"
+    labels:
+      - "frontend"
+      - "dependencies"
 
   # Enable version updates for Python
   - package-ecosystem: "pip"
@@ -20,3 +23,6 @@ updates:
     # Check for updates once a week
     schedule:
       interval: "weekly"
+    labels:
+      - "backend"
+      - "dependencies"


### PR DESCRIPTION
We currently have 2 different sets of GitHub labels to differentiate "frontend" and "backend".

This PR overwrites dependabot's default "javascript" and "python" labels, respectively. 