### PR TITLE
Improve date keyboard input

### DIFF
--- a/src-ui/src/app/components/common/date-dropdown/date-dropdown.component.html
+++ b/src-ui/src/app/components/common/date-dropdown/date-dropdown.component.html
@@ -20,8 +20,8 @@
           </div>
 
           <div class="input-group input-group-sm">
-            <input class="form-control" [placeholder]="datePlaceHolder" (dateSelect)="onChangeDebounce()" (change)="onChangeDebounce()" (focusout)="onFocusOut()"
-                    [(ngModel)]="dateAfter" ngbDatepicker #dateAfterPicker="ngbDatepicker">
+            <input class="form-control" [placeholder]="datePlaceHolder" (dateSelect)="onChangeDebounce()" (change)="onChangeDebounce()" (focusout)="onFocusOut()" (keypress)="onKeyPress($event)"
+                    maxlength="10" [(ngModel)]="dateAfter" ngbDatepicker #dateAfterPicker="ngbDatepicker">
             <button class="btn btn-outline-secondary" (click)="dateAfterPicker.toggle()" type="button">
               <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" fill="currentColor" class="bi bi-calendar" viewBox="0 0 16 16">
                 <path d="M3.5 0a.5.5 0 0 1 .5.5V1h8V.5a.5.5 0 0 1 1 0V1h1a2 2 0 0 1 2 2v11a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V3a2 2 0 0 1 2-2h1V.5a.5.5 0 0 1 .5-.5zM1 4v10a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V4H1z"/>
@@ -43,8 +43,8 @@
           </div>
 
           <div class="input-group input-group-sm">
-            <input class="form-control" [placeholder]="datePlaceHolder" (dateSelect)="onChangeDebounce()" (change)="onChangeDebounce()" (focusout)="onFocusOut()"
-                    [(ngModel)]="dateBefore" ngbDatepicker #dateBeforePicker="ngbDatepicker">
+            <input class="form-control" [placeholder]="datePlaceHolder" (dateSelect)="onChangeDebounce()" (change)="onChangeDebounce()" (focusout)="onFocusOut()" (keypress)="onKeyPress($event)"
+                    maxlength="10" [(ngModel)]="dateBefore" ngbDatepicker #dateBeforePicker="ngbDatepicker">
             <button class="btn btn-outline-secondary" (click)="dateBeforePicker.toggle()" type="button">
               <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" fill="currentColor" class="bi bi-calendar" viewBox="0 0 16 16">
                 <path d="M3.5 0a.5.5 0 0 1 .5.5V1h8V.5a.5.5 0 0 1 1 0V1h1a2 2 0 0 1 2 2v11a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V3a2 2 0 0 1 2-2h1V.5a.5.5 0 0 1 .5-.5zM1 4v10a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V4H1z"/>

--- a/src-ui/src/app/components/common/date-dropdown/date-dropdown.component.html
+++ b/src-ui/src/app/components/common/date-dropdown/date-dropdown.component.html
@@ -20,7 +20,7 @@
           </div>
 
           <div class="input-group input-group-sm">
-            <input class="form-control" [placeholder]="datePlaceHolder" (dateSelect)="onChangeDebounce()" (change)="onChangeDebounce()"
+            <input class="form-control" [placeholder]="datePlaceHolder" (dateSelect)="onChangeDebounce()" (change)="onChangeDebounce()" (focusout)="onFocusOut()"
                     [(ngModel)]="dateAfter" ngbDatepicker #dateAfterPicker="ngbDatepicker">
             <button class="btn btn-outline-secondary" (click)="dateAfterPicker.toggle()" type="button">
               <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" fill="currentColor" class="bi bi-calendar" viewBox="0 0 16 16">
@@ -43,7 +43,7 @@
           </div>
 
           <div class="input-group input-group-sm">
-            <input class="form-control" [placeholder]="datePlaceHolder" (dateSelect)="onChangeDebounce()" (change)="onChangeDebounce()"
+            <input class="form-control" [placeholder]="datePlaceHolder" (dateSelect)="onChangeDebounce()" (change)="onChangeDebounce()" (focusout)="onFocusOut()"
                     [(ngModel)]="dateBefore" ngbDatepicker #dateBeforePicker="ngbDatepicker">
             <button class="btn btn-outline-secondary" (click)="dateBeforePicker.toggle()" type="button">
               <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" fill="currentColor" class="bi bi-calendar" viewBox="0 0 16 16">

--- a/src-ui/src/app/components/common/date-dropdown/date-dropdown.component.html
+++ b/src-ui/src/app/components/common/date-dropdown/date-dropdown.component.html
@@ -20,7 +20,7 @@
           </div>
 
           <div class="input-group input-group-sm">
-            <input class="form-control" [placeholder]="datePlaceHolder" (dateSelect)="onChangeDebounce()" (change)="onChangeDebounce()" (focusout)="onFocusOut()" (keypress)="onKeyPress($event)"
+            <input class="form-control" [placeholder]="datePlaceHolder" (dateSelect)="onChangeDebounce()" (change)="onChangeDebounce()" (keypress)="onKeyPress($event)"
                     maxlength="10" [(ngModel)]="dateAfter" ngbDatepicker #dateAfterPicker="ngbDatepicker">
             <button class="btn btn-outline-secondary" (click)="dateAfterPicker.toggle()" type="button">
               <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" fill="currentColor" class="bi bi-calendar" viewBox="0 0 16 16">
@@ -43,7 +43,7 @@
           </div>
 
           <div class="input-group input-group-sm">
-            <input class="form-control" [placeholder]="datePlaceHolder" (dateSelect)="onChangeDebounce()" (change)="onChangeDebounce()" (focusout)="onFocusOut()" (keypress)="onKeyPress($event)"
+            <input class="form-control" [placeholder]="datePlaceHolder" (dateSelect)="onChangeDebounce()" (change)="onChangeDebounce()" (keypress)="onKeyPress($event)"
                     maxlength="10" [(ngModel)]="dateBefore" ngbDatepicker #dateBeforePicker="ngbDatepicker">
             <button class="btn btn-outline-secondary" (click)="dateBeforePicker.toggle()" type="button">
               <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" fill="currentColor" class="bi bi-calendar" viewBox="0 0 16 16">

--- a/src-ui/src/app/components/common/date-dropdown/date-dropdown.component.ts
+++ b/src-ui/src/app/components/common/date-dropdown/date-dropdown.component.ts
@@ -140,4 +140,10 @@ export class DateDropdownComponent implements OnInit, OnDestroy {
     this.onChange()
   }
 
+  // prevent chars other than numbers and separators
+  onKeyPress(event: KeyboardEvent) {
+    if (!/[0-9,\.\/-]+/.test(event.key)) {
+      event.preventDefault();
+    }
+  }
 }

--- a/src-ui/src/app/components/common/date-dropdown/date-dropdown.component.ts
+++ b/src-ui/src/app/components/common/date-dropdown/date-dropdown.component.ts
@@ -123,7 +123,7 @@ export class DateDropdownComponent implements OnInit, OnDestroy {
   // prevent chars other than numbers and separators
   onKeyPress(event: KeyboardEvent) {
     if (!/[0-9,\.\/-]+/.test(event.key)) {
-      event.preventDefault();
+      event.preventDefault()
     }
   }
 }

--- a/src-ui/src/app/components/common/date-dropdown/date-dropdown.component.ts
+++ b/src-ui/src/app/components/common/date-dropdown/date-dropdown.component.ts
@@ -122,7 +122,7 @@ export class DateDropdownComponent implements OnInit, OnDestroy {
 
   // prevent chars other than numbers and separators
   onKeyPress(event: KeyboardEvent) {
-    if (!/[0-9,\.\/-]+/.test(event.key)) {
+    if ('Enter' !== event.key && !/[0-9,\.\/-]+/.test(event.key)) {
       event.preventDefault()
     }
   }

--- a/src-ui/src/app/components/common/date-dropdown/date-dropdown.component.ts
+++ b/src-ui/src/app/components/common/date-dropdown/date-dropdown.component.ts
@@ -4,7 +4,6 @@ import { NgbDateAdapter } from '@ng-bootstrap/ng-bootstrap';
 import { Subject, Subscription } from 'rxjs';
 import { debounceTime } from 'rxjs/operators';
 import { SettingsService } from 'src/app/services/settings.service';
-import { LocalizedDateParserFormatter } from 'src/app/utils/ngb-date-parser-formatter';
 import { ISODateAdapter } from 'src/app/utils/ngb-iso-date-adapter';
 
 export interface DateSelection {
@@ -26,11 +25,9 @@ const LAST_YEAR = 3
   ]
 })
 export class DateDropdownComponent implements OnInit, OnDestroy {
-  private settings: SettingsService
 
   constructor(settings: SettingsService) {
-    this.settings = settings
-    this.datePlaceHolder = this.settings.getLocalizedDateInputFormat()
+    this.datePlaceHolder = settings.getLocalizedDateInputFormat()
   }
 
   quickFilters = [
@@ -111,23 +108,6 @@ export class DateDropdownComponent implements OnInit, OnDestroy {
 
   onChangeDebounce() {
     this.datesSetDebounce$.next({after: this.dateAfter, before: this.dateBefore})
-  }
-
-  onFocusOut() {
-    this.dateAfter = this.maybePadString(this.dateAfter)
-    this.dateBefore = this.maybePadString(this.dateBefore)
-  }
-
-  maybePadString(value): string {
-    // Allow dates to be specified without 'padding' e.g. 2/3
-    if (!value || value.length == 10) return value; // null or already formatted
-    if ([',','.','/','-'].some(sep => value.includes(sep))) {
-      let valArr = value.split(/[\.,\/-]+/)
-      valArr = valArr.map(segment => segment.padStart(2,'0'))
-      let dateFormatter = new LocalizedDateParserFormatter(this.settings)
-      value = dateFormatter.preformatDateInput(valArr.join(''))
-    }
-    return value
   }
 
   clearBefore() {

--- a/src-ui/src/app/components/common/input/date/date.component.html
+++ b/src-ui/src/app/components/common/input/date/date.component.html
@@ -2,7 +2,7 @@
   <label class="form-label" [for]="inputId">{{title}}</label>
   <div class="input-group" [class.is-invalid]="error">
     <input class="form-control" [class.is-invalid]="error" [placeholder]="placeholder" [id]="inputId" maxlength="10"
-          (dateSelect)="onChange(value)" (change)="onChange(value)" (focusout)="onFocusOut()" (keypress)="onKeyPress($event)"
+          (dateSelect)="onChange(value)" (change)="onChange(value)" (keypress)="onKeyPress($event)"
           name="dp" [(ngModel)]="value" ngbDatepicker #datePicker="ngbDatepicker" #datePickerContent="ngModel">
     <button class="btn btn-outline-secondary calendar" (click)="datePicker.toggle()" type="button">
       <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-calendar" viewBox="0 0 16 16">

--- a/src-ui/src/app/components/common/input/date/date.component.html
+++ b/src-ui/src/app/components/common/input/date/date.component.html
@@ -1,7 +1,7 @@
 <div class="mb-3">
   <label class="form-label" [for]="inputId">{{title}}</label>
   <div class="input-group" [class.is-invalid]="error">
-    <input class="form-control" [class.is-invalid]="error"  [placeholder]="placeholder" [id]="inputId" (dateSelect)="onChange(value)" (change)="onChange(value)"
+    <input class="form-control" [class.is-invalid]="error" [placeholder]="placeholder" [id]="inputId" (dateSelect)="onChange(value)" (change)="onChange(value)" (focusout)="onFocusOut()"
            name="dp" [(ngModel)]="value" ngbDatepicker #datePicker="ngbDatepicker" #datePickerContent="ngModel">
     <button class="btn btn-outline-secondary calendar" (click)="datePicker.toggle()" type="button">
       <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-calendar" viewBox="0 0 16 16">

--- a/src-ui/src/app/components/common/input/date/date.component.html
+++ b/src-ui/src/app/components/common/input/date/date.component.html
@@ -1,8 +1,9 @@
 <div class="mb-3">
   <label class="form-label" [for]="inputId">{{title}}</label>
   <div class="input-group" [class.is-invalid]="error">
-    <input class="form-control" [class.is-invalid]="error" [placeholder]="placeholder" [id]="inputId" (dateSelect)="onChange(value)" (change)="onChange(value)" (focusout)="onFocusOut()"
-           name="dp" [(ngModel)]="value" ngbDatepicker #datePicker="ngbDatepicker" #datePickerContent="ngModel">
+    <input class="form-control" [class.is-invalid]="error" [placeholder]="placeholder" [id]="inputId" maxlength="10"
+          (dateSelect)="onChange(value)" (change)="onChange(value)" (focusout)="onFocusOut()" (keypress)="onKeyPress($event)"
+          name="dp" [(ngModel)]="value" ngbDatepicker #datePicker="ngbDatepicker" #datePickerContent="ngModel">
     <button class="btn btn-outline-secondary calendar" (click)="datePicker.toggle()" type="button">
       <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-calendar" viewBox="0 0 16 16">
         <path d="M3.5 0a.5.5 0 0 1 .5.5V1h8V.5a.5.5 0 0 1 1 0V1h1a2 2 0 0 1 2 2v11a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V3a2 2 0 0 1 2-2h1V.5a.5.5 0 0 1 .5-.5zM1 4v10a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V4H1z"/>

--- a/src-ui/src/app/components/common/input/date/date.component.ts
+++ b/src-ui/src/app/components/common/input/date/date.component.ts
@@ -29,7 +29,7 @@ export class DateComponent extends AbstractInputComponent<string> implements OnI
 
   // prevent chars other than numbers and separators
   onKeyPress(event: KeyboardEvent) {
-    if (!/[0-9,\.\/-]+/.test(event.key)) {
+    if ('Enter' !== event.key && !/[0-9,\.\/-]+/.test(event.key)) {
       event.preventDefault()
     }
   }

--- a/src-ui/src/app/components/common/input/date/date.component.ts
+++ b/src-ui/src/app/components/common/input/date/date.component.ts
@@ -2,6 +2,7 @@ import { Component, forwardRef, Input, OnInit, ViewChild } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { NgbDateAdapter, NgbDateParserFormatter, NgbDatepickerContent } from '@ng-bootstrap/ng-bootstrap';
 import { SettingsService } from 'src/app/services/settings.service';
+import { LocalizedDateParserFormatter } from 'src/app/utils/ngb-date-parser-formatter';
 import { v4 as uuidv4 } from 'uuid';
 import { AbstractInputComponent } from '../abstract-input';
 
@@ -29,4 +30,14 @@ export class DateComponent extends AbstractInputComponent<string> implements OnI
 
   placeholder: string
 
+  // Allow dates to be specified without 'padding' e.g. 2/3
+  onFocusOut() {
+    if (!this.value || this.value.length > 8) return; // its already been formatted
+    if ([',','.','/','-'].some(sep => this.value.includes(sep))) {
+      let valArr = this.value.split(/[\.,\/-]+/)
+      valArr = valArr.map(segment => segment.padStart(2,'0'))
+      let dateFormatter = new LocalizedDateParserFormatter(this.settings)
+      this.value = dateFormatter.preformatDateInput(valArr.join(''))
+    }
+  }
 }

--- a/src-ui/src/app/components/common/input/date/date.component.ts
+++ b/src-ui/src/app/components/common/input/date/date.component.ts
@@ -40,4 +40,11 @@ export class DateComponent extends AbstractInputComponent<string> implements OnI
       this.value = dateFormatter.preformatDateInput(valArr.join(''))
     }
   }
+
+  // prevent chars other than numbers and separators
+  onKeyPress(event: KeyboardEvent) {
+    if (!/[0-9,\.\/-]+/.test(event.key)) {
+      event.preventDefault();
+    }
+  }
 }

--- a/src-ui/src/app/components/common/input/date/date.component.ts
+++ b/src-ui/src/app/components/common/input/date/date.component.ts
@@ -30,7 +30,7 @@ export class DateComponent extends AbstractInputComponent<string> implements OnI
   // prevent chars other than numbers and separators
   onKeyPress(event: KeyboardEvent) {
     if (!/[0-9,\.\/-]+/.test(event.key)) {
-      event.preventDefault();
+      event.preventDefault()
     }
   }
 }

--- a/src-ui/src/app/components/common/input/date/date.component.ts
+++ b/src-ui/src/app/components/common/input/date/date.component.ts
@@ -1,9 +1,6 @@
-import { Component, forwardRef, Input, OnInit, ViewChild } from '@angular/core';
-import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
-import { NgbDateAdapter, NgbDateParserFormatter, NgbDatepickerContent } from '@ng-bootstrap/ng-bootstrap';
+import { Component, forwardRef, OnInit } from '@angular/core';
+import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { SettingsService } from 'src/app/services/settings.service';
-import { LocalizedDateParserFormatter } from 'src/app/utils/ngb-date-parser-formatter';
-import { v4 as uuidv4 } from 'uuid';
 import { AbstractInputComponent } from '../abstract-input';
 
 
@@ -29,17 +26,6 @@ export class DateComponent extends AbstractInputComponent<string> implements OnI
   }
 
   placeholder: string
-
-  // Allow dates to be specified without 'padding' e.g. 2/3
-  onFocusOut() {
-    if (!this.value || this.value.length > 8) return; // its already been formatted
-    if ([',','.','/','-'].some(sep => this.value.includes(sep))) {
-      let valArr = this.value.split(/[\.,\/-]+/)
-      valArr = valArr.map(segment => segment.padStart(2,'0'))
-      let dateFormatter = new LocalizedDateParserFormatter(this.settings)
-      this.value = dateFormatter.preformatDateInput(valArr.join(''))
-    }
-  }
 
   // prevent chars other than numbers and separators
   onKeyPress(event: KeyboardEvent) {

--- a/src-ui/src/app/utils/ngb-date-parser-formatter.ts
+++ b/src-ui/src/app/utils/ngb-date-parser-formatter.ts
@@ -42,7 +42,11 @@ export class LocalizedDateParserFormatter extends NgbDateParserFormatter {
     let inputFormat = this.getDateInputFormat()
     let dateSeparator = inputFormat.replace(/[dmy]/gi, '').charAt(0)
 
-    value = value.replace(/[\/,\.-]/g, '')
+    if ([',','.','/','-'].some(sep => value.includes(sep))) {
+      let valArr = value.split(/[\.,\/-]+/)
+      valArr = valArr.map(segment => segment.padStart(2,'0'))
+      value = valArr.join('')
+    }    
 
     if (value.length == 4 && inputFormat.substring(0, 4) != 'yyyy') {
       return [value.substring(0, 2), value.substring(2, 4), new Date().getFullYear()].join(dateSeparator)

--- a/src-ui/src/app/utils/ngb-date-parser-formatter.ts
+++ b/src-ui/src/app/utils/ngb-date-parser-formatter.ts
@@ -38,7 +38,7 @@ export class LocalizedDateParserFormatter extends NgbDateParserFormatter {
    * It also strips commas or periods before running formatting, 
    * which allows quick entry of the date on the numpad. 
    */
-  private preformatDateInput(value: string): string {
+  public preformatDateInput(value: string): string {
     let inputFormat = this.getDateInputFormat()
     let dateSeparator = inputFormat.replace(/[dmy]/gi, '').charAt(0)
 

--- a/src-ui/src/app/utils/ngb-date-parser-formatter.ts
+++ b/src-ui/src/app/utils/ngb-date-parser-formatter.ts
@@ -35,7 +35,7 @@ export class LocalizedDateParserFormatter extends NgbDateParserFormatter {
    * have it expanded to 10.03.2022, in the case of the German format.
    * (All other formats are also supported)
    * 
-   * It also strips commas or periods before running formatting, 
+   * It also strips any separators before running formatting, 
    * which allows quick entry of the date on the numpad. 
    */
   public preformatDateInput(value: string): string {

--- a/src-ui/src/app/utils/ngb-date-parser-formatter.ts
+++ b/src-ui/src/app/utils/ngb-date-parser-formatter.ts
@@ -4,6 +4,7 @@ import { SettingsService } from "../services/settings.service"
 
 @Injectable()
 export class LocalizedDateParserFormatter extends NgbDateParserFormatter {
+  private separatorRegExp: RegExp = /[\.,\/-]+/
 
   constructor(private settings: SettingsService) {
     super()
@@ -35,17 +36,17 @@ export class LocalizedDateParserFormatter extends NgbDateParserFormatter {
    * have it expanded to 10.03.2022, in the case of the German format.
    * (All other formats are also supported)
    * 
-   * It also strips any separators before running formatting, 
+   * It also strips any separators before running formatting and pads
+   * any parts of the string, e.g. allowing for 1/2/22,
    * which allows quick entry of the date on the numpad. 
    */
   public preformatDateInput(value: string): string {
     let inputFormat = this.getDateInputFormat()
     let dateSeparator = inputFormat.replace(/[dmy]/gi, '').charAt(0)
-
-    if ([',','.','/','-'].some(sep => value.includes(sep))) {
-      let valArr = value.split(/[\.,\/-]+/)
-      valArr = valArr.map(segment => segment.padStart(2,'0'))
-      value = valArr.join('')
+    
+    if (this.separatorRegExp.test(value)) {
+      // split on separator, pad & re-join without separator
+      value = value.split(this.separatorRegExp).map(segment => segment.padStart(2,'0')).join('')
     }    
 
     if (value.length == 4 && inputFormat.substring(0, 4) != 'yyyy') {

--- a/src-ui/src/app/utils/ngb-date-parser-formatter.ts
+++ b/src-ui/src/app/utils/ngb-date-parser-formatter.ts
@@ -35,16 +35,14 @@ export class LocalizedDateParserFormatter extends NgbDateParserFormatter {
    * have it expanded to 10.03.2022, in the case of the German format.
    * (All other formats are also supported)
    * 
-   * It also replaces commas with the date separator. 
-   * This allows quick entry of the date on the numpad. 
+   * It also strips commas or periods before running formatting, 
+   * which allows quick entry of the date on the numpad. 
    */
   private preformatDateInput(value: string): string {
     let inputFormat = this.getDateInputFormat()
     let dateSeparator = inputFormat.replace(/[dmy]/gi, '').charAt(0)
 
-    value = value.replace(/,/g, dateSeparator)
-
-    if (value.includes(dateSeparator)) { return value }
+    value = value.replace(/[\/,\.-]/g, '')
 
     if (value.length == 4 && inputFormat.substring(0, 4) != 'yyyy') {
       return value.substring(0, 2)

--- a/src-ui/src/app/utils/ngb-date-parser-formatter.ts
+++ b/src-ui/src/app/utils/ngb-date-parser-formatter.ts
@@ -40,9 +40,9 @@ export class LocalizedDateParserFormatter extends NgbDateParserFormatter {
    * any parts of the string, e.g. allowing for 1/2/22,
    * which allows quick entry of the date on the numpad. 
    */
-  public preformatDateInput(value: string): string {
-    let inputFormat = this.getDateInputFormat()
-    let dateSeparator = inputFormat.replace(/[dmy]/gi, '').charAt(0)
+  private preformatDateInput(value: string): string {
+    const inputFormat = this.getDateInputFormat()
+    const dateSeparator = inputFormat.replace(/[dmy]/gi, '').charAt(0)
     
     if (this.separatorRegExp.test(value)) {
       // split on separator, pad & re-join without separator

--- a/src-ui/src/app/utils/ngb-date-parser-formatter.ts
+++ b/src-ui/src/app/utils/ngb-date-parser-formatter.ts
@@ -45,41 +45,16 @@ export class LocalizedDateParserFormatter extends NgbDateParserFormatter {
     value = value.replace(/[\/,\.-]/g, '')
 
     if (value.length == 4 && inputFormat.substring(0, 4) != 'yyyy') {
-      return value.substring(0, 2)
-        + dateSeparator
-        + value.substring(2, 4)
-        + dateSeparator
-        + new Date().getFullYear()
-    }
-    else if (value.length == 4 && inputFormat.substring(0, 4) == 'yyyy') {
-      return new Date().getFullYear()
-        + dateSeparator
-        + value.substring(0, 2)
-        + dateSeparator
-        + value.substring(2, 4)
-    }
-    else if (value.length == 6) {
-      return value.substring(0, 2)
-        + dateSeparator
-        + value.substring(2, 4)
-        + dateSeparator
-        + value.substring(4, 6)
-    }
-    else if (value.length == 8 && inputFormat.substring(0, 4) != 'yyyy') {
-      return value.substring(0, 2)
-        + dateSeparator
-        + value.substring(2, 4)
-        + dateSeparator
-        + value.substring(4, 8)
-    }
-    else if (value.length == 8 && inputFormat.substring(0, 4) == 'yyyy') {
-      return value.substring(0, 4)
-        + dateSeparator
-        + value.substring(4, 6)
-        + dateSeparator
-        + value.substring(6, 8)
-    }
-    else {
+      return [value.substring(0, 2), value.substring(2, 4), new Date().getFullYear()].join(dateSeparator)
+    } else if (value.length == 4 && inputFormat.substring(0, 4) == 'yyyy') {
+      return [new Date().getFullYear(), value.substring(0, 2), value.substring(2, 4)].join(dateSeparator)
+    } else if (value.length == 6) {
+      return [value.substring(0, 2), value.substring(2, 4), value.substring(4, 6)].join(dateSeparator)
+    } else if (value.length == 8 && inputFormat.substring(0, 4) != 'yyyy') {
+      return [value.substring(0, 2), value.substring(2, 4), value.substring(4, 8)].join(dateSeparator)
+    } else if (value.length == 8 && inputFormat.substring(0, 4) == 'yyyy') {
+      return [value.substring(0, 4), value.substring(4, 6), value.substring(6, 8)].join(dateSeparator)
+    } else {
       return value
     }
   }

--- a/src-ui/src/app/utils/ngb-date-parser-formatter.ts
+++ b/src-ui/src/app/utils/ngb-date-parser-formatter.ts
@@ -87,7 +87,7 @@ export class LocalizedDateParserFormatter extends NgbDateParserFormatter {
   }
 
   parse(value: string): NgbDateStruct | null {
-    value = this.preformatDateInput(value);
+    value = this.preformatDateInput(value)
     let match = this.getDateParseRegex().exec(value)
     if (match) {
       let dateStruct = {


### PR DESCRIPTION
This PR continues on from #250 and adds support for "non-padded" date input, e.g. if the user types 2/3 --> 02/03/2022
It also adjusts some code formatting. Video attached cause thats how I roll.

@GruberViktor please take a look and let me know what you think. The only real change I made from your code is to just strip out any separators, your formatting function works so well I think its even more useful if we just take them out and run the formatter.

@paperless-ngx/frontend Would be great to test this out a bit, date formatting can have hidden problems in my experience.


https://user-images.githubusercontent.com/4887959/157835552-8bf099ef-04ab-4cb4-957c-603e0885c935.mov

