### PR TITLE
Fix: Include excluded items in dropdown count

### DIFF
--- a/src-ui/src/app/components/common/filterable-dropdown/filterable-dropdown.component.html
+++ b/src-ui/src/app/components/common/filterable-dropdown/filterable-dropdown.component.html
@@ -6,7 +6,7 @@
     <div class="d-none d-sm-inline">&nbsp;{{title}}</div>
     <ng-container *ngIf="!editing && selectionModel.selectionSize() > 0">
       <div *ngIf="multiple" class="position-absolute top-0 start-100 translate-middle badge bg-secondary border border-light text-light rounded-pill">
-        {{selectionModel.selectionSize()}}<span class="visually-hidden">selected</span>
+        {{selectionModel.totalCount}}<span class="visually-hidden">selected</span>
       </div>
       <div *ngIf="!multiple" class="position-absolute top-0 start-100 p-2 translate-middle badge bg-secondary border border-light rounded-circle">
         <span class="visually-hidden">selected</span>

--- a/src-ui/src/app/components/common/filterable-dropdown/filterable-dropdown.component.ts
+++ b/src-ui/src/app/components/common/filterable-dropdown/filterable-dropdown.component.ts
@@ -137,6 +137,10 @@ export class FilterableDropdownSelectionModel {
     return this.getSelectedItems().length
   }
 
+  get totalCount() {
+    return this.getSelectedItems().length + this.getExcludedItems().length
+  }
+
   clear(fireEvent = true) {
     this.temporarySelectionStates.clear()
     this.temporaryLogicalOperator = this._logicalOperator = 'and'


### PR DESCRIPTION
This PR fixes a bug that was reported in the chat where filter dropdowns show an incorrect count (excluded items are not included in the total) see https://matrix.to/#/!lxUkPrXfbmPsCrNwHb:adnidor.de/$bHZDwvcSYQEJykdjfom8K_oqY9yXqgXVK6ZV4bq3D5U?via=matrix.org&via=schnuffle.de&via=matrix.quinncasey.com

Thanks @nicarim for reporting 