### PR TITLE
Python Cleanup from pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,6 +62,7 @@ repos:
         exclude: "(migrations)|(paperless/settings.py)|(.*\\.tox)|(.*/tests/.*)"
         args:
           - "--max-line-length=88"
+          - "--ignore=E203,W503"
   - repo: https://github.com/psf/black
     rev: 22.1.0
     hooks:

--- a/src/documents/__init__.py
+++ b/src/documents/__init__.py
@@ -1,2 +1,5 @@
 # this is here so that django finds the checks.
-from .checks import *
+from .checks import changed_password_check
+from .checks import parser_check
+
+__all__ = ["changed_password_check", "parser_check"]

--- a/src/documents/admin.py
+++ b/src/documents/admin.py
@@ -1,13 +1,11 @@
 from django.contrib import admin
 
-from .models import (
-    Correspondent,
-    Document,
-    DocumentType,
-    Tag,
-    SavedView,
-    SavedViewFilterRule,
-)
+from .models import Correspondent
+from .models import Document
+from .models import DocumentType
+from .models import SavedView
+from .models import SavedViewFilterRule
+from .models import Tag
 
 
 class CorrespondentAdmin(admin.ModelAdmin):

--- a/src/documents/apps.py
+++ b/src/documents/apps.py
@@ -1,5 +1,4 @@
 from django.apps import AppConfig
-
 from django.utils.translation import gettext_lazy as _
 
 

--- a/src/documents/bulk_download.py
+++ b/src/documents/bulk_download.py
@@ -8,7 +8,10 @@ class BulkArchiveStrategy:
         self.zipf = zipf
 
     def make_unique_filename(
-        self, doc: Document, archive: bool = False, folder: str = ""
+        self,
+        doc: Document,
+        archive: bool = False,
+        folder: str = "",
     ):
         counter = 0
         while True:
@@ -34,7 +37,8 @@ class ArchiveOnlyStrategy(BulkArchiveStrategy):
     def add_document(self, doc: Document):
         if doc.has_archive_version:
             self.zipf.write(
-                doc.archive_path, self.make_unique_filename(doc, archive=True)
+                doc.archive_path,
+                self.make_unique_filename(doc, archive=True),
             )
         else:
             self.zipf.write(doc.source_path, self.make_unique_filename(doc))
@@ -49,5 +53,6 @@ class OriginalAndArchiveStrategy(BulkArchiveStrategy):
             )
 
         self.zipf.write(
-            doc.source_path, self.make_unique_filename(doc, folder="originals/")
+            doc.source_path,
+            self.make_unique_filename(doc, folder="originals/"),
         )

--- a/src/documents/bulk_edit.py
+++ b/src/documents/bulk_edit.py
@@ -2,8 +2,9 @@ import itertools
 
 from django.db.models import Q
 from django_q.tasks import async_task
-
-from documents.models import Document, Correspondent, DocumentType
+from documents.models import Correspondent
+from documents.models import Document
+from documents.models import DocumentType
 
 
 def set_correspondent(doc_ids, correspondent):
@@ -40,7 +41,7 @@ def add_tag(doc_ids, tag):
     DocumentTagRelationship = Document.tags.through
 
     DocumentTagRelationship.objects.bulk_create(
-        [DocumentTagRelationship(document_id=doc, tag_id=tag) for doc in affected_docs]
+        [DocumentTagRelationship(document_id=doc, tag_id=tag) for doc in affected_docs],
     )
 
     async_task("documents.tasks.bulk_update_documents", document_ids=affected_docs)
@@ -56,7 +57,7 @@ def remove_tag(doc_ids, tag):
     DocumentTagRelationship = Document.tags.through
 
     DocumentTagRelationship.objects.filter(
-        Q(document_id__in=affected_docs) & Q(tag_id=tag)
+        Q(document_id__in=affected_docs) & Q(tag_id=tag),
     ).delete()
 
     async_task("documents.tasks.bulk_update_documents", document_ids=affected_docs)

--- a/src/documents/checks.py
+++ b/src/documents/checks.py
@@ -1,10 +1,11 @@
 import textwrap
 
 from django.conf import settings
-from django.core.checks import Error, register
+from django.core.checks import Error
+from django.core.checks import register
 from django.core.exceptions import FieldError
-from django.db.utils import OperationalError, ProgrammingError
-
+from django.db.utils import OperationalError
+from django.db.utils import ProgrammingError
 from documents.signals import document_consumer_declaration
 
 
@@ -16,7 +17,7 @@ def changed_password_check(app_configs, **kwargs):
 
     try:
         encrypted_doc = Document.objects.filter(
-            storage_type=Document.STORAGE_TYPE_GPG
+            storage_type=Document.STORAGE_TYPE_GPG,
         ).first()
     except (OperationalError, ProgrammingError, FieldError):
         return []  # No documents table yet
@@ -27,8 +28,8 @@ def changed_password_check(app_configs, **kwargs):
             return [
                 Error(
                     "The database contains encrypted documents but no password "
-                    "is set."
-                )
+                    "is set.",
+                ),
             ]
 
         if not GnuPG.decrypted(encrypted_doc.source_file):
@@ -42,9 +43,9 @@ def changed_password_check(app_configs, **kwargs):
                 If you intend to change your password, you must first export
                 all of the old documents, start fresh with the new password
                 and then re-import them."
-                """
-                    )
-                )
+                """,
+                    ),
+                ),
             ]
 
     return []
@@ -61,8 +62,8 @@ def parser_check(app_configs, **kwargs):
         return [
             Error(
                 "No parsers found. This is a bug. The consumer won't be "
-                "able to consume any documents without parsers."
-            )
+                "able to consume any documents without parsers.",
+            ),
         ]
     else:
         return []

--- a/src/documents/file_handling.py
+++ b/src/documents/file_handling.py
@@ -103,15 +103,17 @@ def generate_unique_filename(doc, archive_filename=False):
     if archive_filename and doc.filename:
         new_filename = os.path.splitext(doc.filename)[0] + ".pdf"
         if new_filename == old_filename or not os.path.exists(
-            os.path.join(root, new_filename)
-        ):  # NOQA: E501
+            os.path.join(root, new_filename),
+        ):
             return new_filename
 
     counter = 0
 
     while True:
         new_filename = generate_filename(
-            doc, counter, archive_filename=archive_filename
+            doc,
+            counter,
+            archive_filename=archive_filename,
         )
         if new_filename == old_filename:
             # still the same as before.
@@ -137,14 +139,16 @@ def generate_filename(doc, counter=0, append_gpg=True, archive_filename=False):
 
             if doc.correspondent:
                 correspondent = pathvalidate.sanitize_filename(
-                    doc.correspondent.name, replacement_text="-"
+                    doc.correspondent.name,
+                    replacement_text="-",
                 )
             else:
                 correspondent = "none"
 
             if doc.document_type:
                 document_type = pathvalidate.sanitize_filename(
-                    doc.document_type.name, replacement_text="-"
+                    doc.document_type.name,
+                    replacement_text="-",
                 )
             else:
                 document_type = "none"
@@ -160,9 +164,7 @@ def generate_filename(doc, counter=0, append_gpg=True, archive_filename=False):
                 document_type=document_type,
                 created=datetime.date.isoformat(doc.created),
                 created_year=doc.created.year if doc.created else "none",
-                created_month=f"{doc.created.month:02}"
-                if doc.created
-                else "none",  # NOQA: E501
+                created_month=f"{doc.created.month:02}" if doc.created else "none",
                 created_day=f"{doc.created.day:02}" if doc.created else "none",
                 added=datetime.date.isoformat(doc.added),
                 added_year=doc.added.year if doc.added else "none",
@@ -178,7 +180,7 @@ def generate_filename(doc, counter=0, append_gpg=True, archive_filename=False):
     except (ValueError, KeyError, IndexError):
         logger.warning(
             f"Invalid PAPERLESS_FILENAME_FORMAT: "
-            f"{settings.PAPERLESS_FILENAME_FORMAT}, falling back to default"
+            f"{settings.PAPERLESS_FILENAME_FORMAT}, falling back to default",
         )
 
     counter_str = f"_{counter:02}" if counter else ""

--- a/src/documents/filters.py
+++ b/src/documents/filters.py
@@ -1,7 +1,13 @@
 from django.db.models import Q
-from django_filters.rest_framework import BooleanFilter, FilterSet, Filter
+from django_filters.rest_framework import BooleanFilter
+from django_filters.rest_framework import Filter
+from django_filters.rest_framework import FilterSet
 
-from .models import Correspondent, Document, Tag, DocumentType, Log
+from .models import Correspondent
+from .models import Document
+from .models import DocumentType
+from .models import Log
+from .models import Tag
 
 CHAR_KWARGS = ["istartswith", "iendswith", "icontains", "iexact"]
 ID_KWARGS = ["in", "exact"]
@@ -75,7 +81,10 @@ class TitleContentFilter(Filter):
 class DocumentFilterSet(FilterSet):
 
     is_tagged = BooleanFilter(
-        label="Is tagged", field_name="tags", lookup_expr="isnull", exclude=True
+        label="Is tagged",
+        field_name="tags",
+        lookup_expr="isnull",
+        exclude=True,
     )
 
     tags__id__all = TagsFilter()

--- a/src/documents/loggers.py
+++ b/src/documents/loggers.py
@@ -1,8 +1,6 @@
 import logging
 import uuid
 
-from django.conf import settings
-
 
 class LoggingMixin:
 

--- a/src/documents/management/commands/decrypt_documents.py
+++ b/src/documents/management/commands/decrypt_documents.py
@@ -1,8 +1,8 @@
 import os
 
 from django.conf import settings
-from django.core.management.base import BaseCommand, CommandError
-
+from django.core.management.base import BaseCommand
+from django.core.management.base import CommandError
 from documents.models import Document
 from paperless.db import GnuPG
 
@@ -31,9 +31,9 @@ class Command(BaseCommand):
                 "this unless you've got a recent backup\nWARNING: handy.  It "
                 "*should* work without a hitch, but be safe and backup your\n"
                 "WARNING: stuff first.\n\nHit Ctrl+C to exit now, or Enter to "
-                "continue.\n\n"
+                "continue.\n\n",
             )
-            __ = input()
+            _ = input()
         except KeyboardInterrupt:
             return
 
@@ -41,7 +41,7 @@ class Command(BaseCommand):
         if not passphrase:
             raise CommandError(
                 "Passphrase not defined.  Please set it with --passphrase or "
-                "by declaring it in your environment or your config."
+                "by declaring it in your environment or your config.",
             )
 
         self.__gpg_to_unencrypted(passphrase)
@@ -50,7 +50,7 @@ class Command(BaseCommand):
     def __gpg_to_unencrypted(passphrase):
 
         encrypted_files = Document.objects.filter(
-            storage_type=Document.STORAGE_TYPE_GPG
+            storage_type=Document.STORAGE_TYPE_GPG,
         )
 
         for document in encrypted_files:
@@ -71,7 +71,7 @@ class Command(BaseCommand):
             if not ext == ".gpg":
                 raise CommandError(
                     f"Abort: encrypted file {document.source_path} does not "
-                    f"end with .gpg"
+                    f"end with .gpg",
                 )
 
             document.filename = os.path.splitext(document.filename)[0]
@@ -83,7 +83,8 @@ class Command(BaseCommand):
                 f.write(raw_thumb)
 
             Document.objects.filter(id=document.id).update(
-                storage_type=document.storage_type, filename=document.filename
+                storage_type=document.storage_type,
+                filename=document.filename,
             )
 
             for path in old_paths:

--- a/src/documents/management/commands/document_create_classifier.py
+++ b/src/documents/management/commands/document_create_classifier.py
@@ -9,7 +9,8 @@ class Command(BaseCommand):
         Trains the classifier on your data and saves the resulting models to a
         file. The document consumer will then automatically use this new model.
     """.replace(
-        "    ", ""
+        "    ",
+        "",
     )
 
     def __init__(self, *args, **kwargs):

--- a/src/documents/management/commands/document_importer.py
+++ b/src/documents/management/commands/document_importer.py
@@ -7,16 +7,16 @@ from contextlib import contextmanager
 import tqdm
 from django.conf import settings
 from django.core.management import call_command
-from django.core.management.base import BaseCommand, CommandError
-from django.db.models.signals import post_save, m2m_changed
+from django.core.management.base import BaseCommand
+from django.core.management.base import CommandError
+from django.db.models.signals import m2m_changed
+from django.db.models.signals import post_save
+from documents.models import Document
+from documents.settings import EXPORTER_ARCHIVE_NAME
+from documents.settings import EXPORTER_FILE_NAME
+from documents.settings import EXPORTER_THUMBNAIL_NAME
 from filelock import FileLock
 
-from documents.models import Document
-from documents.settings import (
-    EXPORTER_FILE_NAME,
-    EXPORTER_THUMBNAIL_NAME,
-    EXPORTER_ARCHIVE_NAME,
-)
 from ...file_handling import create_source_path_directory
 from ...signals.handlers import update_filename_and_move_files
 
@@ -36,7 +36,8 @@ class Command(BaseCommand):
         Using a manifest.json file, load the data from there, and import the
         documents it refers to.
     """.replace(
-        "    ", ""
+        "    ",
+        "",
     )
 
     def add_arguments(self, parser):
@@ -73,7 +74,9 @@ class Command(BaseCommand):
 
         self._check_manifest()
         with disable_signal(
-            post_save, receiver=update_filename_and_move_files, sender=Document
+            post_save,
+            receiver=update_filename_and_move_files,
+            sender=Document,
         ):
             with disable_signal(
                 m2m_changed,
@@ -92,7 +95,7 @@ class Command(BaseCommand):
     def _check_manifest_exists(path):
         if not os.path.exists(path):
             raise CommandError(
-                "That directory doesn't appear to contain a manifest.json " "file."
+                "That directory doesn't appear to contain a manifest.json " "file.",
             )
 
     def _check_manifest(self):
@@ -105,14 +108,14 @@ class Command(BaseCommand):
             if EXPORTER_FILE_NAME not in record:
                 raise CommandError(
                     "The manifest file contains a record which does not "
-                    "refer to an actual document file."
+                    "refer to an actual document file.",
                 )
 
             doc_file = record[EXPORTER_FILE_NAME]
             if not os.path.exists(os.path.join(self.source, doc_file)):
                 raise CommandError(
                     'The manifest file refers to "{}" which does not '
-                    "appear to be in the source directory.".format(doc_file)
+                    "appear to be in the source directory.".format(doc_file),
                 )
 
             if EXPORTER_ARCHIVE_NAME in record:
@@ -120,7 +123,7 @@ class Command(BaseCommand):
                 if not os.path.exists(os.path.join(self.source, archive_file)):
                     raise CommandError(
                         f"The manifest file refers to {archive_file} which "
-                        f"does not appear to be in the source directory."
+                        f"does not appear to be in the source directory.",
                     )
 
     def _import_files_from_manifest(self, progress_bar_disable):
@@ -132,7 +135,7 @@ class Command(BaseCommand):
         print("Copy files into paperless...")
 
         manifest_documents = list(
-            filter(lambda r: r["model"] == "documents.document", self.manifest)
+            filter(lambda r: r["model"] == "documents.document", self.manifest),
         )
 
         for record in tqdm.tqdm(manifest_documents, disable=progress_bar_disable):

--- a/src/documents/management/commands/document_index.py
+++ b/src/documents/management/commands/document_index.py
@@ -1,7 +1,7 @@
 from django.core.management import BaseCommand
 from django.db import transaction
-
-from documents.tasks import index_reindex, index_optimize
+from documents.tasks import index_optimize
+from documents.tasks import index_reindex
 
 
 class Command(BaseCommand):

--- a/src/documents/management/commands/document_renamer.py
+++ b/src/documents/management/commands/document_renamer.py
@@ -3,7 +3,6 @@ import logging
 import tqdm
 from django.core.management.base import BaseCommand
 from django.db.models.signals import post_save
-
 from documents.models import Document
 
 
@@ -12,7 +11,8 @@ class Command(BaseCommand):
     help = """
         This will rename all documents to match the latest filename format.
     """.replace(
-        "    ", ""
+        "    ",
+        "",
     )
 
     def add_arguments(self, parser):
@@ -28,6 +28,7 @@ class Command(BaseCommand):
         logging.getLogger().handlers[0].level = logging.ERROR
 
         for document in tqdm.tqdm(
-            Document.objects.all(), disable=options["no_progress_bar"]
+            Document.objects.all(),
+            disable=options["no_progress_bar"],
         ):
             post_save.send(Document, instance=document)

--- a/src/documents/management/commands/document_retagger.py
+++ b/src/documents/management/commands/document_retagger.py
@@ -2,10 +2,12 @@ import logging
 
 import tqdm
 from django.core.management.base import BaseCommand
-
 from documents.classifier import load_classifier
 from documents.models import Document
-from ...signals.handlers import set_correspondent, set_document_type, set_tags
+
+from ...signals.handlers import set_correspondent
+from ...signals.handlers import set_document_type
+from ...signals.handlers import set_tags
 
 
 logger = logging.getLogger("paperless.management.retagger")
@@ -19,7 +21,8 @@ class Command(BaseCommand):
         back-tag all previously indexed documents with metadata created (or
         modified) after their initial import.
     """.replace(
-        "    ", ""
+        "    ",
+        "",
     )
 
     def add_arguments(self, parser):
@@ -57,7 +60,8 @@ class Command(BaseCommand):
             help="Return the suggestion, don't change anything.",
         )
         parser.add_argument(
-            "--base-url", help="The base URL to use to build the link to the documents."
+            "--base-url",
+            help="The base URL to use to build the link to the documents.",
         )
 
     def handle(self, *args, **options):

--- a/src/documents/management/commands/document_sanity_checker.py
+++ b/src/documents/management/commands/document_sanity_checker.py
@@ -7,7 +7,8 @@ class Command(BaseCommand):
     help = """
         This command checks your document archive for issues.
     """.replace(
-        "    ", ""
+        "    ",
+        "",
     )
 
     def add_arguments(self, parser):

--- a/src/documents/management/commands/document_thumbnails.py
+++ b/src/documents/management/commands/document_thumbnails.py
@@ -5,8 +5,8 @@ import shutil
 import tqdm
 from django import db
 from django.core.management.base import BaseCommand
-
 from documents.models import Document
+
 from ...parsers import get_parser_class_for_mime_type
 
 
@@ -22,7 +22,9 @@ def _process_document(doc_in):
 
     try:
         thumb = parser.get_optimised_thumbnail(
-            document.source_path, document.mime_type, document.get_public_filename()
+            document.source_path,
+            document.mime_type,
+            document.get_public_filename(),
         )
 
         shutil.move(thumb, document.thumbnail_path)
@@ -35,7 +37,8 @@ class Command(BaseCommand):
     help = """
         This will regenerate the thumbnails for all documents.
     """.replace(
-        "    ", ""
+        "    ",
+        "",
     )
 
     def add_arguments(self, parser):
@@ -76,5 +79,5 @@ class Command(BaseCommand):
                     pool.imap_unordered(_process_document, ids),
                     total=len(ids),
                     disable=options["no_progress_bar"],
-                )
+                ),
             )

--- a/src/documents/management/commands/manage_superuser.py
+++ b/src/documents/management/commands/manage_superuser.py
@@ -2,7 +2,7 @@ import logging
 import os
 
 from django.contrib.auth.models import User
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 
 
 logger = logging.getLogger("paperless.management.superuser")
@@ -13,7 +13,8 @@ class Command(BaseCommand):
     help = """
         Creates a Django superuser based on env variables.
     """.replace(
-        "    ", ""
+        "    ",
+        "",
     )
 
     def handle(self, *args, **options):
@@ -39,5 +40,5 @@ class Command(BaseCommand):
             self.stdout.write(f'Did not create superuser "{username}".')
             self.stdout.write(
                 'Make sure you specified "PAPERLESS_ADMIN_PASSWORD" in your '
-                '"docker-compose.env" file.'
+                '"docker-compose.env" file.',
             )

--- a/src/documents/matching.py
+++ b/src/documents/matching.py
@@ -1,8 +1,10 @@
 import logging
 import re
 
-
-from documents.models import MatchingModel, Correspondent, DocumentType, Tag
+from documents.models import Correspondent
+from documents.models import DocumentType
+from documents.models import MatchingModel
+from documents.models import Tag
 
 
 logger = logging.getLogger("paperless.matching")
@@ -12,7 +14,7 @@ def log_reason(matching_model, document, reason):
     class_name = type(matching_model).__name__
     logger.debug(
         f"{class_name} {matching_model.name} matched on document "
-        f"{document} because {reason}"
+        f"{document} because {reason}",
     )
 
 
@@ -25,7 +27,7 @@ def match_correspondents(document, classifier):
     correspondents = Correspondent.objects.all()
 
     return list(
-        filter(lambda o: matches(o, document) or o.pk == pred_id, correspondents)
+        filter(lambda o: matches(o, document) or o.pk == pred_id, correspondents),
     )
 
 
@@ -38,7 +40,7 @@ def match_document_types(document, classifier):
     document_types = DocumentType.objects.all()
 
     return list(
-        filter(lambda o: matches(o, document) or o.pk == pred_id, document_types)
+        filter(lambda o: matches(o, document) or o.pk == pred_id, document_types),
     )
 
 
@@ -51,7 +53,7 @@ def match_tags(document, classifier):
     tags = Tag.objects.all()
 
     return list(
-        filter(lambda o: matches(o, document) or o.pk in predicted_tag_ids, tags)
+        filter(lambda o: matches(o, document) or o.pk in predicted_tag_ids, tags),
     )
 
 
@@ -92,7 +94,7 @@ def matches(matching_model, document):
                 rf"\b{re.escape(matching_model.match)}\b",
                 document_content,
                 **search_kwargs,
-            )
+            ),
         )
         if result:
             log_reason(
@@ -105,11 +107,12 @@ def matches(matching_model, document):
     elif matching_model.matching_algorithm == MatchingModel.MATCH_REGEX:
         try:
             match = re.search(
-                re.compile(matching_model.match, **search_kwargs), document_content
+                re.compile(matching_model.match, **search_kwargs),
+                document_content,
             )
         except re.error:
             logger.error(
-                f"Error while processing regular expression " f"{matching_model.match}"
+                f"Error while processing regular expression " f"{matching_model.match}",
             )
             return False
         if match:

--- a/src/documents/models.py
+++ b/src/documents/models.py
@@ -5,17 +5,14 @@ import os
 import re
 from collections import OrderedDict
 
-import pathvalidate
-
 import dateutil.parser
+import pathvalidate
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.db import models
 from django.utils import timezone
 from django.utils.timezone import is_aware
-
 from django.utils.translation import gettext_lazy as _
-
 from documents.parsers import get_default_file_extension
 
 
@@ -42,7 +39,9 @@ class MatchingModel(models.Model):
     match = models.CharField(_("match"), max_length=256, blank=True)
 
     matching_algorithm = models.PositiveIntegerField(
-        _("matching algorithm"), choices=MATCHING_ALGORITHMS, default=MATCH_ANY
+        _("matching algorithm"),
+        choices=MATCHING_ALGORITHMS,
+        default=MATCH_ANY,
     )
 
     is_insensitive = models.BooleanField(_("is insensitive"), default=True)
@@ -71,7 +70,7 @@ class Tag(MatchingModel):
         default=False,
         help_text=_(
             "Marks this tag as an inbox tag: All newly consumed "
-            "documents will be tagged with inbox tags."
+            "documents will be tagged with inbox tags.",
         ),
     )
 
@@ -120,14 +119,17 @@ class Document(models.Model):
         blank=True,
         help_text=_(
             "The raw, text-only data of the document. This field is "
-            "primarily used for searching."
+            "primarily used for searching.",
         ),
     )
 
     mime_type = models.CharField(_("mime type"), max_length=256, editable=False)
 
     tags = models.ManyToManyField(
-        Tag, related_name="documents", blank=True, verbose_name=_("tags")
+        Tag,
+        related_name="documents",
+        blank=True,
+        verbose_name=_("tags"),
     )
 
     checksum = models.CharField(
@@ -150,7 +152,10 @@ class Document(models.Model):
     created = models.DateTimeField(_("created"), default=timezone.now, db_index=True)
 
     modified = models.DateTimeField(
-        _("modified"), auto_now=True, editable=False, db_index=True
+        _("modified"),
+        auto_now=True,
+        editable=False,
+        db_index=True,
     )
 
     storage_type = models.CharField(
@@ -162,7 +167,10 @@ class Document(models.Model):
     )
 
     added = models.DateTimeField(
-        _("added"), default=timezone.now, editable=False, db_index=True
+        _("added"),
+        default=timezone.now,
+        editable=False,
+        db_index=True,
     )
 
     filename = models.FilePathField(
@@ -192,7 +200,7 @@ class Document(models.Model):
         unique=True,
         db_index=True,
         help_text=_(
-            "The position of this document in your physical document " "archive."
+            "The position of this document in your physical document " "archive.",
         ),
     )
 
@@ -289,7 +297,9 @@ class Log(models.Model):
     message = models.TextField(_("message"))
 
     level = models.PositiveIntegerField(
-        _("level"), choices=LEVELS, default=logging.INFO
+        _("level"),
+        choices=LEVELS,
+        default=logging.INFO,
     )
 
     created = models.DateTimeField(_("created"), auto_now_add=True)
@@ -321,7 +331,10 @@ class SavedView(models.Model):
     )
 
     sort_field = models.CharField(
-        _("sort field"), max_length=128, null=True, blank=True
+        _("sort field"),
+        max_length=128,
+        null=True,
+        blank=True,
     )
     sort_reverse = models.BooleanField(_("sort reverse"), default=False)
 
@@ -383,11 +396,16 @@ class FileInfo:
                 ),
             ),
             ("title", re.compile(r"(?P<title>.*)$", flags=re.IGNORECASE)),
-        ]
+        ],
     )
 
     def __init__(
-        self, created=None, correspondent=None, title=None, tags=(), extension=None
+        self,
+        created=None,
+        correspondent=None,
+        title=None,
+        tags=(),
+        extension=None,
     ):
 
         self.created = created

--- a/src/documents/parsers.py
+++ b/src/documents/parsers.py
@@ -9,6 +9,8 @@ import tempfile
 import magic
 from django.conf import settings
 from django.utils import timezone
+from documents.loggers import LoggingMixin
+from documents.signals import document_consumer_declaration
 
 # This regular expression will try to find dates in the document at
 # hand and will match the following formats:
@@ -21,17 +23,15 @@ from django.utils import timezone
 # - XX. MONTH ZZZZ with XX being 1 or 2 and ZZZZ being 2 or 4 digits
 # - MONTH ZZZZ, with ZZZZ being 4 digits
 # - MONTH XX, ZZZZ with XX being 1 or 2 and ZZZZ being 4 digits
-from documents.loggers import LoggingMixin
-from documents.signals import document_consumer_declaration
 
 # TODO: isnt there a date parsing library for this?
 
 DATE_REGEX = re.compile(
-    r"(\b|(?!=([_-])))([0-9]{1,2})[\.\/-]([0-9]{1,2})[\.\/-]([0-9]{4}|[0-9]{2})(\b|(?=([_-])))|"  # NOQA: E501
-    r"(\b|(?!=([_-])))([0-9]{4}|[0-9]{2})[\.\/-]([0-9]{1,2})[\.\/-]([0-9]{1,2})(\b|(?=([_-])))|"  # NOQA: E501
-    r"(\b|(?!=([_-])))([0-9]{1,2}[\. ]+[^ ]{3,9} ([0-9]{4}|[0-9]{2}))(\b|(?=([_-])))|"  # NOQA: E501
+    r"(\b|(?!=([_-])))([0-9]{1,2})[\.\/-]([0-9]{1,2})[\.\/-]([0-9]{4}|[0-9]{2})(\b|(?=([_-])))|"  # noqa: E501
+    r"(\b|(?!=([_-])))([0-9]{4}|[0-9]{2})[\.\/-]([0-9]{1,2})[\.\/-]([0-9]{1,2})(\b|(?=([_-])))|"  # noqa: E501
+    r"(\b|(?!=([_-])))([0-9]{1,2}[\. ]+[^ ]{3,9} ([0-9]{4}|[0-9]{2}))(\b|(?=([_-])))|"  # noqa: E501
     r"(\b|(?!=([_-])))([^\W\d_]{3,9} [0-9]{1,2}, ([0-9]{4}))(\b|(?=([_-])))|"
-    r"(\b|(?!=([_-])))([^\W\d_]{3,9} [0-9]{4})(\b|(?=([_-])))"
+    r"(\b|(?!=([_-])))([^\W\d_]{3,9} [0-9]{4})(\b|(?=([_-])))",
 )
 
 

--- a/src/documents/sanity_checker.py
+++ b/src/documents/sanity_checker.py
@@ -3,9 +3,8 @@ import logging
 import os
 
 from django.conf import settings
-from tqdm import tqdm
-
 from documents.models import Document
+from tqdm import tqdm
 
 
 class SanityCheckMessages:
@@ -88,19 +87,19 @@ def check_sanity(progress=False):
                 if not checksum == doc.checksum:
                     messages.error(
                         f"Checksum mismatch of document {doc.pk}. "
-                        f"Stored: {doc.checksum}, actual: {checksum}."
+                        f"Stored: {doc.checksum}, actual: {checksum}.",
                     )
 
         # Check sanity of the archive file.
         if doc.archive_checksum and not doc.archive_filename:
             messages.error(
                 f"Document {doc.pk} has an archive file checksum, but no "
-                f"archive filename."
+                f"archive filename.",
             )
         elif not doc.archive_checksum and doc.archive_filename:
             messages.error(
                 f"Document {doc.pk} has an archive file, but its checksum is "
-                f"missing."
+                f"missing.",
             )
         elif doc.has_archive_version:
             if not os.path.isfile(doc.archive_path):
@@ -113,7 +112,7 @@ def check_sanity(progress=False):
                         checksum = hashlib.md5(f.read()).hexdigest()
                 except OSError as e:
                     messages.error(
-                        f"Cannot read archive file of document {doc.pk}: {e}"
+                        f"Cannot read archive file of document {doc.pk}: {e}",
                     )
                 else:
                     if not checksum == doc.archive_checksum:
@@ -121,7 +120,7 @@ def check_sanity(progress=False):
                             f"Checksum mismatch of archived document "
                             f"{doc.pk}. "
                             f"Stored: {doc.archive_checksum}, "
-                            f"actual: {checksum}."
+                            f"actual: {checksum}.",
                         )
 
         # other document checks

--- a/src/documents/serialisers.py
+++ b/src/documents/serialisers.py
@@ -1,24 +1,21 @@
+import math
 import re
 
 import magic
-import math
 from django.utils.text import slugify
+from django.utils.translation import gettext as _
 from rest_framework import serializers
 from rest_framework.fields import SerializerMethodField
 
 from . import bulk_edit
-from .models import (
-    Correspondent,
-    Tag,
-    Document,
-    DocumentType,
-    SavedView,
-    SavedViewFilterRule,
-    MatchingModel,
-)
+from .models import Correspondent
+from .models import Document
+from .models import DocumentType
+from .models import MatchingModel
+from .models import SavedView
+from .models import SavedViewFilterRule
+from .models import Tag
 from .parsers import is_mime_type_supported
-
-from django.utils.translation import gettext as _
 
 
 # https://www.django-rest-framework.org/api-guide/serializers/#example
@@ -56,12 +53,12 @@ class MatchingModelSerializer(serializers.ModelSerializer):
         if (
             "matching_algorithm" in self.initial_data
             and self.initial_data["matching_algorithm"] == MatchingModel.MATCH_REGEX
-        ):  # NOQA: E501
+        ):
             try:
                 re.compile(match)
             except Exception as e:
                 raise serializers.ValidationError(
-                    _("Invalid regular expression: %(error)s") % {"error": str(e)}
+                    _("Invalid regular expression: %(error)s") % {"error": str(e)},
                 )
         return match
 
@@ -156,7 +153,7 @@ class TagSerializer(MatchingModelSerializer):
             luminance = math.sqrt(
                 0.299 * math.pow(rgb[0], 2)
                 + 0.587 * math.pow(rgb[1], 2)
-                + 0.114 * math.pow(rgb[2], 2)
+                + 0.114 * math.pow(rgb[2], 2),
             )
             return "#ffffff" if luminance < 0.53 else "#000000"
         except ValueError:
@@ -298,7 +295,7 @@ class DocumentListSerializer(serializers.Serializer):
         count = Document.objects.filter(id__in=documents).count()
         if not count == len(documents):
             raise serializers.ValidationError(
-                f"Some documents in {name} don't exist or were " f"specified twice."
+                f"Some documents in {name} don't exist or were " f"specified twice.",
             )
 
     def validate_documents(self, documents):
@@ -331,7 +328,7 @@ class BulkEditSerializer(DocumentListSerializer):
         count = Tag.objects.filter(id__in=tags).count()
         if not count == len(tags):
             raise serializers.ValidationError(
-                f"Some tags in {name} don't exist or were specified twice."
+                f"Some tags in {name} don't exist or were specified twice.",
             )
 
     def validate_method(self, method):
@@ -456,7 +453,7 @@ class PostDocumentSerializer(serializers.Serializer):
 
         if not is_mime_type_supported(mime_type):
             raise serializers.ValidationError(
-                _("File type %(type)s not supported") % {"type": mime_type}
+                _("File type %(type)s not supported") % {"type": mime_type},
             )
 
         return document.name, document_data
@@ -483,11 +480,13 @@ class PostDocumentSerializer(serializers.Serializer):
 class BulkDownloadSerializer(DocumentListSerializer):
 
     content = serializers.ChoiceField(
-        choices=["archive", "originals", "both"], default="archive"
+        choices=["archive", "originals", "both"],
+        default="archive",
     )
 
     compression = serializers.ChoiceField(
-        choices=["none", "deflated", "bzip2", "lzma"], default="none"
+        choices=["none", "deflated", "bzip2", "lzma"],
+        default="none",
     )
 
     def validate_compression(self, compression):

--- a/src/documents/serialisers.py
+++ b/src/documents/serialisers.py
@@ -56,9 +56,9 @@ class MatchingModelSerializer(serializers.ModelSerializer):
         ):
             try:
                 re.compile(match)
-            except Exception as e:
+            except re.error as e:
                 raise serializers.ValidationError(
-                    _("Invalid regular expression: %(error)s") % {"error": str(e)},
+                    _("Invalid regular expression: %(error)s") % {"error": str(e.msg)},
                 )
         return match
 

--- a/src/documents/tasks.py
+++ b/src/documents/tasks.py
@@ -3,13 +3,18 @@ import logging
 import tqdm
 from django.conf import settings
 from django.db.models.signals import post_save
-from whoosh.writing import AsyncWriter
-
-from documents import index, sanity_checker
-from documents.classifier import DocumentClassifier, load_classifier
-from documents.consumer import Consumer, ConsumerError
-from documents.models import Document, Tag, DocumentType, Correspondent
+from documents import index
+from documents import sanity_checker
+from documents.classifier import DocumentClassifier
+from documents.classifier import load_classifier
+from documents.consumer import Consumer
+from documents.consumer import ConsumerError
+from documents.models import Correspondent
+from documents.models import Document
+from documents.models import DocumentType
+from documents.models import Tag
 from documents.sanity_checker import SanityCheckFailedException
+from whoosh.writing import AsyncWriter
 
 logger = logging.getLogger("paperless.tasks")
 
@@ -47,7 +52,7 @@ def train_classifier():
     try:
         if classifier.train():
             logger.info(
-                "Saving updated classifier model to {}...".format(settings.MODEL_FILE)
+                "Saving updated classifier model to {}...".format(settings.MODEL_FILE),
             )
             classifier.save()
         else:
@@ -82,7 +87,7 @@ def consume_file(
     else:
         raise ConsumerError(
             "Unknown error: Returned document was null, but "
-            "no error message was given."
+            "no error message was given.",
         )
 
 

--- a/src/documents/tests/factories.py
+++ b/src/documents/tests/factories.py
@@ -1,7 +1,8 @@
 from factory import Faker
 from factory.django import DjangoModelFactory
 
-from ..models import Document, Correspondent
+from ..models import Correspondent
+from ..models import Document
 
 
 class CorrespondentFactory(DjangoModelFactory):

--- a/src/documents/tests/test_admin.py
+++ b/src/documents/tests/test_admin.py
@@ -3,7 +3,6 @@ from unittest import mock
 from django.contrib.admin.sites import AdminSite
 from django.test import TestCase
 from django.utils import timezone
-
 from documents import index
 from documents.admin import DocumentAdmin
 from documents.models import Document
@@ -42,7 +41,8 @@ class TestDocumentAdmin(DirectoriesMixin, TestCase):
         docs = []
         for i in range(42):
             doc = Document.objects.create(
-                title="Many documents with the same title", checksum=f"{i:02}"
+                title="Many documents with the same title",
+                checksum=f"{i:02}",
             )
             docs.append(doc)
             index.add_or_update_document(doc)
@@ -61,6 +61,7 @@ class TestDocumentAdmin(DirectoriesMixin, TestCase):
 
     def test_created(self):
         doc = Document.objects.create(
-            title="test", created=timezone.make_aware(timezone.datetime(2020, 4, 12))
+            title="test",
+            created=timezone.make_aware(timezone.datetime(2020, 4, 12)),
         )
         self.assertEqual(self.doc_admin.created_(doc), "2020-04-12")

--- a/src/documents/tests/test_checks.py
+++ b/src/documents/tests/test_checks.py
@@ -4,10 +4,11 @@ from unittest import mock
 from django.core.checks import Error
 from django.test import TestCase
 
-from .factories import DocumentFactory
-from .. import document_consumer_declaration
-from ..checks import changed_password_check, parser_check
+from ..checks import changed_password_check
+from ..checks import parser_check
 from ..models import Document
+from ..signals import document_consumer_declaration
+from .factories import DocumentFactory
 
 
 class ChecksTestCase(TestCase):
@@ -30,7 +31,7 @@ class ChecksTestCase(TestCase):
                 [
                     Error(
                         "No parsers found. This is a bug. The consumer won't be "
-                        "able to consume any documents without parsers."
-                    )
+                        "able to consume any documents without parsers.",
+                    ),
                 ],
             )

--- a/src/documents/tests/test_classifier.py
+++ b/src/documents/tests/test_classifier.py
@@ -5,14 +5,15 @@ from unittest import mock
 
 import pytest
 from django.conf import settings
-from django.test import TestCase, override_settings
-
-from documents.classifier import (
-    DocumentClassifier,
-    IncompatibleClassifierVersionError,
-    load_classifier,
-)
-from documents.models import Correspondent, Document, Tag, DocumentType
+from django.test import override_settings
+from django.test import TestCase
+from documents.classifier import DocumentClassifier
+from documents.classifier import IncompatibleClassifierVersionError
+from documents.classifier import load_classifier
+from documents.models import Correspondent
+from documents.models import Document
+from documents.models import DocumentType
+from documents.models import Tag
 from documents.tests.utils import DirectoriesMixin
 
 
@@ -23,26 +24,37 @@ class TestClassifier(DirectoriesMixin, TestCase):
 
     def generate_test_data(self):
         self.c1 = Correspondent.objects.create(
-            name="c1", matching_algorithm=Correspondent.MATCH_AUTO
+            name="c1",
+            matching_algorithm=Correspondent.MATCH_AUTO,
         )
         self.c2 = Correspondent.objects.create(name="c2")
         self.c3 = Correspondent.objects.create(
-            name="c3", matching_algorithm=Correspondent.MATCH_AUTO
+            name="c3",
+            matching_algorithm=Correspondent.MATCH_AUTO,
         )
         self.t1 = Tag.objects.create(
-            name="t1", matching_algorithm=Tag.MATCH_AUTO, pk=12
+            name="t1",
+            matching_algorithm=Tag.MATCH_AUTO,
+            pk=12,
         )
         self.t2 = Tag.objects.create(
-            name="t2", matching_algorithm=Tag.MATCH_ANY, pk=34, is_inbox_tag=True
+            name="t2",
+            matching_algorithm=Tag.MATCH_ANY,
+            pk=34,
+            is_inbox_tag=True,
         )
         self.t3 = Tag.objects.create(
-            name="t3", matching_algorithm=Tag.MATCH_AUTO, pk=45
+            name="t3",
+            matching_algorithm=Tag.MATCH_AUTO,
+            pk=45,
         )
         self.dt = DocumentType.objects.create(
-            name="dt", matching_algorithm=DocumentType.MATCH_AUTO
+            name="dt",
+            matching_algorithm=DocumentType.MATCH_AUTO,
         )
         self.dt2 = DocumentType.objects.create(
-            name="dt2", matching_algorithm=DocumentType.MATCH_AUTO
+            name="dt2",
+            matching_algorithm=DocumentType.MATCH_AUTO,
         )
 
         self.doc1 = Document.objects.create(
@@ -59,7 +71,9 @@ class TestClassifier(DirectoriesMixin, TestCase):
             checksum="B",
         )
         self.doc_inbox = Document.objects.create(
-            title="doc235", content="aa", checksum="C"
+            title="doc235",
+            content="aa",
+            checksum="C",
         )
 
         self.doc1.tags.add(self.t1)
@@ -90,27 +104,33 @@ class TestClassifier(DirectoriesMixin, TestCase):
         self.generate_test_data()
         self.classifier.train()
         self.assertListEqual(
-            list(self.classifier.correspondent_classifier.classes_), [-1, self.c1.pk]
+            list(self.classifier.correspondent_classifier.classes_),
+            [-1, self.c1.pk],
         )
         self.assertListEqual(
-            list(self.classifier.tags_binarizer.classes_), [self.t1.pk, self.t3.pk]
+            list(self.classifier.tags_binarizer.classes_),
+            [self.t1.pk, self.t3.pk],
         )
 
     def testPredict(self):
         self.generate_test_data()
         self.classifier.train()
         self.assertEqual(
-            self.classifier.predict_correspondent(self.doc1.content), self.c1.pk
+            self.classifier.predict_correspondent(self.doc1.content),
+            self.c1.pk,
         )
         self.assertEqual(self.classifier.predict_correspondent(self.doc2.content), None)
         self.assertListEqual(
-            self.classifier.predict_tags(self.doc1.content), [self.t1.pk]
+            self.classifier.predict_tags(self.doc1.content),
+            [self.t1.pk],
         )
         self.assertListEqual(
-            self.classifier.predict_tags(self.doc2.content), [self.t1.pk, self.t3.pk]
+            self.classifier.predict_tags(self.doc2.content),
+            [self.t1.pk, self.t3.pk],
         )
         self.assertEqual(
-            self.classifier.predict_document_type(self.doc1.content), self.dt.pk
+            self.classifier.predict_document_type(self.doc1.content),
+            self.dt.pk,
         )
         self.assertEqual(self.classifier.predict_document_type(self.doc2.content), None)
 
@@ -133,7 +153,8 @@ class TestClassifier(DirectoriesMixin, TestCase):
 
         current_ver = DocumentClassifier.FORMAT_VERSION
         with mock.patch(
-            "documents.classifier.DocumentClassifier.FORMAT_VERSION", current_ver + 1
+            "documents.classifier.DocumentClassifier.FORMAT_VERSION",
+            current_ver + 1,
         ):
             # assure that we won't load old classifiers.
             self.assertRaises(IncompatibleClassifierVersionError, classifier2.load)
@@ -157,7 +178,7 @@ class TestClassifier(DirectoriesMixin, TestCase):
         self.assertFalse(new_classifier.train())
 
     @override_settings(
-        MODEL_FILE=os.path.join(os.path.dirname(__file__), "data", "model.pickle")
+        MODEL_FILE=os.path.join(os.path.dirname(__file__), "data", "model.pickle"),
     )
     def test_load_and_classify(self):
         self.generate_test_data()
@@ -169,7 +190,8 @@ class TestClassifier(DirectoriesMixin, TestCase):
 
     def test_one_correspondent_predict(self):
         c1 = Correspondent.objects.create(
-            name="c1", matching_algorithm=Correspondent.MATCH_AUTO
+            name="c1",
+            matching_algorithm=Correspondent.MATCH_AUTO,
         )
         doc1 = Document.objects.create(
             title="doc1",
@@ -183,7 +205,8 @@ class TestClassifier(DirectoriesMixin, TestCase):
 
     def test_one_correspondent_predict_manydocs(self):
         c1 = Correspondent.objects.create(
-            name="c1", matching_algorithm=Correspondent.MATCH_AUTO
+            name="c1",
+            matching_algorithm=Correspondent.MATCH_AUTO,
         )
         doc1 = Document.objects.create(
             title="doc1",
@@ -192,7 +215,9 @@ class TestClassifier(DirectoriesMixin, TestCase):
             checksum="A",
         )
         doc2 = Document.objects.create(
-            title="doc2", content="this is a document from noone", checksum="B"
+            title="doc2",
+            content="this is a document from noone",
+            checksum="B",
         )
 
         self.classifier.train()
@@ -201,7 +226,8 @@ class TestClassifier(DirectoriesMixin, TestCase):
 
     def test_one_type_predict(self):
         dt = DocumentType.objects.create(
-            name="dt", matching_algorithm=DocumentType.MATCH_AUTO
+            name="dt",
+            matching_algorithm=DocumentType.MATCH_AUTO,
         )
 
         doc1 = Document.objects.create(
@@ -216,7 +242,8 @@ class TestClassifier(DirectoriesMixin, TestCase):
 
     def test_one_type_predict_manydocs(self):
         dt = DocumentType.objects.create(
-            name="dt", matching_algorithm=DocumentType.MATCH_AUTO
+            name="dt",
+            matching_algorithm=DocumentType.MATCH_AUTO,
         )
 
         doc1 = Document.objects.create(
@@ -227,7 +254,9 @@ class TestClassifier(DirectoriesMixin, TestCase):
         )
 
         doc2 = Document.objects.create(
-            title="doc1", content="this is a document from c2", checksum="B"
+            title="doc1",
+            content="this is a document from c2",
+            checksum="B",
         )
 
         self.classifier.train()
@@ -238,7 +267,9 @@ class TestClassifier(DirectoriesMixin, TestCase):
         t1 = Tag.objects.create(name="t1", matching_algorithm=Tag.MATCH_AUTO, pk=12)
 
         doc1 = Document.objects.create(
-            title="doc1", content="this is a document from c1", checksum="A"
+            title="doc1",
+            content="this is a document from c1",
+            checksum="A",
         )
 
         doc1.tags.add(t1)
@@ -249,7 +280,9 @@ class TestClassifier(DirectoriesMixin, TestCase):
         t1 = Tag.objects.create(name="t1", matching_algorithm=Tag.MATCH_AUTO, pk=12)
 
         doc1 = Document.objects.create(
-            title="doc1", content="this is a document from c1", checksum="A"
+            title="doc1",
+            content="this is a document from c1",
+            checksum="A",
         )
 
         self.classifier.train()
@@ -260,7 +293,9 @@ class TestClassifier(DirectoriesMixin, TestCase):
         t2 = Tag.objects.create(name="t2", matching_algorithm=Tag.MATCH_AUTO, pk=121)
 
         doc4 = Document.objects.create(
-            title="doc1", content="this is a document from c4", checksum="D"
+            title="doc1",
+            content="this is a document from c4",
+            checksum="D",
         )
 
         doc4.tags.add(t1)
@@ -273,16 +308,24 @@ class TestClassifier(DirectoriesMixin, TestCase):
         t2 = Tag.objects.create(name="t2", matching_algorithm=Tag.MATCH_AUTO, pk=121)
 
         doc1 = Document.objects.create(
-            title="doc1", content="this is a document from c1", checksum="A"
+            title="doc1",
+            content="this is a document from c1",
+            checksum="A",
         )
         doc2 = Document.objects.create(
-            title="doc1", content="this is a document from c2", checksum="B"
+            title="doc1",
+            content="this is a document from c2",
+            checksum="B",
         )
         doc3 = Document.objects.create(
-            title="doc1", content="this is a document from c3", checksum="C"
+            title="doc1",
+            content="this is a document from c3",
+            checksum="C",
         )
         doc4 = Document.objects.create(
-            title="doc1", content="this is a document from c4", checksum="D"
+            title="doc1",
+            content="this is a document from c4",
+            checksum="D",
         )
 
         doc1.tags.add(t1)
@@ -300,10 +343,14 @@ class TestClassifier(DirectoriesMixin, TestCase):
         t1 = Tag.objects.create(name="t1", matching_algorithm=Tag.MATCH_AUTO, pk=12)
 
         doc1 = Document.objects.create(
-            title="doc1", content="this is a document from c1", checksum="A"
+            title="doc1",
+            content="this is a document from c1",
+            checksum="A",
         )
         doc2 = Document.objects.create(
-            title="doc2", content="this is a document from c2", checksum="B"
+            title="doc2",
+            content="this is a document from c2",
+            checksum="B",
         )
 
         doc1.tags.add(t1)
@@ -316,10 +363,14 @@ class TestClassifier(DirectoriesMixin, TestCase):
         t1 = Tag.objects.create(name="t1", matching_algorithm=Tag.MATCH_AUTO, pk=12)
 
         doc1 = Document.objects.create(
-            title="doc1", content="this is a document from c1", checksum="A"
+            title="doc1",
+            content="this is a document from c1",
+            checksum="A",
         )
         doc2 = Document.objects.create(
-            title="doc2", content="this is a document from c2", checksum="B"
+            title="doc2",
+            content="this is a document from c2",
+            checksum="B",
         )
 
         doc1.tags.add(t1)
@@ -338,13 +389,15 @@ class TestClassifier(DirectoriesMixin, TestCase):
         load.assert_called_once()
 
     @override_settings(
-        CACHES={"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}}
+        CACHES={
+            "default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"},
+        },
     )
     @override_settings(
-        MODEL_FILE=os.path.join(os.path.dirname(__file__), "data", "model.pickle")
+        MODEL_FILE=os.path.join(os.path.dirname(__file__), "data", "model.pickle"),
     )
     @pytest.mark.skip(
-        reason="Disabled caching due to high memory usage - need to investigate."
+        reason="Disabled caching due to high memory usage - need to investigate.",
     )
     def test_load_classifier_cached(self):
         classifier = load_classifier()

--- a/src/documents/tests/test_date_parsing.py
+++ b/src/documents/tests/test_date_parsing.py
@@ -5,15 +5,16 @@ from uuid import uuid4
 
 from dateutil import tz
 from django.conf import settings
-from django.test import TestCase, override_settings
-
+from django.test import override_settings
+from django.test import TestCase
 from documents.parsers import parse_date
 
 
 class TestDate(TestCase):
 
     SAMPLE_FILES = os.path.join(
-        os.path.dirname(__file__), "../../paperless_tesseract/tests/samples"
+        os.path.dirname(__file__),
+        "../../paperless_tesseract/tests/samples",
     )
     SCRATCH = "/tmp/paperless-tests-{}".format(str(uuid4())[:8])
 
@@ -111,11 +112,11 @@ class TestDate(TestCase):
     @override_settings(FILENAME_DATE_ORDER="YMD")
     def test_filename_date_parse_invalid(self, *args):
         self.assertIsNone(
-            parse_date("/tmp/20 408000l 2475 - test.pdf", "No date in here")
+            parse_date("/tmp/20 408000l 2475 - test.pdf", "No date in here"),
         )
 
     @override_settings(
-        IGNORE_DATES=(datetime.date(2019, 11, 3), datetime.date(2020, 1, 17))
+        IGNORE_DATES=(datetime.date(2019, 11, 3), datetime.date(2020, 1, 17)),
     )
     def test_ignored_dates(self, *args):
         text = "lorem ipsum 110319, 20200117 and lorem 13.02.2018 lorem " "ipsum"

--- a/src/documents/tests/test_document_model.py
+++ b/src/documents/tests/test_document_model.py
@@ -3,10 +3,12 @@ import tempfile
 from pathlib import Path
 from unittest import mock
 
-from django.test import TestCase, override_settings
+from django.test import override_settings
+from django.test import TestCase
 from django.utils import timezone
 
-from ..models import Document, Correspondent
+from ..models import Correspondent
+from ..models import Document
 
 
 class TestDocument(TestCase):

--- a/src/documents/tests/test_importer.py
+++ b/src/documents/tests/test_importer.py
@@ -1,7 +1,7 @@
 from django.core.management.base import CommandError
 from django.test import TestCase
-
 from documents.settings import EXPORTER_FILE_NAME
+
 from ..management.commands.document_importer import Command
 
 
@@ -12,7 +12,9 @@ class TestImporter(TestCase):
     def test_check_manifest_exists(self):
         cmd = Command()
         self.assertRaises(
-            CommandError, cmd._check_manifest_exists, "/tmp/manifest.json"
+            CommandError,
+            cmd._check_manifest_exists,
+            "/tmp/manifest.json",
         )
 
     def test_check_manifest(self):
@@ -26,11 +28,11 @@ class TestImporter(TestCase):
         self.assertTrue("The manifest file contains a record" in str(cm.exception))
 
         cmd.manifest = [
-            {"model": "documents.document", EXPORTER_FILE_NAME: "noexist.pdf"}
+            {"model": "documents.document", EXPORTER_FILE_NAME: "noexist.pdf"},
         ]
         # self.assertRaises(CommandError, cmd._check_manifest)
         with self.assertRaises(CommandError) as cm:
             cmd._check_manifest()
         self.assertTrue(
-            'The manifest file refers to "noexist.pdf"' in str(cm.exception)
+            'The manifest file refers to "noexist.pdf"' in str(cm.exception),
         )

--- a/src/documents/tests/test_index.py
+++ b/src/documents/tests/test_index.py
@@ -1,5 +1,4 @@
 from django.test import TestCase
-
 from documents import index
 from documents.models import Document
 from documents.tests.utils import DirectoriesMixin
@@ -9,7 +8,9 @@ class TestAutoComplete(DirectoriesMixin, TestCase):
     def test_auto_complete(self):
 
         doc1 = Document.objects.create(
-            title="doc1", checksum="A", content="test test2 test3"
+            title="doc1",
+            checksum="A",
+            content="test test2 test3",
         )
         doc2 = Document.objects.create(title="doc2", checksum="B", content="test test2")
         doc3 = Document.objects.create(title="doc3", checksum="C", content="test2")
@@ -21,10 +22,12 @@ class TestAutoComplete(DirectoriesMixin, TestCase):
         ix = index.open_index()
 
         self.assertListEqual(
-            index.autocomplete(ix, "tes"), [b"test3", b"test", b"test2"]
+            index.autocomplete(ix, "tes"),
+            [b"test3", b"test", b"test2"],
         )
         self.assertListEqual(
-            index.autocomplete(ix, "tes", limit=3), [b"test3", b"test", b"test2"]
+            index.autocomplete(ix, "tes", limit=3),
+            [b"test3", b"test", b"test2"],
         )
         self.assertListEqual(index.autocomplete(ix, "tes", limit=1), [b"test3"])
         self.assertListEqual(index.autocomplete(ix, "tes", limit=0), [])

--- a/src/documents/tests/test_management.py
+++ b/src/documents/tests/test_management.py
@@ -1,16 +1,14 @@
-import hashlib
-import tempfile
 import filecmp
+import hashlib
 import os
 import shutil
+import tempfile
 from pathlib import Path
 from unittest import mock
 
-from django.test import TestCase, override_settings
-
-
 from django.core.management import call_command
-
+from django.test import override_settings
+from django.test import TestCase
 from documents.file_handling import generate_filename
 from documents.management.commands.document_archiver import handle_document
 from documents.models import Document
@@ -34,7 +32,8 @@ class TestArchiver(DirectoriesMixin, TestCase):
 
         doc = self.make_models()
         shutil.copy(
-            sample_file, os.path.join(self.dirs.originals_dir, f"{doc.id:07}.pdf")
+            sample_file,
+            os.path.join(self.dirs.originals_dir, f"{doc.id:07}.pdf"),
         )
 
         call_command("document_archiver")
@@ -43,7 +42,8 @@ class TestArchiver(DirectoriesMixin, TestCase):
 
         doc = self.make_models()
         shutil.copy(
-            sample_file, os.path.join(self.dirs.originals_dir, f"{doc.id:07}.pdf")
+            sample_file,
+            os.path.join(self.dirs.originals_dir, f"{doc.id:07}.pdf"),
         )
 
         handle_document(doc.pk)
@@ -90,7 +90,8 @@ class TestArchiver(DirectoriesMixin, TestCase):
         )
         shutil.copy(sample_file, os.path.join(self.dirs.originals_dir, f"document.pdf"))
         shutil.copy(
-            sample_file, os.path.join(self.dirs.originals_dir, f"document_01.pdf")
+            sample_file,
+            os.path.join(self.dirs.originals_dir, f"document_01.pdf"),
         )
 
         handle_document(doc2.pk)
@@ -120,7 +121,9 @@ class TestDecryptDocuments(TestCase):
         os.makedirs(thumb_dir, exist_ok=True)
 
         override_settings(
-            ORIGINALS_DIR=originals_dir, THUMBNAIL_DIR=thumb_dir, PASSPHRASE="test"
+            ORIGINALS_DIR=originals_dir,
+            THUMBNAIL_DIR=thumb_dir,
+            PASSPHRASE="test",
         ).enable()
 
         doc = Document.objects.create(
@@ -206,7 +209,7 @@ class TestRenamer(DirectoriesMixin, TestCase):
 
 class TestCreateClassifier(TestCase):
     @mock.patch(
-        "documents.management.commands.document_create_classifier.train_classifier"
+        "documents.management.commands.document_create_classifier.train_classifier",
     )
     def test_create_classifier(self, m):
         call_command("document_create_classifier")
@@ -224,7 +227,10 @@ class TestSanityChecker(DirectoriesMixin, TestCase):
 
     def test_errors(self):
         doc = Document.objects.create(
-            title="test", content="test", filename="test.pdf", checksum="abc"
+            title="test",
+            content="test",
+            filename="test.pdf",
+            checksum="abc",
         )
         Path(doc.source_path).touch()
         Path(doc.thumbnail_path).touch()

--- a/src/documents/tests/test_management_consumer.py
+++ b/src/documents/tests/test_management_consumer.py
@@ -6,12 +6,13 @@ from time import sleep
 from unittest import mock
 
 from django.conf import settings
-from django.core.management import call_command, CommandError
-from django.test import override_settings, TransactionTestCase
-
-from documents.models import Tag
+from django.core.management import call_command
+from django.core.management import CommandError
+from django.test import override_settings
+from django.test import TransactionTestCase
 from documents.consumer import ConsumerError
 from documents.management.commands import document_consumer
+from documents.models import Tag
 from documents.tests.utils import DirectoriesMixin
 
 
@@ -41,7 +42,7 @@ class ConsumerMixin:
         super(ConsumerMixin, self).setUp()
         self.t = None
         patcher = mock.patch(
-            "documents.management.commands.document_consumer.async_task"
+            "documents.management.commands.document_consumer.async_task",
         )
         self.task_mock = patcher.start()
         self.addCleanup(patcher.stop)
@@ -208,13 +209,16 @@ class TestConsumer(DirectoriesMixin, ConsumerMixin, TransactionTestCase):
         self.t_start()
 
         shutil.copy(
-            self.sample_file, os.path.join(self.dirs.consumption_dir, ".DS_STORE")
+            self.sample_file,
+            os.path.join(self.dirs.consumption_dir, ".DS_STORE"),
         )
         shutil.copy(
-            self.sample_file, os.path.join(self.dirs.consumption_dir, "my_file.pdf")
+            self.sample_file,
+            os.path.join(self.dirs.consumption_dir, "my_file.pdf"),
         )
         shutil.copy(
-            self.sample_file, os.path.join(self.dirs.consumption_dir, "._my_file.pdf")
+            self.sample_file,
+            os.path.join(self.dirs.consumption_dir, "._my_file.pdf"),
         )
         shutil.copy(
             self.sample_file,
@@ -258,7 +262,9 @@ class TestConsumer(DirectoriesMixin, ConsumerMixin, TransactionTestCase):
 
 
 @override_settings(
-    CONSUMER_POLLING=1, CONSUMER_POLLING_DELAY=3, CONSUMER_POLLING_RETRY_COUNT=20
+    CONSUMER_POLLING=1,
+    CONSUMER_POLLING_DELAY=3,
+    CONSUMER_POLLING_RETRY_COUNT=20,
 )
 class TestConsumerPolling(TestConsumer):
     # just do all the tests with polling
@@ -319,7 +325,9 @@ class TestConsumerTags(DirectoriesMixin, ConsumerMixin, TransactionTestCase):
         self.assertCountEqual(kwargs["override_tag_ids"], tag_ids)
 
     @override_settings(
-        CONSUMER_POLLING=1, CONSUMER_POLLING_DELAY=1, CONSUMER_POLLING_RETRY_COUNT=20
+        CONSUMER_POLLING=1,
+        CONSUMER_POLLING_DELAY=1,
+        CONSUMER_POLLING_RETRY_COUNT=20,
     )
     def test_consume_file_with_path_tags_polling(self):
         self.test_consume_file_with_path_tags()

--- a/src/documents/tests/test_management_retagger.py
+++ b/src/documents/tests/test_management_retagger.py
@@ -1,35 +1,50 @@
 from django.core.management import call_command
 from django.test import TestCase
-
-from documents.models import Document, Tag, Correspondent, DocumentType
+from documents.models import Correspondent
+from documents.models import Document
+from documents.models import DocumentType
+from documents.models import Tag
 from documents.tests.utils import DirectoriesMixin
 
 
 class TestRetagger(DirectoriesMixin, TestCase):
     def make_models(self):
         self.d1 = Document.objects.create(
-            checksum="A", title="A", content="first document"
+            checksum="A",
+            title="A",
+            content="first document",
         )
         self.d2 = Document.objects.create(
-            checksum="B", title="B", content="second document"
+            checksum="B",
+            title="B",
+            content="second document",
         )
         self.d3 = Document.objects.create(
-            checksum="C", title="C", content="unrelated document"
+            checksum="C",
+            title="C",
+            content="unrelated document",
         )
         self.d4 = Document.objects.create(
-            checksum="D", title="D", content="auto document"
+            checksum="D",
+            title="D",
+            content="auto document",
         )
 
         self.tag_first = Tag.objects.create(
-            name="tag1", match="first", matching_algorithm=Tag.MATCH_ANY
+            name="tag1",
+            match="first",
+            matching_algorithm=Tag.MATCH_ANY,
         )
         self.tag_second = Tag.objects.create(
-            name="tag2", match="second", matching_algorithm=Tag.MATCH_ANY
+            name="tag2",
+            match="second",
+            matching_algorithm=Tag.MATCH_ANY,
         )
         self.tag_inbox = Tag.objects.create(name="test", is_inbox_tag=True)
         self.tag_no_match = Tag.objects.create(name="test2")
         self.tag_auto = Tag.objects.create(
-            name="tagauto", matching_algorithm=Tag.MATCH_AUTO
+            name="tagauto",
+            matching_algorithm=Tag.MATCH_AUTO,
         )
 
         self.d3.tags.add(self.tag_inbox)
@@ -37,17 +52,25 @@ class TestRetagger(DirectoriesMixin, TestCase):
         self.d4.tags.add(self.tag_auto)
 
         self.correspondent_first = Correspondent.objects.create(
-            name="c1", match="first", matching_algorithm=Correspondent.MATCH_ANY
+            name="c1",
+            match="first",
+            matching_algorithm=Correspondent.MATCH_ANY,
         )
         self.correspondent_second = Correspondent.objects.create(
-            name="c2", match="second", matching_algorithm=Correspondent.MATCH_ANY
+            name="c2",
+            match="second",
+            matching_algorithm=Correspondent.MATCH_ANY,
         )
 
         self.doctype_first = DocumentType.objects.create(
-            name="dt1", match="first", matching_algorithm=DocumentType.MATCH_ANY
+            name="dt1",
+            match="first",
+            matching_algorithm=DocumentType.MATCH_ANY,
         )
         self.doctype_second = DocumentType.objects.create(
-            name="dt2", match="second", matching_algorithm=DocumentType.MATCH_ANY
+            name="dt2",
+            match="second",
+            matching_algorithm=DocumentType.MATCH_ANY,
         )
 
     def get_updated_docs(self):
@@ -98,10 +121,12 @@ class TestRetagger(DirectoriesMixin, TestCase):
         self.assertIsNotNone(Tag.objects.get(id=self.tag_second.id))
 
         self.assertCountEqual(
-            [tag.id for tag in d_first.tags.all()], [self.tag_first.id]
+            [tag.id for tag in d_first.tags.all()],
+            [self.tag_first.id],
         )
         self.assertCountEqual(
-            [tag.id for tag in d_second.tags.all()], [self.tag_second.id]
+            [tag.id for tag in d_second.tags.all()],
+            [self.tag_second.id],
         )
         self.assertCountEqual(
             [tag.id for tag in d_unrelated.tags.all()],
@@ -133,7 +158,10 @@ class TestRetagger(DirectoriesMixin, TestCase):
 
     def test_add_tags_suggest_url(self):
         call_command(
-            "document_retagger", "--tags", "--suggest", "--base-url=http://localhost"
+            "document_retagger",
+            "--tags",
+            "--suggest",
+            "--base-url=http://localhost",
         )
         d_first, d_second, d_unrelated, d_auto = self.get_updated_docs()
 

--- a/src/documents/tests/test_management_superuser.py
+++ b/src/documents/tests/test_management_superuser.py
@@ -5,9 +5,11 @@ from unittest import mock
 from django.contrib.auth.models import User
 from django.core.management import call_command
 from django.test import TestCase
-
 from documents.management.commands.document_thumbnails import _process_document
-from documents.models import Document, Tag, Correspondent, DocumentType
+from documents.models import Correspondent
+from documents.models import Document
+from documents.models import DocumentType
+from documents.models import Tag
 from documents.tests.utils import DirectoriesMixin
 
 

--- a/src/documents/tests/test_management_thumbnails.py
+++ b/src/documents/tests/test_management_thumbnails.py
@@ -4,9 +4,11 @@ from unittest import mock
 
 from django.core.management import call_command
 from django.test import TestCase
-
 from documents.management.commands.document_thumbnails import _process_document
-from documents.models import Document, Tag, Correspondent, DocumentType
+from documents.models import Correspondent
+from documents.models import Document
+from documents.models import DocumentType
+from documents.models import Tag
 from documents.tests.utils import DirectoriesMixin
 
 

--- a/src/documents/tests/test_matchables.py
+++ b/src/documents/tests/test_matchables.py
@@ -4,10 +4,14 @@ from random import randint
 
 from django.contrib.admin.models import LogEntry
 from django.contrib.auth.models import User
-from django.test import TestCase, override_settings
+from django.test import override_settings
+from django.test import TestCase
 
 from .. import matching
-from ..models import Correspondent, Document, Tag, DocumentType
+from ..models import Correspondent
+from ..models import Document
+from ..models import DocumentType
+from ..models import Tag
 from ..signals import document_consumption_finished
 
 
@@ -209,7 +213,8 @@ class TestDocumentConsumptionFinishedSignal(TestCase):
         TestCase.setUp(self)
         User.objects.create_user(username="test_consumer", password="12345")
         self.doc_contains = Document.objects.create(
-            content="I contain the keyword.", mime_type="application/pdf"
+            content="I contain the keyword.",
+            mime_type="application/pdf",
         )
 
         self.index_dir = tempfile.mkdtemp()
@@ -221,43 +226,56 @@ class TestDocumentConsumptionFinishedSignal(TestCase):
 
     def test_tag_applied_any(self):
         t1 = Tag.objects.create(
-            name="test", match="keyword", matching_algorithm=Tag.MATCH_ANY
+            name="test",
+            match="keyword",
+            matching_algorithm=Tag.MATCH_ANY,
         )
         document_consumption_finished.send(
-            sender=self.__class__, document=self.doc_contains
+            sender=self.__class__,
+            document=self.doc_contains,
         )
         self.assertTrue(list(self.doc_contains.tags.all()) == [t1])
 
     def test_tag_not_applied(self):
         Tag.objects.create(
-            name="test", match="no-match", matching_algorithm=Tag.MATCH_ANY
+            name="test",
+            match="no-match",
+            matching_algorithm=Tag.MATCH_ANY,
         )
         document_consumption_finished.send(
-            sender=self.__class__, document=self.doc_contains
+            sender=self.__class__,
+            document=self.doc_contains,
         )
         self.assertTrue(list(self.doc_contains.tags.all()) == [])
 
     def test_correspondent_applied(self):
         correspondent = Correspondent.objects.create(
-            name="test", match="keyword", matching_algorithm=Correspondent.MATCH_ANY
+            name="test",
+            match="keyword",
+            matching_algorithm=Correspondent.MATCH_ANY,
         )
         document_consumption_finished.send(
-            sender=self.__class__, document=self.doc_contains
+            sender=self.__class__,
+            document=self.doc_contains,
         )
         self.assertTrue(self.doc_contains.correspondent == correspondent)
 
     def test_correspondent_not_applied(self):
         Tag.objects.create(
-            name="test", match="no-match", matching_algorithm=Correspondent.MATCH_ANY
+            name="test",
+            match="no-match",
+            matching_algorithm=Correspondent.MATCH_ANY,
         )
         document_consumption_finished.send(
-            sender=self.__class__, document=self.doc_contains
+            sender=self.__class__,
+            document=self.doc_contains,
         )
         self.assertEqual(self.doc_contains.correspondent, None)
 
     def test_logentry_created(self):
         document_consumption_finished.send(
-            sender=self.__class__, document=self.doc_contains
+            sender=self.__class__,
+            document=self.doc_contains,
         )
 
         self.assertEqual(LogEntry.objects.count(), 1)

--- a/src/documents/tests/test_migration_archive_files.py
+++ b/src/documents/tests/test_migration_archive_files.py
@@ -6,9 +6,9 @@ from unittest import mock
 
 from django.conf import settings
 from django.test import override_settings
-
 from documents.parsers import ParseError
-from documents.tests.utils import DirectoriesMixin, TestMigrations
+from documents.tests.utils import DirectoriesMixin
+from documents.tests.utils import TestMigrations
 
 
 STORAGE_TYPE_GPG = "gpg"
@@ -93,10 +93,18 @@ def make_test_document(
 simple_jpg = os.path.join(os.path.dirname(__file__), "samples", "simple.jpg")
 simple_pdf = os.path.join(os.path.dirname(__file__), "samples", "simple.pdf")
 simple_pdf2 = os.path.join(
-    os.path.dirname(__file__), "samples", "documents", "originals", "0000002.pdf"
+    os.path.dirname(__file__),
+    "samples",
+    "documents",
+    "originals",
+    "0000002.pdf",
 )
 simple_pdf3 = os.path.join(
-    os.path.dirname(__file__), "samples", "documents", "originals", "0000003.pdf"
+    os.path.dirname(__file__),
+    "samples",
+    "documents",
+    "originals",
+    "0000003.pdf",
 )
 simple_txt = os.path.join(os.path.dirname(__file__), "samples", "simple.txt")
 simple_png = os.path.join(os.path.dirname(__file__), "samples", "simple-noalpha.png")
@@ -121,19 +129,43 @@ class TestMigrateArchiveFiles(DirectoriesMixin, TestMigrations):
             simple_pdf,
         )
         self.no_text = make_test_document(
-            Document, "no-text", "image/png", simple_png2, "no-text.png", simple_pdf
+            Document,
+            "no-text",
+            "image/png",
+            simple_png2,
+            "no-text.png",
+            simple_pdf,
         )
         self.doc_no_archive = make_test_document(
-            Document, "no_archive", "text/plain", simple_txt, "no_archive.txt"
+            Document,
+            "no_archive",
+            "text/plain",
+            simple_txt,
+            "no_archive.txt",
         )
         self.clash1 = make_test_document(
-            Document, "clash", "application/pdf", simple_pdf, "clash.pdf", simple_pdf
+            Document,
+            "clash",
+            "application/pdf",
+            simple_pdf,
+            "clash.pdf",
+            simple_pdf,
         )
         self.clash2 = make_test_document(
-            Document, "clash", "image/jpeg", simple_jpg, "clash.jpg", simple_pdf
+            Document,
+            "clash",
+            "image/jpeg",
+            simple_jpg,
+            "clash.jpg",
+            simple_pdf,
         )
         self.clash3 = make_test_document(
-            Document, "clash", "image/png", simple_png, "clash.png", simple_pdf
+            Document,
+            "clash",
+            "image/png",
+            simple_png,
+            "clash.png",
+            simple_pdf,
         )
         self.clash4 = make_test_document(
             Document,
@@ -147,7 +179,8 @@ class TestMigrateArchiveFiles(DirectoriesMixin, TestMigrations):
         self.assertEqual(archive_path_old(self.clash1), archive_path_old(self.clash2))
         self.assertEqual(archive_path_old(self.clash1), archive_path_old(self.clash3))
         self.assertNotEqual(
-            archive_path_old(self.clash1), archive_path_old(self.clash4)
+            archive_path_old(self.clash1),
+            archive_path_old(self.clash4),
         )
 
     def testArchiveFilesMigrated(self):
@@ -171,19 +204,23 @@ class TestMigrateArchiveFiles(DirectoriesMixin, TestMigrations):
                 self.assertEqual(archive_checksum, doc.archive_checksum)
 
         self.assertEqual(
-            Document.objects.filter(archive_checksum__isnull=False).count(), 6
+            Document.objects.filter(archive_checksum__isnull=False).count(),
+            6,
         )
 
     def test_filenames(self):
         Document = self.apps.get_model("documents", "Document")
         self.assertEqual(
-            Document.objects.get(id=self.unrelated.id).archive_filename, "unrelated.pdf"
+            Document.objects.get(id=self.unrelated.id).archive_filename,
+            "unrelated.pdf",
         )
         self.assertEqual(
-            Document.objects.get(id=self.no_text.id).archive_filename, "no-text.pdf"
+            Document.objects.get(id=self.no_text.id).archive_filename,
+            "no-text.pdf",
         )
         self.assertEqual(
-            Document.objects.get(id=self.doc_no_archive.id).archive_filename, None
+            Document.objects.get(id=self.doc_no_archive.id).archive_filename,
+            None,
         )
         self.assertEqual(
             Document.objects.get(id=self.clash1.id).archive_filename,
@@ -198,7 +235,8 @@ class TestMigrateArchiveFiles(DirectoriesMixin, TestMigrations):
             f"{self.clash3.id:07}.pdf",
         )
         self.assertEqual(
-            Document.objects.get(id=self.clash4.id).archive_filename, "clash.png.pdf"
+            Document.objects.get(id=self.clash4.id).archive_filename,
+            "clash.png.pdf",
         )
 
 
@@ -207,16 +245,20 @@ class TestMigrateArchiveFilesWithFilenameFormat(TestMigrateArchiveFiles):
     def test_filenames(self):
         Document = self.apps.get_model("documents", "Document")
         self.assertEqual(
-            Document.objects.get(id=self.unrelated.id).archive_filename, "unrelated.pdf"
+            Document.objects.get(id=self.unrelated.id).archive_filename,
+            "unrelated.pdf",
         )
         self.assertEqual(
-            Document.objects.get(id=self.no_text.id).archive_filename, "no-text.pdf"
+            Document.objects.get(id=self.no_text.id).archive_filename,
+            "no-text.pdf",
         )
         self.assertEqual(
-            Document.objects.get(id=self.doc_no_archive.id).archive_filename, None
+            Document.objects.get(id=self.doc_no_archive.id).archive_filename,
+            None,
         )
         self.assertEqual(
-            Document.objects.get(id=self.clash1.id).archive_filename, "none/clash.pdf"
+            Document.objects.get(id=self.clash1.id).archive_filename,
+            "none/clash.pdf",
         )
         self.assertEqual(
             Document.objects.get(id=self.clash2.id).archive_filename,
@@ -227,7 +269,8 @@ class TestMigrateArchiveFilesWithFilenameFormat(TestMigrateArchiveFiles):
             "none/clash_02.pdf",
         )
         self.assertEqual(
-            Document.objects.get(id=self.clash4.id).archive_filename, "clash.png.pdf"
+            Document.objects.get(id=self.clash4.id).archive_filename,
+            "clash.png.pdf",
         )
 
 
@@ -248,12 +291,19 @@ class TestMigrateArchiveFilesErrors(DirectoriesMixin, TestMigrations):
         Document = self.apps.get_model("documents", "Document")
 
         doc = make_test_document(
-            Document, "clash", "application/pdf", simple_pdf, "clash.pdf", simple_pdf
+            Document,
+            "clash",
+            "application/pdf",
+            simple_pdf,
+            "clash.pdf",
+            simple_pdf,
         )
         os.unlink(archive_path_old(doc))
 
         self.assertRaisesMessage(
-            ValueError, "does not exist at: ", self.performMigration
+            ValueError,
+            "does not exist at: ",
+            self.performMigration,
         )
 
     def test_parser_missing(self):
@@ -277,7 +327,9 @@ class TestMigrateArchiveFilesErrors(DirectoriesMixin, TestMigrations):
         )
 
         self.assertRaisesMessage(
-            ValueError, "no parsers are available", self.performMigration
+            ValueError,
+            "no parsers are available",
+            self.performMigration,
         )
 
     @mock.patch("documents.migrations.1012_fix_archive_files.parse_wrapper")
@@ -286,7 +338,12 @@ class TestMigrateArchiveFilesErrors(DirectoriesMixin, TestMigrations):
         Document = self.apps.get_model("documents", "Document")
 
         doc1 = make_test_document(
-            Document, "document", "image/png", simple_png, "document.png", simple_pdf
+            Document,
+            "document",
+            "image/png",
+            simple_png,
+            "document.png",
+            simple_pdf,
         )
         doc2 = make_test_document(
             Document,
@@ -311,8 +368,8 @@ class TestMigrateArchiveFilesErrors(DirectoriesMixin, TestMigrations):
                     filter(
                         lambda log: "Parse error, will try again in 5 seconds" in log,
                         capture.output,
-                    )
-                )
+                    ),
+                ),
             ),
             4,
         )
@@ -324,8 +381,8 @@ class TestMigrateArchiveFilesErrors(DirectoriesMixin, TestMigrations):
                         lambda log: "Unable to regenerate archive document for ID:"
                         in log,
                         capture.output,
-                    )
-                )
+                    ),
+                ),
             ),
             2,
         )
@@ -347,7 +404,12 @@ class TestMigrateArchiveFilesErrors(DirectoriesMixin, TestMigrations):
         Document = self.apps.get_model("documents", "Document")
 
         doc1 = make_test_document(
-            Document, "document", "image/png", simple_png, "document.png", simple_pdf
+            Document,
+            "document",
+            "image/png",
+            simple_png,
+            "document.png",
+            simple_pdf,
         )
         doc2 = make_test_document(
             Document,
@@ -368,8 +430,8 @@ class TestMigrateArchiveFilesErrors(DirectoriesMixin, TestMigrations):
                         lambda log: "Parser did not return an archive document for document"
                         in log,
                         capture.output,
-                    )
-                )
+                    ),
+                ),
             ),
             2,
         )
@@ -405,7 +467,11 @@ class TestMigrateArchiveFilesBackwards(DirectoriesMixin, TestMigrations):
             "unrelated.pdf",
         )
         doc_no_archive = make_test_document(
-            Document, "no_archive", "text/plain", simple_txt, "no_archive.txt"
+            Document,
+            "no_archive",
+            "text/plain",
+            simple_txt,
+            "no_archive.txt",
         )
         clashB = make_test_document(
             Document,
@@ -434,13 +500,14 @@ class TestMigrateArchiveFilesBackwards(DirectoriesMixin, TestMigrations):
                 self.assertEqual(archive_checksum, doc.archive_checksum)
 
         self.assertEqual(
-            Document.objects.filter(archive_checksum__isnull=False).count(), 2
+            Document.objects.filter(archive_checksum__isnull=False).count(),
+            2,
         )
 
 
 @override_settings(PAPERLESS_FILENAME_FORMAT="{correspondent}/{title}")
 class TestMigrateArchiveFilesBackwardsWithFilenameFormat(
-    TestMigrateArchiveFilesBackwards
+    TestMigrateArchiveFilesBackwards,
 ):
     pass
 
@@ -505,5 +572,7 @@ class TestMigrateArchiveFilesBackwardsErrors(DirectoriesMixin, TestMigrations):
         )
 
         self.assertRaisesMessage(
-            ValueError, "file already exists.", self.performMigration
+            ValueError,
+            "file already exists.",
+            self.performMigration,
         )

--- a/src/documents/tests/test_migration_mime_type.py
+++ b/src/documents/tests/test_migration_mime_type.py
@@ -3,9 +3,9 @@ import shutil
 
 from django.conf import settings
 from django.test import override_settings
-
 from documents.parsers import get_default_file_extension
-from documents.tests.utils import DirectoriesMixin, TestMigrations
+from documents.tests.utils import DirectoriesMixin
+from documents.tests.utils import TestMigrations
 
 STORAGE_TYPE_UNENCRYPTED = "unencrypted"
 STORAGE_TYPE_GPG = "gpg"
@@ -46,7 +46,9 @@ class TestMigrateMimeType(DirectoriesMixin, TestMigrations):
     def setUpBeforeMigration(self, apps):
         Document = apps.get_model("documents", "Document")
         doc = Document.objects.create(
-            title="test", file_type="pdf", filename="file1.pdf"
+            title="test",
+            file_type="pdf",
+            filename="file1.pdf",
         )
         self.doc_id = doc.id
         shutil.copy(
@@ -55,7 +57,9 @@ class TestMigrateMimeType(DirectoriesMixin, TestMigrations):
         )
 
         doc2 = Document.objects.create(
-            checksum="B", file_type="pdf", storage_type=STORAGE_TYPE_GPG
+            checksum="B",
+            file_type="pdf",
+            storage_type=STORAGE_TYPE_GPG,
         )
         self.doc2_id = doc2.id
         shutil.copy(
@@ -88,7 +92,9 @@ class TestMigrateMimeTypeBackwards(DirectoriesMixin, TestMigrations):
     def setUpBeforeMigration(self, apps):
         Document = apps.get_model("documents", "Document")
         doc = Document.objects.create(
-            title="test", mime_type="application/pdf", filename="file1.pdf"
+            title="test",
+            mime_type="application/pdf",
+            filename="file1.pdf",
         )
         self.doc_id = doc.id
         shutil.copy(

--- a/src/documents/tests/test_migration_remove_null_characters.py
+++ b/src/documents/tests/test_migration_remove_null_characters.py
@@ -1,4 +1,5 @@
-from documents.tests.utils import DirectoriesMixin, TestMigrations
+from documents.tests.utils import DirectoriesMixin
+from documents.tests.utils import TestMigrations
 
 
 class TestMigrateNullCharacters(DirectoriesMixin, TestMigrations):

--- a/src/documents/tests/test_migration_tag_colors.py
+++ b/src/documents/tests/test_migration_tag_colors.py
@@ -1,4 +1,5 @@
-from documents.tests.utils import DirectoriesMixin, TestMigrations
+from documents.tests.utils import DirectoriesMixin
+from documents.tests.utils import TestMigrations
 
 
 class TestMigrateTagColor(DirectoriesMixin, TestMigrations):

--- a/src/documents/tests/test_models.py
+++ b/src/documents/tests/test_models.py
@@ -1,7 +1,9 @@
 from django.test import TestCase
 
-from .factories import DocumentFactory, CorrespondentFactory
-from ..models import Document, Correspondent
+from ..models import Correspondent
+from ..models import Document
+from .factories import CorrespondentFactory
+from .factories import DocumentFactory
 
 
 class CorrespondentTestCase(TestCase):

--- a/src/documents/tests/test_parsers.py
+++ b/src/documents/tests/test_parsers.py
@@ -4,16 +4,14 @@ import tempfile
 from tempfile import TemporaryDirectory
 from unittest import mock
 
-from django.test import TestCase, override_settings
-
-from documents.parsers import (
-    get_parser_class,
-    get_supported_file_extensions,
-    get_default_file_extension,
-    get_parser_class_for_mime_type,
-    DocumentParser,
-    is_file_ext_supported,
-)
+from django.test import override_settings
+from django.test import TestCase
+from documents.parsers import DocumentParser
+from documents.parsers import get_default_file_extension
+from documents.parsers import get_parser_class
+from documents.parsers import get_parser_class_for_mime_type
+from documents.parsers import get_supported_file_extensions
+from documents.parsers import is_file_ext_supported
 from paperless_tesseract.parsers import RasterisedDocumentParser
 from paperless_text.parsers import TextDocumentParser
 

--- a/src/documents/tests/test_sanity_check.py
+++ b/src/documents/tests/test_sanity_check.py
@@ -6,9 +6,9 @@ from pathlib import Path
 import filelock
 from django.conf import settings
 from django.test import TestCase
-
 from documents.models import Document
-from documents.sanity_checker import check_sanity, SanityCheckMessages
+from documents.sanity_checker import check_sanity
+from documents.sanity_checker import SanityCheckMessages
 from documents.tests.utils import DirectoriesMixin
 
 
@@ -23,7 +23,8 @@ class TestSanityCheckMessages(TestCase):
             self.assertEqual(len(capture.output), 1)
             self.assertEqual(capture.records[0].levelno, logging.INFO)
             self.assertEqual(
-                capture.records[0].message, "Sanity checker detected no issues."
+                capture.records[0].message,
+                "Sanity checker detected no issues.",
             )
 
     def test_info(self):

--- a/src/documents/tests/test_settings.py
+++ b/src/documents/tests/test_settings.py
@@ -2,8 +2,8 @@ import logging
 from unittest import mock
 
 from django.test import TestCase
-
-from paperless.settings import default_task_workers, default_threads_per_worker
+from paperless.settings import default_task_workers
+from paperless.settings import default_threads_per_worker
 
 
 class TestSettings(TestCase):
@@ -21,7 +21,7 @@ class TestSettings(TestCase):
     def test_workers_threads(self):
         for i in range(1, 64):
             with mock.patch(
-                "paperless.settings.multiprocessing.cpu_count"
+                "paperless.settings.multiprocessing.cpu_count",
             ) as cpu_count:
                 cpu_count.return_value = i
 

--- a/src/documents/tests/test_tasks.py
+++ b/src/documents/tests/test_tasks.py
@@ -4,10 +4,13 @@ from unittest import mock
 from django.conf import settings
 from django.test import TestCase
 from django.utils import timezone
-
 from documents import tasks
-from documents.models import Document, Tag, Correspondent, DocumentType
-from documents.sanity_checker import SanityCheckMessages, SanityCheckFailedException
+from documents.models import Correspondent
+from documents.models import Document
+from documents.models import DocumentType
+from documents.models import Tag
+from documents.sanity_checker import SanityCheckFailedException
+from documents.sanity_checker import SanityCheckMessages
 from documents.tests.utils import DirectoriesMixin
 
 
@@ -106,7 +109,8 @@ class TestTasks(DirectoriesMixin, TestCase):
         messages.warning("Some warning")
         m.return_value = messages
         self.assertEqual(
-            tasks.sanity_check(), "Sanity check exited with warnings. See log."
+            tasks.sanity_check(),
+            "Sanity check exited with warnings. See log.",
         )
         m.assert_called_once()
 
@@ -116,7 +120,8 @@ class TestTasks(DirectoriesMixin, TestCase):
         messages.info("Some info")
         m.return_value = messages
         self.assertEqual(
-            tasks.sanity_check(), "Sanity check exited with infos. See log."
+            tasks.sanity_check(),
+            "Sanity check exited with infos. See log.",
         )
         m.assert_called_once()
 

--- a/src/documents/tests/test_views.py
+++ b/src/documents/tests/test_views.py
@@ -25,7 +25,7 @@ class TestViews(TestCase):
         ]:
             if language_given:
                 self.client.cookies.load(
-                    {settings.LANGUAGE_COOKIE_NAME: language_given}
+                    {settings.LANGUAGE_COOKIE_NAME: language_given},
                 )
             elif settings.LANGUAGE_COOKIE_NAME in self.client.cookies.keys():
                 self.client.cookies.pop(settings.LANGUAGE_COOKIE_NAME)
@@ -51,5 +51,6 @@ class TestViews(TestCase):
                 f"frontend/{language_actual}/polyfills.js",
             )
             self.assertEqual(
-                response.context_data["main_js"], f"frontend/{language_actual}/main.js"
+                response.context_data["main_js"],
+                f"frontend/{language_actual}/main.js",
             )

--- a/src/documents/tests/utils.py
+++ b/src/documents/tests/utils.py
@@ -7,7 +7,8 @@ from contextlib import contextmanager
 from django.apps import apps
 from django.db import connection
 from django.db.migrations.executor import MigrationExecutor
-from django.test import override_settings, TransactionTestCase
+from django.test import override_settings
+from django.test import TransactionTestCase
 
 
 def setup_directories():
@@ -97,7 +98,7 @@ class TestMigrations(TransactionTestCase):
         assert (
             self.migrate_from and self.migrate_to
         ), "TestCase '{}' must define migrate_from and migrate_to     properties".format(
-            type(self).__name__
+            type(self).__name__,
         )
         self.migrate_from = [(self.app, self.migrate_from)]
         self.migrate_to = [(self.app, self.migrate_to)]

--- a/src/paperless/__init__.py
+++ b/src/paperless/__init__.py
@@ -1,1 +1,4 @@
-from .checks import paths_check, binaries_check
+from .checks import binaries_check
+from .checks import paths_check
+
+__all__ = ["binaries_check", "paths_check"]

--- a/src/paperless/asgi.py
+++ b/src/paperless/asgi.py
@@ -9,14 +9,14 @@ from django.core.asgi import get_asgi_application
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "paperless.settings")
 django_asgi_app = get_asgi_application()
 
-from channels.auth import AuthMiddlewareStack  # NOQA: E402
-from channels.routing import ProtocolTypeRouter, URLRouter  # NOQA: E402
+from channels.auth import AuthMiddlewareStack  # noqa: E402
+from channels.routing import ProtocolTypeRouter, URLRouter  # noqa: E402
 
-from paperless.urls import websocket_urlpatterns  # NOQA: E402
+from paperless.urls import websocket_urlpatterns  # noqa: E402
 
 application = ProtocolTypeRouter(
     {
         "http": get_asgi_application(),
         "websocket": AuthMiddlewareStack(URLRouter(websocket_urlpatterns)),
-    }
+    },
 )

--- a/src/paperless/auth.py
+++ b/src/paperless/auth.py
@@ -1,9 +1,9 @@
 from django.conf import settings
 from django.contrib import auth
+from django.contrib.auth.middleware import RemoteUserMiddleware
 from django.contrib.auth.models import User
 from django.utils.deprecation import MiddlewareMixin
 from rest_framework import authentication
-from django.contrib.auth.middleware import RemoteUserMiddleware
 
 
 class AutoLoginMiddleware(MiddlewareMixin):
@@ -25,7 +25,7 @@ class AngularApiAuthenticationOverride(authentication.BaseAuthentication):
             settings.DEBUG
             and "Referer" in request.headers
             and request.headers["Referer"].startswith("http://localhost:4200/")
-        ):  # NOQA: E501
+        ):
             user = User.objects.filter(is_staff=True).first()
             print("Auto-Login with user {}".format(user))
             return (user, None)

--- a/src/paperless/checks.py
+++ b/src/paperless/checks.py
@@ -3,7 +3,9 @@ import shutil
 import stat
 
 from django.conf import settings
-from django.core.checks import Error, Warning, register
+from django.core.checks import Error
+from django.core.checks import register
+from django.core.checks import Warning
 
 exists_message = "{} is set but doesn't exist."
 exists_hint = "Create a directory at {}"
@@ -19,11 +21,12 @@ def path_check(var, directory):
     if directory:
         if not os.path.isdir(directory):
             messages.append(
-                Error(exists_message.format(var), exists_hint.format(directory))
+                Error(exists_message.format(var), exists_hint.format(directory)),
             )
         else:
             test_file = os.path.join(
-                directory, f"__paperless_write_test_{os.getpid()}__"
+                directory,
+                f"__paperless_write_test_{os.getpid()}__",
             )
             try:
                 with open(test_file, "w"):
@@ -34,9 +37,9 @@ def path_check(var, directory):
                         writeable_message.format(var),
                         writeable_hint.format(
                             f"\n{stat.filemode(os.stat(directory).st_mode)} "
-                            f"{directory}\n"
+                            f"{directory}\n",
                         ),
-                    )
+                    ),
                 )
             finally:
                 if os.path.isfile(test_file):
@@ -88,8 +91,8 @@ def debug_mode_check(app_configs, **kwargs):
                 "security issue, since it puts security overides in place which "
                 "are meant to be only used during development. This "
                 "also means that paperless will tell anyone various "
-                "debugging information when something goes wrong."
-            )
+                "debugging information when something goes wrong.",
+            ),
         ]
     else:
         return []

--- a/src/paperless/consumers.py
+++ b/src/paperless/consumers.py
@@ -1,7 +1,8 @@
 import json
 
 from asgiref.sync import async_to_sync
-from channels.exceptions import DenyConnection, AcceptConnection
+from channels.exceptions import AcceptConnection
+from channels.exceptions import DenyConnection
 from channels.generic.websocket import WebsocketConsumer
 
 
@@ -14,13 +15,15 @@ class StatusConsumer(WebsocketConsumer):
             raise DenyConnection()
         else:
             async_to_sync(self.channel_layer.group_add)(
-                "status_updates", self.channel_name
+                "status_updates",
+                self.channel_name,
             )
             raise AcceptConnection()
 
     def disconnect(self, close_code):
         async_to_sync(self.channel_layer.group_discard)(
-            "status_updates", self.channel_name
+            "status_updates",
+            self.channel_name,
         )
 
     def status_update(self, event):

--- a/src/paperless/db.py
+++ b/src/paperless/db.py
@@ -1,5 +1,4 @@
 import gnupg
-
 from django.conf import settings
 
 

--- a/src/paperless/middleware.py
+++ b/src/paperless/middleware.py
@@ -1,5 +1,4 @@
 from django.conf import settings
-
 from paperless import version
 
 

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -5,9 +5,8 @@ import os
 import re
 
 from concurrent_log_handler.queue import setup_logging_queues
-from dotenv import load_dotenv
-
 from django.utils.translation import gettext_lazy as _
+from dotenv import load_dotenv
 
 # Tap paperless.conf if it's available
 if os.path.exists("../paperless.conf"):
@@ -68,7 +67,8 @@ MODEL_FILE = os.path.join(DATA_DIR, "classification_model.pickle")
 LOGGING_DIR = os.getenv("PAPERLESS_LOGGING_DIR", os.path.join(DATA_DIR, "log"))
 
 CONSUMPTION_DIR = os.getenv(
-    "PAPERLESS_CONSUMPTION_DIR", os.path.join(BASE_DIR, "..", "consume")
+    "PAPERLESS_CONSUMPTION_DIR",
+    os.path.join(BASE_DIR, "..", "consume"),
 )
 
 # This will be created if it doesn't exist
@@ -119,7 +119,7 @@ REST_FRAMEWORK = {
 
 if DEBUG:
     REST_FRAMEWORK["DEFAULT_AUTHENTICATION_CLASSES"].append(
-        "paperless.auth.AngularApiAuthenticationOverride"
+        "paperless.auth.AngularApiAuthenticationOverride",
     )
 
 MIDDLEWARE = [
@@ -191,7 +191,8 @@ if AUTO_LOGIN_USERNAME:
 
 ENABLE_HTTP_REMOTE_USER = __get_boolean("PAPERLESS_ENABLE_HTTP_REMOTE_USER")
 HTTP_REMOTE_USER_HEADER_NAME = os.getenv(
-    "PAPERLESS_HTTP_REMOTE_USER_HEADER_NAME", "HTTP_REMOTE_USER"
+    "PAPERLESS_HTTP_REMOTE_USER_HEADER_NAME",
+    "HTTP_REMOTE_USER",
 )
 
 if ENABLE_HTTP_REMOTE_USER:
@@ -201,7 +202,7 @@ if ENABLE_HTTP_REMOTE_USER:
         "django.contrib.auth.backends.ModelBackend",
     ]
     REST_FRAMEWORK["DEFAULT_AUTHENTICATION_CLASSES"].append(
-        "rest_framework.authentication.RemoteUserAuthentication"
+        "rest_framework.authentication.RemoteUserAuthentication",
     )
 
 # X-Frame options for embedded PDF display:
@@ -212,7 +213,7 @@ else:
 
 # We allow CORS from localhost:8080
 CORS_ALLOWED_ORIGINS = tuple(
-    os.getenv("PAPERLESS_CORS_ALLOWED_HOSTS", "http://localhost:8000").split(",")
+    os.getenv("PAPERLESS_CORS_ALLOWED_HOSTS", "http://localhost:8000").split(","),
 )
 
 if DEBUG:
@@ -223,7 +224,8 @@ if DEBUG:
 # Paperless on a closed network.  However, if you're putting this anywhere
 # public, you should change the key to something unique and verbose.
 SECRET_KEY = os.getenv(
-    "PAPERLESS_SECRET_KEY", "e11fl1oa-*ytql8p)(06fbj4ukrlo+n7k&q5+$1md7i+mge=ee"
+    "PAPERLESS_SECRET_KEY",
+    "e11fl1oa-*ytql8p)(06fbj4ukrlo+n7k&q5+$1md7i+mge=ee",
 )
 
 _allowed_hosts = os.getenv("PAPERLESS_ALLOWED_HOSTS")
@@ -268,7 +270,7 @@ DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.sqlite3",
         "NAME": os.path.join(DATA_DIR, "db.sqlite3"),
-    }
+    },
 }
 
 if os.getenv("PAPERLESS_DBHOST"):
@@ -423,7 +425,8 @@ def default_threads_per_worker(task_workers):
 
 
 THREADS_PER_WORKER = os.getenv(
-    "PAPERLESS_THREADS_PER_WORKER", default_threads_per_worker(TASK_WORKERS)
+    "PAPERLESS_THREADS_PER_WORKER",
+    default_threads_per_worker(TASK_WORKERS),
 )
 
 ###############################################################################
@@ -435,7 +438,7 @@ CONSUMER_POLLING = int(os.getenv("PAPERLESS_CONSUMER_POLLING", 0))
 CONSUMER_POLLING_DELAY = int(os.getenv("PAPERLESS_CONSUMER_POLLING_DELAY", 5))
 
 CONSUMER_POLLING_RETRY_COUNT = int(
-    os.getenv("PAPERLESS_CONSUMER_POLLING_RETRY_COUNT", 5)
+    os.getenv("PAPERLESS_CONSUMER_POLLING_RETRY_COUNT", 5),
 )
 
 CONSUMER_DELETE_DUPLICATES = __get_boolean("PAPERLESS_CONSUMER_DELETE_DUPLICATES")
@@ -448,8 +451,8 @@ CONSUMER_IGNORE_PATTERNS = list(
         os.getenv(
             "PAPERLESS_CONSUMER_IGNORE_PATTERNS",
             '[".DS_STORE/*", "._*", ".stfolder/*"]',
-        )
-    )
+        ),
+    ),
 )
 
 CONSUMER_SUBDIRS_AS_TAGS = __get_boolean("PAPERLESS_CONSUMER_SUBDIRS_AS_TAGS")
@@ -479,7 +482,7 @@ OCR_DESKEW = __get_boolean("PAPERLESS_OCR_DESKEW", "true")
 OCR_ROTATE_PAGES = __get_boolean("PAPERLESS_OCR_ROTATE_PAGES", "true")
 
 OCR_ROTATE_PAGES_THRESHOLD = float(
-    os.getenv("PAPERLESS_OCR_ROTATE_PAGES_THRESHOLD", 12.0)
+    os.getenv("PAPERLESS_OCR_ROTATE_PAGES_THRESHOLD", 12.0),
 )
 
 OCR_USER_ARGS = os.getenv("PAPERLESS_OCR_USER_ARGS", "{}")
@@ -536,7 +539,8 @@ THUMBNAIL_FONT_NAME = os.getenv(
 PAPERLESS_TIKA_ENABLED = __get_boolean("PAPERLESS_TIKA_ENABLED", "NO")
 PAPERLESS_TIKA_ENDPOINT = os.getenv("PAPERLESS_TIKA_ENDPOINT", "http://localhost:9998")
 PAPERLESS_TIKA_GOTENBERG_ENDPOINT = os.getenv(
-    "PAPERLESS_TIKA_GOTENBERG_ENDPOINT", "http://localhost:3000"
+    "PAPERLESS_TIKA_GOTENBERG_ENDPOINT",
+    "http://localhost:3000",
 )
 
 if PAPERLESS_TIKA_ENABLED:

--- a/src/paperless/tests/test_checks.py
+++ b/src/paperless/tests/test_checks.py
@@ -1,10 +1,11 @@
 import os
 import shutil
 
-from django.test import TestCase, override_settings
-
+from django.test import override_settings
+from django.test import TestCase
 from documents.tests.utils import DirectoriesMixin
-from paperless import binaries_check, paths_check
+from paperless import binaries_check
+from paperless import paths_check
 from paperless.checks import debug_mode_check
 
 
@@ -20,7 +21,9 @@ class TestChecks(DirectoriesMixin, TestCase):
         self.assertEqual(paths_check(None), [])
 
     @override_settings(
-        MEDIA_ROOT="uuh", DATA_DIR="whatever", CONSUMPTION_DIR="idontcare"
+        MEDIA_ROOT="uuh",
+        DATA_DIR="whatever",
+        CONSUMPTION_DIR="idontcare",
     )
     def test_paths_check_dont_exist(self):
         msgs = paths_check(None)

--- a/src/paperless/tests/test_websockets.py
+++ b/src/paperless/tests/test_websockets.py
@@ -2,8 +2,8 @@ from unittest import mock
 
 from channels.layers import get_channel_layer
 from channels.testing import WebsocketCommunicator
-from django.test import TestCase, override_settings
-
+from django.test import override_settings
+from django.test import TestCase
 from paperless.asgi import application
 
 
@@ -46,7 +46,8 @@ class TestWebSockets(TestCase):
 
         channel_layer = get_channel_layer()
         await channel_layer.group_send(
-            "status_updates", {"type": "status_update", "data": message}
+            "status_updates",
+            {"type": "status_update", "data": message},
         )
 
         response = await communicator.receive_json_from()

--- a/src/paperless/urls.py
+++ b/src/paperless/urls.py
@@ -1,33 +1,29 @@
+from django.conf import settings
 from django.conf.urls import include
 from django.contrib import admin
 from django.contrib.auth.decorators import login_required
-from django.urls import path, re_path
+from django.urls import path
+from django.urls import re_path
+from django.utils.translation import gettext_lazy as _
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import RedirectView
+from documents.views import BulkDownloadView
+from documents.views import BulkEditView
+from documents.views import CorrespondentViewSet
+from documents.views import DocumentTypeViewSet
+from documents.views import IndexView
+from documents.views import LogViewSet
+from documents.views import PostDocumentView
+from documents.views import SavedViewViewSet
+from documents.views import SearchAutoCompleteView
+from documents.views import SelectionDataView
+from documents.views import StatisticsView
+from documents.views import TagViewSet
+from documents.views import UnifiedSearchViewSet
+from paperless.consumers import StatusConsumer
+from paperless.views import FaviconView
 from rest_framework.authtoken import views
 from rest_framework.routers import DefaultRouter
-
-from django.utils.translation import gettext_lazy as _
-
-from django.conf import settings
-
-from paperless.consumers import StatusConsumer
-from documents.views import (
-    CorrespondentViewSet,
-    UnifiedSearchViewSet,
-    LogViewSet,
-    TagViewSet,
-    DocumentTypeViewSet,
-    IndexView,
-    SearchAutoCompleteView,
-    StatisticsView,
-    PostDocumentView,
-    SavedViewViewSet,
-    BulkEditView,
-    SelectionDataView,
-    BulkDownloadView,
-)
-from paperless.views import FaviconView
 
 api_router = DefaultRouter()
 api_router.register(r"correspondents", CorrespondentViewSet)
@@ -62,7 +58,9 @@ urlpatterns = [
                     name="post_document",
                 ),
                 re_path(
-                    r"^documents/bulk_edit/", BulkEditView.as_view(), name="bulk_edit"
+                    r"^documents/bulk_edit/",
+                    BulkEditView.as_view(),
+                    name="bulk_edit",
                 ),
                 re_path(
                     r"^documents/selection_data/",
@@ -76,7 +74,7 @@ urlpatterns = [
                 ),
                 path("token/", views.obtain_auth_token),
             ]
-            + api_router.urls
+            + api_router.urls,
         ),
     ),
     re_path(r"^favicon.ico$", FaviconView.as_view(), name="favicon"),
@@ -88,35 +86,37 @@ urlpatterns = [
                 re_path(
                     r"^doc/(?P<pk>\d+)$",
                     RedirectView.as_view(
-                        url=settings.BASE_URL + "api/documents/%(pk)s/download/"
+                        url=settings.BASE_URL + "api/documents/%(pk)s/download/",
                     ),
                 ),
                 re_path(
                     r"^thumb/(?P<pk>\d+)$",
                     RedirectView.as_view(
-                        url=settings.BASE_URL + "api/documents/%(pk)s/thumb/"
+                        url=settings.BASE_URL + "api/documents/%(pk)s/thumb/",
                     ),
                 ),
                 re_path(
                     r"^preview/(?P<pk>\d+)$",
                     RedirectView.as_view(
-                        url=settings.BASE_URL + "api/documents/%(pk)s/preview/"
+                        url=settings.BASE_URL + "api/documents/%(pk)s/preview/",
                     ),
                 ),
-            ]
+            ],
         ),
     ),
     re_path(
         r"^push$",
         csrf_exempt(
-            RedirectView.as_view(url=settings.BASE_URL + "api/documents/post_document/")
+            RedirectView.as_view(
+                url=settings.BASE_URL + "api/documents/post_document/",
+            ),
         ),
     ),
     # Frontend assets TODO: this is pretty bad, but it works.
     path(
         "assets/<path:path>",
         RedirectView.as_view(
-            url=settings.STATIC_URL + "frontend/en-US/assets/%(path)s"
+            url=settings.STATIC_URL + "frontend/en-US/assets/%(path)s",
         ),
     ),
     # TODO: with localization, this is even worse! :/

--- a/src/paperless/views.py
+++ b/src/paperless/views.py
@@ -14,7 +14,11 @@ class StandardPagination(PageNumberPagination):
 class FaviconView(View):
     def get(self, request, *args, **kwargs):
         favicon = os.path.join(
-            os.path.dirname(__file__), "static", "paperless", "img", "favicon.ico"
+            os.path.dirname(__file__),
+            "static",
+            "paperless",
+            "img",
+            "favicon.ico",
         )
         with open(favicon, "rb") as f:
             return HttpResponse(f, content_type="image/x-icon")

--- a/src/paperless/workers.py
+++ b/src/paperless/workers.py
@@ -1,6 +1,7 @@
 import os
-from uvicorn.workers import UvicornWorker
+
 from django.conf import settings
+from uvicorn.workers import UvicornWorker
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "paperless.settings")
 

--- a/src/paperless/wsgi.py
+++ b/src/paperless/wsgi.py
@@ -6,7 +6,6 @@ It exposes the WSGI callable as a module-level variable named ``application``.
 For more information on this file, see
 https://docs.djangoproject.com/en/1.10/howto/deployment/wsgi/
 """
-
 import os
 
 from django.core.wsgi import get_wsgi_application

--- a/src/paperless_mail/admin.py
+++ b/src/paperless_mail/admin.py
@@ -1,8 +1,8 @@
-from django.contrib import admin
 from django import forms
-from paperless_mail.models import MailAccount, MailRule
-
+from django.contrib import admin
 from django.utils.translation import gettext_lazy as _
+from paperless_mail.models import MailAccount
+from paperless_mail.models import MailRule
 
 
 class MailAccountAdminForm(forms.ModelForm):
@@ -48,7 +48,7 @@ class MailRuleAdmin(admin.ModelAdmin):
             {
                 "description": _(
                     "Paperless will only process mails that match ALL of the "
-                    "filters given below."
+                    "filters given below.",
                 ),
                 "fields": (
                     "filter_from",
@@ -66,7 +66,7 @@ class MailRuleAdmin(admin.ModelAdmin):
                 "description": _(
                     "The action applied to the mail. This action is only "
                     "performed when documents were consumed from the mail. "
-                    "Mails without attachments will remain entirely untouched."
+                    "Mails without attachments will remain entirely untouched.",
                 ),
                 "fields": ("action", "action_parameter"),
             },
@@ -78,7 +78,7 @@ class MailRuleAdmin(admin.ModelAdmin):
                     "Assign metadata to documents consumed from this rule "
                     "automatically. If you do not assign tags, types or "
                     "correspondents here, paperless will still process all "
-                    "matching rules that you have defined."
+                    "matching rules that you have defined.",
                 ),
                 "fields": (
                     "assign_title_from",

--- a/src/paperless_mail/apps.py
+++ b/src/paperless_mail/apps.py
@@ -1,5 +1,4 @@
 from django.apps import AppConfig
-
 from django.utils.translation import gettext_lazy as _
 
 

--- a/src/paperless_mail/management/commands/mail_fetcher.py
+++ b/src/paperless_mail/management/commands/mail_fetcher.py
@@ -1,5 +1,4 @@
 from django.core.management.base import BaseCommand
-
 from paperless_mail import tasks
 
 
@@ -7,7 +6,8 @@ class Command(BaseCommand):
 
     help = """
     """.replace(
-        "    ", ""
+        "    ",
+        "",
     )
 
     def handle(self, *args, **options):

--- a/src/paperless_mail/models.py
+++ b/src/paperless_mail/models.py
@@ -1,7 +1,5 @@
-from django.db import models
-
 import documents.models as document_models
-
+from django.db import models
 from django.utils.translation import gettext_lazy as _
 
 
@@ -30,12 +28,14 @@ class MailAccount(models.Model):
         null=True,
         help_text=_(
             "This is usually 143 for unencrypted and STARTTLS "
-            "connections, and 993 for SSL connections."
+            "connections, and 993 for SSL connections.",
         ),
     )
 
     imap_security = models.PositiveIntegerField(
-        _("IMAP security"), choices=IMAP_SECURITY_OPTIONS, default=IMAP_SECURITY_SSL
+        _("IMAP security"),
+        choices=IMAP_SECURITY_OPTIONS,
+        default=IMAP_SECURITY_SSL,
     )
 
     username = models.CharField(_("username"), max_length=256)
@@ -48,7 +48,7 @@ class MailAccount(models.Model):
         default="UTF-8",
         help_text=_(
             "The character set to use when communicating with the "
-            "mail server, such as 'UTF-8' or 'US-ASCII'."
+            "mail server, such as 'UTF-8' or 'US-ASCII'.",
         ),
     )
 
@@ -123,13 +123,22 @@ class MailRule(models.Model):
     )
 
     filter_from = models.CharField(
-        _("filter from"), max_length=256, null=True, blank=True
+        _("filter from"),
+        max_length=256,
+        null=True,
+        blank=True,
     )
     filter_subject = models.CharField(
-        _("filter subject"), max_length=256, null=True, blank=True
+        _("filter subject"),
+        max_length=256,
+        null=True,
+        blank=True,
     )
     filter_body = models.CharField(
-        _("filter body"), max_length=256, null=True, blank=True
+        _("filter body"),
+        max_length=256,
+        null=True,
+        blank=True,
     )
 
     filter_attachment_filename = models.CharField(
@@ -140,12 +149,14 @@ class MailRule(models.Model):
         help_text=_(
             "Only consume documents which entirely match this "
             "filename if specified. Wildcards such as *.pdf or "
-            "*invoice* are allowed. Case insensitive."
+            "*invoice* are allowed. Case insensitive.",
         ),
     )
 
     maximum_age = models.PositiveIntegerField(
-        _("maximum age"), default=30, help_text=_("Specified in days.")
+        _("maximum age"),
+        default=30,
+        help_text=_("Specified in days."),
     )
 
     attachment_type = models.PositiveIntegerField(
@@ -154,7 +165,7 @@ class MailRule(models.Model):
         default=ATTACHMENT_TYPE_ATTACHMENTS_ONLY,
         help_text=_(
             "Inline attachments include embedded images, so it's best "
-            "to combine this option with a filename filter."
+            "to combine this option with a filename filter.",
         ),
     )
 
@@ -173,12 +184,14 @@ class MailRule(models.Model):
             "Additional parameter for the action selected above, "
             "i.e., "
             "the target folder of the move to folder action. "
-            "Subfolders must be separated by dots."
+            "Subfolders must be separated by dots.",
         ),
     )
 
     assign_title_from = models.PositiveIntegerField(
-        _("assign title from"), choices=TITLE_SELECTOR, default=TITLE_FROM_SUBJECT
+        _("assign title from"),
+        choices=TITLE_SELECTOR,
+        default=TITLE_FROM_SUBJECT,
     )
 
     assign_tag = models.ForeignKey(

--- a/src/paperless_mail/tasks.py
+++ b/src/paperless_mail/tasks.py
@@ -1,6 +1,7 @@
 import logging
 
-from paperless_mail.mail import MailAccountHandler, MailError
+from paperless_mail.mail import MailAccountHandler
+from paperless_mail.mail import MailError
 from paperless_mail.models import MailAccount
 
 

--- a/src/paperless_mail/tests/test_mail.py
+++ b/src/paperless_mail/tests/test_mail.py
@@ -7,13 +7,15 @@ from unittest import mock
 from django.core.management import call_command
 from django.db import DatabaseError
 from django.test import TestCase
-from imap_tools import MailMessageFlags, MailboxFolderSelectError
-
 from documents.models import Correspondent
 from documents.tests.utils import DirectoriesMixin
+from imap_tools import MailboxFolderSelectError
+from imap_tools import MailMessageFlags
 from paperless_mail import tasks
-from paperless_mail.mail import MailError, MailAccountHandler
-from paperless_mail.models import MailRule, MailAccount
+from paperless_mail.mail import MailAccountHandler
+from paperless_mail.mail import MailError
+from paperless_mail.models import MailAccount
+from paperless_mail.models import MailRule
 
 
 class BogusFolderManager:
@@ -83,7 +85,7 @@ class BogusMailBox(ContextManager):
     def move(self, uid_list, folder):
         if folder == "spam":
             self.messages_spam.append(
-                filter(lambda m: m.uid in uid_list, self.messages)
+                filter(lambda m: m.uid in uid_list, self.messages),
             )
             self.messages = list(filter(lambda m: m.uid not in uid_list, self.messages))
         else:
@@ -115,7 +117,9 @@ def create_message(
 
 
 def create_attachment(
-    filename="the_file.pdf", content_disposition="attachment", payload=b"a PDF document"
+    filename="the_file.pdf",
+    content_disposition="attachment",
+    payload=b"a PDF document",
 ):
     attachment = namedtuple("Attachment", [])
     attachment.filename = filename
@@ -163,7 +167,7 @@ class TestMail(DirectoriesMixin, TestCase):
                 body="cables",
                 seen=True,
                 flagged=False,
-            )
+            ),
         )
         self.bogus_mailbox.messages.append(
             create_message(
@@ -171,14 +175,14 @@ class TestMail(DirectoriesMixin, TestCase):
                 body="from my favorite electronic store",
                 seen=False,
                 flagged=True,
-            )
+            ),
         )
         self.bogus_mailbox.messages.append(
             create_message(
                 subject="Claim your $10M price now!",
                 from_="amazon@amazon-some-indian-site.org",
                 seen=False,
-            )
+            ),
         )
 
     def test_get_correspondent(self):
@@ -196,12 +200,14 @@ class TestMail(DirectoriesMixin, TestCase):
         handler = MailAccountHandler()
 
         rule = MailRule(
-            name="a", assign_correspondent_from=MailRule.CORRESPONDENT_FROM_NOTHING
+            name="a",
+            assign_correspondent_from=MailRule.CORRESPONDENT_FROM_NOTHING,
         )
         self.assertIsNone(handler.get_correspondent(message, rule))
 
         rule = MailRule(
-            name="b", assign_correspondent_from=MailRule.CORRESPONDENT_FROM_EMAIL
+            name="b",
+            assign_correspondent_from=MailRule.CORRESPONDENT_FROM_EMAIL,
         )
         c = handler.get_correspondent(message, rule)
         self.assertIsNotNone(c)
@@ -212,7 +218,8 @@ class TestMail(DirectoriesMixin, TestCase):
         self.assertEqual(c.id, me_localhost.id)
 
         rule = MailRule(
-            name="c", assign_correspondent_from=MailRule.CORRESPONDENT_FROM_NAME
+            name="c",
+            assign_correspondent_from=MailRule.CORRESPONDENT_FROM_NAME,
         )
         c = handler.get_correspondent(message, rule)
         self.assertIsNotNone(c)
@@ -244,7 +251,9 @@ class TestMail(DirectoriesMixin, TestCase):
 
     def test_handle_message(self):
         message = create_message(
-            subject="the message title", from_="Myself", num_attachments=2
+            subject="the message title",
+            from_="Myself",
+            num_attachments=2,
         )
 
         account = MailAccount()
@@ -376,11 +385,16 @@ class TestMail(DirectoriesMixin, TestCase):
     def test_handle_mail_account_mark_read(self):
 
         account = MailAccount.objects.create(
-            name="test", imap_server="", username="admin", password="secret"
+            name="test",
+            imap_server="",
+            username="admin",
+            password="secret",
         )
 
         rule = MailRule.objects.create(
-            name="testrule", account=account, action=MailRule.ACTION_MARK_READ
+            name="testrule",
+            account=account,
+            action=MailRule.ACTION_MARK_READ,
         )
 
         self.assertEqual(len(self.bogus_mailbox.messages), 3)
@@ -394,7 +408,10 @@ class TestMail(DirectoriesMixin, TestCase):
     def test_handle_mail_account_delete(self):
 
         account = MailAccount.objects.create(
-            name="test", imap_server="", username="admin", password="secret"
+            name="test",
+            imap_server="",
+            username="admin",
+            password="secret",
         )
 
         rule = MailRule.objects.create(
@@ -412,7 +429,10 @@ class TestMail(DirectoriesMixin, TestCase):
 
     def test_handle_mail_account_flag(self):
         account = MailAccount.objects.create(
-            name="test", imap_server="", username="admin", password="secret"
+            name="test",
+            imap_server="",
+            username="admin",
+            password="secret",
         )
 
         rule = MailRule.objects.create(
@@ -432,7 +452,10 @@ class TestMail(DirectoriesMixin, TestCase):
 
     def test_handle_mail_account_move(self):
         account = MailAccount.objects.create(
-            name="test", imap_server="", username="admin", password="secret"
+            name="test",
+            imap_server="",
+            username="admin",
+            password="secret",
         )
 
         rule = MailRule.objects.create(
@@ -453,7 +476,10 @@ class TestMail(DirectoriesMixin, TestCase):
 
     def test_error_login(self):
         account = MailAccount.objects.create(
-            name="test", imap_server="", username="admin", password="wrong"
+            name="test",
+            imap_server="",
+            username="admin",
+            password="wrong",
         )
 
         try:
@@ -465,11 +491,17 @@ class TestMail(DirectoriesMixin, TestCase):
 
     def test_error_skip_account(self):
         account_faulty = MailAccount.objects.create(
-            name="test", imap_server="", username="admin", password="wroasdng"
+            name="test",
+            imap_server="",
+            username="admin",
+            password="wroasdng",
         )
 
         account = MailAccount.objects.create(
-            name="test2", imap_server="", username="admin", password="secret"
+            name="test2",
+            imap_server="",
+            username="admin",
+            password="secret",
         )
         rule = MailRule.objects.create(
             name="testrule",
@@ -487,7 +519,10 @@ class TestMail(DirectoriesMixin, TestCase):
     def test_error_skip_rule(self):
 
         account = MailAccount.objects.create(
-            name="test2", imap_server="", username="admin", password="secret"
+            name="test2",
+            imap_server="",
+            username="admin",
+            password="secret",
         )
         rule = MailRule.objects.create(
             name="testrule",
@@ -523,7 +558,10 @@ class TestMail(DirectoriesMixin, TestCase):
         m.side_effect = get_correspondent_fake
 
         account = MailAccount.objects.create(
-            name="test2", imap_server="", username="admin", password="secret"
+            name="test2",
+            imap_server="",
+            username="admin",
+            password="secret",
         )
         rule = MailRule.objects.create(
             name="testrule",
@@ -544,7 +582,10 @@ class TestMail(DirectoriesMixin, TestCase):
     def test_error_create_correspondent(self):
 
         account = MailAccount.objects.create(
-            name="test2", imap_server="", username="admin", password="secret"
+            name="test2",
+            imap_server="",
+            username="admin",
+            password="secret",
         )
         rule = MailRule.objects.create(
             name="testrule",
@@ -579,7 +620,10 @@ class TestMail(DirectoriesMixin, TestCase):
     def test_filters(self):
 
         account = MailAccount.objects.create(
-            name="test3", imap_server="", username="admin", password="secret"
+            name="test3",
+            imap_server="",
+            username="admin",
+            password="secret",
         )
         rule = MailRule.objects.create(
             name="testrule3",
@@ -629,7 +673,7 @@ class TestMail(DirectoriesMixin, TestCase):
 
 class TestManagementCommand(TestCase):
     @mock.patch(
-        "paperless_mail.management.commands.mail_fetcher.tasks.process_mail_accounts"
+        "paperless_mail.management.commands.mail_fetcher.tasks.process_mail_accounts",
     )
     def test_mail_fetcher(self, m):
 
@@ -644,10 +688,16 @@ class TestTasks(TestCase):
         m.side_effect = lambda account: 6
 
         MailAccount.objects.create(
-            name="A", imap_server="A", username="A", password="A"
+            name="A",
+            imap_server="A",
+            username="A",
+            password="A",
         )
         MailAccount.objects.create(
-            name="B", imap_server="A", username="A", password="A"
+            name="B",
+            imap_server="A",
+            username="A",
+            password="A",
         )
 
         result = tasks.process_mail_accounts()
@@ -663,7 +713,10 @@ class TestTasks(TestCase):
     def test_single_accounts(self, m):
 
         MailAccount.objects.create(
-            name="A", imap_server="A", username="A", password="A"
+            name="A",
+            imap_server="A",
+            username="A",
+            password="A",
         )
 
         tasks.process_mail_account("A")

--- a/src/paperless_tesseract/__init__.py
+++ b/src/paperless_tesseract/__init__.py
@@ -1,2 +1,5 @@
 # this is here so that django finds the checks.
-from .checks import *
+from .checks import check_default_language_available
+from .checks import get_tesseract_langs
+
+__all__ = ["get_tesseract_langs", "check_default_language_available"]

--- a/src/paperless_tesseract/apps.py
+++ b/src/paperless_tesseract/apps.py
@@ -1,5 +1,4 @@
 from django.apps import AppConfig
-
 from paperless_tesseract.signals import tesseract_consumer_declaration
 
 

--- a/src/paperless_tesseract/checks.py
+++ b/src/paperless_tesseract/checks.py
@@ -1,7 +1,9 @@
 import subprocess
 
 from django.conf import settings
-from django.core.checks import Error, Warning, register
+from django.core.checks import Error
+from django.core.checks import register
+from django.core.checks import Warning
 
 
 def get_tesseract_langs():
@@ -19,8 +21,8 @@ def check_default_language_available(app_configs, **kwargs):
         return [
             Warning(
                 "No OCR language has been specified with PAPERLESS_OCR_LANGUAGE. "
-                "This means that tesseract will fallback to english."
-            )
+                "This means that tesseract will fallback to english.",
+            ),
         ]
 
     specified_langs = settings.OCR_LANGUAGE.split("+")
@@ -31,8 +33,8 @@ def check_default_language_available(app_configs, **kwargs):
                 Error(
                     f"The selected ocr language {lang} is "
                     f"not installed. Paperless cannot OCR your documents "
-                    f"without it. Please fix PAPERLESS_OCR_LANGUAGE."
-                )
+                    f"without it. Please fix PAPERLESS_OCR_LANGUAGE.",
+                ),
             ]
 
     return []

--- a/src/paperless_tesseract/parsers.py
+++ b/src/paperless_tesseract/parsers.py
@@ -2,10 +2,11 @@ import json
 import os
 import re
 
-from PIL import Image
 from django.conf import settings
-
-from documents.parsers import DocumentParser, ParseError, make_thumbnail_from_pdf
+from documents.parsers import DocumentParser
+from documents.parsers import make_thumbnail_from_pdf
+from documents.parsers import ParseError
+from PIL import Image
 
 
 class NoTextFoundException(Exception):
@@ -42,7 +43,7 @@ class RasterisedDocumentParser(DocumentParser):
                             "prefix": meta.REVERSE_NS[m.group(1)],
                             "key": m.group(2),
                             "value": value,
-                        }
+                        },
                     )
                 except Exception as e:
                     self.log(
@@ -53,7 +54,9 @@ class RasterisedDocumentParser(DocumentParser):
 
     def get_thumbnail(self, document_path, mime_type, file_name=None):
         return make_thumbnail_from_pdf(
-            self.archive_path or document_path, self.tempdir, self.logging_group
+            self.archive_path or document_path,
+            self.tempdir,
+            self.logging_group,
         )
 
     def is_image(self, mime_type):
@@ -110,7 +113,6 @@ class RasterisedDocumentParser(DocumentParser):
             return None
 
         from pdfminer.high_level import extract_text as pdfminer_extract_text
-        from pdfminer.pdftypes import PDFException
 
         try:
             stripped = post_process_text(pdfminer_extract_text(pdf_file))
@@ -129,7 +131,12 @@ class RasterisedDocumentParser(DocumentParser):
             return None
 
     def construct_ocrmypdf_parameters(
-        self, input_file, mime_type, output_file, sidecar_file, safe_fallback=False
+        self,
+        input_file,
+        mime_type,
+        output_file,
+        sidecar_file,
+        safe_fallback=False,
     ):
         ocrmypdf_args = {
             "input_file": input_file,
@@ -167,7 +174,7 @@ class RasterisedDocumentParser(DocumentParser):
             ocrmypdf_args["rotate_pages"] = True
             ocrmypdf_args[
                 "rotate_pages_threshold"
-            ] = settings.OCR_ROTATE_PAGES_THRESHOLD  # NOQA: E501
+            ] = settings.OCR_ROTATE_PAGES_THRESHOLD
 
         if settings.OCR_PAGES > 0:
             ocrmypdf_args["pages"] = f"1-{settings.OCR_PAGES}"
@@ -202,7 +209,7 @@ class RasterisedDocumentParser(DocumentParser):
                 raise ParseError(
                     f"Cannot produce archive PDF for image {input_file}, "
                     f"no DPI information is present in this image and "
-                    f"OCR_IMAGE_DPI is not set."
+                    f"OCR_IMAGE_DPI is not set.",
                 )
 
         if settings.OCR_USER_ARGS and not safe_fallback:
@@ -241,7 +248,10 @@ class RasterisedDocumentParser(DocumentParser):
         sidecar_file = os.path.join(self.tempdir, "sidecar.txt")
 
         args = self.construct_ocrmypdf_parameters(
-            document_path, mime_type, archive_path, sidecar_file
+            document_path,
+            mime_type,
+            archive_path,
+            sidecar_file,
         )
 
         try:
@@ -289,7 +299,8 @@ class RasterisedDocumentParser(DocumentParser):
                 # is bigger and blurry due to --force-ocr.
 
                 self.text = self.extract_text(
-                    sidecar_file_fallback, archive_path_fallback
+                    sidecar_file_fallback,
+                    archive_path_fallback,
                 )
 
             except Exception as e:

--- a/src/paperless_tesseract/tests/test_checks.py
+++ b/src/paperless_tesseract/tests/test_checks.py
@@ -1,8 +1,8 @@
 from unittest import mock
 
 from django.core.checks import ERROR
-from django.test import TestCase, override_settings
-
+from django.test import override_settings
+from django.test import TestCase
 from paperless_tesseract import check_default_language_available
 
 
@@ -16,8 +16,8 @@ class TestChecks(TestCase):
         self.assertEqual(len(msgs), 1)
         self.assertTrue(
             msgs[0].msg.startswith(
-                "No OCR language has been specified with PAPERLESS_OCR_LANGUAGE"
-            )
+                "No OCR language has been specified with PAPERLESS_OCR_LANGUAGE",
+            ),
         )
 
     @override_settings(OCR_LANGUAGE="ita")

--- a/src/paperless_tesseract/tests/test_parser.py
+++ b/src/paperless_tesseract/tests/test_parser.py
@@ -3,11 +3,13 @@ import uuid
 from typing import ContextManager
 from unittest import mock
 
-from django.test import TestCase, override_settings
-
-from documents.parsers import ParseError, run_convert
+from django.test import override_settings
+from django.test import TestCase
+from documents.parsers import ParseError
+from documents.parsers import run_convert
 from documents.tests.utils import DirectoriesMixin
-from paperless_tesseract.parsers import RasterisedDocumentParser, post_process_text
+from paperless_tesseract.parsers import post_process_text
+from paperless_tesseract.parsers import RasterisedDocumentParser
 
 image_to_string_calls = []
 
@@ -56,7 +58,9 @@ class TestParser(DirectoriesMixin, TestCase):
                 result,
                 actual_result,
                 "strip_exceess_whitespace({}) != '{}', but '{}'".format(
-                    source, result, actual_result
+                    source,
+                    result,
+                    actual_result,
                 ),
             )
 
@@ -65,7 +69,8 @@ class TestParser(DirectoriesMixin, TestCase):
     def test_get_text_from_pdf(self):
         parser = RasterisedDocumentParser(uuid.uuid4())
         text = parser.extract_text(
-            None, os.path.join(self.SAMPLE_FILES, "simple-digital.pdf")
+            None,
+            os.path.join(self.SAMPLE_FILES, "simple-digital.pdf"),
         )
 
         self.assertContainsStrings(text.strip(), ["This is a test document."])
@@ -73,7 +78,8 @@ class TestParser(DirectoriesMixin, TestCase):
     def test_thumbnail(self):
         parser = RasterisedDocumentParser(uuid.uuid4())
         thumb = parser.get_thumbnail(
-            os.path.join(self.SAMPLE_FILES, "simple-digital.pdf"), "application/pdf"
+            os.path.join(self.SAMPLE_FILES, "simple-digital.pdf"),
+            "application/pdf",
         )
         self.assertTrue(os.path.isfile(thumb))
 
@@ -89,14 +95,16 @@ class TestParser(DirectoriesMixin, TestCase):
 
         parser = RasterisedDocumentParser(uuid.uuid4())
         thumb = parser.get_thumbnail(
-            os.path.join(self.SAMPLE_FILES, "simple-digital.pdf"), "application/pdf"
+            os.path.join(self.SAMPLE_FILES, "simple-digital.pdf"),
+            "application/pdf",
         )
         self.assertTrue(os.path.isfile(thumb))
 
     def test_thumbnail_encrypted(self):
         parser = RasterisedDocumentParser(uuid.uuid4())
         thumb = parser.get_thumbnail(
-            os.path.join(self.SAMPLE_FILES, "encrypted.pdf"), "application/pdf"
+            os.path.join(self.SAMPLE_FILES, "encrypted.pdf"),
+            "application/pdf",
         )
         self.assertTrue(os.path.isfile(thumb))
 
@@ -113,7 +121,8 @@ class TestParser(DirectoriesMixin, TestCase):
         parser = RasterisedDocumentParser(None)
 
         parser.parse(
-            os.path.join(self.SAMPLE_FILES, "simple-digital.pdf"), "application/pdf"
+            os.path.join(self.SAMPLE_FILES, "simple-digital.pdf"),
+            "application/pdf",
         )
 
         self.assertTrue(os.path.isfile(parser.archive_path))
@@ -124,7 +133,8 @@ class TestParser(DirectoriesMixin, TestCase):
         parser = RasterisedDocumentParser(None)
 
         parser.parse(
-            os.path.join(self.SAMPLE_FILES, "with-form.pdf"), "application/pdf"
+            os.path.join(self.SAMPLE_FILES, "with-form.pdf"),
+            "application/pdf",
         )
 
         self.assertTrue(os.path.isfile(parser.archive_path))
@@ -139,7 +149,8 @@ class TestParser(DirectoriesMixin, TestCase):
         parser = RasterisedDocumentParser(None)
 
         parser.parse(
-            os.path.join(self.SAMPLE_FILES, "with-form.pdf"), "application/pdf"
+            os.path.join(self.SAMPLE_FILES, "with-form.pdf"),
+            "application/pdf",
         )
 
         self.assertIsNone(parser.archive_path)
@@ -168,7 +179,8 @@ class TestParser(DirectoriesMixin, TestCase):
         parser = RasterisedDocumentParser(None)
 
         parser.parse(
-            os.path.join(self.SAMPLE_FILES, "encrypted.pdf"), "application/pdf"
+            os.path.join(self.SAMPLE_FILES, "encrypted.pdf"),
+            "application/pdf",
         )
 
         self.assertIsNone(parser.archive_path)
@@ -178,7 +190,8 @@ class TestParser(DirectoriesMixin, TestCase):
     def test_with_form_error_notext(self):
         parser = RasterisedDocumentParser(None)
         parser.parse(
-            os.path.join(self.SAMPLE_FILES, "with-form.pdf"), "application/pdf"
+            os.path.join(self.SAMPLE_FILES, "with-form.pdf"),
+            "application/pdf",
         )
 
         self.assertContainsStrings(
@@ -191,7 +204,8 @@ class TestParser(DirectoriesMixin, TestCase):
         parser = RasterisedDocumentParser(None)
 
         parser.parse(
-            os.path.join(self.SAMPLE_FILES, "with-form.pdf"), "application/pdf"
+            os.path.join(self.SAMPLE_FILES, "with-form.pdf"),
+            "application/pdf",
         )
 
         self.assertContainsStrings(
@@ -221,7 +235,7 @@ class TestParser(DirectoriesMixin, TestCase):
         parser = RasterisedDocumentParser(None)
 
         dpi = parser.calculate_a4_dpi(
-            os.path.join(self.SAMPLE_FILES, "simple-no-dpi.png")
+            os.path.join(self.SAMPLE_FILES, "simple-no-dpi.png"),
         )
 
         self.assertEqual(dpi, 62)
@@ -233,7 +247,8 @@ class TestParser(DirectoriesMixin, TestCase):
 
         def f():
             parser.parse(
-                os.path.join(self.SAMPLE_FILES, "simple-no-dpi.png"), "image/png"
+                os.path.join(self.SAMPLE_FILES, "simple-no-dpi.png"),
+                "image/png",
             )
 
         self.assertRaises(ParseError, f)
@@ -247,68 +262,80 @@ class TestParser(DirectoriesMixin, TestCase):
         self.assertTrue(os.path.isfile(parser.archive_path))
 
         self.assertContainsStrings(
-            parser.get_text().lower(), ["this is a test document."]
+            parser.get_text().lower(),
+            ["this is a test document."],
         )
 
     def test_multi_page(self):
         parser = RasterisedDocumentParser(None)
         parser.parse(
-            os.path.join(self.SAMPLE_FILES, "multi-page-digital.pdf"), "application/pdf"
+            os.path.join(self.SAMPLE_FILES, "multi-page-digital.pdf"),
+            "application/pdf",
         )
         self.assertTrue(os.path.isfile(parser.archive_path))
         self.assertContainsStrings(
-            parser.get_text().lower(), ["page 1", "page 2", "page 3"]
+            parser.get_text().lower(),
+            ["page 1", "page 2", "page 3"],
         )
 
     @override_settings(OCR_PAGES=2, OCR_MODE="skip")
     def test_multi_page_pages_skip(self):
         parser = RasterisedDocumentParser(None)
         parser.parse(
-            os.path.join(self.SAMPLE_FILES, "multi-page-digital.pdf"), "application/pdf"
+            os.path.join(self.SAMPLE_FILES, "multi-page-digital.pdf"),
+            "application/pdf",
         )
         self.assertTrue(os.path.isfile(parser.archive_path))
         self.assertContainsStrings(
-            parser.get_text().lower(), ["page 1", "page 2", "page 3"]
+            parser.get_text().lower(),
+            ["page 1", "page 2", "page 3"],
         )
 
     @override_settings(OCR_PAGES=2, OCR_MODE="redo")
     def test_multi_page_pages_redo(self):
         parser = RasterisedDocumentParser(None)
         parser.parse(
-            os.path.join(self.SAMPLE_FILES, "multi-page-digital.pdf"), "application/pdf"
+            os.path.join(self.SAMPLE_FILES, "multi-page-digital.pdf"),
+            "application/pdf",
         )
         self.assertTrue(os.path.isfile(parser.archive_path))
         self.assertContainsStrings(
-            parser.get_text().lower(), ["page 1", "page 2", "page 3"]
+            parser.get_text().lower(),
+            ["page 1", "page 2", "page 3"],
         )
 
     @override_settings(OCR_PAGES=2, OCR_MODE="force")
     def test_multi_page_pages_force(self):
         parser = RasterisedDocumentParser(None)
         parser.parse(
-            os.path.join(self.SAMPLE_FILES, "multi-page-digital.pdf"), "application/pdf"
+            os.path.join(self.SAMPLE_FILES, "multi-page-digital.pdf"),
+            "application/pdf",
         )
         self.assertTrue(os.path.isfile(parser.archive_path))
         self.assertContainsStrings(
-            parser.get_text().lower(), ["page 1", "page 2", "page 3"]
+            parser.get_text().lower(),
+            ["page 1", "page 2", "page 3"],
         )
 
     @override_settings(OOCR_MODE="skip")
     def test_multi_page_analog_pages_skip(self):
         parser = RasterisedDocumentParser(None)
         parser.parse(
-            os.path.join(self.SAMPLE_FILES, "multi-page-images.pdf"), "application/pdf"
+            os.path.join(self.SAMPLE_FILES, "multi-page-images.pdf"),
+            "application/pdf",
         )
         self.assertTrue(os.path.isfile(parser.archive_path))
         self.assertContainsStrings(
-            parser.get_text().lower(), ["page 1", "page 2", "page 3"]
+            parser.get_text().lower(),
+            ["page 1", "page 2", "page 3"],
         )
 
     @override_settings(OCR_PAGES=2, OCR_MODE="redo")
     def test_multi_page_analog_pages_redo(self):
         parser = RasterisedDocumentParser(None)
         parser.parse(
-            os.path.join(self.SAMPLE_FILES, "multi-page-images.pdf"), "application/pdf"
+            os.path.join(self.SAMPLE_FILES, "multi-page-images.pdf"),
+            "application/pdf",
         )
         self.assertTrue(os.path.isfile(parser.archive_path))
         self.assertContainsStrings(parser.get_text().lower(), ["page 1", "page 2"])
@@ -318,7 +345,8 @@ class TestParser(DirectoriesMixin, TestCase):
     def test_multi_page_analog_pages_force(self):
         parser = RasterisedDocumentParser(None)
         parser.parse(
-            os.path.join(self.SAMPLE_FILES, "multi-page-images.pdf"), "application/pdf"
+            os.path.join(self.SAMPLE_FILES, "multi-page-images.pdf"),
+            "application/pdf",
         )
         self.assertTrue(os.path.isfile(parser.archive_path))
         self.assertContainsStrings(parser.get_text().lower(), ["page 1"])
@@ -329,29 +357,34 @@ class TestParser(DirectoriesMixin, TestCase):
     def test_skip_noarchive_withtext(self):
         parser = RasterisedDocumentParser(None)
         parser.parse(
-            os.path.join(self.SAMPLE_FILES, "multi-page-digital.pdf"), "application/pdf"
+            os.path.join(self.SAMPLE_FILES, "multi-page-digital.pdf"),
+            "application/pdf",
         )
         self.assertIsNone(parser.archive_path)
         self.assertContainsStrings(
-            parser.get_text().lower(), ["page 1", "page 2", "page 3"]
+            parser.get_text().lower(),
+            ["page 1", "page 2", "page 3"],
         )
 
     @override_settings(OCR_MODE="skip_noarchive")
     def test_skip_noarchive_notext(self):
         parser = RasterisedDocumentParser(None)
         parser.parse(
-            os.path.join(self.SAMPLE_FILES, "multi-page-images.pdf"), "application/pdf"
+            os.path.join(self.SAMPLE_FILES, "multi-page-images.pdf"),
+            "application/pdf",
         )
         self.assertTrue(os.path.isfile(parser.archive_path))
         self.assertContainsStrings(
-            parser.get_text().lower(), ["page 1", "page 2", "page 3"]
+            parser.get_text().lower(),
+            ["page 1", "page 2", "page 3"],
         )
 
     @override_settings(OCR_MODE="skip")
     def test_multi_page_mixed(self):
         parser = RasterisedDocumentParser(None)
         parser.parse(
-            os.path.join(self.SAMPLE_FILES, "multi-page-mixed.pdf"), "application/pdf"
+            os.path.join(self.SAMPLE_FILES, "multi-page-mixed.pdf"),
+            "application/pdf",
         )
         self.assertTrue(os.path.isfile(parser.archive_path))
         self.assertContainsStrings(
@@ -368,11 +401,13 @@ class TestParser(DirectoriesMixin, TestCase):
     def test_multi_page_mixed_no_archive(self):
         parser = RasterisedDocumentParser(None)
         parser.parse(
-            os.path.join(self.SAMPLE_FILES, "multi-page-mixed.pdf"), "application/pdf"
+            os.path.join(self.SAMPLE_FILES, "multi-page-mixed.pdf"),
+            "application/pdf",
         )
         self.assertIsNone(parser.archive_path)
         self.assertContainsStrings(
-            parser.get_text().lower(), ["page 4", "page 5", "page 6"]
+            parser.get_text().lower(),
+            ["page 4", "page 5", "page 6"],
         )
 
     @override_settings(OCR_MODE="skip", OCR_ROTATE_PAGES=True)

--- a/src/paperless_text/apps.py
+++ b/src/paperless_text/apps.py
@@ -1,5 +1,4 @@
 from django.apps import AppConfig
-
 from paperless_text.signals import text_consumer_declaration
 
 

--- a/src/paperless_text/parsers.py
+++ b/src/paperless_text/parsers.py
@@ -1,9 +1,10 @@
 import os
 
-from PIL import ImageDraw, ImageFont, Image
 from django.conf import settings
-
 from documents.parsers import DocumentParser
+from PIL import Image
+from PIL import ImageDraw
+from PIL import ImageFont
 
 
 class TextDocumentParser(DocumentParser):

--- a/src/paperless_text/tests/test_parser.py
+++ b/src/paperless_text/tests/test_parser.py
@@ -1,7 +1,6 @@
 import os
 
 from django.test import TestCase
-
 from documents.tests.utils import DirectoriesMixin
 from paperless_text.parsers import TextDocumentParser
 
@@ -13,7 +12,8 @@ class TestTextParser(DirectoriesMixin, TestCase):
 
         # just make sure that it does not crash
         f = parser.get_thumbnail(
-            os.path.join(os.path.dirname(__file__), "samples", "test.txt"), "text/plain"
+            os.path.join(os.path.dirname(__file__), "samples", "test.txt"),
+            "text/plain",
         )
         self.assertTrue(os.path.isfile(f))
 
@@ -22,7 +22,8 @@ class TestTextParser(DirectoriesMixin, TestCase):
         parser = TextDocumentParser(None)
 
         parser.parse(
-            os.path.join(os.path.dirname(__file__), "samples", "test.txt"), "text/plain"
+            os.path.join(os.path.dirname(__file__), "samples", "test.txt"),
+            "text/plain",
         )
 
         self.assertEqual(parser.get_text(), "This is a test file.\n")

--- a/src/paperless_tika/signals.py
+++ b/src/paperless_tika/signals.py
@@ -10,12 +10,12 @@ def tika_consumer_declaration(sender, **kwargs):
         "weight": 10,
         "mime_types": {
             "application/msword": ".doc",
-            "application/vnd.openxmlformats-officedocument.wordprocessingml.document": ".docx",  # NOQA: E501
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document": ".docx",  # noqa: E501
             "application/vnd.ms-excel": ".xls",
-            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": ".xlsx",  # NOQA: E501
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": ".xlsx",  # noqa: E501
             "application/vnd.ms-powerpoint": ".ppt",
-            "application/vnd.openxmlformats-officedocument.presentationml.presentation": ".pptx",  # NOQA: E501
-            "application/vnd.openxmlformats-officedocument.presentationml.slideshow": ".ppsx",  # NOQA: E501
+            "application/vnd.openxmlformats-officedocument.presentationml.presentation": ".pptx",  # noqa: E501
+            "application/vnd.openxmlformats-officedocument.presentationml.slideshow": ".ppsx",  # noqa: E501
             "application/vnd.oasis.opendocument.presentation": ".odp",
             "application/vnd.oasis.opendocument.spreadsheet": ".ods",
             "application/vnd.oasis.opendocument.text": ".odt",

--- a/src/paperless_tika/tests/test_tika_parser.py
+++ b/src/paperless_tika/tests/test_tika_parser.py
@@ -4,9 +4,8 @@ from pathlib import Path
 from unittest import mock
 
 from django.test import TestCase
-from requests import Response
-
 from paperless_tika.parsers import TikaDocumentParser
+from requests import Response
 
 
 class TestTikaParser(TestCase):
@@ -42,14 +41,15 @@ class TestTikaParser(TestCase):
     @mock.patch("paperless_tika.parsers.parser.from_file")
     def test_metadata(self, from_file):
         from_file.return_value = {
-            "metadata": {"Creation-Date": "2020-11-21", "Some-key": "value"}
+            "metadata": {"Creation-Date": "2020-11-21", "Some-key": "value"},
         }
 
         file = os.path.join(self.parser.tempdir, "input.odt")
         Path(file).touch()
 
         metadata = self.parser.extract_metadata(
-            file, "application/vnd.oasis.opendocument.text"
+            file,
+            "application/vnd.oasis.opendocument.text",
         )
 
         self.assertTrue("Creation-Date" in [m["key"] for m in metadata])


### PR DESCRIPTION
This pull runs the new pre-commit hooks against the Python files.  Obviously, it's a large diff, but the tests all pass, so I'm confident in the changes.

While running, I found 2 conflicts in the hook configuration.  `black` adds some whitespace around the ":" but `flake8` doesn't like that.  So E203 is now ignored.  `black` also likes to split lines on binary operators, but `flake8` doesn't like that (but [it will someday](https://www.flake8rules.com/rules/W503.html).  So now W503 is ignored too.  These changes actually align the hooks a little better with `pycodestyle` from the CI.

See #182 for the addition of the hooks.