### PR TITLE
Updates to use GHA Python caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       -
         name: Install dependencies
         run: |
-          pipenv install --dev --ignore-pipfile
+          pipenv sync --dev
       -
         name: Make documentation
         run: |
@@ -63,7 +63,7 @@ jobs:
       -
         name: Install dependencies
         run: |
-          pipenv install --dev --ignore-pipfile
+          pipenv sync --dev
       -
         name: Codestyle
         run: |
@@ -110,7 +110,7 @@ jobs:
       -
         name: Install Python dependencies
         run: |
-          pipenv install --dev --ignore-pipfile
+          pipenv sync --dev
       -
         name: Tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,33 +107,29 @@ jobs:
         name: Checkout
         uses: actions/checkout@v2
       -
+        name: Install pipenv
+        run: pip install pipenv
+      -
         name: Set up Python
         uses: actions/setup-python@v2
         with:
           python-version: "${{ matrix.python-version }}"
+          cache: "pipenv"
       -
-        name: Get pip cache dir
-        id: pip-cache
-        run: |
-          echo "::set-output name=dir::$(pip cache dir)"
-      -
-        name: Persistent Github pip cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-pip${{ matrix.python-version }}
-      -
-        name: Install dependencies
+        name: Install system dependencies
         run: |
           sudo apt-get update -qq
           sudo apt-get install -qq --no-install-recommends unpaper tesseract-ocr imagemagick ghostscript optipng
+      -
+        name: Install Python dependencies
+        run: |
           pip install --upgrade pipenv
-          pipenv install --system --dev --ignore-pipfile
+          pipenv install --dev --ignore-pipfile
       -
         name: Tests
         run: |
           cd src/
-          pytest
+          pipenv run pytest
       -
         name: Publish coverage results
         if: matrix.python-version == '3.9'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
         # https://github.com/coveralls-clients/coveralls-python/issues/251
         run: |
           cd src/
-          coveralls --service=github
+          pipenv run coveralls --service=github
 
   # build and push image to docker hub.
   build-docker-image:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,31 +19,24 @@ jobs:
         name: Checkout
         uses: actions/checkout@v2
       -
+        name: Install pipenv
+        run: pipx install pipenv
+      -
         name: Set up Python
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
-      -
-        name: Get pip cache dir
-        id: pip-cache
-        run: |
-          echo "::set-output name=dir::$(pip cache dir)"
-      -
-        name: Persistent Github pip cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-pip3.8}
+          cache: "pipenv"
+          cache-dependency-path: 'Pipfile.lock'
       -
         name: Install dependencies
         run: |
-          pip install --upgrade pipenv
-          pipenv install --system --dev --ignore-pipfile
+          pipenv install --dev --ignore-pipfile
       -
         name: Make documentation
         run: |
           cd docs/
-          make html
+          pipenv run make html
       -
         name: Upload artifact
         uses: actions/upload-artifact@v2
@@ -58,31 +51,24 @@ jobs:
         name: Checkout
         uses: actions/checkout@v2
       -
+        name: Install pipenv
+        run: pipx install pipenv
+      -
         name: Set up Python
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
-      -
-        name: Get pip cache dir
-        id: pip-cache
-        run: |
-          echo "::set-output name=dir::$(pip cache dir)"
-      -
-        name: Persistent Github pip cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-pip${{ matrix.python-version }}
+          cache: "pipenv"
+          cache-dependency-path: 'Pipfile.lock'
       -
         name: Install dependencies
         run: |
-          pip install --upgrade pipenv
-          pipenv install --system --dev --ignore-pipfile
+          pipenv install --dev --ignore-pipfile
       -
         name: Codestyle
         run: |
           cd src/
-          pycodestyle --max-line-length=88 --ignore=E121,E123,E126,E226,E24,E704,W503,W504,E203
+          pipenv run pycodestyle --max-line-length=88 --ignore=E121,E123,E126,E226,E24,E704,W503,W504,E203
   codeformatting:
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,13 +108,14 @@ jobs:
         uses: actions/checkout@v2
       -
         name: Install pipenv
-        run: pip install pipenv
+        run: pipx install pipenv
       -
         name: Set up Python
         uses: actions/setup-python@v2
         with:
           python-version: "${{ matrix.python-version }}"
           cache: "pipenv"
+          cache-dependency-path: 'Pipfile.lock'
       -
         name: Install system dependencies
         run: |
@@ -123,7 +124,6 @@ jobs:
       -
         name: Install Python dependencies
         run: |
-          pip install --upgrade pipenv
           pipenv install --dev --ignore-pipfile
       -
         name: Tests


### PR DESCRIPTION
This pull request updates our Github Actions workflow file a bit.  As a [some what new feature](https://github.blog/changelog/2021-11-23-github-actions-setup-python-now-supports-dependency-caching/) the `actions/setup-python` can now handle doing the caching for us, just tell it its pipenv.

This means we can cache the whole venv and even share that cache for the documentation and codestyle steps.

Contrast the [latest dev timing](https://github.com/paperless-ngx/paperless-ngx/actions/runs/1973809486) to [the last run on this branch](https://github.com/stumpylog/paperless-ngx/actions/runs/1974865440).  It's a highly noticeable savings for the docs and codestyle steps, but we see some savings in the test matrix as well.

[Further docs on the caching setup](https://github.com/actions/setup-python#caching-packages-dependencies)