### PR TITLE
Enable dependabot GHA updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,3 +26,13 @@ updates:
     labels:
       - "backend"
       - "dependencies"
+
+  # Enable updates for Github Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every month
+      interval: "monthly"
+    labels:
+      - "ci-cd"
+      - "dependencies"


### PR DESCRIPTION
Pretty much as the title says, this enables dependabot to check our used Github Actions versions.  I set it to be monthly, since we don't use very specific versions and I doubt these see a lot of major version updates.

[Docs reference](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/keeping-your-actions-up-to-date-with-dependabot)