### PR TITLE
Align CI checks with pre-commit (mostly)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,45 +44,68 @@ jobs:
           name: documentation
           path: docs/_build/html/
 
-  codestyle:
+  backend-code-checks:
+    name: "Backend Code Checks"
     runs-on: ubuntu-20.04
     steps:
       -
         name: Checkout
         uses: actions/checkout@v2
       -
-        name: Install pipenv
-        run: pipx install pipenv
-      -
-        name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
-          cache: "pipenv"
-          cache-dependency-path: 'Pipfile.lock'
-      -
-        name: Install dependencies
+        name: Install checkers
         run: |
-          pipenv sync --dev
+          pipx install reorder-python-imports
+          pipx install yesqa
+          pipx install add-trailing-comma
+          pipx install flake8
       -
-        name: Codestyle
+        name: Run reorder-python-imports
         run: |
-          cd src/
-          pipenv run pycodestyle --max-line-length=88 --ignore=E121,E123,E126,E226,E24,E704,W503,W504,E203
-  codeformatting:
-    runs-on: ubuntu-20.04
-    steps:
+          find src/ -type f -name '*.py' ! -path "*/migrations/*" | xargs reorder-python-imports
       -
-        name: Checkout
-        uses: actions/checkout@v2
+        name: Run yesqa
+        run: |
+          find src/ -type f -name '*.py' ! -path "*/migrations/*" | xargs yesqa
+      -
+        name: Run add-trailing-comma
+        run: |
+          find src/ -type f -name '*.py' ! -path "*/migrations/*" | xargs add-trailing-comma
+      # black is placed after add-trailing-comma because it may format differently
+      # if a trailing comma is added
       -
         name: Run black
         uses: psf/black@stable
         with:
           options: "--check --diff"
           version: "22.1.0"
+      -
+        name: Run flake8 checks
+        run: |
+          cd src/
+          flake8 --max-line-length=88 --ignore=E203,W503
 
-  tests:
+  frontend-code-checks:
+    name: "Frontend Code Checks"
+    runs-on: ubuntu-20.04
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+      -
+        name: Install prettier
+        run: |
+          npm install prettier
+      -
+        name: Run prettier
+        run:
+          npx prettier --check --ignore-path Pipfile.lock **/*.js **/*.ts *.md **/*.md
+
+  backend-tests:
+    needs: [backend-code-checks]
+    name: "Backend Tests (${{ matrix.python-version }})"
     runs-on: ubuntu-20.04
     strategy:
       matrix:
@@ -130,7 +153,7 @@ jobs:
   build-docker-image:
     if: github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/feature-') || github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/beta' || startsWith(github.ref, 'refs/tags/ngx-') || startsWith(github.ref, 'refs/tags/beta-'))
     runs-on: ubuntu-latest
-    needs: [tests, codeformatting, codestyle]
+    needs: [backend-tests, frontend-code-checks]
     steps:
       -
         name: Prepare
@@ -195,7 +218,7 @@ jobs:
           path: src/documents/static/frontend/
 
   build-release:
-    needs: [build-docker-image, documentation, tests, codeformatting, codestyle]
+    needs: [build-docker-image, documentation, backend-tests, backend-code-checks, frontend-code-checks]
     runs-on: ubuntu-20.04
     steps:
       -

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,9 +30,6 @@ repos:
     rev: "v2.5.1"
     hooks:
       - id: prettier
-        args:
-          - "--no-semi"
-          - "--single-quote"
         types_or:
           - javascript
           - ts
@@ -59,10 +56,8 @@ repos:
     hooks:
       - id: flake8
         files: ^src/
-        exclude: "(migrations)|(paperless/settings.py)|(.*\\.tox)|(.*/tests/.*)"
         args:
-          - "--max-line-length=88"
-          - "--ignore=E203,W503"
+          - "--config=./src/setup.cfg"
   - repo: https://github.com/psf/black
     rev: 22.1.0
     hooks:

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+# https://prettier.io/docs/en/options.html#semicolons
+semi: false
+# https://prettier.io/docs/en/options.html#quotes
+singleQuote: true

--- a/src/setup.cfg
+++ b/src/setup.cfg
@@ -1,12 +1,15 @@
-[pycodestyle]
-exclude = migrations, paperless/settings.py, .tox, */tests/*
+[flake8]
+extend-exclude = */migrations/*, paperless/settings.py, */tests/*
+# E203 - https://www.flake8rules.com/rules/E203.html
+# W503 - https://www.flake8rules.com/rules/W503.html
+ignore = E203,W503
+max-line-length = 88
 
 [tool:pytest]
 DJANGO_SETTINGS_MODULE=paperless.settings
 addopts = --pythonwarnings=all --cov --cov-report=html -n auto
 env =
   PAPERLESS_DISABLE_DBHANDLER=true
-
 
 [coverage:run]
 source =


### PR DESCRIPTION
This pull request re-works the Github Actions so we can double check at least some of the formatting and checks for both backend and frontend code, plus some checks against documentation for pushes and pull requests.

Best [viewed in the graph form](https://github.com/stumpylog/paperless-ngx/actions/runs/1978360726), the following checks now run:
* Backend Code Checks
  * reorder-python-imports
  * yesqa
  * add-trailing-comma
  * black
  * flake8
* Frontend Code Checks
  * prettier (over JS, TS and MD files)

Additionally, the dependencies were updated a bit between the jobs so backend things block backend, etc.

Finally, I was able to tweak, modify and add some configuration files so there less duplication between `.pre-commit-config.yaml`, `ci.yml`, `.prettierrc` and `setup.cfg` settings.  There's still some, but it's more configured in a single location now.