### PR TITLE
Fix dependabot tests under Python 3.8

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -46,6 +46,9 @@ channels-redis = "*"
 uvicorn = {extras = ["standard"], version = "*"}
 concurrent-log-handler = "*"
 "pdfminer.six" = "*"
+"backports.zoneinfo" = {version = "*", markers = "python_version < '3.9'"}
+"importlib-resources" = {version = "*", markers = "python_version < '3.9'"}
+zipp = {version = "*", markers = "python_version < '3.9'"}
 
 [dev-packages]
 coveralls = "*"


### PR DESCRIPTION
## The Problem

Python 3.8 tests in dependabot version bump PRs are failing.  Errors I see:
* `ModuleNotFoundError: No module named 'backports'`
* `ModuleNotFoundError: No module named 'importlib_resources'`
* `ModuleNotFoundError: No module named 'zipp'`

## The Solution

I kind up beat up dependabot [over here on my fork](https://github.com/stumpylog/paperless-ngx/pull/29).

With the addition of the dependencies below, under certain Python versions, seems to have fixed it.  
1. We need `backports.zoneinfo`, because Python 3.8 doesn't include `zoneinfo` in the stdlib and `pytz` needs `zoneinfo`
2. `ocrmypdf` needs `importlib-resources` in 3.8 as well, but in 3.9 some of it has moved in the stdlib
3. `importlib-resources` needs `zipp`

I pushed [this commit](https://github.com/stumpylog/paperless-ngx/commit/6e992eb62b70b02e7b73a741884142e95d476083) to my dev, then had dependabot recreate its pull request.  All tests then passed.  Examining [Pipfile.lock in pull request](https://github.com/stumpylog/paperless-ngx/blob/e658b0276ebc7981f61475b4764ae59cec8e0b30/Pipfile.lock), we can see the packages Python 3.8 tests were failing to import still exist in the lockfile after dependabot was through.

Why on earth these dependabot is removing these packages, I couldn't say.  `ocrmypdf` [includes `importlib-resources`](https://github.com/ocrmypdf/OCRmyPDF/blob/13917c051c91e677b245d2e57098d6b8ab316e0d/setup.cfg) as a requirement.  `dateparser` requires `tzlocal` which requires `backports.zoneinfo`.  Maybe dependabot uses a newer version of Python to lock the file, so these get dropped?  Based on some research, there's not a documented way to tell dependabot about Python versions.

After merging, the dependabot PRs can be recreated and they should work.