### PR TITLE
Update @ngneat/dirty-check-forms to 2.0.0

### DIFF
--- a/src-ui/package-lock.json
+++ b/src-ui/package-lock.json
@@ -19,7 +19,7 @@
         "@angular/router": "~13.2.6",
         "@ng-bootstrap/ng-bootstrap": "^12.0.0",
         "@ng-select/ng-select": "^8.1.1",
-        "@ngneat/dirty-check-forms": "^1.1.0",
+        "@ngneat/dirty-check-forms": "^2.0.0",
         "@popperjs/core": "^2.11.4",
         "bootstrap": "^5.1.3",
         "file-saver": "^2.0.5",
@@ -2499,11 +2499,17 @@
       }
     },
     "node_modules/@ngneat/dirty-check-forms": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@ngneat/dirty-check-forms/-/dirty-check-forms-1.1.0.tgz",
-      "integrity": "sha512-Ak6SUMUV2oFlaylhUnar1yT4ahmq3Y2mHrd9uQHesE0iUZWfQTrIN07kMtwyT2JXR/x4RqdAmvp/+IJ+QlUPGg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@ngneat/dirty-check-forms/-/dirty-check-forms-2.0.0.tgz",
+      "integrity": "sha512-9i3lUA/g+CwZry+iOG/diiM4K14+3JBsuuDU007gx60kxHJQCVUKZckILZCXA5O092KzqdaAfli4DVrMS3LVoA==",
+      "dependencies": {
+        "tslib": ">=2.0.0"
+      },
       "peerDependencies": {
-        "tslib": "^1.10.0"
+        "@angular/core": ">=13.0.0",
+        "@angular/forms": ">=13.0.0",
+        "@angular/router": ">=13.0.0",
+        "rxjs": ">=6.0.0"
       }
     },
     "node_modules/@ngtools/webpack": {
@@ -14926,10 +14932,12 @@
       }
     },
     "@ngneat/dirty-check-forms": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@ngneat/dirty-check-forms/-/dirty-check-forms-1.1.0.tgz",
-      "integrity": "sha512-Ak6SUMUV2oFlaylhUnar1yT4ahmq3Y2mHrd9uQHesE0iUZWfQTrIN07kMtwyT2JXR/x4RqdAmvp/+IJ+QlUPGg==",
-      "requires": {}
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@ngneat/dirty-check-forms/-/dirty-check-forms-2.0.0.tgz",
+      "integrity": "sha512-9i3lUA/g+CwZry+iOG/diiM4K14+3JBsuuDU007gx60kxHJQCVUKZckILZCXA5O092KzqdaAfli4DVrMS3LVoA==",
+      "requires": {
+        "tslib": ">=2.0.0"
+      }
     },
     "@ngtools/webpack": {
       "version": "13.2.6",

--- a/src-ui/package.json
+++ b/src-ui/package.json
@@ -22,7 +22,7 @@
     "@angular/router": "~13.2.6",
     "@ng-bootstrap/ng-bootstrap": "^12.0.0",
     "@ng-select/ng-select": "^8.1.1",
-    "@ngneat/dirty-check-forms": "^1.1.0",
+    "@ngneat/dirty-check-forms": "^2.0.0",
     "@popperjs/core": "^2.11.4",
     "bootstrap": "^5.1.3",
     "file-saver": "^2.0.5",


### PR DESCRIPTION
## Proposed change

This PR updates one of our dependencies @ngneat/dirty-check-forms which just was updated to be compatible with Angular 13. Mostly its just one less dependabot alert =) Code is tested and verified.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Dependency update

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/contributing.html#pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
