### PR TITLE
Fix imap tools bug

### DIFF
--- a/src/paperless_mail/mail.py
+++ b/src/paperless_mail/mail.py
@@ -16,6 +16,7 @@ from imap_tools import AND
 from imap_tools import MailBox
 from imap_tools import MailboxFolderSelectError
 from imap_tools import MailBoxUnencrypted
+from imap_tools import MailMessage
 from imap_tools import MailMessageFlags
 from paperless_mail.models import MailAccount
 from paperless_mail.models import MailRule
@@ -122,7 +123,7 @@ class MailAccountHandler(LoggingMixin):
                 "Unknown title selector.",
             )  # pragma: nocover
 
-    def get_correspondent(self, message, rule):
+    def get_correspondent(self, message: MailMessage, rule):
         c_from = rule.assign_correspondent_from
 
         if c_from == MailRule.CORRESPONDENT_FROM_NOTHING:
@@ -132,12 +133,9 @@ class MailAccountHandler(LoggingMixin):
             return self._correspondent_from_name(message.from_)
 
         elif c_from == MailRule.CORRESPONDENT_FROM_NAME:
-            if (
-                message.from_values
-                and "name" in message.from_values
-                and message.from_values["name"]
-            ):
-                return self._correspondent_from_name(message.from_values["name"])
+            from_values = message.from_values
+            if from_values is not None and len(from_values.name) > 0:
+                return self._correspondent_from_name(from_values.name)
             else:
                 return self._correspondent_from_name(message.from_)
 


### PR DESCRIPTION
## Proposed change

This updates the mail handling to account for a change introduced by `imap_tools` where the `from_values` field was changed from a `dict` to an `EmailAddress`.  This leads to the bug in question because we can no longer ask if a value is `in` the object.

The mail testing is now updated so it builds up an email address using the same type as `imap_tools` instead of using a namedtuple with fields we control.  That should assist in catching such bugs earlier next time.

Beyond the unit tests, I haven't tested the fix, as I don't have a setup using email consumption.  So if anyone is able to, that would be great.

Fixes #377 and probably fixes #293

@paperless-ngx/backend

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/contributing.html#pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
