### PR TITLE
Add minimum length for documents text filter

### DIFF
--- a/src-ui/src/app/components/document-list/filter-editor/filter-editor.component.ts
+++ b/src-ui/src/app/components/document-list/filter-editor/filter-editor.component.ts
@@ -12,7 +12,7 @@ import { PaperlessTag } from 'src/app/data/paperless-tag'
 import { PaperlessCorrespondent } from 'src/app/data/paperless-correspondent'
 import { PaperlessDocumentType } from 'src/app/data/paperless-document-type'
 import { Subject, Subscription } from 'rxjs'
-import { debounceTime, distinctUntilChanged } from 'rxjs/operators'
+import { debounceTime, distinctUntilChanged, filter } from 'rxjs/operators'
 import { DocumentTypeService } from 'src/app/services/rest/document-type.service'
 import { TagService } from 'src/app/services/rest/tag.service'
 import { CorrespondentService } from 'src/app/services/rest/correspondent.service'
@@ -422,7 +422,11 @@ export class FilterEditorComponent implements OnInit, OnDestroy {
     this.textFilterDebounce = new Subject<string>()
 
     this.subscription = this.textFilterDebounce
-      .pipe(debounceTime(400), distinctUntilChanged())
+      .pipe(
+        debounceTime(400),
+        distinctUntilChanged(),
+        filter((query) => !query.length || query.length > 2)
+      )
       .subscribe((text) => {
         this._textFilter = text
         this.documentService.searchQuery = text


### PR DESCRIPTION
## Proposed change

This PR adds a minimum length on the text search field for the filter editor discussed in #288, i.e. it prevents the 'auto' searching with strings of only 1 / 2 characters. The minimum length is set to 3 currently.

I debated adding some kind of 'notification' to the user with strings < 3 chars, like a tooltip or validation but ultimately thought it was clutter. My feeling is most people aren't surprised when theres a minimum length and as soon as you type 3 characters you realize the requirement and never really think about it again =) Welcome other thoughts.

Fixes #288 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] ~~If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).~~
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/contributing.html#pre-commit-hooks).
- [ ] ~~I have made corresponding changes to the documentation as needed.~~
- [x] I have checked my modifications for any breaking changes.
