### PR TITLE
Use progress bar for delayed buttons

### DIFF
--- a/src-ui/src/app/components/common/confirm-dialog/confirm-dialog.component.html
+++ b/src-ui/src/app/components/common/confirm-dialog/confirm-dialog.component.html
@@ -8,9 +8,12 @@
       <p *ngIf="message">{{message}}</p>
     </div>
     <div class="modal-footer">
-      <button type="button" class="btn btn-outline-secondary" (click)="cancel()" [disabled]="!buttonsEnabled" i18n>Cancel</button>
+      <button type="button" class="btn btn-outline-secondary" (click)="cancel()" [disabled]="!buttonsEnabled" i18n>
+        <span class="d-inline-block" style="padding-bottom: 1px;" >Cancel</span>
+      </button>
       <button type="button" class="btn" [class]="btnClass" (click)="confirm()" [disabled]="!confirmButtonEnabled || !buttonsEnabled">
         {{btnCaption}}
-        <span *ngIf="!confirmButtonEnabled"> ({{seconds}})</span>
+        <ngb-progressbar *ngIf="!confirmButtonEnabled" style="height: 1px;" type="dark" [max]="secondsTotal" [value]="seconds"></ngb-progressbar>
+        <span class="visually-hidden">{{ seconds | number: '1.0-0' }} seconds</span>
       </button>
     </div>

--- a/src-ui/src/app/components/common/confirm-dialog/confirm-dialog.component.ts
+++ b/src-ui/src/app/components/common/confirm-dialog/confirm-dialog.component.ts
@@ -1,6 +1,6 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core'
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap'
-import { Subject } from 'rxjs'
+import { interval, Subject, switchMap, take } from 'rxjs'
 
 @Component({
   selector: 'app-confirm-dialog',
@@ -33,19 +33,28 @@ export class ConfirmDialogComponent {
 
   confirmButtonEnabled = true
   seconds = 0
+  secondsTotal = 0
 
   confirmSubject: Subject<boolean>
 
   delayConfirm(seconds: number) {
-    this.confirmButtonEnabled = false
+    const refreshInterval = 0.15 // s
+
+    this.secondsTotal = seconds
     this.seconds = seconds
-    setTimeout(() => {
-      if (this.seconds <= 1) {
-        this.confirmButtonEnabled = true
-      } else {
-        this.delayConfirm(seconds - 1)
-      }
-    }, 1000)
+
+    interval(refreshInterval * 1000)
+      .pipe(
+        take(this.secondsTotal / refreshInterval + 2) // need 2 more for animation to complete after 0
+      )
+      .subscribe((count) => {
+        this.seconds = Math.max(
+          0,
+          this.secondsTotal - refreshInterval * (count + 1)
+        )
+        this.confirmButtonEnabled =
+          this.secondsTotal - refreshInterval * count < 0
+      })
   }
 
   cancel() {


### PR DESCRIPTION
## Proposed change

This small PR changes the delayed button to use a small progress bar instead of numbers (X) which cause the button to change size. The seconds text is still included but hidden to maintain accessibility. Welcome all feedback, video comparison is below.

New:

https://user-images.githubusercontent.com/4887959/158684028-f188c1fd-9ffe-4a82-8770-e449cec757ab.mov

Old:

https://user-images.githubusercontent.com/4887959/158684110-f8152550-375b-41fc-a757-52e51ea07caf.mov


## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] ~~If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).~~
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/contributing.html#pre-commit-hooks).
- [ ] ~~I have made corresponding changes to the documentation as needed.~~
- [x] I have checked my modifications for any breaking changes.
