### PR TITLE
Allow shorter search strings with Enter key

### DIFF
--- a/src-ui/src/app/components/document-list/filter-editor/filter-editor.component.html
+++ b/src-ui/src/app/components/document-list/filter-editor/filter-editor.component.html
@@ -8,7 +8,7 @@
               <button *ngFor="let t of textFilterTargets" ngbDropdownItem [class.active]="textFilterTarget == t.id" (click)="changeTextFilterTarget(t.id)">{{t.name}}</button>
             </div>
           </div>
-          <input #textFilterInput class="form-control form-control-sm" type="text" [(ngModel)]="textFilter" [readonly]="textFilterTarget == 'fulltext-morelike'">
+          <input #textFilterInput class="form-control form-control-sm" type="text" [(ngModel)]="textFilter" (keyup.enter)="textFilterEnter()" [readonly]="textFilterTarget == 'fulltext-morelike'">
          </div>
      </div>
   </div>

--- a/src-ui/src/app/components/document-list/filter-editor/filter-editor.component.ts
+++ b/src-ui/src/app/components/document-list/filter-editor/filter-editor.component.ts
@@ -427,11 +427,7 @@ export class FilterEditorComponent implements OnInit, OnDestroy {
         distinctUntilChanged(),
         filter((query) => !query.length || query.length > 2)
       )
-      .subscribe((text) => {
-        this._textFilter = text
-        this.documentService.searchQuery = text
-        this.updateRules()
-      })
+      .subscribe((text) => this.updateTextFilter(text))
 
     if (this._textFilter) this.documentService.searchQuery = this._textFilter
   }
@@ -474,6 +470,21 @@ export class FilterEditorComponent implements OnInit, OnDestroy {
 
   onDocumentTypeDropdownOpen() {
     this.documentTypeSelectionModel.apply()
+  }
+
+  updateTextFilter(text) {
+    this._textFilter = text
+    this.documentService.searchQuery = text
+    this.updateRules()
+  }
+
+  textFilterEnter() {
+    const filterString = (
+      this.textFilterInput.nativeElement as HTMLInputElement
+    ).value
+    if (filterString.length) {
+      this.updateTextFilter(filterString)
+    }
   }
 
   changeTextFilterTarget(target) {


### PR DESCRIPTION
## Proposed change

This PR allows searching for shorter strings < 3 chars in the "filter" editor that was removed in PR #401 . See comments https://github.com/paperless-ngx/paperless-ngx/pull/401#issuecomment-1072363345 and https://github.com/paperless-ngx/paperless-ngx/pull/401#issuecomment-1072876582

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] ~~If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).~~
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/contributing.html#pre-commit-hooks).
- [ ] ~~I have made corresponding changes to the documentation as needed.~~
- [x] I have checked my modifications for any breaking changes.
