### PR TITLE
Change dependabot to check npm monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     directory: "/src-ui"
     # Check the npm registry for updates every week
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     # Add reviewers
     reviewers:
       - "paperless-ngx/frontend"


### PR DESCRIPTION
[ci skip]

## Proposed change
make dependabot check npm only monthly. Weekly seems overkill for this project. This was discussed in matrix chat, ofc open to input.

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (please explain)