### PR TITLE
Add arm64 compatible docker-compose for sqlite-tika - resubmission of #27

### DIFF
--- a/docker/compose/docker-compose.postgres-tika.yml
+++ b/docker/compose/docker-compose.postgres-tika.yml
@@ -1,4 +1,4 @@
-# docker-compose file for running paperless from the Docker Hub.
+# docker-compose file for running paperless from the docker container registry.
 # This file contains everything paperless needs to run.
 # Paperless supports amd64, arm and arm64 hardware. The apache/tika image
 # does not support arm or arm64, however.

--- a/docker/compose/docker-compose.postgres-tika.yml
+++ b/docker/compose/docker-compose.postgres-tika.yml
@@ -1,6 +1,7 @@
 # docker-compose file for running paperless from the Docker Hub.
 # This file contains everything paperless needs to run.
-# Paperless supports amd64, arm and arm64 hardware.
+# Paperless supports amd64, arm and arm64 hardware. The apache/tika image
+# does not support arm or arm64, however.
 #
 # All compose files of paperless configure paperless in the following way:
 #

--- a/docker/compose/docker-compose.sqlite-tika.arm.yml
+++ b/docker/compose/docker-compose.sqlite-tika.arm.yml
@@ -75,7 +75,7 @@ services:
       DISABLE_GOOGLE_CHROME: 1
 
   tika:
-    image: iwishiwasaneagle/apache-tika-arm
+    image: iwishiwasaneagle/apache-tika-arm@sha256:c1b16bcadcb97a08d47a09fc99bea4d47b63cec06bbf4f437b99c2c3b17181eb
     restart: unless-stopped
 
   media:

--- a/docker/compose/docker-compose.sqlite-tika.arm.yml
+++ b/docker/compose/docker-compose.sqlite-tika.arm.yml
@@ -39,9 +39,11 @@ services:
   broker:
     image: redis:6.0
     restart: unless-stopped
+    volumes:
+      - redisdata:/data
 
   webserver:
-    image: jonaswinkler/paperless-ng:latest
+    image: ghcr.io/paperless-ngx/paperless-ngx:latest
     restart: unless-stopped
     depends_on:
       - broker
@@ -76,6 +78,7 @@ services:
     image: iwishiwasaneagle/apache-tika-arm
     restart: unless-stopped
 
-volumes:
+  media:
+  redisdata:
   data:
   media:

--- a/docker/compose/docker-compose.sqlite-tika.arm.yml
+++ b/docker/compose/docker-compose.sqlite-tika.arm.yml
@@ -75,7 +75,7 @@ services:
       DISABLE_GOOGLE_CHROME: 1
 
   tika:
-    image: iwishiwasaneagle/apache-tika-arm@sha256:c1b16bcadcb97a08d47a09fc99bea4d47b63cec06bbf4f437b99c2c3b17181eb
+    image: iwishiwasaneagle/apache-tika-arm@sha256:a78c25ffe57ecb1a194b2859d42a61af46e9e845191512b8f1a4bf90578ffdfd
     restart: unless-stopped
 
 volumes:

--- a/docker/compose/docker-compose.sqlite-tika.arm.yml
+++ b/docker/compose/docker-compose.sqlite-tika.arm.yml
@@ -1,4 +1,4 @@
-# docker-compose file for running paperless from the Docker Hub.
+# docker-compose file for running paperless from the docker container registry.
 # This file contains everything paperless needs to run.
 # Paperless supports amd64, arm and arm64 hardware.
 #

--- a/docker/compose/docker-compose.sqlite-tika.arm.yml
+++ b/docker/compose/docker-compose.sqlite-tika.arm.yml
@@ -81,3 +81,4 @@ services:
 volumes:
   data:
   media:
+  redisdata:

--- a/docker/compose/docker-compose.sqlite-tika.arm.yml
+++ b/docker/compose/docker-compose.sqlite-tika.arm.yml
@@ -12,6 +12,9 @@
 #
 # SQLite is used as the database. The SQLite file is stored in the data volume.
 #
+# iwishiwasaneagle/apache-tika-arm docker image is used to enable arm64 arch
+# which apache/tika does not currently support.
+#
 # In addition to that, this docker-compose file adds the following optional
 # configurations:
 #

--- a/docker/compose/docker-compose.sqlite-tika.arm.yml
+++ b/docker/compose/docker-compose.sqlite-tika.arm.yml
@@ -1,0 +1,78 @@
+# docker-compose file for running paperless from the Docker Hub.
+# This file contains everything paperless needs to run.
+# Paperless supports amd64, arm and arm64 hardware.
+#
+# All compose files of paperless configure paperless in the following way:
+#
+# - Paperless is (re)started on system boot, if it was running before shutdown.
+# - Docker volumes for storing data are managed by Docker.
+# - Folders for importing and exporting files are created in the same directory
+#   as this file and mounted to the correct folders inside the container.
+# - Paperless listens on port 8000.
+#
+# SQLite is used as the database. The SQLite file is stored in the data volume.
+#
+# In addition to that, this docker-compose file adds the following optional
+# configurations:
+#
+# - Apache Tika and Gotenberg servers are started with paperless and paperless
+#   is configured to use these services. These provide support for consuming
+#   Office documents (Word, Excel, Power Point and their LibreOffice counter-
+#   parts.
+#
+# To install and update paperless with this file, do the following:
+#
+# - Copy this file as 'docker-compose.yml' and the files 'docker-compose.env'
+#   and '.env' into a folder.
+# - Run 'docker-compose pull'.
+# - Run 'docker-compose run --rm webserver createsuperuser' to create a user.
+# - Run 'docker-compose up -d'.
+#
+# For more extensive installation and update instructions, refer to the
+# documentation.
+
+version: "3.4"
+services:
+  broker:
+    image: redis:6.0
+    restart: unless-stopped
+
+  webserver:
+    image: jonaswinkler/paperless-ng:latest
+    restart: unless-stopped
+    depends_on:
+      - broker
+      - gotenberg
+      - tika
+    ports:
+      - 8000:8000
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+    volumes:
+      - data:/usr/src/paperless/data
+      - media:/usr/src/paperless/media
+      - ./export:/usr/src/paperless/export
+      - ./consume:/usr/src/paperless/consume
+    env_file: docker-compose.env
+    environment:
+      PAPERLESS_REDIS: redis://broker:6379
+      PAPERLESS_TIKA_ENABLED: 1
+      PAPERLESS_TIKA_GOTENBERG_ENDPOINT: http://gotenberg:3000
+      PAPERLESS_TIKA_ENDPOINT: http://tika:9998
+
+  gotenberg:
+    image: thecodingmachine/gotenberg
+    restart: unless-stopped
+    environment:
+      DISABLE_GOOGLE_CHROME: 1
+
+  tika:
+    image: iwishiwasaneagle/apache-tika-arm
+    restart: unless-stopped
+
+volumes:
+  data:
+  media:

--- a/docker/compose/docker-compose.sqlite-tika.arm.yml
+++ b/docker/compose/docker-compose.sqlite-tika.arm.yml
@@ -78,7 +78,6 @@ services:
     image: iwishiwasaneagle/apache-tika-arm@sha256:c1b16bcadcb97a08d47a09fc99bea4d47b63cec06bbf4f437b99c2c3b17181eb
     restart: unless-stopped
 
-  media:
-  redisdata:
+volumes:
   data:
   media:

--- a/docker/compose/docker-compose.sqlite-tika.yml
+++ b/docker/compose/docker-compose.sqlite-tika.yml
@@ -1,4 +1,4 @@
-# docker-compose file for running paperless from the Docker Hub.
+# docker-compose file for running paperless from the docker container registry.
 # This file contains everything paperless needs to run.
 # Paperless supports amd64, arm and arm64 hardware. The apache/tika image
 # does not support arm or arm64, however.

--- a/docker/compose/docker-compose.sqlite-tika.yml
+++ b/docker/compose/docker-compose.sqlite-tika.yml
@@ -1,6 +1,7 @@
 # docker-compose file for running paperless from the Docker Hub.
 # This file contains everything paperless needs to run.
-# Paperless supports amd64, arm and arm64 hardware.
+# Paperless supports amd64, arm and arm64 hardware. The apache/tika image
+# does not support arm or arm64, however.
 #
 # All compose files of paperless configure paperless in the following way:
 #

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -725,7 +725,7 @@ configuring some options in paperless can help improve performance immensely:
 *   If using docker, consider setting ``PAPERLESS_WEBSERVER_WORKERS`` to
     1. This will save some memory.
 *   Use the arm compatible docker-compose if you're wanting to use Tika on something like
-		a raspberry pi. The official apache/tika image doesn not support the arm architecture.
+		a raspberry pi. The official apache/tika image does not support the arm architecture.
 
 For details, refer to :ref:`configuration`.
 

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -724,6 +724,8 @@ configuring some options in paperless can help improve performance immensely:
     times. Thumbnails will be about 20% larger.
 *   If using docker, consider setting ``PAPERLESS_WEBSERVER_WORKERS`` to
     1. This will save some memory.
+*   Use the arm compatible docker-compose if you're wanting to use Tika on something like 
+		a raspberry pi. The official apache/tika image doesn not support the arm architecture.
 
 For details, refer to :ref:`configuration`.
 

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -724,7 +724,7 @@ configuring some options in paperless can help improve performance immensely:
     times. Thumbnails will be about 20% larger.
 *   If using docker, consider setting ``PAPERLESS_WEBSERVER_WORKERS`` to
     1. This will save some memory.
-*   Use the arm compatible docker-compose if you're wanting to use Tika on something like 
+*   Use the arm compatible docker-compose if you're wanting to use Tika on something like
 		a raspberry pi. The official apache/tika image doesn not support the arm architecture.
 
 For details, refer to :ref:`configuration`.


### PR DESCRIPTION
The old repo was still pointing towards paperless-ng, so a fork of paperless-ngx was made to apply changes requested during review of #27 

See also:
- https://github.com/paperless-ngx/paperless-ngx/pull/27#issuecomment-1074468974