### PR TITLE
Adds settings for worker retry time

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -540,6 +540,10 @@ PAPERLESS_WORKER_TIMEOUT=<num>
     large documents within the default 1800 seconds. So extending this timeout
     may prove to be useful on weak hardware setups.
 
+PAPERLESS_WORKER_RETRY=<num>
+    If PAPERLESS_WORKER_TIMEOUT has been configured, the retry time for a task can
+    also be configured.  By default, this value will be set to 10s more than the
+    worker timeout.  This value should never be set less than the worker timeout.
 
 PAPERLESS_TIME_ZONE=<timezone>
     Set the time zone here.


### PR DESCRIPTION
## Proposed change

This pull request adds configuration for the `django-q` worker retry time.  Previously, this value was a hardcoded default of 1800.  However, if `PAPERLESS_WORKER_TIMEOUT` is set, the retry time leads to warnings in the log.

Per the `django-q` docs, worker timeout must be less than worker retry.  Though this is now configurable, the "sensible" default of retry being 10s more than timeout was used.  This means for a user, setting `PAPERLESS_WORKER_TIMEOUT` alone should be sufficient and paperless will do the right thing.

Fixes #496

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
