### PR TITLE
Add API Scanning Setup section to scanners.rst

### DIFF
--- a/docs/scanners.rst
+++ b/docs/scanners.rst
@@ -130,5 +130,5 @@ This part assumes your Doxie is connected to WiFi and you know its IP.
 5. Add the username and password to the respective fields (Consider creating a user just for your Doxie)
 6. Click *Submit* at the bottom of the page
 
-Congrats, you can now scan directly from your Doxie to your Paperless-ng instance!
+Congrats, you can now scan directly from your Doxie to your Paperless-ngx instance!
 

--- a/docs/scanners.rst
+++ b/docs/scanners.rst
@@ -125,7 +125,7 @@ This part assumes your Doxie is connected to WiFi and you know its IP.
 
 1. Open your Doxie web UI by navigating to its IP address
 2. Navigate to Options -> Webhook
-3. Set the *URL* to ``https://[your-paperless-ng-instance]/api/documents/post_document/``
+3. Set the *URL* to ``https://[your-paperless-ngx-instance]/api/documents/post_document/``
 4. Set the *File Parameter Name* to ``document``
 5. Add the username and password to the respective fields (Consider creating a user just for your Doxie)
 6. Click *Submit* at the bottom of the page

--- a/docs/scanners.rst
+++ b/docs/scanners.rst
@@ -112,3 +112,23 @@ On Android, you can use these applications in combination with one of the :ref:`
 
 .. _hannahswain: https://github.com/hannahswain
 .. _benjaminfrank: https://github.com/benjaminfrank
+
+API Scanning Setup
+==================
+
+This sections contains information on how to set up scanners to post directly to :ref:`Paperless API <api-file_uploads>`.
+
+Doxie Q2
+--------
+
+This part assumes your Doxie is connected to WiFi and you know it's IP.
+
+1. Open your Doxie web UI by navigating to its IP address
+2. Navigate to Options -> Webhook
+3. Set the *URL* to ``https://[your-paperless-ng-instance]/api/documents/post_document/``
+4. Set the *File Parameter Name* to ``document``
+5. Add the username and password to the respective fields (Consider creating a user just for your Doxie)
+6. Click *Submit* at the bottom of the page
+
+Congrats, you can now scan directly from your Doxie to your Paperless-ng instance!
+

--- a/docs/scanners.rst
+++ b/docs/scanners.rst
@@ -121,7 +121,7 @@ This sections contains information on how to set up scanners to post directly to
 Doxie Q2
 --------
 
-This part assumes your Doxie is connected to WiFi and you know it's IP.
+This part assumes your Doxie is connected to WiFi and you know its IP.
 
 1. Open your Doxie web UI by navigating to its IP address
 2. Navigate to Options -> Webhook


### PR DESCRIPTION
## Proposed change

This PR adds an "API Scanning Setup" section to docs/scanners.rst with instructions on how to connect compatible scanners directly to the Paperless-ngx API.

This change is motivated by the fact I got multiple emails / DMs asking me how to set this up. Due to that I think it's beneficial to have this section in the official documentation.

## Type of change

- [x] Other (please explain)

Documentation update.

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
