### PR TITLE
Clickable tags in dashboard widgets

### DIFF
--- a/src-ui/src/app/components/dashboard/widgets/saved-view-widget/saved-view-widget.component.html
+++ b/src-ui/src/app/components/dashboard/widgets/saved-view-widget/saved-view-widget.component.html
@@ -13,7 +13,7 @@
     <tbody>
       <tr *ngFor="let doc of documents" routerLink="/documents/{{doc.id}}">
         <td>{{doc.created | customDate}}</td>
-        <td>{{doc.title | documentTitle}}<app-tag [tag]="t" *ngFor="let t of doc.tags$ | async" class="ms-1"></app-tag></td>
+        <td>{{doc.title | documentTitle}}<app-tag [tag]="t" *ngFor="let t of doc.tags$ | async" class="ms-1" (click)="clickTag(t); $event.stopPropagation();"></app-tag></td>
       </tr>
     </tbody>
   </table>

--- a/src-ui/src/app/components/dashboard/widgets/saved-view-widget/saved-view-widget.component.html
+++ b/src-ui/src/app/components/dashboard/widgets/saved-view-widget/saved-view-widget.component.html
@@ -11,7 +11,7 @@
       </tr>
     </thead>
     <tbody>
-      <tr *ngFor="let doc of documents" routerLink="/documents/{{doc.id}}">
+      <tr *ngFor="let doc of documents" [routerLink]="['/', 'documents', doc.id]">
         <td>{{doc.created | customDate}}</td>
         <td>{{doc.title | documentTitle}}<app-tag [tag]="t" *ngFor="let t of doc.tags$ | async" class="ms-1" (click)="clickTag(t); $event.stopPropagation();"></app-tag></td>
       </tr>

--- a/src-ui/src/app/components/dashboard/widgets/saved-view-widget/saved-view-widget.component.ts
+++ b/src-ui/src/app/components/dashboard/widgets/saved-view-widget/saved-view-widget.component.ts
@@ -6,6 +6,8 @@ import { PaperlessSavedView } from 'src/app/data/paperless-saved-view'
 import { DocumentListViewService } from 'src/app/services/document-list-view.service'
 import { ConsumerStatusService } from 'src/app/services/consumer-status.service'
 import { DocumentService } from 'src/app/services/rest/document.service'
+import { PaperlessTag } from 'src/app/data/paperless-tag'
+import { FILTER_HAS_TAGS_ALL } from 'src/app/data/filter-rule-type'
 
 @Component({
   selector: 'app-saved-view-widget',
@@ -61,5 +63,11 @@ export class SavedViewWidgetComponent implements OnInit, OnDestroy {
       this.list.loadSavedView(this.savedView, true)
       this.router.navigate(['documents'])
     }
+  }
+
+  clickTag(tag: PaperlessTag) {
+    this.list.quickFilter([
+      { rule_type: FILTER_HAS_TAGS_ALL, value: tag.id.toString() },
+    ])
   }
 }


### PR DESCRIPTION
## Proposed change

This PR makes tags shown in dashboard widgets clickable. Currently it justs goes to the document. Been meaning to do this one for a while =)

After:

https://user-images.githubusercontent.com/4887959/159845940-72b1684d-0784-46e5-b4e4-f36af7d9260b.mov

Before:

https://user-images.githubusercontent.com/4887959/159845973-3a4d548d-178e-4e27-a70c-c580e36ff543.mov

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] ~~I have made corresponding changes to the documentation as needed.~~
- [x] I have checked my modifications for any breaking changes.
