### PR TITLE
Revert "Bump pdfminer-six from 20211012 to 20220319"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -60,7 +60,7 @@ numpy==1.22.3; python_version >= '3.8'
 ocrmypdf==13.4.1
 packaging==21.3; python_version >= '3.6'
 pathvalidate==2.5.0
-pdfminer.six==20220319
+pdfminer.six==20211012
 pikepdf==5.0.1
 pillow==9.0.1
 pluggy==1.0.0; python_version >= '3.6'


### PR DESCRIPTION
## Proposed change

Revert the version bump of pdfminer-six so the dev branch builds.

Fixes issue #519


@paperless-ngx/backend (Python / django, database, etc.)
@paperless-ngx/ci-cd (GitHub Actions, deployment)


## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
