### PR TITLE
Realign frontend ci pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ on:
 
 jobs:
   documentation:
+    name: "Build Documentation"
     runs-on: ubuntu-20.04
     steps:
       -
@@ -44,7 +45,7 @@ jobs:
           name: documentation
           path: docs/_build/html/
 
-  backend-code-checks:
+  code-checks-backend:
     name: "Backend Code Checks"
     runs-on: ubuntu-20.04
     steps:
@@ -84,7 +85,7 @@ jobs:
           cd src/
           flake8 --max-line-length=88 --ignore=E203,W503
 
-  frontend-code-checks:
+  code-checks-frontend:
     name: "Frontend Code Checks"
     runs-on: ubuntu-20.04
     steps:
@@ -103,8 +104,8 @@ jobs:
         run:
           npx prettier --check --ignore-path Pipfile.lock **/*.js **/*.ts *.md **/*.md
 
-  backend-tests:
-    needs: [backend-code-checks]
+  tests-backend:
+    needs: [code-checks-backend]
     name: "Backend Tests (${{ matrix.python-version }})"
     runs-on: ubuntu-20.04
     strategy:
@@ -165,8 +166,9 @@ jobs:
           pipenv run coveralls --service=github
 
   tests-frontend:
+    needs: [code-checks-frontend]
+    name: "Frontend Tests"
     runs-on: ubuntu-latest
-
     strategy:
       matrix:
         node-version: [16.x]
@@ -184,7 +186,7 @@ jobs:
   build-docker-image:
     if: github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/feature-') || github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/beta' || startsWith(github.ref, 'refs/tags/ngx-') || startsWith(github.ref, 'refs/tags/beta-'))
     runs-on: ubuntu-latest
-    needs: [backend-tests, frontend-code-checks]
+    needs: [tests-backend, tests-frontend]
     steps:
       -
         name: Prepare
@@ -249,7 +251,7 @@ jobs:
           path: src/documents/static/frontend/
 
   build-release:
-    needs: [build-docker-image, documentation, backend-tests, backend-code-checks, frontend-code-checks]
+    needs: [build-docker-image, documentation]
     runs-on: ubuntu-20.04
     steps:
       -


### PR DESCRIPTION
## Proposed change

This PR just reorganizes and renames some of the ci actions. It doesnt change any functionality. Specifically, the frontend tests now depend on frontend code checks, docker image build depends on both tests. Please let me know if I missed anything but should be straightforward. And makes the actions slightly easier to see:

<img width="972" alt="Screen Shot 2022-03-25 at 12 40 41 AM" src="https://user-images.githubusercontent.com/4887959/160076124-c47187b4-31fa-47f3-8145-aa69f1a6ee0f.png">


## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other: ci tweak

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] ~~If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.~~
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] ~~I have made corresponding changes to the documentation as needed.~~
- [x] I have checked my modifications for any breaking changes.
