### PR TITLE
Feature: Filtering query params aka browser navigation for filtering

### DIFF
--- a/src-ui/src/app/components/app-frame/app-frame.component.html
+++ b/src-ui/src/app/components/app-frame/app-frame.component.html
@@ -62,7 +62,7 @@
             </a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" routerLink="documents" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" (click)="closeMenu()">
+            <a class="nav-link" routerLink="documents" routerLinkActive="active" (click)="closeMenu()">
               <svg class="sidebaricon" fill="currentColor">
                 <use xlink:href="assets/bootstrap-icons.svg#files"/>
               </svg>&nbsp;<ng-container i18n>Documents</ng-container>

--- a/src-ui/src/app/components/app-frame/app-frame.component.ts
+++ b/src-ui/src/app/components/app-frame/app-frame.component.ts
@@ -81,7 +81,10 @@ export class AppFrameComponent {
   search() {
     this.closeMenu()
     this.list.quickFilter([
-      { rule_type: FILTER_FULLTEXT_QUERY, value: this.searchField.value },
+      {
+        rule_type: FILTER_FULLTEXT_QUERY,
+        value: (this.searchField.value as string).trim(),
+      },
     ])
   }
 

--- a/src-ui/src/app/components/common/tag/tag.component.html
+++ b/src-ui/src/app/components/common/tag/tag.component.html
@@ -1,2 +1,2 @@
 <span *ngIf="!clickable" class="badge" [style.background]="tag.color" [style.color]="tag.text_color">{{tag.name}}</span>
-<a [routerLink]="[]" [title]="linkTitle" *ngIf="clickable" class="badge" [style.background]="tag.color" [style.color]="tag.text_color">{{tag.name}}</a>
+<a [title]="linkTitle" *ngIf="clickable" class="badge" [style.background]="tag.color" [style.color]="tag.text_color">{{tag.name}}</a>

--- a/src-ui/src/app/components/common/tag/tag.component.scss
+++ b/src-ui/src/app/components/common/tag/tag.component.scss
@@ -1,0 +1,3 @@
+a {
+    cursor: pointer;
+}

--- a/src-ui/src/app/components/document-list/document-card-large/document-card-large.component.html
+++ b/src-ui/src/app/components/document-list/document-card-large/document-card-large.component.html
@@ -17,7 +17,7 @@
         <div class="d-flex justify-content-between align-items-center">
           <h5 class="card-title">
             <ng-container *ngIf="document.correspondent">
-              <a *ngIf="clickCorrespondent.observers.length ; else nolink" [routerLink]="[]" title="Filter by correspondent" i18n-title (click)="clickCorrespondent.emit(document.correspondent);$event.stopPropagation()" class="fw-bold btn-link">{{(document.correspondent$ | async)?.name}}</a>
+              <a *ngIf="clickCorrespondent.observers.length ; else nolink" title="Filter by correspondent" i18n-title (click)="clickCorrespondent.emit(document.correspondent);$event.stopPropagation()" class="fw-bold btn-link">{{(document.correspondent$ | async)?.name}}</a>
               <ng-template #nolink>{{(document.correspondent$ | async)?.name}}</ng-template>:
             </ng-container>
             {{document.title | documentTitle}}

--- a/src-ui/src/app/components/document-list/document-card-large/document-card-large.component.scss
+++ b/src-ui/src/app/components/document-list/document-card-large/document-card-large.component.scss
@@ -90,3 +90,7 @@ span ::ng-deep .match {
   color: black;
   background-color: rgb(255, 211, 66);
 }
+
+a {
+  cursor: pointer;
+}

--- a/src-ui/src/app/components/document-list/document-card-small/document-card-small.component.html
+++ b/src-ui/src/app/components/document-list/document-card-small/document-card-small.component.html
@@ -23,7 +23,7 @@
     <div class="card-body p-2">
       <p class="card-text">
         <ng-container *ngIf="document.correspondent">
-          <a [routerLink]="[]" title="Filter by correspondent" i18n-title (click)="clickCorrespondent.emit(document.correspondent);$event.stopPropagation()" class="fw-bold btn-link">{{(document.correspondent$ | async)?.name}}</a>:
+          <a title="Filter by correspondent" i18n-title (click)="clickCorrespondent.emit(document.correspondent);$event.stopPropagation()" class="fw-bold btn-link">{{(document.correspondent$ | async)?.name}}</a>:
         </ng-container>
         {{document.title | documentTitle}}
       </p>

--- a/src-ui/src/app/components/document-list/document-card-small/document-card-small.component.scss
+++ b/src-ui/src/app/components/document-list/document-card-small/document-card-small.component.scss
@@ -76,3 +76,7 @@
   text-align: left !important;
   font-size: 90%;
 }
+
+a {
+  cursor: pointer;
+}

--- a/src-ui/src/app/components/document-list/document-list.component.html
+++ b/src-ui/src/app/components/document-list/document-list.component.html
@@ -163,7 +163,7 @@
         </td>
         <td class="d-none d-md-table-cell">
           <ng-container *ngIf="d.correspondent">
-            <a [routerLink]="[]" (click)="clickCorrespondent(d.correspondent);$event.stopPropagation()" title="Filter by correspondent">{{(d.correspondent$ | async)?.name}}</a>
+            <a (click)="clickCorrespondent(d.correspondent);$event.stopPropagation()" title="Filter by correspondent">{{(d.correspondent$ | async)?.name}}</a>
           </ng-container>
         </td>
         <td>
@@ -172,7 +172,7 @@
         </td>
         <td class="d-none d-xl-table-cell">
           <ng-container *ngIf="d.document_type">
-            <a [routerLink]="[]" (click)="clickDocumentType(d.document_type);$event.stopPropagation()" title="Filter by document type">{{(d.document_type$ | async)?.name}}</a>
+            <a (click)="clickDocumentType(d.document_type);$event.stopPropagation()" title="Filter by document type">{{(d.document_type$ | async)?.name}}</a>
           </ng-container>
         </td>
         <td>

--- a/src-ui/src/app/components/document-list/document-list.component.scss
+++ b/src-ui/src/app/components/document-list/document-list.component.scss
@@ -53,3 +53,7 @@ $paperless-card-breakpoints: (
     margin-left: 0;
   }
 }
+
+a {
+  cursor: pointer;
+}

--- a/src-ui/src/app/components/document-list/document-list.component.ts
+++ b/src-ui/src/app/components/document-list/document-list.component.ts
@@ -68,7 +68,6 @@ export class DocumentListComponent implements OnInit, OnDestroy, AfterViewInit {
   unmodifiedFilterRules: FilterRule[] = []
 
   private unsubscribeNotifier: Subject<any> = new Subject()
-  private consumptionFinishedSubscription: Subscription
 
   get isFiltered() {
     return this.list.filterRules?.length > 0
@@ -101,7 +100,7 @@ export class DocumentListComponent implements OnInit, OnDestroy, AfterViewInit {
       this.displayMode = localStorage.getItem('document-list:displayMode')
     }
 
-    this.consumptionFinishedSubscription = this.consumerStatusService
+    this.consumerStatusService
       .onDocumentConsumptionFinished()
       .pipe(takeUntil(this.unsubscribeNotifier))
       .subscribe(() => {

--- a/src-ui/src/app/components/document-list/document-list.component.ts
+++ b/src-ui/src/app/components/document-list/document-list.component.ts
@@ -33,8 +33,6 @@ import { ToastService } from 'src/app/services/toast.service'
 import { FilterEditorComponent } from './filter-editor/filter-editor.component'
 import { SaveViewConfigDialogComponent } from './save-view-config-dialog/save-view-config-dialog.component'
 
-const filterQueryVars: string[] = FILTER_RULE_TYPES.map((rt) => rt.filtervar)
-
 @Component({
   selector: 'app-document-list',
   templateUrl: './document-list.component.html',
@@ -113,6 +111,10 @@ export class DocumentListComponent implements OnInit, OnDestroy, AfterViewInit {
           this.unmodifiedFilterRules = view.filter_rules
         })
       })
+
+    const filterQueryVars: string[] = FILTER_RULE_TYPES.map(
+      (rt) => rt.filtervar
+    )
 
     this.route.queryParamMap
       .pipe(filter((qp) => !this.route.snapshot.paramMap.has('id'))) // only when not on saved view

--- a/src-ui/src/app/components/document-list/document-list.component.ts
+++ b/src-ui/src/app/components/document-list/document-list.component.ts
@@ -151,8 +151,9 @@ export class DocumentListComponent implements OnInit, OnDestroy, AfterViewInit {
 
   ngAfterViewInit(): void {
     this.filterEditor.filterRulesChange.subscribe({
-      next: (rules) => {
-        const params = this.documentService.queryParams
+      next: (filterRules) => {
+        const params =
+          this.documentService.filterRulesToQueryParams(filterRules)
 
         // if we were on a saved view we navigate 'away' to /documents
         let base = []

--- a/src-ui/src/app/services/document-list-view.service.ts
+++ b/src-ui/src/app/services/document-list-view.service.ts
@@ -143,8 +143,8 @@ export class DocumentListViewService {
         activeListViewState.sortReverse,
         activeListViewState.filterRules
       )
-      .subscribe(
-        (result) => {
+      .subscribe({
+        next: (result) => {
           this.isReloading = false
           activeListViewState.collectionSize = result.count
           activeListViewState.documents = result.results
@@ -153,7 +153,7 @@ export class DocumentListViewService {
           }
           this.rangeSelectionAnchorIndex = this.lastRangeSelectionToIndex = null
         },
-        (error) => {
+        error: (error) => {
           this.isReloading = false
           if (activeListViewState.currentPage != 1 && error.status == 404) {
             // this happens when applying a filter: the current page might not be available anymore due to the reduced result set.
@@ -162,8 +162,8 @@ export class DocumentListViewService {
           } else {
             this.error = error.error
           }
-        }
-      )
+        },
+      })
   }
 
   set filterRules(filterRules: FilterRule[]) {

--- a/src-ui/src/app/services/document-list-view.service.ts
+++ b/src-ui/src/app/services/document-list-view.service.ts
@@ -249,20 +249,11 @@ export class DocumentListViewService {
   }
 
   quickFilter(filterRules: FilterRule[]) {
-    this._activeSavedViewId = null
-    this.activeListViewState.filterRules = filterRules
-    this.activeListViewState.currentPage = 1
-    if (isFullTextFilterRule(filterRules)) {
-      this.activeListViewState.sortField = 'score'
-      this.activeListViewState.sortReverse = false
-    }
-    this.reduceSelectionToFilter()
-    this.saveDocumentListView()
-    if (this.router.url == '/documents') {
-      this.reload()
-    } else {
-      this.router.navigate(['documents'])
-    }
+    const params = this.documentService.filterRulesToQueryParams(filterRules)
+    this.router.navigate(['/documents'], {
+      relativeTo: this.route,
+      queryParams: params,
+    })
   }
 
   getLastPage(): number {

--- a/src-ui/src/app/services/rest/document.service.ts
+++ b/src-ui/src/app/services/rest/document.service.ts
@@ -47,6 +47,7 @@ export interface SelectionData {
 })
 export class DocumentService extends AbstractPaperlessService<PaperlessDocument> {
   private _searchQuery: string
+  public queryParams: Object = {}
 
   constructor(
     http: HttpClient,
@@ -57,7 +58,7 @@ export class DocumentService extends AbstractPaperlessService<PaperlessDocument>
     super(http, 'documents')
   }
 
-  private filterRulesToQueryParams(filterRules: FilterRule[]) {
+  private filterRulesToQueryParams(filterRules: FilterRule[]): Object {
     if (filterRules) {
       let params = {}
       for (let rule of filterRules) {
@@ -101,12 +102,13 @@ export class DocumentService extends AbstractPaperlessService<PaperlessDocument>
     filterRules?: FilterRule[],
     extraParams = {}
   ): Observable<Results<PaperlessDocument>> {
+    this.queryParams = this.filterRulesToQueryParams(filterRules)
     return this.list(
       page,
       pageSize,
       sortField,
       sortReverse,
-      Object.assign(extraParams, this.filterRulesToQueryParams(filterRules))
+      Object.assign(extraParams, this.queryParams)
     ).pipe(
       map((results) => {
         results.results.forEach((doc) => this.addObservablesToDocument(doc))

--- a/src-ui/src/app/services/rest/document.service.ts
+++ b/src-ui/src/app/services/rest/document.service.ts
@@ -47,7 +47,6 @@ export interface SelectionData {
 })
 export class DocumentService extends AbstractPaperlessService<PaperlessDocument> {
   private _searchQuery: string
-  public queryParams: Object = {}
 
   constructor(
     http: HttpClient,
@@ -58,7 +57,7 @@ export class DocumentService extends AbstractPaperlessService<PaperlessDocument>
     super(http, 'documents')
   }
 
-  private filterRulesToQueryParams(filterRules: FilterRule[]): Object {
+  public filterRulesToQueryParams(filterRules: FilterRule[]): Object {
     if (filterRules) {
       let params = {}
       for (let rule of filterRules) {
@@ -102,13 +101,12 @@ export class DocumentService extends AbstractPaperlessService<PaperlessDocument>
     filterRules?: FilterRule[],
     extraParams = {}
   ): Observable<Results<PaperlessDocument>> {
-    this.queryParams = this.filterRulesToQueryParams(filterRules)
     return this.list(
       page,
       pageSize,
       sortField,
       sortReverse,
-      Object.assign(extraParams, this.queryParams)
+      Object.assign(extraParams, this.filterRulesToQueryParams(filterRules))
     ).pipe(
       map((results) => {
         results.results.forEach((doc) => this.addObservablesToDocument(doc))


### PR DESCRIPTION
## Proposed change

This PR introduces query parameters for document filtering. This came up a lot on -ng and as a user I often find myself wanting this i.e. when I instinctually hit the browser back button and accidentally leave the documents page. IMHO its just easier to use a keyboard shortcut to move back / forward when filtering, like undo / redo. This also has the bonus that you can directly link to a filtered view (without needing to necessarily save it).

Im pretty happy with this one! But I would def appreciate some eyes on this. The only real side-effect I see is that the last filtered view isnt saved between sessions (used to be done via `localStorage`) but that seems neglibible since you can use the browser buttons during a session and I feel that saving the last filter between sessions that are distant in time is a small use-case.

Here's some videos:


https://user-images.githubusercontent.com/4887959/160271606-0e2df6c6-eec3-492f-ad00-af7573eb6e18.mov


https://user-images.githubusercontent.com/4887959/160272000-e4c2c9b8-deab-45f0-b117-abce6633953a.mov


## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] ~~I have made corresponding changes to the documentation as needed.~~
- [x] I have checked my modifications for any breaking changes.
