### PR TITLE
FIX BUG: case-sensitive matching was not possible

### DIFF
--- a/src/documents/matching.py
+++ b/src/documents/matching.py
@@ -58,14 +58,15 @@ def match_tags(document, classifier):
 def matches(matching_model, document):
     search_kwargs = {}
 
-    document_content = document.content.lower()
-
     # Check that match is not empty
     if matching_model.match.strip() == "":
         return False
 
     if matching_model.is_insensitive:
         search_kwargs = {"flags": re.IGNORECASE}
+        document_content = document.content.lower()
+    else:
+        document_content = document.content
 
     if matching_model.matching_algorithm == MatchingModel.MATCH_ALL:
         for word in _split_match(matching_model):


### PR DESCRIPTION
I encountered a bug for tags with upper case letters and case-sensitivity turned on.
They don't produce any matches.
The cause is that the document content is always converted to lower case before matching.

### My changes:
In the default case of case-insensitive matching everything stays as is.
In case of case-sensitive matching the document content is not converted to lower cases.

I haven't build the whole paperless developer environment.
@paperless-ngx/backend @paperless-ngx/test would you please be so kind to run the tests

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
