### PR TITLE
Fix reference from Paperless-ngx to Paperless-ng

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ For bugs please [open an issue](https://github.com/paperless-ngx/paperless-ngx/i
 
 Paperless has been around a while now, and people are starting to build stuff on top of it. If you're one of those people, we can add your project to this list:
 
-* [Paperless App](https://github.com/bauerj/paperless_app): An Android/iOS app for Paperless-ngx. Also works with the original Paperless and Paperless-ngx.
+* [Paperless App](https://github.com/bauerj/paperless_app): An Android/iOS app for Paperless-ngx. Also works with the original Paperless and Paperless-ng.
 * [Paperless Share](https://github.com/qcasey/paperless_share). Share any files from your Android application with paperless. Very simple, but works with all of the mobile scanning apps out there that allow you to share scanned documents.
 * [Scan to Paperless](https://github.com/sbrunner/scan-to-paperless): Scan and prepare (crop, deskew, OCR, ...) your documents for Paperless.
 


### PR DESCRIPTION
> An Android/iOS app for Paperless-ngx. Also works with the original Paperless and Paperless-ngx

I assume the latter "Paperless-ngx" was actually meant to reference "Paperless-ng" instead and was changed by mistake when all ng references were changed to ngx.