### PR TITLE
feat: add install of custom packages

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -74,11 +74,49 @@ install_languages() {
 	done
 }
 
+install_packages() {
+	echo "Installing packages..."
+
+	local packages="$1"
+	read -ra packages <<<"$packages"
+
+	# Check that it is not empty
+	if [ ${#packages[@]} -eq 0 ]; then
+		return
+	fi
+	apt-get update
+
+	for package in "${packages[@]}"; do
+		pkg="$package"
+
+		if dpkg -s "$pkg" &>/dev/null; then
+			echo "Package $pkg already installed!"
+			continue
+		fi
+
+		if ! apt-cache show "$pkg" &>/dev/null; then
+			echo "Package $pkg not found! :("
+			continue
+		fi
+
+		echo "Installing package $pkg..."
+		if ! apt-get -y install "$pkg" &>/dev/null; then
+			echo "Could not install $pkg"
+			exit 1
+		fi
+	done
+}
+
 echo "Paperless-ngx docker container starting..."
 
 # Install additional languages if specified
 if [[ -n "$PAPERLESS_OCR_LANGUAGES" ]]; then
 	install_languages "$PAPERLESS_OCR_LANGUAGES"
+fi
+
+# Install additional packages if specified
+if [[ -n "$PAPERLESS_CUSTOM_PACKAGES" ]]; then
+	install_packages "$PAPERLESS_CUSTOM_PACKAGES"
 fi
 
 initialize


### PR DESCRIPTION


## Proposed change

adds the support for the `PAPERLESS_CUSTOM_PACKAGES`
environment variable to install custom packages during startup.

This will support usage of custom CLI in pre-/post consumption scripts


Fixes: did not see an issue about that topic

@paperless-ngx/ci-cd <= is this the correct team?

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [X] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [X] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [X] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [X] I have checked my modifications for any breaking changes.
