### PR TITLE
Update troubleshooting.rst

### DIFF
--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -25,6 +25,19 @@ Check for the following issues:
 *   Go to the admin interface, and check if there are failed tasks. If so, the
     tasks will contain an error message.
 
+Consumer warns ``OCR for XX failed``
+####################################
+
+If you find the OCR accuracy to be too low, and/or the document consumer warns
+that ``OCR for XX failed, but we're going to stick with what we've got since
+FORGIVING_OCR is enabled``, then you might need to install the
+`Tesseract language files <http://packages.ubuntu.com/search?keywords=tesseract-ocr>`_
+marching your document's languages.
+
+As an example, if you are running Paperless-ngx from any Ubuntu or Debian
+box, and your documents are written in Spanish you may need to run::
+
+    apt-get install -y tesseract-ocr-spa
 
 Consumer fails to pickup any new files
 ######################################


### PR DESCRIPTION
<!-- 
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change
Updated `Troubleshooting` section of documentation.

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your poposed change can be tested. Screenshots and / or videos can also be helpful if appropriate. 
-->

## Fixes
 Added `Consumer warns OCR for XX failed` section.

<!--
Please also tag the relevant team to help with review. You can tag any of the following:
@paperless-ngx/backend (Python / django, database, etc.)
@paperless-ngx/frontend (JavaScript/Typescript, HTML, CSS, etc.)
@paperless-ngx/ci-cd (GitHub Actions, deployment)
@paperless-ngx/test (General testing for larger PRs)
-->

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Other (please explain)

## Checklist:

- [X] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [X] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
