### PR TITLE
fixes a regression introduced in 78258eb9

### DIFF
--- a/src/documents/tests/test_consumer.py
+++ b/src/documents/tests/test_consumer.py
@@ -5,11 +5,6 @@ import tempfile
 from unittest import mock
 from unittest.mock import MagicMock
 
-try:
-    import zoneinfo
-except ImportError:
-    import backports.zoneinfo as zoneinfo
-
 from django.conf import settings
 from django.test import override_settings
 from django.test import TestCase
@@ -346,7 +341,7 @@ class TestConsumer(DirectoriesMixin, TestCase):
 
         self._assert_first_last_send_progress()
 
-        self.assertEqual(document.created.tzinfo, zoneinfo.ZoneInfo("America/Chicago"))
+        self.assertEqual(document.created.tzinfo.zone, "America/Chicago")
 
     @override_settings(PAPERLESS_FILENAME_FORMAT=None)
     def testDeleteMacFiles(self):


### PR DESCRIPTION
I notied a regression in our python test suite in 78258eb9cb243282a72200fdf9c2fc5cdad15d55

The change in https://github.com/paperless-ngx/paperless-ngx/blob/8b26ddcd2c8d6e34e5be6b51f62eb2de0eb04931/src/documents/tests/test_consumer.py#L349

gives:
```
AssertionError: <DstTzInfo 'America/Chicago' CDT-1 day, 19:00:00 DST> != zoneinfo.ZoneInfo(key='America/Chicago')
```



Signed-off-by: Florian Brandes <florian.brandes@posteo.de>

## Proposed change

Reverting the assertion to:
`self.assertEqual(document.created.tzinfo.zone, "America/Chicago")`

fixes the issue.

I'm not quite sure, how this plays a role in the timezone settings here, but maybe @stumpylog could have a look here?


Fixes # (issue)

<!--
Please also tag the relevant team to help with review. You can tag any of the following:
@paperless-ngx/backend (Python / django, database, etc.)
@paperless-ngx/frontend (JavaScript/Typescript, HTML, CSS, etc.)
@paperless-ngx/ci-cd (GitHub Actions, deployment)
@paperless-ngx/test (General testing for larger PRs)
-->

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
