### PR TITLE
Merge pull request #552 from stumpylog/bugfix-black (attempt #2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
         uses: psf/black@stable
         with:
           options: "--check --diff"
-          version: "22.1.0"
+          version: "22.3.0"
 
   tests:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
<!-- 
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

This PR is to merge changes that are present on `dev` to the codeformatting action that is now broken due to the version of black e.g. https://github.com/paperless-ngx/paperless-ngx/runs/5755469756?check_suite_focus=true . The original commit into `dev` was #552

@stumpylog is there any issue with merging this into main now? It updates the whole ci.yml, of course

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)