### PR TITLE
Support docker-compose v2 in install

### DIFF
--- a/install-paperless-ngx.sh
+++ b/install-paperless-ngx.sh
@@ -47,24 +47,29 @@ if [[ $(id -u) == "0" ]] ; then
 	exit 1
 fi
 
-if [[ -z $(which wget) ]] ; then
+if ! command -v wget &> /dev/null ; then
 	echo "wget executable not found. Is wget installed?"
 	exit 1
 fi
 
-if [[ -z $(which docker) ]] ; then
+if ! command -v docker &> /dev/null ; then
 	echo "docker executable not found. Is docker installed?"
 	exit 1
 fi
 
-if [[ -z $(which docker-compose) ]] ; then
-	echo "docker-compose executable not found. Is docker-compose installed?"
-	exit 1
+DOCKER_COMPOSE_CMD="docker-compose"
+if ! command -v ${DOCKER_COMPOSE_CMD} ; then
+	{
+		docker compose version &> /dev/null && DOCKER_COMPOSE_CMD="docker compose"
+		} || {
+		echo "docker-compose executable not found. Is docker-compose installed?"
+		exit 1
+	}
 fi
 
 # Check if user has permissions to run Docker by trying to get the status of Docker (docker status).
 # If this fails, the user probably does not have permissions for Docker.
-if [ ! "$(docker stats --no-stream 2>/dev/null 1>&2)" ] ; then
+if ! docker stats --no-stream &> /dev/null ; then
 	echo ""
 	echo "WARN: It look like the current user does not have Docker permissions."
 	echo "WARN: Use 'sudo usermod -aG docker $USER' to assign Docker permissions to the user."
@@ -351,8 +356,8 @@ if [ "$l1" -eq "$l2" ] ; then
 fi
 
 
-docker-compose pull
+${DOCKER_COMPOSE_CMD} pull
 
-docker-compose run --rm -e DJANGO_SUPERUSER_PASSWORD="$PASSWORD" webserver createsuperuser --noinput --username "$USERNAME" --email "$EMAIL"
+${DOCKER_COMPOSE_CMD} run --rm -e DJANGO_SUPERUSER_PASSWORD="$PASSWORD" webserver createsuperuser --noinput --username "$USERNAME" --email "$EMAIL"
 
-docker-compose up -d
+${DOCKER_COMPOSE_CMD} up -d

--- a/install-paperless-ngx.sh
+++ b/install-paperless-ngx.sh
@@ -59,12 +59,12 @@ fi
 
 DOCKER_COMPOSE_CMD="docker-compose"
 if ! command -v ${DOCKER_COMPOSE_CMD} ; then
-	{
-		docker compose version &> /dev/null && DOCKER_COMPOSE_CMD="docker compose"
-		} || {
+	if docker compose version &> /dev/null ; then
+		DOCKER_COMPOSE_CMD="docker compose"
+	else
 		echo "docker-compose executable not found. Is docker-compose installed?"
 		exit 1
-	}
+	fi
 fi
 
 # Check if user has permissions to run Docker by trying to get the status of Docker (docker status).


### PR DESCRIPTION
## Proposed change

This fixes the install script so it will support docker-compose v2, which updated from being a standalone command to a sub-command/plugin of the main docker command.

The script now checks if `docker-compose` command exists, then checks for `docker compose`.  If one of those is found, it's used in following steps.

Fixes #598

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
