### PR TITLE
fix some api error displaying

### DIFF
--- a/src-ui/src/app/components/document-list/document-list.component.html
+++ b/src-ui/src/app/components/document-list/document-list.component.html
@@ -100,7 +100,7 @@
 <ng-container *ngTemplateOutlet="pagination"></ng-container>
 
 <ng-container *ngIf="list.error ; else documentListNoError">
-  <div class="alert alert-danger" role="alert">Error while loading documents: {{list.error}}</div>
+  <div class="alert alert-danger" role="alert"><ng-container i18n>Error while loading documents</ng-container>: {{list.error}}</div>
 </ng-container>
 
 <ng-template #documentListNoError>

--- a/src-ui/src/app/components/document-list/document-list.component.ts
+++ b/src-ui/src/app/components/document-list/document-list.component.ts
@@ -243,8 +243,12 @@ export class DocumentListComponent implements OnInit, OnDestroy, AfterViewInit {
               $localize`View "${savedView.name}" created successfully.`
             )
           },
-          error: (error) => {
-            modal.componentInstance.error = error.error
+          error: (httpError) => {
+            let error = httpError.error
+            if (error.filter_rules) {
+              error.filter_rules = error.filter_rules.map((r) => r.value)
+            }
+            modal.componentInstance.error = error
             modal.componentInstance.buttonsEnabled = true
           },
         })

--- a/src-ui/src/app/components/document-list/save-view-config-dialog/save-view-config-dialog.component.html
+++ b/src-ui/src/app/components/document-list/save-view-config-dialog/save-view-config-dialog.component.html
@@ -8,6 +8,11 @@
     <app-input-text i18n-title title="Name" formControlName="name" [error]="error?.name"></app-input-text>
     <app-input-check i18n-title title="Show in sidebar" formControlName="showInSideBar"></app-input-check>
     <app-input-check i18n-title title="Show on dashboard" formControlName="showOnDashboard"></app-input-check>
+    <div *ngIf="error?.filter_rules" class="alert alert-danger" role="alert">
+      <h6 class="alert-heading" i18n>Filter rules error occurred while saving this view</h6>
+      <ng-container i18n>The error returned was</ng-container>:<br/>
+      {{ error.filter_rules }}
+    </div>
   </div>
   <div class="modal-footer">
     <button type="button" class="btn btn-outline-dark" (click)="cancel()" i18n [disabled]="!buttonsEnabled">Cancel</button>

--- a/src-ui/src/app/services/document-list-view.service.ts
+++ b/src-ui/src/app/services/document-list-view.service.ts
@@ -9,7 +9,7 @@ import {
 import { PaperlessDocument } from '../data/paperless-document'
 import { PaperlessSavedView } from '../data/paperless-saved-view'
 import { DOCUMENT_LIST_SERVICE } from '../data/storage-keys'
-import { DocumentService } from './rest/document.service'
+import { DocumentService, DOCUMENT_SORT_FIELDS } from './rest/document.service'
 import { SettingsService, SETTINGS_KEYS } from './settings.service'
 
 /**
@@ -160,7 +160,21 @@ export class DocumentListViewService {
             activeListViewState.currentPage = 1
             this.reload()
           } else {
-            this.error = error.error
+            let errorMessage
+            if (Object.keys(error.error).length > 0) {
+              // e.g. { archive_serial_number: Array<string> }
+              errorMessage = Object.keys(error.error)
+                .map((fieldName) => {
+                  const fieldError: Array<string> = error.error[fieldName]
+                  return `${
+                    DOCUMENT_SORT_FIELDS.find((f) => f.field == fieldName)?.name
+                  }: ${fieldError[0]}`
+                })
+                .join(', ')
+            } else {
+              errorMessage = error.error
+            }
+            this.error = errorMessage
           }
         },
       })


### PR DESCRIPTION
<!-- 
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

This PR addresses a couple of areas where errors were not being displayed properly. It also adds localization to one of the error messages.

<img width="526" alt="Screen Shot 2022-04-02 at 5 56 08 PM" src="https://user-images.githubusercontent.com/4887959/161406651-5d07c65f-d434-4688-a108-06be30077ac1.png">

Note the above error is different than if the view title is too long:
<img width="527" alt="Screen Shot 2022-04-02 at 5 55 45 PM" src="https://user-images.githubusercontent.com/4887959/161406655-950b8cf9-b09c-480f-b985-b163b229ffbd.png">

<img width="576" alt="Screen Shot 2022-04-02 at 5 11 18 PM" src="https://user-images.githubusercontent.com/4887959/161406647-bc2f37de-796f-4e53-9b6d-acee01ed28b2.png">


Part of #601
Closes #530

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] ~~I have made corresponding changes to the documentation as needed.~~
- [x] I have checked my modifications for any breaking changes.
