### PR TITLE
uses shutil.move instead of rename

### DIFF
--- a/src/documents/signals/handlers.py
+++ b/src/documents/signals/handlers.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import shutil
 
 from django.conf import settings
 from django.contrib.admin.models import ADDITION
@@ -252,7 +253,7 @@ def cleanup_document_deletion(sender, instance, using, **kwargs):
 
             logger.debug(f"Moving {instance.source_path} to trash at {new_file_path}")
             try:
-                os.rename(instance.source_path, new_file_path)
+                shutil.move(instance.source_path, new_file_path)
             except OSError as e:
                 logger.error(
                     f"Failed to move {instance.source_path} to trash at "


### PR DESCRIPTION
## Proposed change

fixes #615 


@paperless-ngx/backend (Python / django, database, etc.)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
