### PR TITLE
Fix: download buttons should disable while waiting

### DIFF
--- a/src-ui/src/app/components/document-list/bulk-editor/bulk-editor.component.html
+++ b/src-ui/src/app/components/document-list/bulk-editor/bulk-editor.component.html
@@ -57,13 +57,18 @@
   </div>
   <div class="col-auto ms-auto mb-2 mb-xl-0 d-flex">
     <div class="btn-group btn-group-sm me-2">
-      <button type="button" class="btn btn-outline-primary btn-sm" (click)="downloadSelected()">
-        <svg width="1em" height="1em" viewBox="0 0 16 16" fill="currentColor">
+      <button type="button" [disabled]="awaitingDownload" class="btn btn-outline-primary btn-sm" (click)="downloadSelected()">
+        <svg *ngIf="!awaitingDownload" width="1em" height="1em" viewBox="0 0 16 16" fill="currentColor">
           <use xlink:href="assets/bootstrap-icons.svg#download" />
-        </svg>&nbsp;<ng-container i18n>Download</ng-container>
+        </svg>
+        <div *ngIf="awaitingDownload" class="spinner-border spinner-border-sm" role="status">
+          <span class="visually-hidden">Preparing download...</span>
+        </div>
+        &nbsp;
+        <ng-container i18n>Download</ng-container>
       </button>
       <div class="btn-group" ngbDropdown role="group" aria-label="Button group with nested dropdown">
-        <button class="btn btn-outline-primary btn-sm dropdown-toggle-split" ngbDropdownToggle></button>
+        <button [disabled]="awaitingDownload" class="btn btn-outline-primary btn-sm dropdown-toggle-split" ngbDropdownToggle></button>
         <div class="dropdown-menu shadow" ngbDropdownMenu>
           <button ngbDropdownItem i18n (click)="downloadSelected('originals')">Download originals</button>
         </div>

--- a/src-ui/src/app/components/document-list/bulk-editor/bulk-editor.component.ts
+++ b/src-ui/src/app/components/document-list/bulk-editor/bulk-editor.component.ts
@@ -39,6 +39,7 @@ export class BulkEditorComponent {
   tagSelectionModel = new FilterableDropdownSelectionModel()
   correspondentSelectionModel = new FilterableDropdownSelectionModel()
   documentTypeSelectionModel = new FilterableDropdownSelectionModel()
+  awaitingDownload: boolean
 
   constructor(
     private documentTypeService: DocumentTypeService,
@@ -317,10 +318,12 @@ export class BulkEditorComponent {
   }
 
   downloadSelected(content = 'archive') {
+    this.awaitingDownload = true
     this.documentService
       .bulkDownload(Array.from(this.list.selected), content)
       .subscribe((result: any) => {
         saveAs(result, 'documents.zip')
+        this.awaitingDownload = false
       })
   }
 }


### PR DESCRIPTION
<!-- 
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

This PR implements a small change / fix where the download as zip button was not disabled after first press allowing it to be pressed multiple times even though a zip was being created. It now disables until the download returns and also adds a 'spinner' as a visual indicator, see below.

![Screenshot_2022-04-02_22-16-07](https://user-images.githubusercontent.com/4887959/161413285-3f755b65-8d1f-4964-845f-b4224156f515.png)

Fixes #621 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [x] I have checked my modifications for any breaking changes.
