### PR TITLE
[feature] Make pytest quieter

### DIFF
--- a/src/setup.cfg
+++ b/src/setup.cfg
@@ -7,7 +7,7 @@ max-line-length = 88
 
 [tool:pytest]
 DJANGO_SETTINGS_MODULE=paperless.settings
-addopts = --pythonwarnings=all --cov --cov-report=html -n auto
+addopts = --pythonwarnings=all --cov --cov-report=html --numprocesses auto --quiet
 env =
   PAPERLESS_DISABLE_DBHANDLER=true
 


### PR DESCRIPTION
## Proposed change

This is a simple PR to add the pytest quiet flag.  This doesn't reduce any important information like failures, but most noticeably reduces how much pytest-xdist spams, especially when run on a device with many cores.  I get a veritable spam of information for each worker at startup, which makes it harder to locate other warnings that may be output.  It's less of an issue for fewer cores (like the Github runners).

@paperless-ngx/backend (Python / django, database, etc.)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
