### PR TITLE
Updates the base image tag to use the :dev tag from the base image de…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /src/src-ui
 RUN npm update npm -g && npm ci --no-optional
 RUN ./node_modules/.bin/ng build --configuration production
 
-FROM ghcr.io/paperless-ngx/builder/ngx-base:1.0 as main-app
+FROM ghcr.io/paperless-ngx/builder/ngx-base:dev as main-app
 
 LABEL org.opencontainers.image.authors="paperless-ngx team <hello@paperless-ngx.com>"
 LABEL org.opencontainers.image.documentation="https://paperless-ngx.readthedocs.io/en/latest/"


### PR DESCRIPTION
## Proposed change

This PR updates the `dev` branch to use the `:dev` tag from our base image.  This is the tag which will be updated as dependabot tells us of new versions of `pikepdf` and `psycopg2` and then tagged to a version as we prepare for a release.

@paperless-ngx/backend (Python / django, database, etc.)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other - dependency version fixing in the Docker image

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
