### PR TITLE
Chore: Add CODEOWNERS

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-<!-- 
+<!--
 Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
 -->
 
@@ -9,14 +9,6 @@ Please include a summary of the change and which issue is fixed (if any) and any
 -->
 
 Fixes # (issue)
-
-<!--
-Please also tag the relevant team to help with review. You can tag any of the following:
-@paperless-ngx/backend (Python / django, database, etc.)
-@paperless-ngx/frontend (JavaScript/Typescript, HTML, CSS, etc.)
-@paperless-ngx/ci-cd (GitHub Actions, deployment)
-@paperless-ngx/test (General testing for larger PRs)
--->
 
 ## Type of change
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@ Note: All PRs with code changes should be targeted to the `dev` branch, pure doc
 ## Proposed change
 
 <!--
-Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your poposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
+Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
 -->
 
 Fixes # (issue)

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,10 @@
+/.github/workflows/ @paperless-ngx/ci-cd
+/docker/ @paperless-ngx/ci-cd
+/scripts/ @paperless-ngx/ci-cd
+
+/src-ui/ @paperless-ngx/frontend
+
+/src/ @paperless-ngx/backend
+Pipfile* @paperless-ngx/backend
+*.py @paperless-ngx/backend
+requirements.txt @paperless-ngx/backend


### PR DESCRIPTION
<!-- 
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Creates CODEOWNERS file, as [documented here](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners).

> Code owners are automatically requested for review when someone opens a pull request that modifies code that they own.

This PR also removes the explicit request for team tagging from the PR template. The CODEOWNERS should do it automatically.

Not covered here, but if we wanted we can **require** that reviews come from the CODEOWNERS teams as part of Branch Protection. I don't see a downside to this, since we require review anyway? It would just make that requirement a little more strict as the reviewer(s) would need to be one of the CODEOWNERS. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
