### PR TITLE
Chore: Implement release-drafter action for Changelogs

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -4,8 +4,6 @@ categories:
       - 'enhancement'
   - title: 'Bug Fixes'
     labels:
-      - 'fix'
-      - 'bugfix'
       - 'bug'
   - title: 'Documentation'
     label: 'documentation'
@@ -16,9 +14,20 @@ categories:
       - 'translation'
   - title: 'Dependencies'
     label: 'dependencies'
+include-labels:
+  - 'enhancement'
+  - 'bug'
+  - 'chore'
+  - 'deployment'
+  - 'translation'
+  - 'dependencies'
+replacers: # Changes "Feature: Update checker" to "Update checker"
+  - search: '/Feature:|Feat:|\[feature\]/gi'
+    replace: ''
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 change-title-escapes: '\<*_&#@'
+tag-prefix: "ngx-"
 template: |
-  ## Changes
+  ## Changelog
 
   $CHANGES

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,24 @@
+categories:
+  - title: 'Features'
+    labels:
+      - 'enhancement'
+  - title: 'Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: 'Documentation'
+    label: 'documentation'
+  - title: 'Maintenance'
+    labels:
+      - 'chore'
+      - 'deployment'
+      - 'translation'
+  - title: 'Dependencies'
+    label: 'dependencies'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&#@'
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -13,6 +13,7 @@ categories:
       - 'deployment'
       - 'translation'
   - title: 'Dependencies'
+    collapse-after: 3
     label: 'dependencies'
 include-labels:
   - 'enhancement'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -327,24 +327,22 @@ jobs:
           if [[ $GITHUB_REF == refs/tags/ngx-* ]]; then
             echo ::set-output name=version::${GITHUB_REF#refs/tags/ngx-}
             echo ::set-output name=prerelease::false
-            echo ::set-output name=body::"For a complete list of changes, see the changelog at https://paperless-ngx.readthedocs.io/en/latest/changelog.html"
           elif [[ $GITHUB_REF == refs/tags/beta-* ]]; then
             echo ::set-output name=version::${GITHUB_REF#refs/tags/beta-}
             echo ::set-output name=prerelease::true
-            echo ::set-output name=body::"For a complete list of changes, see the changelog at https://github.com/paperless-ngx/paperless-ngx/blob/beta/docs/changelog.rst"
           fi
       -
-        name: Create release
-        id: create_release
-        uses: actions/create-release@v1
+        name: Create Release and Changelog
+        id: create-release
+        uses: release-drafter/release-drafter@v5
+        with:
+          name: Paperless-ngx ${{ steps.get_version.outputs.version }}
+          tag: ngx-${{ steps.get_version.outputs.version }}
+          version: ${{ steps.get_version.outputs.version }}
+          prerelease: ${{ steps.get_version.outputs.prerelease }}
+          publish: true # ensures release is not marked as draft
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ngx-${{ steps.get_version.outputs.version }}
-          release_name: Paperless-ngx ${{ steps.get_version.outputs.version }}
-          draft: false
-          prerelease: ${{ steps.get_version.outputs.prerelease }}
-          body: ${{ steps.get_version.outputs.body }}
       -
         name: Upload release archive
         id: upload-release-asset
@@ -352,13 +350,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          upload_url: ${{ steps.create-release.outputs.upload_url }}
           asset_path: ./paperless-ngx.tar.xz
           asset_name: paperless-ngx-${{ steps.get_version.outputs.version }}.tar.xz
           asset_content_type: application/x-xz
-      -
-        name: Create Changelog
-        id: create-changelog
-        uses: release-drafter/release-drafter@v5
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -356,3 +356,9 @@ jobs:
           asset_path: ./paperless-ngx.tar.xz
           asset_name: paperless-ngx-${{ steps.get_version.outputs.version }}.tar.xz
           asset_content_type: application/x-xz
+      -
+        name: Create Changelog
+        id: create-changelog
+        uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- 
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Implements the [release-drafter](https://github.com/release-drafter/release-drafter) action, replacing the `create-release` action. The created release should now include a generated changelog based on the PRs that were merged since last release. This organizes by label, in descending `merged-at` order:

1. Features (`enhancement`)
2. Bug Fixes (`bug`)
3. Documentation (`documentation`)
4. Maintenance (`chore`, `deployment`, `translation`)
5. Dependencies (`dependencies`)

I obviously haven't tested this, but we can make tweaks during the upcoming beta release. I expect if we're good with using the above labels it should be pretty comprehensive. Although this wouldn't include the individual contributions made on Crowdin.

**Question:** Should this replace [changelog.rst](https://github.com/paperless-ngx/paperless-ngx/blob/dev/docs/changelog.rst), or should we continue to update that file? At the moment the generated changelog would need to be converted to restructured text and manually appended to `changelog.rst`.

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
