### PR TITLE
Add `PAPERLESS_URL` env variable & CSRF var

### DIFF
--- a/docker/compose/docker-compose.env
+++ b/docker/compose/docker-compose.env
@@ -22,6 +22,10 @@
 # Docker setup does not use the configuration file.
 # A few commonly adjusted settings are provided below.
 
+# This is required if you will be exposing Paperless-ngx on a public domain
+# (if doing so please consider security measures such as reverse proxy)
+#PAPERLESS_URL=https://paperless.example.com
+
 # Adjust this key if you plan to make paperless available publicly. It should
 # be a very long sequence of random characters. You don't need to remember it.
 #PAPERLESS_SECRET_KEY=change-me

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -142,7 +142,24 @@ PAPERLESS_SECRET_KEY=<key>
 
     Default is listed in the file ``src/paperless/settings.py``.
 
-PAPERLESS_ALLOWED_HOSTS<comma-separated-list>
+PAPERLESS_URL=<url>
+    This setting can be used to set the three options below (ALLOWED_HOSTS,
+    CORS_ALLOWED_HOSTS and CSRF_TRUSTED_ORIGINS). If the other options are
+    set the values will be combined with this one. Do not include a trailing
+    slash. E.g. https://paperless.domain.com
+
+    Defaults to empty string, leaving the other settings unaffected.
+
+PAPERLESS_CSRF_TRUSTED_ORIGINS=<comma-separated-list>
+    A list of trusted origins for unsafe requests (e.g. POST). As of Django 4.0
+    this is required to access the Django admin via the web.
+    See https://docs.djangoproject.com/en/4.0/ref/settings/#csrf-trusted-origins
+
+    Can also be set using PAPERLESS_URL (see above).
+
+    Defaults to empty string, which does not add any origins to the trusted list.
+
+PAPERLESS_ALLOWED_HOSTS=<comma-separated-list>
     If you're planning on putting Paperless on the open internet, then you
     really should set this value to the domain name you're using.  Failing to do
     so leaves you open to HTTP host header attacks:
@@ -151,11 +168,15 @@ PAPERLESS_ALLOWED_HOSTS<comma-separated-list>
     Just remember that this is a comma-separated list, so "example.com" is fine,
     as is "example.com,www.example.com", but NOT " example.com" or "example.com,"
 
+    Can also be set using PAPERLESS_URL (see above).
+
     Defaults to "*", which is all hosts.
 
-PAPERLESS_CORS_ALLOWED_HOSTS<comma-separated-list>
+PAPERLESS_CORS_ALLOWED_HOSTS=<comma-separated-list>
     You need to add your servers to the list of allowed hosts that can do CORS
     calls. Set this to your public domain name.
+
+    Can also be set using PAPERLESS_URL (see above).
 
     Defaults to "http://localhost:8000".
 

--- a/install-paperless-ngx.sh
+++ b/install-paperless-ngx.sh
@@ -93,6 +93,14 @@ echo "1. Application configuration"
 echo "============================"
 
 echo ""
+echo "The URL paperless will be available at. This is required if the"
+echo "installation will be accessible via the web, otherwise can be left blank."
+echo ""
+
+ask "URL" ""
+URL=$ask_result
+
+echo ""
 echo "The port on which the paperless webserver will listen for incoming"
 echo "connections."
 echo ""
@@ -278,6 +286,7 @@ if [[ "$DATABASE_BACKEND" == "postgres" ]] ; then
 	fi
 fi
 echo ""
+echo "URL: $URL"
 echo "Port: $PORT"
 echo "Database: $DATABASE_BACKEND"
 echo "Tika enabled: $TIKA_ENABLED"
@@ -313,6 +322,9 @@ SECRET_KEY=$(tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w 64 | head -n 1)
 DEFAULT_LANGUAGES="deu eng fra ita spa"
 
 {
+	if [[ ! $URL == "" ]] ; then
+		echo "PAPERLESS_URL=$URL"
+	fi
 	if [[ ! $USERMAP_UID == "1000" ]] ; then
 		echo "USERMAP_UID=$USERMAP_UID"
 	fi

--- a/paperless.conf.example
+++ b/paperless.conf.example
@@ -27,8 +27,10 @@
 # Security and hosting
 
 #PAPERLESS_SECRET_KEY=change-me
-#PAPERLESS_ALLOWED_HOSTS=example.com,www.example.com
-#PAPERLESS_CORS_ALLOWED_HOSTS=http://example.com,http://localhost:8000
+#PAPERLESS_URL=https://example.com
+#PAPERLESS_CSRF_TRUSTED_ORIGINS=https://example.com # can be set using PAPERLESS_URL
+#PAPERLESS_ALLOWED_HOSTS=example.com,www.example.com # can be set using PAPERLESS_URL
+#PAPERLESS_CORS_ALLOWED_HOSTS=https://localhost:8080,https://example.com # can be set using PAPERLESS_URL
 #PAPERLESS_FORCE_SCRIPT_NAME=
 #PAPERLESS_STATIC_URL=/static/
 #PAPERLESS_AUTO_LOGIN_USERNAME=


### PR DESCRIPTION
<!-- 
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

This PR creates a `PAPERLESS_URL` env var to handle a few different options we have at the moment (also `PAPERLESS_CSRF_TRUSTED_ORIGINS`). This was sparked by Django 4.0's new CSRF requirement (see #670) which would require a new env variable, so I decided to combine them. When `PAPERLESS_URL` is set, it will add that value to:

- `CSRF_TRUSTED_ORIGINS` (alias `PAPERLESS_CSRF_TRUSTED_ORIGINS`). This is the new setting required by Django 4.0 see https://docs.djangoproject.com/en/4.0/ref/settings/#csrf-trusted-origins
- `CORS_ALLOWED_ORIGINS` (alias `PAPERLESS_CORS_ALLOWED_HOSTS`)
- `ALLOWED_HOSTS` (alias `PAPERLESS_ALLOWED_HOSTS`)

All three can also be set individually, in which case the values are combined with `PAPERLESS_URL`, if specified. This also maintains backwards compatibility, of course. This actually has a good security side-effect in that setting `PAPERLESS_URL` sets the others which though not required, are a good idea on a public-facing install.

Its obviously not a lot of Python / bash but appreciate review from you guys as I am not entirely comfortable in python/Django nor shell scripts.

I tested this out and seemed to work well, should be testable with [`ghcr.io/paperless-ngx/paperless-ngx:feature-django4-csrf`](https://ghcr.io/paperless-ngx/paperless-ngx:feature-django4-csrf)

Fixes #670

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
