### PR TITLE
[bug] - Fixes attachment filename matching during mail fetching

### DIFF
--- a/src/paperless_mail/mail.py
+++ b/src/paperless_mail/mail.py
@@ -253,7 +253,7 @@ class MailAccountHandler(LoggingMixin):
 
         return total_processed_files
 
-    def handle_message(self, message, rule):
+    def handle_message(self, message, rule) -> int:
         if not message.attachments:
             return 0
 
@@ -285,7 +285,12 @@ class MailAccountHandler(LoggingMixin):
                 continue
 
             if rule.filter_attachment_filename:
-                if not fnmatch(att.filename, rule.filter_attachment_filename):
+                # Force the filename and pattern to the lowercase
+                # as this is system dependent otherwise
+                if not fnmatch(
+                    att.filename.lower(),
+                    rule.filter_attachment_filename.lower(),
+                ):
                     continue
 
             title = self.get_title(message, att, rule)

--- a/src/paperless_mail/tests/test_mail.py
+++ b/src/paperless_mail/tests/test_mail.py
@@ -409,18 +409,21 @@ class TestMail(DirectoriesMixin, TestCase):
                 _AttachmentDef(filename="f2.pdf"),
                 _AttachmentDef(filename="f3.pdf"),
                 _AttachmentDef(filename="f2.png"),
+                _AttachmentDef(filename="file.PDf"),
+                _AttachmentDef(filename="f1.Pdf"),
             ],
         )
 
         tests = [
-            ("*.pdf", ["f1.pdf", "f2.pdf", "f3.pdf"]),
-            ("f1.pdf", ["f1.pdf"]),
+            ("*.pdf", ["f1.pdf", "f1.Pdf", "f2.pdf", "f3.pdf", "file.PDf"]),
+            ("f1.pdf", ["f1.pdf", "f1.Pdf"]),
             ("f1", []),
-            ("*", ["f1.pdf", "f2.pdf", "f3.pdf", "f2.png"]),
+            ("*", ["f1.pdf", "f2.pdf", "f3.pdf", "f2.png", "f1.Pdf", "file.PDf"]),
             ("*.png", ["f2.png"]),
         ]
 
         for (pattern, matches) in tests:
+            matches.sort()
             self.async_task.reset_mock()
             account = MailAccount()
             rule = MailRule(
@@ -431,11 +434,11 @@ class TestMail(DirectoriesMixin, TestCase):
 
             result = self.mail_account_handler.handle_message(message, rule)
 
-            self.assertEqual(result, len(matches))
-            filenames = [
-                a[1]["override_filename"] for a in self.async_task.call_args_list
-            ]
-            self.assertCountEqual(filenames, matches)
+            self.assertEqual(result, len(matches), f"Error with pattern: {pattern}")
+            filenames = sorted(
+                [a[1]["override_filename"] for a in self.async_task.call_args_list],
+            )
+            self.assertListEqual(filenames, matches)
 
     def test_handle_mail_account_mark_read(self):
 


### PR DESCRIPTION
## Proposed change

Updates the mail attachment filename matching to be case incentive, as this is what the model's help text says it will do.  Adds testing steps to cover insensitive matching.

Fixes #645

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
