### PR TITLE
add "localhost" to ALLOWED_HOSTS

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -170,6 +170,9 @@ PAPERLESS_ALLOWED_HOSTS=<comma-separated-list>
 
     Can also be set using PAPERLESS_URL (see above).
 
+    If manually set, please remember to include "localhost". Otherwise docker
+    healthcheck will fail.
+
     Defaults to "*", which is all hosts.
 
 PAPERLESS_CORS_ALLOWED_HOSTS=<comma-separated-list>

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -251,7 +251,8 @@ if _paperless_url:
     if _allowed_hosts:
         ALLOWED_HOSTS.append(_paperless_uri.hostname)
     else:
-        ALLOWED_HOSTS = [_paperless_uri.hostname]
+        # always allow localhost. Necessary e.g. for healthcheck in docker.
+        ALLOWED_HOSTS = [_paperless_uri.hostname] + ["localhost"]
 
 # The secret key has a default that should be fine so long as you're hosting
 # Paperless on a closed network.  However, if you're putting this anywhere


### PR DESCRIPTION
add "localhost" to ALLOWED_HOSTS if PAPERLESS_URL is set and ALLOWED_HOSTS is NOT set.


## Proposed change

Set ALLOWED_HOSTS not only to PAPERLESS_URL, but also to "localhost". This allows dockers heath check.

If PAPERLESS_URL wasn't set, ALLOWED_HOSTS would've been `"*"`. So just adding "localhost" shouldn't introduce any security concerns (IMHO).
Fixes #696 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
