### PR TITLE
Chore: Add Breaking Changes to release notes

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,4 +1,7 @@
 categories:
+  - title: 'Breaking Changes'
+    labels:
+      - 'breaking-change'
   - title: 'Features'
     labels:
       - 'enhancement'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -29,6 +29,6 @@ change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 change-title-escapes: '\<*_&#@'
 tag-prefix: "ngx-"
 template: |
-  ## Changelog
+  # Changelog
 
   $CHANGES


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

This adds a **Breaking Changes** section to the release notes / changelog, which would include PRs like #674.

After the release notes are created automatically, these **Breaking Changes** should be edited so they make sense to users.

- Add PAPERLESS_URL env variable & CSRF var
- _becomes_
- `PAPERLESS_URL` is now required when using a reverse proxy. See #674. 

I'll add that to the org-docs on merge.

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
