### PR TITLE
Fix: v1.7.0-rc1 Tags input should use body color

### DIFF
--- a/src-ui/src/styles.scss
+++ b/src-ui/src/styles.scss
@@ -209,7 +209,8 @@ input,
 select,
 textarea,
 .form-select:not(.is-invalid):not(:disabled),
-.form-check-input {
+.form-check-input,
+.ng-select .ng-select-container .ng-value-container .ng-input > input {
   color: var(--bs-body-color);
   background-color: var(--bs-body-bg);
   border-color: var(--bs-border-color);


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

This PR fixes an issue reported in v1.7.0-rc1 where tag inputs had the wrong (illegible) color. Screenshot below.

<img width="501" alt="Screen Shot 2022-04-12 at 2 39 40 PM" src="https://user-images.githubusercontent.com/4887959/163059744-e6a76a6d-9b81-4865-bfa4-71b3cd33a140.png">

Closes #707 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] ~~I have made corresponding changes to the documentation as needed.~~
- [x] I have checked my modifications for any breaking changes.
