### PR TITLE
Fixes IMAP UTF8 Authenication

### DIFF
--- a/src/paperless_mail/mail.py
+++ b/src/paperless_mail/mail.py
@@ -167,6 +167,7 @@ class MailAccountHandler(LoggingMixin):
                 M.login(account.username, account.password)
 
             except UnicodeEncodeError:
+                self.log("debug", "Falling back to AUTH=PLAIN")
                 try:
                     # rfc2595 section 6 - PLAIN SASL mechanism
                     client: IMAP4 = M.client
@@ -184,8 +185,13 @@ class MailAccountHandler(LoggingMixin):
                     # Need to transition out of AUTH state to SELECTED
                     M.folder.set("INBOX")
                 except Exception:
+                    self.log(
+                        "error",
+                        "Unable to authenticate with mail server using AUTH=PLAIN",
+                    )
                     raise MailError(f"Error while authenticating account {account}")
             except Exception:
+                self.log("error", "Unable to authenticate with mail server")
                 raise MailError(f"Error while authenticating account {account}")
 
             self.log(

--- a/src/paperless_mail/tests/test_mail.py
+++ b/src/paperless_mail/tests/test_mail.py
@@ -869,7 +869,7 @@ class TestMail(DirectoriesMixin, TestCase):
         """
         GIVEN:
             - Mail account with password containing non-ASCII characters
-            - Incorrect password alue
+            - Incorrect password value
         THEN:
             - Should raise a MailError for the account
         """

--- a/src/paperless_mail/tests/test_mail.py
+++ b/src/paperless_mail/tests/test_mail.py
@@ -852,7 +852,7 @@ class TestMail(DirectoriesMixin, TestCase):
         _ = MailRule.objects.create(
             name="testrule",
             account=account,
-            action=MailRule.AttachmentAction.MARK_READ,
+            action=MailRule.MailAction.MARK_READ,
         )
 
         self.assertEqual(len(self.bogus_mailbox.messages), 3)
@@ -885,7 +885,7 @@ class TestMail(DirectoriesMixin, TestCase):
         _ = MailRule.objects.create(
             name="testrule",
             account=account,
-            action=MailRule.AttachmentAction.MARK_READ,
+            action=MailRule.MailAction.MARK_READ,
         )
 
         self.assertRaises(

--- a/src/paperless_mail/tests/test_mail.py
+++ b/src/paperless_mail/tests/test_mail.py
@@ -17,6 +17,7 @@ from documents.tests.utils import DirectoriesMixin
 from imap_tools import EmailAddress
 from imap_tools import FolderInfo
 from imap_tools import MailboxFolderSelectError
+from imap_tools import MailboxLoginError
 from imap_tools import MailMessage
 from imap_tools import MailMessageFlags
 from paperless_mail import tasks
@@ -44,6 +45,14 @@ class BogusFolderManager:
         self.current_folder = new_folder
 
 
+class BogusClient(object):
+    def authenticate(self, mechanism, authobject):
+        # authobject must be a callable object
+        auth_bytes = authobject(None)
+        if auth_bytes != b"\x00admin\x00w57\xc3\xa4\xc3\xb6\xc3\xbcw4b6huwb6nhu":
+            raise MailboxLoginError("BAD", "OK")
+
+
 class BogusMailBox(ContextManager):
     def __enter__(self):
         return self
@@ -55,10 +64,14 @@ class BogusMailBox(ContextManager):
         self.messages: List[MailMessage] = []
         self.messages_spam: List[MailMessage] = []
         self.folder = BogusFolderManager()
+        self.client = BogusClient()
 
     def login(self, username, password):
-        if not (username == "admin" and password == "secret"):
-            raise Exception()
+        # This will raise a UnicodeEncodeError if the password is not ASCII only
+        password.encode("ascii")
+        # Otherwise, check for correct values
+        if username != "admin" or password not in {"secret"}:
+            raise MailboxLoginError("BAD", "OK")
 
     def fetch(self, criteria, mark_seen, charset=""):
         msg = self.messages
@@ -820,6 +833,66 @@ class TestMail(DirectoriesMixin, TestCase):
         self.mail_account_handler.handle_mail_account(account)
         self.assertEqual(len(self.bogus_mailbox.messages), 2)
         self.assertEqual(self.async_task.call_count, 5)
+
+    def test_auth_plain_fallback(self):
+        """
+        GIVEN:
+            - Mail account with password containing non-ASCII characters
+        THEN:
+            - Should still authenticate to the mail account
+        """
+        account = MailAccount.objects.create(
+            name="test",
+            imap_server="",
+            username="admin",
+            # Note the non-ascii characters here
+            password="w57äöüw4b6huwb6nhu",
+        )
+
+        _ = MailRule.objects.create(
+            name="testrule",
+            account=account,
+            action=MailRule.AttachmentAction.MARK_READ,
+        )
+
+        self.assertEqual(len(self.bogus_mailbox.messages), 3)
+        self.assertEqual(self.async_task.call_count, 0)
+        self.assertEqual(len(self.bogus_mailbox.fetch("UNSEEN", False)), 2)
+
+        self.mail_account_handler.handle_mail_account(account)
+
+        self.assertEqual(self.async_task.call_count, 2)
+        self.assertEqual(len(self.bogus_mailbox.fetch("UNSEEN", False)), 0)
+        self.assertEqual(len(self.bogus_mailbox.messages), 3)
+
+    def test_auth_plain_fallback_fails_still(self):
+        """
+        GIVEN:
+            - Mail account with password containing non-ASCII characters
+            - Incorrect password alue
+        THEN:
+            - Should raise a MailError for the account
+        """
+        account = MailAccount.objects.create(
+            name="test",
+            imap_server="",
+            username="admin",
+            # Note the non-ascii characters here
+            # Passes the check in login, not in authenticate
+            password="réception",
+        )
+
+        _ = MailRule.objects.create(
+            name="testrule",
+            account=account,
+            action=MailRule.AttachmentAction.MARK_READ,
+        )
+
+        self.assertRaises(
+            MailError,
+            self.mail_account_handler.handle_mail_account,
+            account,
+        )
 
 
 class TestManagementCommand(TestCase):


### PR DESCRIPTION
## Proposed change

In the event of a UnicodeEncodeError during normal login, we'll now try to fallback to an [AUTH=PLAIN](https://datatracker.ietf.org/doc/html/rfc2595#section-6) login type, which encodes the username and password differently.

I successfully tested this with a password containing UTF8 characters and was able to view the inbox.

Fixes #663

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
