### PR TITLE
Beta 1.7.0 rc1 CSS Fixes #1

### DIFF
--- a/src-ui/src/app/components/manage/settings/settings.component.html
+++ b/src-ui/src/app/components/manage/settings/settings.component.html
@@ -7,7 +7,7 @@
 
   <ul ngbNav #nav="ngbNav" class="nav-tabs">
     <li [ngbNavItem]="1">
-      <a ngbNavLink i18n>General settings</a>
+      <a ngbNavLink i18n>General</a>
       <ng-template ngbNavContent>
 
         <h4 i18n>Appearance</h4>
@@ -104,7 +104,7 @@
           <div class="col-md-3 col-form-label">
             <span i18n>Theme Color</span>
           </div>
-          <div class="col-3">
+          <div class="col col-md-3">
             <app-input-color i18n-title formControlName="themeColor" [error]="error?.color"></app-input-color>
           </div>
           <div class="col-2">

--- a/src-ui/src/styles.scss
+++ b/src-ui/src/styles.scss
@@ -442,10 +442,8 @@ table.table {
   border-color: var(--bs-danger);
 }
 
-.alert-secondary {
-  background-color: var(--pngx-primary-darken-18);
-  border-color: var(--pngx-primary-darken-15);
-  color: var(--bs-body-color);
+.progress {
+  background-color: var(--bs-body-bg);
 }
 
 .ngb-dp-header,

--- a/src-ui/src/theme.scss
+++ b/src-ui/src/theme.scss
@@ -15,6 +15,7 @@ body {
   --pngx-primary-darken-5: hsl(var(--pngx-primary), calc(var(--pngx-primary-lightness) - 5%));
   --pngx-primary-darken-15: hsl(var(--pngx-primary), calc(var(--pngx-primary-lightness) - 15%));
   --pngx-primary-darken-18: hsl(var(--pngx-primary), calc(var(--pngx-primary-lightness) - 18%));
+  --pngx-bg-alt: #fff;
   --pngx-bg-darker: var(--bs-gray-100);
   --pngx-focus-alpha: 0.3;
 }

--- a/src-ui/src/theme.scss
+++ b/src-ui/src/theme.scss
@@ -25,8 +25,8 @@ $text-color-light-bg: #212529;
 $text-color-dark-bg: #abb2bf;
 $text-color-dark-bg-accent: lighten($text-color-dark-bg, 10%);
 // Taken from bootstrap
-$form-check-input-checked-bg-image-dark: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><path fill='none' stroke='#212529' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='M6 10l3 3l6-6'/></svg>");
-$form-check-radio-checked-bg-image-dark: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='2' fill='#212529'/></svg>");
+$form-check-input-checked-bg-image-dark: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><path fill='none' stroke='#{$text-color-light-bg}' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='M6 10l3 3l6-6'/></svg>");
+$form-check-radio-checked-bg-image-dark: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='2' fill='#{$text-color-light-bg}'/></svg>");
 
 .primary-light {
   --pngx-primary-text-contrast: #{$text-color-light-bg} !important;

--- a/src-ui/src/theme.scss
+++ b/src-ui/src/theme.scss
@@ -48,28 +48,18 @@ $form-check-radio-checked-bg-image-dark: url("data:image/svg+xml,<svg xmlns='htt
   --pngx-primary-lightness: 31%;
 }
 
-$danger-dark-mode: #b71631;
-$danger-dark-mode-rgb: 183, 22, 49;
-$bg-dark-mode: #161618;
-$bg-dark-mode-rgb: 22, 22, 24;
-$bg-dark-mode-accent: #101216;
-$bg-dark-mode-alt: #242529;
-$bg-light-dark-mode: #1c1c1f;
-$bg-light-dark-mode-rgb: 28, 28, 31;
-$border-color-dark-mode: #47494f;
-
 @mixin dark-mode {
   --bs-body-color: #{$text-color-dark-bg};
   --pngx-body-color-accent: #{$text-color-dark-bg-accent};
-  --bs-danger: #{$danger-dark-mode};
-  --bs-danger-rgb: #{$danger-dark-mode-rgb};
-  --bs-body-bg: #{$bg-dark-mode};
-  --bs-body-bg-rgb: #{$bg-dark-mode-rgb};
-  --bs-light: #{$bg-light-dark-mode};
-  --bs-light-rgb: #{$bg-light-dark-mode-rgb};
-  --bs-border-color: #{$border-color-dark-mode};
-  --pngx-bg-darker: #{$bg-dark-mode-accent};
-  --pngx-bg-alt: #{$bg-dark-mode-alt};
+  --bs-danger: #b71631;
+  --bs-danger-rgb: 183, 22, 49;
+  --bs-body-bg: #161618;
+  --bs-body-bg-rgb: 22, 22, 24;
+  --bs-light: #1c1c1f;
+  --bs-light-rgb: 28, 28, 31;
+  --bs-border-color: #47494f;
+  --pngx-bg-darker: #101216;
+  --pngx-bg-alt: #242529;
   --pngx-focus-alpha: 0.6;
   --pngx-primary-faded: var(--pngx-primary-darken-15);
   --pngx-primary-text-contrast: var(--bs-body-color);
@@ -145,7 +135,7 @@ $border-color-dark-mode: #47494f;
 
   .ng-dropdown-panel .ng-dropdown-panel-items .ng-option:hover,
   .ng-dropdown-panel .ng-dropdown-panel-items .ng-option.ng-option-marked {
-    background-color: $bg-light-dark-mode;
+    background-color: var(--bs-light);
   }
 
   table {
@@ -157,7 +147,7 @@ $border-color-dark-mode: #47494f;
     }
 
     &.table-hover > tbody > tr:hover > * {
-      background-color: $bg-light-dark-mode;
+      background-color: var(--bs-light);
       color: var(--pngx-body-color-accent);
     }
 

--- a/src-ui/src/theme.scss
+++ b/src-ui/src/theme.scss
@@ -38,6 +38,10 @@ $form-check-radio-checked-bg-image-dark: url("data:image/svg+xml,<svg xmlns='htt
   .form-check-input:checked[type=radio] {
     background-image: escape-svg($form-check-radio-checked-bg-image-dark);
   }
+
+  .btn-close {
+    filter: none !important;
+  }
 }
 
 .primary-dark {
@@ -168,7 +172,7 @@ $form-check-radio-checked-bg-image-dark: url("data:image/svg+xml,<svg xmlns='htt
     text-shadow: 0 1px 0 #666;
   }
 
-  .modal .btn-close, .alert .btn-close {
+  .modal .btn-close, .alert .btn-close, .toast .btn-close {
     filter: invert(1) grayscale(100%) brightness(200%);
   }
 

--- a/src-ui/src/theme.scss
+++ b/src-ui/src/theme.scss
@@ -153,6 +153,12 @@ $form-check-radio-checked-bg-image-dark: url("data:image/svg+xml,<svg xmlns='htt
 
   }
 
+  .alert-secondary {
+    background-color: var(--bs-light);
+    border-color: var(--pngx-bg-darker);
+    color: var(--bs-body-color);
+  }
+
   .table-striped > tbody > tr:nth-of-type(odd) > * {
     color: var(--pngx-body-color-accent);
   }


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

This PR includes a few random CSS fixes for bugs found in v1.7.0-rc1, including a couple reported by @smseidl in https://github.com/paperless-ngx/paperless-ngx/pull/717#issuecomment-1100758310. Screenshots are below. I expect our CSS to stabilize a bit from here, there were a lot of changes in 1.7.0.

- fix dark mode progress bars showing in light mode
  - <img width="406" alt="Screen Shot 2022-04-17 at 12 15 30 AM" src="https://user-images.githubusercontent.com/4887959/163705843-b4194047-4c45-45f1-b542-87dd4213d3a7.png">
  - <img width="422" alt="Screen Shot 2022-04-17 at 12 15 22 AM" src="https://user-images.githubusercontent.com/4887959/163705846-f3882b54-790d-4a54-87f6-a740158f453e.png">
- fix dark mode popover carets showing in light mode
  - after: <img width="71" alt="Screen Shot 2022-04-17 at 12 36 27 AM" src="https://user-images.githubusercontent.com/4887959/163705871-c2cc5ea3-a394-4341-8d2f-703b4c3a59bc.png">
  - before: <img width="124" alt="Screen Shot 2022-04-17 at 12 36 08 AM" src="https://user-images.githubusercontent.com/4887959/163705872-b8df17a3-eddf-47ae-a5c5-d2cffa8c3e6e.png">
- fix settings tabs are too wide for mobile and theme color input not full width on mobile
  - after: <img width="401" alt="Screen Shot 2022-04-17 at 12 31 24 AM" src="https://user-images.githubusercontent.com/4887959/163705887-8c2d049e-9b65-4055-bf00-53cdc28284e9.png">
  - before: <img width="393" alt="Screen Shot 2022-04-17 at 12 31 29 AM" src="https://user-images.githubusercontent.com/4887959/163705892-43445e3f-8632-4f7b-a002-45ac66156cdd.png">
  - after: <img width="410" alt="Screen Shot 2022-04-17 at 12 33 36 AM" src="https://user-images.githubusercontent.com/4887959/163705911-695e60cb-81c8-4f01-b5af-2b42f7daea29.png">
  - before: <img width="508" alt="Screen Shot 2022-04-17 at 12 33 49 AM" src="https://user-images.githubusercontent.com/4887959/163705954-962d2db4-6cc6-43e6-ab7a-eb167c1454a3.png">
- fix toasts close X button doesnt respect background contrast
  - after: <img width="380" alt="Screen Shot 2022-04-17 at 12 47 33 AM" src="https://user-images.githubusercontent.com/4887959/163705927-a297a887-dc17-42b0-9bbd-3004bdcdc172.png">
  - after: <img width="379" alt="Screen Shot 2022-04-17 at 12 37 47 AM" src="https://user-images.githubusercontent.com/4887959/163705932-d91001aa-bedc-42e9-aaf9-7dca1e888058.png">


## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] ~~I have made corresponding changes to the documentation as needed.~~
- [x] I have checked my modifications for any breaking changes.
