### PR TITLE
List Email Account Folders In Event of Error Changing Folder

### DIFF
--- a/docs/usage_overview.rst
+++ b/docs/usage_overview.rst
@@ -182,11 +182,10 @@ These are as follows:
 
     When defining a mail rule with a folder, you may need to try different characters to
     define how the sub-folders are separated.  Common values include ".", "/" or "|", but
-    this varies by the mail server.  Unfortunately, this isn't a value we can determine
-    automatically.  Either check the documentation for your mail server, or check for
-    errors in the logs and try different folder separator values.  If possible,
-    the log will contain a listing of account folders, in the event of an error when
-    trying to fetch mail from a certain folder.
+    this varies by the mail server.  Check the documentation for your mail server.  In the
+    event of an error fetching mail from a certain folder, check the Paperless logs.  When
+    a folder is not located, Paperless will attempt to list all folders found in the account
+    to the Paperless logs.
 
 .. note::
 

--- a/docs/usage_overview.rst
+++ b/docs/usage_overview.rst
@@ -184,7 +184,9 @@ These are as follows:
     define how the sub-folders are separated.  Common values include ".", "/" or "|", but
     this varies by the mail server.  Unfortunately, this isn't a value we can determine
     automatically.  Either check the documentation for your mail server, or check for
-    errors in the logs and try different folder separator values.
+    errors in the logs and try different folder separator values.  If possible,
+    the log will contain a listing of account folders, in the event of an error when
+    trying to fetch mail from a certain folder.
 
 .. note::
 

--- a/src/paperless_mail/mail.py
+++ b/src/paperless_mail/mail.py
@@ -197,7 +197,7 @@ class MailAccountHandler(LoggingMixin):
             )
             try:
                 for folder_info in M.folder.list():
-                    self.log("info", f"Located folder: {str(folder_info)}")
+                    self.log("info", f"Located folder: {folder_info.name}")
             except Exception:
                 self.log(
                     "error",

--- a/src/paperless_mail/mail.py
+++ b/src/paperless_mail/mail.py
@@ -198,10 +198,11 @@ class MailAccountHandler(LoggingMixin):
             try:
                 for folder_info in M.folder.list():
                     self.log("info", f"Located folder: {folder_info.name}")
-            except Exception:
+            except Exception as e:
                 self.log(
                     "error",
-                    "Exception during folder listing, unable to provide list folders",
+                    "Exception during folder listing, unable to provide list folders: "
+                    + str(e),
                 )
 
             raise MailError(

--- a/src/paperless_mail/mail.py
+++ b/src/paperless_mail/mail.py
@@ -190,6 +190,20 @@ class MailAccountHandler(LoggingMixin):
         try:
             M.folder.set(rule.folder)
         except MailboxFolderSelectError:
+
+            self.log(
+                "error",
+                f"Unable to access folder {rule.folder}, attempting folder listing",
+            )
+            try:
+                for folder_info in M.folder.list():
+                    self.log("info", f"Located folder: {str(folder_info)}")
+            except Exception:
+                self.log(
+                    "error",
+                    "Exception during folder listing, unable to provide list folders",
+                )
+
             raise MailError(
                 f"Rule {rule}: Folder {rule.folder} "
                 f"does not exist in account {rule.account}",


### PR DESCRIPTION
## Proposed change

There seems to be a lot of variance with how email server represent folders over IMAP.  Users often encounter errors because folders may be delimited by different characters (`|` vs `/` vs `.` to name a few) or folders might be nested differently from how they are viewed in a web UI.

This pull request attempts to list all the account folders, if there is an error changing to the folder a mail rule is using.  If an exception is raised during the listing, we'll give up.  The folders visible are listed to the log, and a user will probably see the folder they wanted listed in a form they can then copy directly.  See the examples

Full info listing:
```
FolderInfo(name='Drafts', delim='/', flags=('\\Drafts', '\\NoInferiors'))
FolderInfo(name='INBOX', delim='/', flags=('\\HasNoChildren',))
FolderInfo(name='OUTBOX', delim='/', flags=('\\NoInferiors',))
FolderInfo(name='OtherFolder', delim='/', flags=('\\HasChildren',))
FolderInfo(name='OtherFolder/Othernested', delim='/', flags=('\\HasChildren',))
FolderInfo(name='OtherFolder/Othernested/Really really nested', delim='/', flags=('\\NoInferiors',))
FolderInfo(name='Sent', delim='/', flags=('\\Sent', '\\NoInferiors'))
FolderInfo(name='SomeFolder', delim='/', flags=('\\HasChildren',))
FolderInfo(name='SomeFolder/NestedFolder', delim='/', flags=('\\HasNoChildren',))
FolderInfo(name='Spam', delim='/', flags=('\\Junk', '\\NoInferiors'))
FolderInfo(name='Trash', delim='/', flags=('\\Trash', '\\HasNoChildren'))
```

The actual log output is filtered to output only the folder name, as the delimiter will be in the name, and the flags are just extra information.

Fixes #753 (by providing a user more information)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
