### PR TITLE
Adds simple Python to wait for Redis broker to be ready

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -138,6 +138,8 @@ RUN set -eux \
   && chmod 755 /sbin/docker-entrypoint.sh \
   && cp docker-prepare.sh /sbin/docker-prepare.sh \
   && chmod 755 /sbin/docker-prepare.sh \
+  && cp wait-for-redis.py /sbin/wait-for-redis.py \
+  && chmod 755 /sbin/wait-for-redis.py \
   && chmod +x install_management_commands.sh \
   && ./install_management_commands.sh
 

--- a/docker/docker-prepare.sh
+++ b/docker/docker-prepare.sh
@@ -27,6 +27,14 @@ wait_for_postgres() {
 	done
 }
 
+wait_for_redis() {
+	# We use a Python script to send the Redis ping
+	# instead of installing redis-tools just for 1 thing
+	if ! python3 /sbin/wait-for-redis.py; then
+		exit 1
+	fi
+}
+
 migrations() {
 	(
 		# flock is in place to prevent multiple containers from doing migrations
@@ -59,6 +67,8 @@ do_work() {
 	if [[ -n "${PAPERLESS_DBHOST}" ]]; then
 		wait_for_postgres
 	fi
+
+	wait_for_redis
 
 	migrations
 

--- a/docker/wait-for-redis.py
+++ b/docker/wait-for-redis.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""
+Simple script which attempts to ping the Redis broker as set in the environment for
+a certain number of times, waiting a little bit in between
+
+"""
+import os
+import sys
+import time
+from typing import Final
+
+from redis import Redis
+
+if __name__ == "__main__":
+
+    MAX_RETRY_COUNT: Final[int] = 5
+    RETRY_SLEEP_SECONDS: Final[int] = 5
+
+    REDIS_URL: Final[str] = os.getenv("PAPERLESS_REDIS", "redis://localhost:6379")
+
+    print(f"Waiting for Redis: {REDIS_URL}", flush=True)
+
+    attempt = 0
+    with Redis.from_url(url=REDIS_URL) as client:
+        while attempt < MAX_RETRY_COUNT:
+            try:
+                client.ping()
+                break
+            except Exception:
+                print(
+                    f"Redis ping #{attempt} failed, waiting {RETRY_SLEEP_SECONDS}s",
+                    flush=True,
+                )
+                time.sleep(RETRY_SLEEP_SECONDS)
+                attempt += 1
+
+    if attempt >= MAX_RETRY_COUNT:
+        print(f"Failed to connect to: {REDIS_URL}")
+        sys.exit(os.EX_UNAVAILABLE)
+    else:
+        print(f"Connected to Redis broker: {REDIS_URL}")
+        sys.exit(os.EX_OK)


### PR DESCRIPTION
## Proposed change

When starting the Docker container, adds a wait for the Redis broker to be up and ready.  Generally this sort of thing is taken care of by the `depends_on`, but certain ways of running don't have that functionality.

Why Python?  Mostly because we already include the redis library, so it doesn't require installing a new package just for this startup functionality.

Fixes #780

Passing logs
```
paperless-ngx-dev-webserver  | Waiting for Redis: redis://paperless-ngx-dev-broker:6379
paperless-ngx-dev-webserver  | Connected to Redis broker: redis://paperless-ngx-dev-broker:6379
```

Failing logs
```
paperless-ngx-dev-webserver  | Waiting for Redis: redis://paperless-ngx-dev-broker:6378
paperless-ngx-dev-webserver  | Redis ping #0 failed, waiting 5s
paperless-ngx-dev-webserver  | Redis ping #1 failed, waiting 5s
paperless-ngx-dev-webserver  | Redis ping #2 failed, waiting 5s
paperless-ngx-dev-webserver  | Redis ping #3 failed, waiting 5s
paperless-ngx-dev-webserver  | Redis ping #4 failed, waiting 5s
paperless-ngx-dev-webserver  | Failed to connect to: redis://paperless-ngx-dev-broker:6378
paperless-ngx-dev-webserver exited with code 1
```


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
