### PR TITLE
Fixes Pillow build for armv7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,14 @@ ARG RUNTIME_PACKAGES="\
   liblept5 \
   libpq5 \
   libxml2 \
+  liblcms2-2 \
+  libtiff5 \
   libxslt1.1 \
+  libfreetype6 \
+  libwebp6 \
+  libopenjp2-7 \
+  libimagequant0 \
+  libraqm0 \
   libgnutls30 \
   libjpeg62-turbo \
   optipng \

--- a/build-docker-image.sh
+++ b/build-docker-image.sh
@@ -37,6 +37,9 @@ psycopg2_git_tag=${psycopg2_version//./_}
 # pikepdf uses vX.Y.Z
 pikepdf_git_tag="v${pikepdf_version}"
 
+# https://docs.docker.com/develop/develop-images/build_enhancements/
+export DOCKER_BUILDKIT=1
+
 docker build --file "$1" \
 	--build-arg JBIG2ENC_VERSION="${jbig2enc_version}" \
 	--build-arg QPDF_VERSION="${qpdf_version}" \

--- a/docker-builders/Dockerfile.jbig2enc
+++ b/docker-builders/Dockerfile.jbig2enc
@@ -2,7 +2,7 @@
 # Inputs:
 #    - JBIG2ENC_VERSION - the Git tag to checkout and build
 
-FROM debian:bullseye-slim
+FROM debian:bullseye-slim as main
 
 LABEL org.opencontainers.image.description="A intermediate image with jbig2enc built"
 

--- a/docker-builders/Dockerfile.pikepdf
+++ b/docker-builders/Dockerfile.pikepdf
@@ -13,7 +13,7 @@ FROM ghcr.io/${REPO}/builder/qpdf:${QPDF_VERSION} as qpdf-builder
 
 # This does nothing, except provide a name for a copy below
 
-FROM python:3.9-slim-bullseye
+FROM python:3.9-slim-bullseye as main
 
 LABEL org.opencontainers.image.description="A intermediate image with pikepdf wheel built"
 
@@ -21,14 +21,33 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 ARG BUILD_PACKAGES="\
   build-essential \
+  python3-dev \
+  python3-pip \
   git \
-  libjpeg62-turbo-dev \
-  zlib1g-dev \
+  # qpdf requirement - https://github.com/qpdf/qpdf#crypto-providers
   libgnutls28-dev \
+  # lxml requrements - https://lxml.de/installation.html
   libxml2-dev \
   libxslt1-dev \
-  python3-dev \
-  python3-pip"
+  # Pillow requirements - https://pillow.readthedocs.io/en/stable/installation.html
+  # JPEG functionality
+  libjpeg62-turbo-dev \
+  # conpressed PNG
+  zlib1g-dev \
+  # compressed TIFF
+  libtiff-dev \
+  # type related services
+  libfreetype-dev \
+  # color management
+  liblcms2-dev \
+  # WebP format
+  libwebp-dev \
+  # JPEG 2000
+  libopenjp2-7-dev \
+  # improved color quantization
+  libimagequant-dev \
+  # complex text layout support
+  libraqm-dev"
 
 WORKDIR /usr/src
 
@@ -42,7 +61,11 @@ RUN set -eux \
   && apt-get install --yes --quiet --no-install-recommends $BUILD_PACKAGES \
   && dpkg --install libqpdf28_*.deb \
   && dpkg --install libqpdf-dev_*.deb \
-  && python3 -m pip install --no-cache-dir --upgrade pip wheel pybind11 \
+  && python3 -m pip install --no-cache-dir --upgrade \
+    pip \
+    wheel \
+    # https://pikepdf.readthedocs.io/en/latest/installation.html#requirements
+    pybind11 \
   && rm -rf /var/lib/apt/lists/*
 
 # Layers after this point change according to required version

--- a/docker-builders/Dockerfile.pikepdf
+++ b/docker-builders/Dockerfile.pikepdf
@@ -29,7 +29,7 @@ ARG BUILD_PACKAGES="\
   # lxml requrements - https://lxml.de/installation.html
   libxml2-dev \
   libxslt1-dev \
-  # Pillow requirements - https://pillow.readthedocs.io/en/stable/installation.html
+  # Pillow requirements - https://pillow.readthedocs.io/en/stable/installation.html#external-libraries
   # JPEG functionality
   libjpeg62-turbo-dev \
   # conpressed PNG

--- a/docker-builders/Dockerfile.psycopg2
+++ b/docker-builders/Dockerfile.psycopg2
@@ -3,7 +3,7 @@
 #    - PSYCOPG2_GIT_TAG - The Git tag to clone and build from
 #    - PSYCOPG2_VERSION - Unused, kept for future possible usage
 
-FROM python:3.9-slim-bullseye
+FROM python:3.9-slim-bullseye as main
 
 LABEL org.opencontainers.image.description="A intermediate image with psycopg2 wheel built"
 
@@ -12,9 +12,10 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG BUILD_PACKAGES="\
   build-essential \
   git \
-  libpq-dev \
   python3-dev \
-  python3-pip"
+  python3-pip \
+  # https://www.psycopg.org/docs/install.html#prerequisites
+  libpq-dev"
 
 WORKDIR /usr/src
 

--- a/docker-builders/Dockerfile.qpdf
+++ b/docker-builders/Dockerfile.qpdf
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM debian:bullseye-slim as main
 
 LABEL org.opencontainers.image.description="A intermediate image with qpdf built"
 
@@ -11,6 +11,7 @@ ARG BUILD_PACKAGES="\
   devscripts \
   equivs  \
   libtool \
+  # https://qpdf.readthedocs.io/en/stable/installation.html#system-requirements
   libjpeg62-turbo-dev \
   libgnutls28-dev \
   packaging-dev \


### PR DESCRIPTION
## Proposed change

I'm reasonably sure this will fix the issue with Pillow on armv7 platforms.  However, I don't have an arm device (like a raspberry pi) to test it against.  So we'll need to either find a way or just cross our fingers and try it.

To Test:
1. We need to delete the package `paperless-ngx/paperless-ngx/builder/pikepdf:5.1.1`
2. Re-run the workflow to rebuild that image
3. Find someone with an arm device or figure out emulation

The root of the issue is building Pillow from source, without [certain development libraries](https://pillow.readthedocs.io/en/stable/installation.html#external-libraries) installed isn't an error, but doesn't enable the full set of features for Pillow, including the color management of littlecms.  For amd64 or aarch64, PyPi provides pre-built wheels, so it isn't a problem there.

Fixes #810

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
