### PR TITLE
Updates GHA workflow to rebuild intermediate images on changes

### DIFF
--- a/.github/scripts/common.py
+++ b/.github/scripts/common.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+
+def get_image_tag(
+    repo_name: str,
+    pkg_name: str,
+    pkg_version: str,
+) -> str:
+    """
+    Returns a string representing the normal image for a given package
+    """
+    return f"ghcr.io/{repo_name}/builder/{pkg_name}:{pkg_version}"
+
+
+def get_cache_image_tag(
+    repo_name: str,
+    pkg_name: str,
+    pkg_version: str,
+    branch_name: str,
+) -> str:
+    """
+    Returns a string representing the expected image cache tag for a given package
+
+    Registry type caching is utilized for the builder images, to allow fast
+    rebuilds, generally almost instant for the same version
+    """
+    return f"ghcr.io/{repo_name}/builder/cache/{pkg_name}:{pkg_version}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,14 +76,10 @@ jobs:
         with:
           python-version: "3.9"
       -
-        name: Make script executable
-        run: |
-          chmod +x ${GITHUB_WORKSPACE}/docker-builders/get-build-json.py
-      -
         name: Setup qpdf image
         id: qpdf-setup
         run: |
-          build_json=$(python ${GITHUB_WORKSPACE}/docker-builders/get-build-json.py qpdf)
+          build_json=$(python ${GITHUB_WORKSPACE}/.github/scripts/get-build-json.py qpdf)
 
           echo ${build_json}
 
@@ -92,7 +88,7 @@ jobs:
         name: Setup psycopg2 image
         id: psycopg2-setup
         run: |
-          build_json=$(python ${GITHUB_WORKSPACE}/docker-builders/get-build-json.py psycopg2)
+          build_json=$(python ${GITHUB_WORKSPACE}/.github/scripts/get-build-json.py psycopg2)
 
           echo ${build_json}
 
@@ -101,7 +97,7 @@ jobs:
         name: Setup pikepdf image
         id: pikepdf-setup
         run: |
-          build_json=$(python ${GITHUB_WORKSPACE}/docker-builders/get-build-json.py pikepdf)
+          build_json=$(python ${GITHUB_WORKSPACE}/.github/scripts/get-build-json.py pikepdf)
 
           echo ${build_json}
 
@@ -110,7 +106,7 @@ jobs:
         name: Setup jbig2enc image
         id: jbig2enc-setup
         run: |
-          build_json=$(python ${GITHUB_WORKSPACE}/docker-builders/get-build-json.py jbig2enc)
+          build_json=$(python ${GITHUB_WORKSPACE}/.github/scripts/get-build-json.py jbig2enc)
 
           echo ${build_json}
 
@@ -119,7 +115,7 @@ jobs:
         name: Setup frontend image
         id: frontend-setup
         run: |
-          build_json=$(python ${GITHUB_WORKSPACE}/docker-builders/get-build-json.py frontend)
+          build_json=$(python ${GITHUB_WORKSPACE}/.github/scripts/get-build-json.py frontend)
 
           echo ${build_json}
 
@@ -198,15 +194,6 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 2
-      -
-        name: Get changed frontend files
-        id: changed-files-specific
-        uses: tj-actions/changed-files@v18.1
-        with:
-          files: |
-            src-ui/**
       -
         name: Login to Github Container Registry
         uses: docker/login-action@v1
@@ -215,32 +202,14 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       -
-        name: Determine if build needed
-        id: build-skip-check
-        # Skip building the frontend if the tag exists and no src-ui files changed
-        run: |
-          if ! docker manifest inspect ${{ fromJSON(needs.prepare-docker-build.outputs.frontend-json).image_tag }} &> /dev/null ; then
-            echo "Build required, no existing image"
-            echo ::set-output name=frontend-build-needed::true
-          elif ${{ steps.changed-files-specific.outputs.any_changed }} == 'true' ; then
-            echo "Build required, src-ui changes"
-            echo ::set-output name=frontend-build-needed::true
-          else
-            echo "No build required"
-            echo ::set-output name=frontend-build-needed::false
-          fi
-      -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-        if: ${{ steps.build-skip-check.outputs.frontend-build-needed == 'true' }}
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v1
-        if: ${{ steps.build-skip-check.outputs.frontend-build-needed == 'true' }}
       -
         name: Compile frontend
         uses: docker/build-push-action@v2
-        if: ${{ steps.build-skip-check.outputs.frontend-build-needed == 'true' }}
         with:
           context: .
           file: ./docker-builders/Dockerfile.frontend
@@ -250,8 +219,8 @@ jobs:
           # But the platform is set to the runner's native for speedup
           platforms: linux/amd64
           push: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=${{ fromJSON(needs.prepare-docker-build.outputs.frontend-json).cache_tag }}
+          cache-to: type=registry,mode=max,ref=${{ fromJSON(needs.prepare-docker-build.outputs.frontend-json).cache_tag }}
       -
         name: Export frontend artifact from docker
         run: |

--- a/.github/workflows/reusable-ci-backend.yml
+++ b/.github/workflows/reusable-ci-backend.yml
@@ -87,7 +87,7 @@ jobs:
       -
         name: Get changed files
         id: changed-files-specific
-        uses: tj-actions/changed-files@v18.1
+        uses: tj-actions/changed-files@v18.7
         with:
           files: |
             src/**

--- a/.github/workflows/reusable-workflow-builder.yml
+++ b/.github/workflows/reusable-workflow-builder.yml
@@ -24,6 +24,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
         name: Login to Github Container Registry
         uses: docker/login-action@v1
         with:
@@ -31,32 +34,14 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       -
-        name: Determine if build needed
-        id: build-skip-check
-        run: |
-          if ! docker manifest inspect ${{ fromJSON(inputs.build-json).image_tag }} &> /dev/null ; then
-            echo "Building, no image exists with this version"
-            echo ::set-output name=image-exists::false
-          else
-            echo "Not building, image exists with this version"
-            echo ::set-output name=image-exists::true
-          fi
-      -
-        name: Checkout
-        uses: actions/checkout@v3
-        if: ${{ steps.build-skip-check.outputs.image-exists == 'false' }}
-      -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-        if: ${{ steps.build-skip-check.outputs.image-exists == 'false' }}
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v1
-        if: ${{ steps.build-skip-check.outputs.image-exists == 'false' }}
       -
         name: Build ${{ fromJSON(inputs.build-json).name }}
         uses: docker/build-push-action@v2
-        if: ${{ steps.build-skip-check.outputs.image-exists == 'false' }}
         with:
           context: .
           file: ${{ inputs.dockerfile }}
@@ -64,5 +49,5 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           build-args: ${{ inputs.build-args }}
           push: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=${{ fromJSON(inputs.build-json).cache_tag }}
+          cache-to: type=registry,mode=max,ref=${{ fromJSON(inputs.build-json).cache_tag }}


### PR DESCRIPTION
## Proposed change

As noticed in #815, if there is an issue with one of the intermediate images we build ahead of time, the only way to rebuild it would be delete the image or tag, then re-run a workflow, while hoping that another running workflow doesn't re-create it before the branch you want to does.  That's not really great and we may want to add new system packages to the intermediate images or make other improvements and fixes as the gets tested.  So, to fix this, this PR updates how the workflow builds those images.  

Previously, if the package version already existed, the build of that package was skipped.  So `pikepdf == 5.1.1` exists, don't rebuild it.  This was done for speeding up the workflow, as rebuilding some packages (qpdf) can take around 2hrs.  

Now, the image will be rebuilt, but the action will cache to the registry, using an image tag like `builder/cache/{package}:{version}`.  If there are no changes to the image Dockerfile, the rebuild will take only seconds.  If we've made improvements to the Dockerfile or a new version, the image build will take just as long as it did before, but we'll get those new features or fixes.

Why the registry?  The cache is limited in size, to something like [10GB](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy) and it never seemed to work quite right for multi-platform images anyway.  However, for public packages (like these), storage [looks to be un-restricted](https://docs.github.com/en/billing/managing-billing-for-github-packages/about-billing-for-github-packages#about-billing-for-github-packages).

The primary Docker image build will take the same roughly 25mins to build as before.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
