### PR TITLE
Enable Docker Hub push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,13 +64,6 @@ jobs:
         name: Checkout
         uses: actions/checkout@v3
       -
-        name: Login to Github Container Registry
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      -
         name: Set up Python
         uses: actions/setup-python@v3
         with:
@@ -248,11 +241,24 @@ jobs:
       - build-frontend
     steps:
       -
+        name: Check pushing to Docker Hub
+        id: docker-hub
+        # Only push to Dockerhub from the main repo
+        # Otherwise forks would require a Docker Hub account and secrets setup
+        run: |
+          if [[ ${{ github.repository }} == "paperless-ngx/paperless-ngx" ]] ; then
+            echo ::set-output name=enable::"true"
+          else
+            echo ::set-output name=enable::"false"
+          fi
+      -
         name: Gather Docker metadata
         id: docker-meta
         uses: docker/metadata-action@v3
         with:
-          images: ghcr.io/${{ github.repository }}
+          images: |
+            ghcr.io/${{ github.repository }}
+            name=paperlessngx/paperless-ngx,enable=${{ steps.docker-hub.outputs.enable }}
           tags: |
             type=ref,event=branch
             type=ref,event=tag
@@ -272,6 +278,14 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Login to Docker Hub
+        uses: docker/login-action@v1
+        # Don't attempt to login is not pushing to Docker Hub
+        if: steps.docker-hub.outputs.enable == 'true'
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Build and push
         uses: docker/build-push-action@v2


### PR DESCRIPTION
## Proposed change

This PR enables pushing our images to the [Docker Hub](https://hub.docker.com/r/paperlessngx/paperless-ngx/tags), in addition to GitHub Container Registry.  

As a future enhancement, we should probably figure out how to push the README to the hub as well.  It would require a different action, such as: https://github.com/peter-evans/dockerhub-description

Fixes #457

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
