### PR TITLE
Fix: Older dates do not display on frontend

### DIFF
--- a/src-ui/src/app/components/document-detail/document-detail.component.ts
+++ b/src-ui/src/app/components/document-detail/document-detail.component.ts
@@ -34,6 +34,7 @@ import {
 } from 'rxjs/operators'
 import { PaperlessDocumentSuggestions } from 'src/app/data/paperless-document-suggestions'
 import { FILTER_FULLTEXT_MORELIKE } from 'src/app/data/filter-rule-type'
+import { normalizeDateStr } from 'src/app/utils/date'
 
 @Component({
   selector: 'app-document-detail',
@@ -146,7 +147,7 @@ export class DocumentDetailComponent
       .pipe(takeUntil(this.unsubscribeNotifier))
       .subscribe((changes) => {
         if (this.ogDate) {
-          let newDate = new Date(changes['created'])
+          let newDate = new Date(normalizeDateStr(changes['created']))
           newDate.setHours(
             this.ogDate.getHours(),
             this.ogDate.getMinutes(),
@@ -154,7 +155,7 @@ export class DocumentDetailComponent
             this.ogDate.getMilliseconds()
           )
           this.documentForm.patchValue(
-            { created: this.formatDate(newDate) },
+            { created: newDate.toISOString() },
             { emitEvent: false }
           )
         }
@@ -199,22 +200,22 @@ export class DocumentDetailComponent
             this.updateComponent(doc)
           }
 
-          this.ogDate = new Date(doc.created)
+          this.ogDate = new Date(normalizeDateStr(doc.created.toString()))
 
           // Initialize dirtyCheck
           this.store = new BehaviorSubject({
             title: doc.title,
             content: doc.content,
-            created: this.formatDate(this.ogDate),
+            created: this.ogDate.toISOString(),
             correspondent: doc.correspondent,
             document_type: doc.document_type,
             archive_serial_number: doc.archive_serial_number,
             tags: [...doc.tags],
           })
 
-          // ensure we're always starting with 24-char ISO8601 string
+          // start with ISO8601 string
           this.documentForm.patchValue(
-            { created: this.formatDate(this.ogDate) },
+            { created: this.ogDate.toISOString() },
             { emitEvent: false }
           )
 
@@ -484,9 +485,5 @@ export class DocumentDetailComponent
     if ('Enter' == event.key) {
       this.password = (event.target as HTMLInputElement).value
     }
-  }
-
-  formatDate(date: Date): string {
-    return date.toISOString().split('.')[0] + 'Z'
   }
 }

--- a/src-ui/src/app/pipes/custom-date.pipe.ts
+++ b/src-ui/src/app/pipes/custom-date.pipe.ts
@@ -1,6 +1,7 @@
 import { DatePipe } from '@angular/common'
 import { Inject, LOCALE_ID, Pipe, PipeTransform } from '@angular/core'
 import { SettingsService, SETTINGS_KEYS } from '../services/settings.service'
+import { normalizeDateStr } from '../utils/date'
 
 const FORMAT_TO_ISO_FORMAT = {
   longDate: 'y-MM-dd',
@@ -33,6 +34,7 @@ export class CustomDatePipe implements PipeTransform {
       this.settings.get(SETTINGS_KEYS.DATE_LOCALE) ||
       this.defaultLocale
     let f = format || this.settings.get(SETTINGS_KEYS.DATE_FORMAT)
+    if (typeof value == 'string') value = normalizeDateStr(value)
     if (l == 'iso-8601') {
       return this.datePipe.transform(value, FORMAT_TO_ISO_FORMAT[f], timezone)
     } else {

--- a/src-ui/src/app/utils/date.ts
+++ b/src-ui/src/app/utils/date.ts
@@ -1,0 +1,5 @@
+// see https://github.com/dateutil/dateutil/issues/878 , JS Date does not
+// seem to accept these strings as valid dates so we must normalize offset
+export function normalizeDateStr(dateStr: string): string {
+  return dateStr.replace(/-(\d\d):\d\d:\d\d/gm, `-$1:00`)
+}


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

This PR fixes an issue with very old date strings which correctly report odd tz offsets like 07:52:38 which seem to be incompatible with Javascript's Date object. See linked issue

Fixes #818 

<img width="707" alt="Screen Shot 2022-04-30 at 9 37 27 PM" src="https://user-images.githubusercontent.com/4887959/166132518-499598c4-c06e-42ed-a212-927d92e85176.png">

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] ~~I have made corresponding changes to the documentation as needed.~~
- [x] I have checked my modifications for any breaking changes.
