### PR TITLE
Bugfix document exporter document dates are off by one day #267

### DIFF
--- a/src/documents/models.py
+++ b/src/documents/models.py
@@ -11,7 +11,6 @@ from django.conf import settings
 from django.contrib.auth.models import User
 from django.db import models
 from django.utils import timezone
-from django.utils.timezone import is_aware
 from django.utils.translation import gettext_lazy as _
 from documents.parsers import get_default_file_extension
 
@@ -210,10 +209,8 @@ class Document(models.Model):
         verbose_name_plural = _("documents")
 
     def __str__(self):
-        if is_aware(self.created):
-            created = timezone.localdate(self.created).isoformat()
-        else:
-            created = datetime.date.isoformat(self.created)
+        created = datetime.date.isoformat(self.created)
+
         if self.correspondent and self.title:
             return f"{created} {self.correspondent} {self.title}"
         else:

--- a/src/documents/tests/test_document_model.py
+++ b/src/documents/tests/test_document_model.py
@@ -1,8 +1,12 @@
 import shutil
 import tempfile
-import zoneinfo
 from pathlib import Path
 from unittest import mock
+
+try:
+    import zoneinfo
+except ImportError:
+    import backports.zoneinfo as zoneinfo
 
 from django.test import override_settings
 from django.test import TestCase

--- a/src/documents/tests/test_document_model.py
+++ b/src/documents/tests/test_document_model.py
@@ -3,6 +3,7 @@ import tempfile
 from pathlib import Path
 from unittest import mock
 
+import pytz
 from django.test import override_settings
 from django.test import TestCase
 from django.utils import timezone
@@ -52,6 +53,24 @@ class TestDocument(TestCase):
             mime_type="application/pdf",
             title="test",
             created=timezone.datetime(2020, 12, 25),
+        )
+        self.assertEqual(doc.get_public_filename(), "2020-12-25 test.pdf")
+
+    def test_file_name_with_timezone(self):
+
+        doc = Document(
+            mime_type="application/pdf",
+            title="test",
+            created=timezone.datetime(
+                2020,
+                12,
+                25,
+                0,
+                0,
+                0,
+                0,
+                pytz.timezone("Europe/Berlin"),
+            ),
         )
         self.assertEqual(doc.get_public_filename(), "2020-12-25 test.pdf")
 

--- a/src/documents/tests/test_document_model.py
+++ b/src/documents/tests/test_document_model.py
@@ -1,9 +1,9 @@
 import shutil
 import tempfile
+import zoneinfo
 from pathlib import Path
 from unittest import mock
 
-import pytz
 from django.test import override_settings
 from django.test import TestCase
 from django.utils import timezone
@@ -69,7 +69,7 @@ class TestDocument(TestCase):
                 0,
                 0,
                 0,
-                pytz.timezone("Europe/Berlin"),
+                zoneinfo.ZoneInfo("Europe/Berlin"),
             ),
         )
         self.assertEqual(doc.get_public_filename(), "2020-12-25 test.pdf")


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

I added a test to describe the expectation for a filename if you have a timezone different then UTC, to simulate a bug described in #267. The test failed so I made it pass. 

Even while I'm happy to fix a bug, I'm confused. paperless-ng already had this issue (see https://github.com/jonaswinkler/paperless-ng/issues/331) and basically I reverted the production code change (see https://github.com/jonaswinkler/paperless-ng/commit/623893b528f3cd688627b59eabf67f45d439f05d). 
All tests of the suite still are passing so it seems I haven't broken something.

Fixes #267

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
