### PR TITLE
Always accept yyyy-mm-dd date inputs

### DIFF
--- a/src-ui/src/app/utils/ngb-date-parser-formatter.ts
+++ b/src-ui/src/app/utils/ngb-date-parser-formatter.ts
@@ -51,11 +51,22 @@ export class LocalizedDateParserFormatter extends NgbDateParserFormatter {
     const dateSeparator = inputFormat.replace(/[dmy]/gi, '').charAt(0)
 
     if (this.separatorRegExp.test(value)) {
-      // split on separator, pad & re-join without separator
-      value = value
-        .split(this.separatorRegExp)
-        .map((segment) => segment.padStart(2, '0'))
-        .join('')
+      let segments = value.split(this.separatorRegExp)
+
+      // always accept strict yyyy*mm*dd format even if thats not the input format since we can be certain its not yyyy*dd*mm
+      if (
+        value.length == 10 &&
+        segments.length == 3 &&
+        segments[0].length == 4
+      ) {
+        return inputFormat
+          .replace('yyyy', segments[0])
+          .replace('mm', segments[1])
+          .replace('dd', segments[2])
+      } else {
+        // otherwise pad & re-join without separator
+        value = segments.map((segment) => segment.padStart(2, '0')).join('')
+      }
     }
 
     if (value.length == 4 && inputFormat.substring(0, 4) != 'yyyy') {


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

This PR allows for using yyyy*mm*dd strings in date inputs, see linked issue. Dates, man.

Fixes #863

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] ~~I have made corresponding changes to the documentation as needed.~~
- [x] I have checked my modifications for any breaking changes.
