### PR TITLE
Feature / fix saved view & sort field query params

### DIFF
--- a/src-ui/src/app/components/app-frame/app-frame.component.ts
+++ b/src-ui/src/app/components/app-frame/app-frame.component.ts
@@ -94,7 +94,7 @@ export class AppFrameComponent {
 
   search() {
     this.closeMenu()
-    this.queryParamsService.loadFilterRules([
+    this.queryParamsService.navigateWithFilterRules([
       {
         rule_type: FILTER_FULLTEXT_QUERY,
         value: (this.searchField.value as string).trim(),

--- a/src-ui/src/app/components/app-frame/app-frame.component.ts
+++ b/src-ui/src/app/components/app-frame/app-frame.component.ts
@@ -22,6 +22,7 @@ import {
   RemoteVersionService,
   AppRemoteVersion,
 } from 'src/app/services/rest/remote-version.service'
+import { QueryParamsService } from 'src/app/services/query-params.service'
 
 @Component({
   selector: 'app-app-frame',
@@ -37,7 +38,8 @@ export class AppFrameComponent {
     public savedViewService: SavedViewService,
     private list: DocumentListViewService,
     private meta: Meta,
-    private remoteVersionService: RemoteVersionService
+    private remoteVersionService: RemoteVersionService,
+    private queryParamsService: QueryParamsService
   ) {
     this.remoteVersionService
       .checkForUpdates()
@@ -92,7 +94,7 @@ export class AppFrameComponent {
 
   search() {
     this.closeMenu()
-    this.list.quickFilter([
+    this.queryParamsService.loadFilterRules([
       {
         rule_type: FILTER_FULLTEXT_QUERY,
         value: (this.searchField.value as string).trim(),

--- a/src-ui/src/app/components/dashboard/widgets/saved-view-widget/saved-view-widget.component.ts
+++ b/src-ui/src/app/components/dashboard/widgets/saved-view-widget/saved-view-widget.component.ts
@@ -3,11 +3,11 @@ import { Router } from '@angular/router'
 import { Subscription } from 'rxjs'
 import { PaperlessDocument } from 'src/app/data/paperless-document'
 import { PaperlessSavedView } from 'src/app/data/paperless-saved-view'
-import { DocumentListViewService } from 'src/app/services/document-list-view.service'
 import { ConsumerStatusService } from 'src/app/services/consumer-status.service'
 import { DocumentService } from 'src/app/services/rest/document.service'
 import { PaperlessTag } from 'src/app/data/paperless-tag'
 import { FILTER_HAS_TAGS_ALL } from 'src/app/data/filter-rule-type'
+import { QueryParamsService } from 'src/app/services/query-params.service'
 
 @Component({
   selector: 'app-saved-view-widget',
@@ -18,7 +18,7 @@ export class SavedViewWidgetComponent implements OnInit, OnDestroy {
   constructor(
     private documentService: DocumentService,
     private router: Router,
-    private list: DocumentListViewService,
+    private queryParamsService: QueryParamsService,
     private consumerStatusService: ConsumerStatusService
   ) {}
 
@@ -67,7 +67,7 @@ export class SavedViewWidgetComponent implements OnInit, OnDestroy {
   }
 
   clickTag(tag: PaperlessTag) {
-    this.list.quickFilter([
+    this.queryParamsService.loadFilterRules([
       { rule_type: FILTER_HAS_TAGS_ALL, value: tag.id.toString() },
     ])
   }

--- a/src-ui/src/app/components/dashboard/widgets/saved-view-widget/saved-view-widget.component.ts
+++ b/src-ui/src/app/components/dashboard/widgets/saved-view-widget/saved-view-widget.component.ts
@@ -60,8 +60,9 @@ export class SavedViewWidgetComponent implements OnInit, OnDestroy {
     if (this.savedView.show_in_sidebar) {
       this.router.navigate(['view', this.savedView.id])
     } else {
-      this.list.loadSavedView(this.savedView, true)
-      this.router.navigate(['documents'])
+      this.router.navigate(['documents'], {
+        queryParams: { view: this.savedView.id },
+      })
     }
   }
 

--- a/src-ui/src/app/components/dashboard/widgets/saved-view-widget/saved-view-widget.component.ts
+++ b/src-ui/src/app/components/dashboard/widgets/saved-view-widget/saved-view-widget.component.ts
@@ -67,7 +67,7 @@ export class SavedViewWidgetComponent implements OnInit, OnDestroy {
   }
 
   clickTag(tag: PaperlessTag) {
-    this.queryParamsService.loadFilterRules([
+    this.queryParamsService.navigateWithFilterRules([
       { rule_type: FILTER_HAS_TAGS_ALL, value: tag.id.toString() },
     ])
   }

--- a/src-ui/src/app/components/document-detail/document-detail.component.ts
+++ b/src-ui/src/app/components/document-detail/document-detail.component.ts
@@ -448,7 +448,7 @@ export class DocumentDetailComponent
   }
 
   moreLike() {
-    this.queryParamsService.loadFilterRules([
+    this.queryParamsService.navigateWithFilterRules([
       {
         rule_type: FILTER_FULLTEXT_MORELIKE,
         value: this.documentId.toString(),

--- a/src-ui/src/app/components/document-detail/document-detail.component.ts
+++ b/src-ui/src/app/components/document-detail/document-detail.component.ts
@@ -35,6 +35,7 @@ import {
 import { PaperlessDocumentSuggestions } from 'src/app/data/paperless-document-suggestions'
 import { FILTER_FULLTEXT_MORELIKE } from 'src/app/data/filter-rule-type'
 import { normalizeDateStr } from 'src/app/utils/date'
+import { QueryParamsService } from 'src/app/services/query-params.service'
 
 @Component({
   selector: 'app-document-detail',
@@ -114,7 +115,8 @@ export class DocumentDetailComponent
     private documentListViewService: DocumentListViewService,
     private documentTitlePipe: DocumentTitlePipe,
     private toastService: ToastService,
-    private settings: SettingsService
+    private settings: SettingsService,
+    private queryParamsService: QueryParamsService
   ) {
     this.titleSubject
       .pipe(
@@ -446,7 +448,7 @@ export class DocumentDetailComponent
   }
 
   moreLike() {
-    this.documentListViewService.quickFilter([
+    this.queryParamsService.loadFilterRules([
       {
         rule_type: FILTER_FULLTEXT_MORELIKE,
         value: this.documentId.toString(),

--- a/src-ui/src/app/components/document-list/document-list.component.html
+++ b/src-ui/src/app/components/document-list/document-list.component.html
@@ -38,7 +38,7 @@
   <div ngbDropdown class="btn-group ms-2 flex-fill">
     <button class="btn btn-outline-primary btn-sm" id="dropdownBasic1" ngbDropdownToggle i18n>Sort</button>
     <div ngbDropdownMenu aria-labelledby="dropdownBasic1" class="shadow dropdown-menu-right">
-      <div class="w-100 d-flex btn-group-toggle pb-2 mb-1 border-bottom" ngbRadioGroup [(ngModel)]="list.sortReverse">
+      <div class="w-100 d-flex btn-group-toggle pb-2 mb-1 border-bottom" ngbRadioGroup [(ngModel)]="listSort">
         <label ngbButtonLabel class="btn-outline-primary btn-sm mx-2 flex-fill">
           <input ngbButton type="radio" class="btn btn-check btn-sm" [value]="false">
           <svg class="toolbaricon" fill="currentColor">
@@ -53,7 +53,7 @@
         </label>
       </div>
       <div>
-        <button *ngFor="let f of getSortFields()" ngbDropdownItem (click)="list.sortField = f.field"
+        <button *ngFor="let f of getSortFields()" ngbDropdownItem (click)="setSortField(f.field)"
           [class.active]="list.sortField == f.field">{{f.name}}
         </button>
       </div>

--- a/src-ui/src/app/components/document-list/document-list.component.html
+++ b/src-ui/src/app/components/document-list/document-list.component.html
@@ -64,7 +64,7 @@
     <button class="btn btn-sm btn-outline-primary dropdown-toggle flex-fill" ngbDropdownToggle i18n>Views</button>
     <div class="dropdown-menu shadow dropdown-menu-right" ngbDropdownMenu>
       <ng-container *ngIf="!list.activeSavedViewId">
-        <button ngbDropdownItem *ngFor="let view of savedViewService.allViews" (click)="loadViewConfig(view)">{{view.name}}</button>
+        <button ngbDropdownItem *ngFor="let view of savedViewService.allViews" (click)="loadViewConfig(view.id)">{{view.name}}</button>
         <div class="dropdown-divider" *ngIf="savedViewService.allViews.length > 0"></div>
       </ng-container>
 

--- a/src-ui/src/app/components/manage/correspondent-list/correspondent-list.component.ts
+++ b/src-ui/src/app/components/manage/correspondent-list/correspondent-list.component.ts
@@ -3,7 +3,7 @@ import { NgbModal } from '@ng-bootstrap/ng-bootstrap'
 import { FILTER_CORRESPONDENT } from 'src/app/data/filter-rule-type'
 import { PaperlessCorrespondent } from 'src/app/data/paperless-correspondent'
 import { CustomDatePipe } from 'src/app/pipes/custom-date.pipe'
-import { DocumentListViewService } from 'src/app/services/document-list-view.service'
+import { QueryParamsService } from 'src/app/services/query-params.service'
 import { CorrespondentService } from 'src/app/services/rest/correspondent.service'
 import { ToastService } from 'src/app/services/toast.service'
 import { CorrespondentEditDialogComponent } from '../../common/edit-dialog/correspondent-edit-dialog/correspondent-edit-dialog.component'
@@ -20,7 +20,7 @@ export class CorrespondentListComponent extends ManagementListComponent<Paperles
     correspondentsService: CorrespondentService,
     modalService: NgbModal,
     toastService: ToastService,
-    list: DocumentListViewService,
+    queryParamsService: QueryParamsService,
     private datePipe: CustomDatePipe
   ) {
     super(
@@ -28,7 +28,7 @@ export class CorrespondentListComponent extends ManagementListComponent<Paperles
       modalService,
       CorrespondentEditDialogComponent,
       toastService,
-      list,
+      queryParamsService,
       FILTER_CORRESPONDENT,
       $localize`correspondent`,
       [

--- a/src-ui/src/app/components/manage/document-type-list/document-type-list.component.ts
+++ b/src-ui/src/app/components/manage/document-type-list/document-type-list.component.ts
@@ -2,7 +2,7 @@ import { Component } from '@angular/core'
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap'
 import { FILTER_DOCUMENT_TYPE } from 'src/app/data/filter-rule-type'
 import { PaperlessDocumentType } from 'src/app/data/paperless-document-type'
-import { DocumentListViewService } from 'src/app/services/document-list-view.service'
+import { QueryParamsService } from 'src/app/services/query-params.service'
 import { DocumentTypeService } from 'src/app/services/rest/document-type.service'
 import { ToastService } from 'src/app/services/toast.service'
 import { DocumentTypeEditDialogComponent } from '../../common/edit-dialog/document-type-edit-dialog/document-type-edit-dialog.component'
@@ -18,14 +18,14 @@ export class DocumentTypeListComponent extends ManagementListComponent<Paperless
     documentTypeService: DocumentTypeService,
     modalService: NgbModal,
     toastService: ToastService,
-    list: DocumentListViewService
+    queryParamsService: QueryParamsService
   ) {
     super(
       documentTypeService,
       modalService,
       DocumentTypeEditDialogComponent,
       toastService,
-      list,
+      queryParamsService,
       FILTER_DOCUMENT_TYPE,
       $localize`document type`,
       []

--- a/src-ui/src/app/components/manage/management-list/management-list.component.ts
+++ b/src-ui/src/app/components/manage/management-list/management-list.component.ts
@@ -19,6 +19,7 @@ import {
   SortEvent,
 } from 'src/app/directives/sortable.directive'
 import { DocumentListViewService } from 'src/app/services/document-list-view.service'
+import { QueryParamsService } from 'src/app/services/query-params.service'
 import { AbstractNameFilterService } from 'src/app/services/rest/abstract-name-filter-service'
 import { ToastService } from 'src/app/services/toast.service'
 import { ConfirmDialogComponent } from '../../common/confirm-dialog/confirm-dialog.component'
@@ -42,7 +43,7 @@ export abstract class ManagementListComponent<T extends ObjectWithId>
     private modalService: NgbModal,
     private editDialogComponent: any,
     private toastService: ToastService,
-    private list: DocumentListViewService,
+    private queryParamsService: QueryParamsService,
     protected filterRuleType: number,
     public typeName: string,
     public extraColumns: ManagementListColumn[]
@@ -140,7 +141,7 @@ export abstract class ManagementListComponent<T extends ObjectWithId>
   }
 
   filterDocuments(object: ObjectWithId) {
-    this.list.quickFilter([
+    this.queryParamsService.loadFilterRules([
       { rule_type: this.filterRuleType, value: object.id.toString() },
     ])
   }

--- a/src-ui/src/app/components/manage/management-list/management-list.component.ts
+++ b/src-ui/src/app/components/manage/management-list/management-list.component.ts
@@ -18,7 +18,6 @@ import {
   SortableDirective,
   SortEvent,
 } from 'src/app/directives/sortable.directive'
-import { DocumentListViewService } from 'src/app/services/document-list-view.service'
 import { QueryParamsService } from 'src/app/services/query-params.service'
 import { AbstractNameFilterService } from 'src/app/services/rest/abstract-name-filter-service'
 import { ToastService } from 'src/app/services/toast.service'
@@ -141,7 +140,7 @@ export abstract class ManagementListComponent<T extends ObjectWithId>
   }
 
   filterDocuments(object: ObjectWithId) {
-    this.queryParamsService.loadFilterRules([
+    this.queryParamsService.navigateWithFilterRules([
       { rule_type: this.filterRuleType, value: object.id.toString() },
     ])
   }

--- a/src-ui/src/app/components/manage/tag-list/tag-list.component.ts
+++ b/src-ui/src/app/components/manage/tag-list/tag-list.component.ts
@@ -2,7 +2,7 @@ import { Component } from '@angular/core'
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap'
 import { FILTER_HAS_TAGS_ALL } from 'src/app/data/filter-rule-type'
 import { PaperlessTag } from 'src/app/data/paperless-tag'
-import { DocumentListViewService } from 'src/app/services/document-list-view.service'
+import { QueryParamsService } from 'src/app/services/query-params.service'
 import { TagService } from 'src/app/services/rest/tag.service'
 import { ToastService } from 'src/app/services/toast.service'
 import { TagEditDialogComponent } from '../../common/edit-dialog/tag-edit-dialog/tag-edit-dialog.component'
@@ -18,14 +18,14 @@ export class TagListComponent extends ManagementListComponent<PaperlessTag> {
     tagService: TagService,
     modalService: NgbModal,
     toastService: ToastService,
-    list: DocumentListViewService
+    queryParamsService: QueryParamsService
   ) {
     super(
       tagService,
       modalService,
       TagEditDialogComponent,
       toastService,
-      list,
+      queryParamsService,
       FILTER_HAS_TAGS_ALL,
       $localize`tag`,
       [

--- a/src-ui/src/app/services/document-list-view.service.ts
+++ b/src-ui/src/app/services/document-list-view.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core'
-import { ActivatedRoute, Router } from '@angular/router'
+import { ActivatedRoute, Params, Router } from '@angular/router'
 import { Observable } from 'rxjs'
 import {
   cloneFilterRules,
@@ -9,6 +9,7 @@ import {
 import { PaperlessDocument } from '../data/paperless-document'
 import { PaperlessSavedView } from '../data/paperless-saved-view'
 import { DOCUMENT_LIST_SERVICE } from '../data/storage-keys'
+import { QueryParamsService } from './query-params.service'
 import { DocumentService, DOCUMENT_SORT_FIELDS } from './rest/document.service'
 import { SettingsService, SETTINGS_KEYS } from './settings.service'
 
@@ -220,6 +221,13 @@ export class DocumentListViewService {
     return this.activeListViewState.sortReverse
   }
 
+  get sortParams(): Params {
+    return {
+      sortField: this.sortField,
+      sortReverse: this.sortReverse,
+    }
+  }
+
   get collectionSize(): number {
     return this.activeListViewState.collectionSize
   }
@@ -263,14 +271,6 @@ export class DocumentListViewService {
         JSON.stringify(savedState)
       )
     }
-  }
-
-  quickFilter(filterRules: FilterRule[]) {
-    const params = this.documentService.filterRulesToQueryParams(filterRules)
-    this.router.navigate(['/documents'], {
-      relativeTo: this.route,
-      queryParams: params,
-    })
   }
 
   getLastPage(): number {
@@ -435,8 +435,7 @@ export class DocumentListViewService {
   constructor(
     private documentService: DocumentService,
     private settings: SettingsService,
-    private router: Router,
-    private route: ActivatedRoute
+    private queryParamsService: QueryParamsService
   ) {
     let documentListViewConfigJson = localStorage.getItem(
       DOCUMENT_LIST_SERVICE.CURRENT_VIEW_CONFIG

--- a/src-ui/src/app/services/document-list-view.service.ts
+++ b/src-ui/src/app/services/document-list-view.service.ts
@@ -9,7 +9,6 @@ import {
 import { PaperlessDocument } from '../data/paperless-document'
 import { PaperlessSavedView } from '../data/paperless-saved-view'
 import { DOCUMENT_LIST_SERVICE } from '../data/storage-keys'
-import { QueryParamsService } from './query-params.service'
 import { DocumentService, DOCUMENT_SORT_FIELDS } from './rest/document.service'
 import { SettingsService, SETTINGS_KEYS } from './settings.service'
 
@@ -434,8 +433,7 @@ export class DocumentListViewService {
 
   constructor(
     private documentService: DocumentService,
-    private settings: SettingsService,
-    private queryParamsService: QueryParamsService
+    private settings: SettingsService
   ) {
     let documentListViewConfigJson = localStorage.getItem(
       DOCUMENT_LIST_SERVICE.CURRENT_VIEW_CONFIG

--- a/src-ui/src/app/services/query-params.service.ts
+++ b/src-ui/src/app/services/query-params.service.ts
@@ -1,101 +1,138 @@
 import { Injectable } from '@angular/core'
-import {
-  ActivatedRoute,
-  convertToParamMap,
-  ParamMap,
-  Params,
-  Router,
-} from '@angular/router'
+import { ParamMap, Params, Router } from '@angular/router'
 import { FilterRule } from '../data/filter-rule'
 import { FILTER_RULE_TYPES } from '../data/filter-rule-type'
+import { DocumentListViewService } from './document-list-view.service'
+
+const SORT_FIELD_PARAMETER = 'sort'
+const SORT_REVERSE_PARAMETER = 'reverse'
 
 @Injectable({
   providedIn: 'root',
 })
 export class QueryParamsService {
-  constructor(private router: Router, private route: ActivatedRoute) {}
+  constructor(private router: Router, private list: DocumentListViewService) {}
 
-  private filterParams: Params
-  private _filterRules: FilterRule[]
+  private filterParams: Params = {}
+  private sortParams: Params = {}
 
-  set filterRules(filterRules: FilterRule[]) {
-    this._filterRules = filterRules
-    this.filterParams = this.filterRulesToQueryParams(filterRules)
+  updateFilterRules(
+    filterRules: FilterRule[],
+    updateQueryParams: boolean = true
+  ) {
+    this.filterParams = filterRulesToQueryParams(filterRules)
+    if (updateQueryParams) this.updateQueryParams()
   }
 
-  get filterRules(): FilterRule[] {
-    return this._filterRules
+  set sortField(field: string) {
+    this.sortParams[SORT_FIELD_PARAMETER] = field
+    this.updateQueryParams()
   }
 
-  set params(params: any) {
-    this.filterParams = params
-    this._filterRules = this.filterRulesFromQueryParams(
-      params.keys ? params : convertToParamMap(params) // ParamMap
-    )
+  set sortReverse(reverse: boolean) {
+    if (!reverse) this.sortParams[SORT_REVERSE_PARAMETER] = undefined
+    else this.sortParams[SORT_REVERSE_PARAMETER] = reverse
+    this.updateQueryParams()
   }
 
   get params(): Params {
     return {
+      ...this.sortParams,
       ...this.filterParams,
     }
   }
 
-  private filterRulesToQueryParams(filterRules: FilterRule[]): Object {
-    if (filterRules) {
-      let params = {}
-      for (let rule of filterRules) {
-        let ruleType = FILTER_RULE_TYPES.find((t) => t.id == rule.rule_type)
-        if (ruleType.multi) {
-          params[ruleType.filtervar] = params[ruleType.filtervar]
-            ? params[ruleType.filtervar] + ',' + rule.value
-            : rule.value
-        } else if (ruleType.isnull_filtervar && rule.value == null) {
-          params[ruleType.isnull_filtervar] = true
-        } else {
-          params[ruleType.filtervar] = rule.value
-        }
-      }
-      return params
-    } else {
-      return null
-    }
-  }
+  private updateQueryParams() {
+    // if we were on a saved view we navigate 'away' to /documents
+    let base = []
+    if (this.router.routerState.snapshot.url.includes('/view/'))
+      base = ['/documents']
 
-  private filterRulesFromQueryParams(queryParams: ParamMap) {
-    const allFilterRuleQueryParams: string[] = FILTER_RULE_TYPES.map(
-      (rt) => rt.filtervar
-    )
-
-    // transform query params to filter rules
-    let filterRulesFromQueryParams: FilterRule[] = []
-    allFilterRuleQueryParams
-      .filter((frqp) => queryParams.has(frqp))
-      .forEach((filterQueryParamName) => {
-        const filterQueryParamValues: string[] = queryParams
-          .get(filterQueryParamName)
-          .split(',')
-
-        filterRulesFromQueryParams = filterRulesFromQueryParams.concat(
-          // map all values to filter rules
-          filterQueryParamValues.map((val) => {
-            return {
-              rule_type: FILTER_RULE_TYPES.find(
-                (rt) => rt.filtervar == filterQueryParamName
-              ).id,
-              value: val,
-            }
-          })
-        )
-      })
-
-    return filterRulesFromQueryParams
-  }
-
-  loadFilterRules(filterRules: FilterRule[]) {
-    this.filterRules = filterRules
-    this.router.navigate(['/documents'], {
-      relativeTo: this.route,
+    this.router.navigate(base, {
       queryParams: this.params,
     })
   }
+
+  public parseQueryParams(queryParams: ParamMap) {
+    let filterRules = filterRulesFromQueryParams(queryParams)
+    if (
+      filterRules.length ||
+      queryParams.has(SORT_FIELD_PARAMETER) ||
+      queryParams.has(SORT_REVERSE_PARAMETER)
+    ) {
+      this.list.filterRules = filterRules
+      this.list.sortField = queryParams.get(SORT_FIELD_PARAMETER)
+      this.list.sortReverse =
+        queryParams.has(SORT_REVERSE_PARAMETER) ||
+        (!queryParams.has(SORT_FIELD_PARAMETER) &&
+          !queryParams.has(SORT_REVERSE_PARAMETER))
+      this.list.reload()
+    } else if (
+      filterRules.length == 0 &&
+      !queryParams.has(SORT_FIELD_PARAMETER)
+    ) {
+      // this is navigating to /documents so we need to update the params from the list
+      this.updateFilterRules(this.list.filterRules, false)
+      this.sortField = this.list.sortField
+      this.sortReverse = this.list.sortReverse
+    }
+  }
+
+  navigateWithFilterRules(filterRules: FilterRule[]) {
+    this.updateFilterRules(filterRules)
+    this.router.navigate(['/documents'], {
+      queryParams: this.params,
+    })
+  }
+}
+
+export function filterRulesToQueryParams(filterRules: FilterRule[]): Object {
+  if (filterRules) {
+    let params = {}
+    for (let rule of filterRules) {
+      let ruleType = FILTER_RULE_TYPES.find((t) => t.id == rule.rule_type)
+      if (ruleType.multi) {
+        params[ruleType.filtervar] = params[ruleType.filtervar]
+          ? params[ruleType.filtervar] + ',' + rule.value
+          : rule.value
+      } else if (ruleType.isnull_filtervar && rule.value == null) {
+        params[ruleType.isnull_filtervar] = true
+      } else {
+        params[ruleType.filtervar] = rule.value
+      }
+    }
+    return params
+  } else {
+    return null
+  }
+}
+
+export function filterRulesFromQueryParams(queryParams: ParamMap) {
+  const allFilterRuleQueryParams: string[] = FILTER_RULE_TYPES.map(
+    (rt) => rt.filtervar
+  )
+
+  // transform query params to filter rules
+  let filterRulesFromQueryParams: FilterRule[] = []
+  allFilterRuleQueryParams
+    .filter((frqp) => queryParams.has(frqp))
+    .forEach((filterQueryParamName) => {
+      const filterQueryParamValues: string[] = queryParams
+        .get(filterQueryParamName)
+        .split(',')
+
+      filterRulesFromQueryParams = filterRulesFromQueryParams.concat(
+        // map all values to filter rules
+        filterQueryParamValues.map((val) => {
+          return {
+            rule_type: FILTER_RULE_TYPES.find(
+              (rt) => rt.filtervar == filterQueryParamName
+            ).id,
+            value: val,
+          }
+        })
+      )
+    })
+
+  return filterRulesFromQueryParams
 }

--- a/src-ui/src/app/services/query-params.service.ts
+++ b/src-ui/src/app/services/query-params.service.ts
@@ -1,0 +1,101 @@
+import { Injectable } from '@angular/core'
+import {
+  ActivatedRoute,
+  convertToParamMap,
+  ParamMap,
+  Params,
+  Router,
+} from '@angular/router'
+import { FilterRule } from '../data/filter-rule'
+import { FILTER_RULE_TYPES } from '../data/filter-rule-type'
+
+@Injectable({
+  providedIn: 'root',
+})
+export class QueryParamsService {
+  constructor(private router: Router, private route: ActivatedRoute) {}
+
+  private filterParams: Params
+  private _filterRules: FilterRule[]
+
+  set filterRules(filterRules: FilterRule[]) {
+    this._filterRules = filterRules
+    this.filterParams = this.filterRulesToQueryParams(filterRules)
+  }
+
+  get filterRules(): FilterRule[] {
+    return this._filterRules
+  }
+
+  set params(params: any) {
+    this.filterParams = params
+    this._filterRules = this.filterRulesFromQueryParams(
+      params.keys ? params : convertToParamMap(params) // ParamMap
+    )
+  }
+
+  get params(): Params {
+    return {
+      ...this.filterParams,
+    }
+  }
+
+  private filterRulesToQueryParams(filterRules: FilterRule[]): Object {
+    if (filterRules) {
+      let params = {}
+      for (let rule of filterRules) {
+        let ruleType = FILTER_RULE_TYPES.find((t) => t.id == rule.rule_type)
+        if (ruleType.multi) {
+          params[ruleType.filtervar] = params[ruleType.filtervar]
+            ? params[ruleType.filtervar] + ',' + rule.value
+            : rule.value
+        } else if (ruleType.isnull_filtervar && rule.value == null) {
+          params[ruleType.isnull_filtervar] = true
+        } else {
+          params[ruleType.filtervar] = rule.value
+        }
+      }
+      return params
+    } else {
+      return null
+    }
+  }
+
+  private filterRulesFromQueryParams(queryParams: ParamMap) {
+    const allFilterRuleQueryParams: string[] = FILTER_RULE_TYPES.map(
+      (rt) => rt.filtervar
+    )
+
+    // transform query params to filter rules
+    let filterRulesFromQueryParams: FilterRule[] = []
+    allFilterRuleQueryParams
+      .filter((frqp) => queryParams.has(frqp))
+      .forEach((filterQueryParamName) => {
+        const filterQueryParamValues: string[] = queryParams
+          .get(filterQueryParamName)
+          .split(',')
+
+        filterRulesFromQueryParams = filterRulesFromQueryParams.concat(
+          // map all values to filter rules
+          filterQueryParamValues.map((val) => {
+            return {
+              rule_type: FILTER_RULE_TYPES.find(
+                (rt) => rt.filtervar == filterQueryParamName
+              ).id,
+              value: val,
+            }
+          })
+        )
+      })
+
+    return filterRulesFromQueryParams
+  }
+
+  loadFilterRules(filterRules: FilterRule[]) {
+    this.filterRules = filterRules
+    this.router.navigate(['/documents'], {
+      relativeTo: this.route,
+      queryParams: this.params,
+    })
+  }
+}

--- a/src-ui/src/app/services/query-params.service.ts
+++ b/src-ui/src/app/services/query-params.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core'
 import { ParamMap, Params, Router } from '@angular/router'
 import { FilterRule } from '../data/filter-rule'
 import { FILTER_RULE_TYPES } from '../data/filter-rule-type'
+import { PaperlessSavedView } from '../data/paperless-saved-view'
 import { DocumentListViewService } from './document-list-view.service'
 
 const SORT_FIELD_PARAMETER = 'sort'
@@ -76,6 +77,19 @@ export class QueryParamsService {
       this.sortField = this.list.sortField
       this.sortReverse = this.list.sortReverse
     }
+  }
+
+  updateFromView(view: PaperlessSavedView) {
+    if (!this.router.routerState.snapshot.url.includes('/view/')) {
+      // navigation for /documents?view=
+      this.router.navigate([], {
+        queryParams: { view: view.id },
+      })
+    }
+    // make sure params are up-to-date
+    this.updateFilterRules(view.filter_rules, false)
+    this.sortParams[SORT_FIELD_PARAMETER] = this.list.sortField
+    this.sortParams[SORT_REVERSE_PARAMETER] = this.list.sortReverse
   }
 
   navigateWithFilterRules(filterRules: FilterRule[]) {

--- a/src-ui/src/app/services/rest/document.service.ts
+++ b/src-ui/src/app/services/rest/document.service.ts
@@ -10,9 +10,8 @@ import { map } from 'rxjs/operators'
 import { CorrespondentService } from './correspondent.service'
 import { DocumentTypeService } from './document-type.service'
 import { TagService } from './tag.service'
-import { FILTER_RULE_TYPES } from 'src/app/data/filter-rule-type'
 import { PaperlessDocumentSuggestions } from 'src/app/data/paperless-document-suggestions'
-import { QueryParamsService } from '../query-params.service'
+import { filterRulesToQueryParams } from '../query-params.service'
 
 export const DOCUMENT_SORT_FIELDS = [
   { field: 'archive_serial_number', name: $localize`ASN` },
@@ -53,8 +52,7 @@ export class DocumentService extends AbstractPaperlessService<PaperlessDocument>
     http: HttpClient,
     private correspondentService: CorrespondentService,
     private documentTypeService: DocumentTypeService,
-    private tagService: TagService,
-    private queryParamsService: QueryParamsService
+    private tagService: TagService
   ) {
     super(http, 'documents')
   }
@@ -82,13 +80,12 @@ export class DocumentService extends AbstractPaperlessService<PaperlessDocument>
     filterRules?: FilterRule[],
     extraParams = {}
   ): Observable<Results<PaperlessDocument>> {
-    this.queryParamsService.filterRules = filterRules
     return this.list(
       page,
       pageSize,
       sortField,
       sortReverse,
-      Object.assign(extraParams, this.queryParamsService.params)
+      Object.assign(extraParams, filterRulesToQueryParams(filterRules))
     ).pipe(
       map((results) => {
         results.results.forEach((doc) => this.addObservablesToDocument(doc))


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

This PR adds a query parameter (`view`) for saved views on the Documents page & supports the sort fields (this should probably have been in #540). This fixes the linked issue where currently "Show all" doesnt work for saved views that aren't in the sidebar and also makes it possible to use browser navigation when choosing saved views from the **Views** dropdown on the Documents page as well as changing sort parameters. Note this doesnt affect the `/view/X` url which is used for views in the sidebar. Videos below if youre curious.

https://user-images.githubusercontent.com/4887959/166868467-59b22843-7e24-46a7-8882-7426bc2523ee.mov

https://user-images.githubusercontent.com/4887959/166962476-9d952600-5ec6-4691-a2c6-d9dcbba3aeeb.mov

Fixes #877 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] ~~I have made corresponding changes to the documentation as needed.~~
- [x] I have checked my modifications for any breaking changes.
