### PR TITLE
Fix: Minor update to Q Cluster Configuration

### DIFF
--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -28,6 +28,7 @@ stderr_logfile_maxbytes=0
 [program:scheduler]
 command=python3 manage.py qcluster
 user=paperless
+stopasgroup = true
 
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0


### PR DESCRIPTION
## Proposed change

While looking into the django-q documentation, I noticed it recommends [a setting when using supervisor](https://django-q.readthedocs.io/en/latest/cluster.html#process-managers): setting the configuration `stopasgroup`

As we don't set that, and it looks [useful in the supervisor docs](http://supervisord.org/configuration.html), this PR adds it.

I don't think this is the cause of anything, nor likely to change much, but we might as well follow the recommendation from the library.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
