### PR TITLE
Fix: Include version in export for better error messages

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
         exclude: "(^Pipfile\\.lock$)"
   # Python hooks
   - repo: https://github.com/asottile/reorder_python_imports
-    rev: v3.0.1
+    rev: v3.1.0
     hooks:
       - id: reorder-python-imports
         exclude: "(migrations)"

--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -287,6 +287,10 @@ When you use the provided docker compose script, put the export inside the
 ``export`` folder in your paperless source directory. Specify ``../export``
 as the ``source``.
 
+.. note::
+
+    Importing from a previous version of Paperless may work, but for best results
+    it is suggested to match the versions.
 
 .. _utilities-retagger:
 

--- a/src/documents/management/commands/document_archiver.py
+++ b/src/documents/management/commands/document_archiver.py
@@ -152,4 +152,4 @@ class Command(BaseCommand):
                     ),
                 )
         except KeyboardInterrupt:
-            print("Aborting...")
+            self.stdout.write(self.style.NOTICE(("Aborting...")))

--- a/src/documents/management/commands/document_exporter.py
+++ b/src/documents/management/commands/document_exporter.py
@@ -22,6 +22,7 @@ from documents.settings import EXPORTER_ARCHIVE_NAME
 from documents.settings import EXPORTER_FILE_NAME
 from documents.settings import EXPORTER_THUMBNAIL_NAME
 from filelock import FileLock
+from paperless import version
 from paperless.db import GnuPG
 from paperless_mail.models import MailAccount
 from paperless_mail.models import MailRule
@@ -232,11 +233,17 @@ class Command(BaseCommand):
                         archive_target,
                     )
 
-        # 4. write manifest to target forlder
+        # 4.1 write manifest to target folder
         manifest_path = os.path.abspath(os.path.join(self.target, "manifest.json"))
 
         with open(manifest_path, "w") as f:
             json.dump(manifest, f, indent=2)
+
+        # 4.2 write version information to target folder
+        version_path = os.path.abspath(os.path.join(self.target, "version.json"))
+
+        with open(version_path, "w") as f:
+            json.dump({"version": version.__full_version_str__}, f, indent=2)
 
         if self.delete:
             # 5. Remove files which we did not explicitly export in this run

--- a/src/documents/management/commands/document_importer.py
+++ b/src/documents/management/commands/document_importer.py
@@ -84,9 +84,10 @@ class Command(BaseCommand):
                 if self.version != version.__full_version_str__:
                     self.stdout.write(
                         self.style.WARNING(
-                            "Version mismatch:"
-                            f" {self.version} vs {version.__full_version_str__}."
-                            "  Continuing, but import may fail",
+                            "Version mismatch: "
+                            f"Currently {version.__full_version_str__},"
+                            f" importing {self.version}."
+                            " Continuing, but import may fail.",
                         ),
                     )
 


### PR DESCRIPTION
## Proposed change

This PR adds a new file to the `document_exporter` command output called `version.json`.  This file exists to give the user more feedback about why an import may fail, as new version might add database migrations, which then break importing from versions which don't match the exact model fields.

On import, this file is checked for and a warning presented to the user if the version doesn't match, notifying them the import _may_ fail.  If the file doesn't exist, the lesser notice style is used to also inform of this.  In both cases, the import is still attempted.

version mismatch (but works):
```
>> document_importer ../export/
Version mismatch: 1.7.1 vs 1.7.0.  Continuing, but import may fail
Installed 3 object(s) from 1 fixture(s)
```

no version file (but works):
```
>> document_importer ../export/
No version.json file located
Installed 3 object(s) from 1 fixture(s)
```

failure to load with version.json:
```
>> document_importer ../export/
Version mismatch: 1.7.1 vs 1.7.0.  Continuing, but import may fail
Database import failed
Version mismatch: Currently 1.7.0, importing 1.7.1
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/django/db/models/options.py", line 672, in get_field
    return self.fields_map[field_name]
KeyError: 'some_new_field'

etc, etc, etc
```

failure to load without version.json:
```
>> document_importer ../export/
No version.json file located
Database import failed
No version information present
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/django/db/models/options.py", line 672, in get_field
    return self.fields_map[field_name]
KeyError: 'some_new_field'

etc, etc, etc
```

Fixes #812

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
