### PR TITLE
Chore: Minor improvements for quality of life

### DIFF
--- a/docker/docker-prepare.sh
+++ b/docker/docker-prepare.sh
@@ -52,7 +52,7 @@ search_index() {
 
 	if [[ (! -f "$index_version_file") || $(<$index_version_file) != "$index_version" ]]; then
 		echo "Search index out of date. Updating..."
-		python3 manage.py document_index reindex
+		python3 manage.py document_index reindex --no-progress-bar
 		echo $index_version | tee $index_version_file >/dev/null
 	fi
 }

--- a/src/documents/management/commands/document_consumer.py
+++ b/src/documents/management/commands/document_consumer.py
@@ -28,8 +28,11 @@ def _tags_from_path(filepath):
     """Walk up the directory tree from filepath to CONSUMPTION_DIR
     and get or create Tag IDs for every directory.
     """
+    normalized_consumption_dir = os.path.abspath(
+        os.path.normpath(settings.CONSUMPTION_DIR),
+    )
     tag_ids = set()
-    path_parts = Path(filepath).relative_to(settings.CONSUMPTION_DIR).parent.parts
+    path_parts = Path(filepath).relative_to(normalized_consumption_dir).parent.parts
     for part in path_parts:
         tag_ids.add(
             Tag.objects.get_or_create(name__iexact=part, defaults={"name": part})[0].pk,
@@ -39,7 +42,10 @@ def _tags_from_path(filepath):
 
 
 def _is_ignored(filepath: str) -> bool:
-    filepath_relative = PurePath(filepath).relative_to(settings.CONSUMPTION_DIR)
+    normalized_consumption_dir = os.path.abspath(
+        os.path.normpath(settings.CONSUMPTION_DIR),
+    )
+    filepath_relative = PurePath(filepath).relative_to(normalized_consumption_dir)
     return any(filepath_relative.match(p) for p in settings.CONSUMER_IGNORE_PATTERNS)
 
 
@@ -159,6 +165,8 @@ class Command(BaseCommand):
 
         if not directory:
             raise CommandError("CONSUMPTION_DIR does not appear to be set.")
+
+        directory = os.path.abspath(directory)
 
         if not os.path.isdir(directory):
             raise CommandError(f"Consumption directory {directory} does not exist")


### PR DESCRIPTION
## Proposed change

This PR implements two minor changes for a slightly improved expereience:

1. The progress bar when creating the search index is disabled, so no more log lines like this:
![image](https://user-images.githubusercontent.com/797416/167487598-f23cdec7-65a7-41f0-8b35-bdffabd7ce07.png)

2. The consumer paths are now resolved when output, removing the minor distraction of needing to follow `..` around:
`Polling directory for changes: /usr/src/paperless/src/../consume` -> `Polling directory for changes: /usr/src/paperless/src/consume`

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
