### PR TITLE
Fix: allow commas in non-multi rules query params

### DIFF
--- a/src-ui/src/app/services/query-params.service.ts
+++ b/src-ui/src/app/services/query-params.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core'
 import { ParamMap, Params, Router } from '@angular/router'
 import { FilterRule } from '../data/filter-rule'
-import { FILTER_RULE_TYPES } from '../data/filter-rule-type'
+import { FilterRuleType, FILTER_RULE_TYPES } from '../data/filter-rule-type'
 import { PaperlessSavedView } from '../data/paperless-saved-view'
 import { DocumentListViewService } from './document-list-view.service'
 
@@ -135,17 +135,19 @@ export function filterRulesFromQueryParams(queryParams: ParamMap) {
   allFilterRuleQueryParams
     .filter((frqp) => queryParams.has(frqp))
     .forEach((filterQueryParamName) => {
-      const filterQueryParamValues: string[] = queryParams
-        .get(filterQueryParamName)
-        .split(',')
+      const rule_type: FilterRuleType = FILTER_RULE_TYPES.find(
+        (rt) => rt.filtervar == filterQueryParamName
+      )
+      const valueURIComponent: string = queryParams.get(filterQueryParamName)
+      const filterQueryParamValues: string[] = rule_type.multi
+        ? valueURIComponent.split(',')
+        : [valueURIComponent]
 
       filterRulesFromQueryParams = filterRulesFromQueryParams.concat(
         // map all values to filter rules
         filterQueryParamValues.map((val) => {
           return {
-            rule_type: FILTER_RULE_TYPES.find(
-              (rt) => rt.filtervar == filterQueryParamName
-            ).id,
+            rule_type: rule_type.id,
             value: val,
           }
         })


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

This PR fixes an issue where strings with a comma `,` would incorrectly be interpreted as multiple values and split by the frontend causing unexpected behavior.

<img width="808" alt="Screen Shot 2022-05-11 at 10 25 42 AM" src="https://user-images.githubusercontent.com/4887959/167910447-35a64920-a2d2-4429-8608-c1619cb55b58.png">

Fixes #922 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] ~~I have made corresponding changes to the documentation as needed.~~
- [x] I have checked my modifications for any breaking changes.
