### PR TITLE
gunicorn: Allow IPv6 sockets

### DIFF
--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,6 +1,6 @@
 import os
 
-bind = f'0.0.0.0:{os.getenv("PAPERLESS_PORT", 8000)}'
+bind = f'[::]:{os.getenv("PAPERLESS_PORT", 8000)}'
 workers = int(os.getenv("PAPERLESS_WEBSERVER_WORKERS", 2))
 worker_class = "paperless.workers.ConfigurableWorker"
 timeout = 120


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

The gunicorn process only listened for IPv4 connections. This small change makes gunicorn dualstack.

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [X] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [X] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [X] I have checked my modifications for any breaking changes.

## Proof of work:

From inside a container:

```
root@13a77c4a61b4:/app/paperless# curl -D - http://[::1]:8000
HTTP/1.1 302 Found
date: Wed, 11 May 2022 18:59:05 GMT
server: uvicorn
content-type: text/html; charset=utf-8
location: /accounts/login/?next=/
x-frame-options: SAMEORIGIN
content-length: 0
vary: Accept-Language, Origin, Cookie
content-language: en-us
x-content-type-options: nosniff
referrer-policy: same-origin
cross-origin-opener-policy: same-origin

root@13a77c4a61b4:/app/paperless# curl -D - http://127.0.0.1:8000
HTTP/1.1 302 Found
date: Wed, 11 May 2022 18:59:40 GMT
server: uvicorn
content-type: text/html; charset=utf-8
location: /accounts/login/?next=/
x-frame-options: SAMEORIGIN
content-length: 0
vary: Accept-Language, Origin, Cookie
content-language: en-us
x-content-type-options: nosniff
referrer-policy: same-origin
cross-origin-opener-policy: same-origin
```

Listening changes from:

> tcp                                   LISTEN                                 0                                      2048                                                                           0.0.0.0:8000                                                                        0.0.0.0:*

to

> tcp                                   LISTEN                                 0                                      2048                                                                                 *:8000                                                                              *:*