### PR TITLE
Chore: Add testing for remote version checking

### DIFF
--- a/src/documents/tests/test_api.py
+++ b/src/documents/tests/test_api.py
@@ -4,8 +4,10 @@ import json
 import os
 import shutil
 import tempfile
+import urllib.request
 import zipfile
 from unittest import mock
+from unittest.mock import MagicMock
 
 import pytest
 from django.conf import settings
@@ -21,6 +23,7 @@ from documents.models import MatchingModel
 from documents.models import SavedView
 from documents.models import Tag
 from documents.tests.utils import DirectoriesMixin
+from paperless import version
 from rest_framework.test import APITestCase
 from whoosh.writing import AsyncWriter
 
@@ -2094,3 +2097,170 @@ class TestApiAuth(APITestCase):
         response = self.client.get("/api/")
         self.assertIn("X-Api-Version", response)
         self.assertIn("X-Version", response)
+
+
+class TestRemoteVersion(APITestCase):
+    ENDPOINT = "/api/remote_version/"
+
+    def setUp(self):
+        super().setUp()
+
+    def test_remote_version_default(self):
+        response = self.client.get(self.ENDPOINT)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertDictEqual(
+            response.data,
+            {
+                "version": "0.0.0",
+                "update_available": False,
+                "feature_is_set": False,
+            },
+        )
+
+    @override_settings(
+        ENABLE_UPDATE_CHECK=False,
+    )
+    def test_remote_version_disabled(self):
+        response = self.client.get(self.ENDPOINT)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertDictEqual(
+            response.data,
+            {
+                "version": "0.0.0",
+                "update_available": False,
+                "feature_is_set": True,
+            },
+        )
+
+    @override_settings(
+        ENABLE_UPDATE_CHECK=True,
+    )
+    @mock.patch("urllib.request.urlopen")
+    def test_remote_version_enabled_no_update_prefix(self, urlopen_mock):
+
+        cm = MagicMock()
+        cm.getcode.return_value = 200
+        cm.read.return_value = json.dumps({"tag_name": "ngx-1.6.0"}).encode()
+        cm.__enter__.return_value = cm
+        urlopen_mock.return_value = cm
+
+        response = self.client.get(self.ENDPOINT)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertDictEqual(
+            response.data,
+            {
+                "version": "1.6.0",
+                "update_available": False,
+                "feature_is_set": True,
+            },
+        )
+
+    @override_settings(
+        ENABLE_UPDATE_CHECK=True,
+    )
+    @mock.patch("urllib.request.urlopen")
+    def test_remote_version_enabled_no_update_no_prefix(self, urlopen_mock):
+
+        cm = MagicMock()
+        cm.getcode.return_value = 200
+        cm.read.return_value = json.dumps(
+            {"tag_name": version.__full_version_str__},
+        ).encode()
+        cm.__enter__.return_value = cm
+        urlopen_mock.return_value = cm
+
+        response = self.client.get(self.ENDPOINT)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertDictEqual(
+            response.data,
+            {
+                "version": version.__full_version_str__,
+                "update_available": False,
+                "feature_is_set": True,
+            },
+        )
+
+    @override_settings(
+        ENABLE_UPDATE_CHECK=True,
+    )
+    @mock.patch("urllib.request.urlopen")
+    def test_remote_version_enabled_update(self, urlopen_mock):
+
+        new_version = (
+            version.__version__[0],
+            version.__version__[1],
+            version.__version__[2] + 1,
+        )
+        new_version_str = ".".join(map(str, new_version))
+
+        cm = MagicMock()
+        cm.getcode.return_value = 200
+        cm.read.return_value = json.dumps(
+            {"tag_name": new_version_str},
+        ).encode()
+        cm.__enter__.return_value = cm
+        urlopen_mock.return_value = cm
+
+        response = self.client.get(self.ENDPOINT)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertDictEqual(
+            response.data,
+            {
+                "version": new_version_str,
+                "update_available": True,
+                "feature_is_set": True,
+            },
+        )
+
+    @override_settings(
+        ENABLE_UPDATE_CHECK=True,
+    )
+    @mock.patch("urllib.request.urlopen")
+    def test_remote_version_bad_json(self, urlopen_mock):
+
+        cm = MagicMock()
+        cm.getcode.return_value = 200
+        cm.read.return_value = b'{ "blah":'
+        cm.__enter__.return_value = cm
+        urlopen_mock.return_value = cm
+
+        response = self.client.get(self.ENDPOINT)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertDictEqual(
+            response.data,
+            {
+                "version": "0.0.0",
+                "update_available": False,
+                "feature_is_set": True,
+            },
+        )
+
+    @override_settings(
+        ENABLE_UPDATE_CHECK=True,
+    )
+    @mock.patch("urllib.request.urlopen")
+    def test_remote_version_exception(self, urlopen_mock):
+
+        cm = MagicMock()
+        cm.getcode.return_value = 200
+        cm.read.side_effect = urllib.error.URLError("an error")
+        cm.__enter__.return_value = cm
+        urlopen_mock.return_value = cm
+
+        response = self.client.get(self.ENDPOINT)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertDictEqual(
+            response.data,
+            {
+                "version": "0.0.0",
+                "update_available": False,
+                "feature_is_set": True,
+            },
+        )

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -692,7 +692,10 @@ class RemoteVersionView(GenericAPIView):
                     remote = response.read().decode("utf-8")
                 try:
                     remote_json = json.loads(remote)
-                    remote_version = remote_json["tag_name"].removeprefix("ngx-")
+                    remote_version = remote_json["tag_name"]
+                    # Basically PEP 616 but that only went in 3.9
+                    if remote_version.startswith("ngx-"):
+                        remote_version = remote_version[len("ngx-") :]
                 except ValueError:
                     logger.debug("An error occurred parsing remote version json")
             except urllib.error.URLError:


### PR DESCRIPTION
## Proposed change

Minor updates to add new unit testing for covering the remote version checking (where the app might go ask Github about the last release).  The line coverage looks good and the existing version is used as possible so nothing should break once a new release is made.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
