### PR TITLE
Fix: unassigned query params ignored

### DIFF
--- a/src-ui/src/app/services/query-params.service.ts
+++ b/src-ui/src/app/services/query-params.service.ts
@@ -129,6 +129,8 @@ export function filterRulesFromQueryParams(queryParams: ParamMap) {
   const allFilterRuleQueryParams: string[] = FILTER_RULE_TYPES.map(
     (rt) => rt.filtervar
   )
+    .concat(FILTER_RULE_TYPES.map((rt) => rt.isnull_filtervar))
+    .filter((rt) => rt !== undefined)
 
   // transform query params to filter rules
   let filterRulesFromQueryParams: FilterRule[] = []
@@ -136,8 +138,11 @@ export function filterRulesFromQueryParams(queryParams: ParamMap) {
     .filter((frqp) => queryParams.has(frqp))
     .forEach((filterQueryParamName) => {
       const rule_type: FilterRuleType = FILTER_RULE_TYPES.find(
-        (rt) => rt.filtervar == filterQueryParamName
+        (rt) =>
+          rt.filtervar == filterQueryParamName ||
+          rt.isnull_filtervar == filterQueryParamName
       )
+      const isNullRuleType = rule_type.isnull_filtervar == filterQueryParamName
       const valueURIComponent: string = queryParams.get(filterQueryParamName)
       const filterQueryParamValues: string[] = rule_type.multi
         ? valueURIComponent.split(',')
@@ -148,7 +153,7 @@ export function filterRulesFromQueryParams(queryParams: ParamMap) {
         filterQueryParamValues.map((val) => {
           return {
             rule_type: rule_type.id,
-            value: val,
+            value: isNullRuleType ? null : val,
           }
         })
       )


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

This PR fixes a bug that "Not assigned" tags / correspondents / doc types are currently being ignored. See video.

https://user-images.githubusercontent.com/4887959/167956556-3223651b-ee81-409c-8db3-628f305ab5fe.mov

Fixes #929

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] ~~I have made corresponding changes to the documentation as needed.~~
- [x] I have checked my modifications for any breaking changes.
