### PR TITLE
Bugfix: Fixes document filename date off by 1 issue

### DIFF
--- a/src/documents/file_handling.py
+++ b/src/documents/file_handling.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 import pathvalidate
 from django.conf import settings
 from django.template.defaultfilters import slugify
+from django.utils import timezone
 
 
 logger = logging.getLogger("paperless.filehandling")
@@ -158,18 +159,22 @@ def generate_filename(doc, counter=0, append_gpg=True, archive_filename=False):
             else:
                 asn = "none"
 
+            # Convert UTC database date to localized date
+            local_added = timezone.localdate(doc.added)
+            local_created = timezone.localdate(doc.created)
+
             path = settings.PAPERLESS_FILENAME_FORMAT.format(
                 title=pathvalidate.sanitize_filename(doc.title, replacement_text="-"),
                 correspondent=correspondent,
                 document_type=document_type,
-                created=datetime.date.isoformat(doc.created),
-                created_year=doc.created.year if doc.created else "none",
-                created_month=f"{doc.created.month:02}" if doc.created else "none",
-                created_day=f"{doc.created.day:02}" if doc.created else "none",
-                added=datetime.date.isoformat(doc.added),
-                added_year=doc.added.year if doc.added else "none",
-                added_month=f"{doc.added.month:02}" if doc.added else "none",
-                added_day=f"{doc.added.day:02}" if doc.added else "none",
+                created=datetime.date.isoformat(local_created),
+                created_year=local_created.year,
+                created_month=f"{local_created.month:02}",
+                created_day=f"{local_created.day:02}",
+                added=datetime.date.isoformat(local_added),
+                added_year=local_added.year,
+                added_month=f"{local_added.month:02}",
+                added_day=f"{local_added.day:02}",
                 asn=asn,
                 tags=tags,
                 tag_list=tag_list,

--- a/src/documents/models.py
+++ b/src/documents/models.py
@@ -208,7 +208,9 @@ class Document(models.Model):
         verbose_name_plural = _("documents")
 
     def __str__(self):
-        created = datetime.date.isoformat(self.created)
+
+        # Convert UTC database time to local time
+        created = datetime.date.isoformat(timezone.localdate(self.created))
 
         if self.correspondent and self.title:
             return f"{created} {self.correspondent} {self.title}"

--- a/src/documents/tests/test_document_model.py
+++ b/src/documents/tests/test_document_model.py
@@ -56,26 +56,35 @@ class TestDocument(TestCase):
         doc = Document(
             mime_type="application/pdf",
             title="test",
-            created=timezone.datetime(2020, 12, 25),
+            created=timezone.datetime(2020, 12, 25, tzinfo=zoneinfo.ZoneInfo("UTC")),
         )
         self.assertEqual(doc.get_public_filename(), "2020-12-25 test.pdf")
 
+    @override_settings(
+        TIME_ZONE="Europe/Berlin",
+    )
     def test_file_name_with_timezone(self):
+
+        # See https://docs.djangoproject.com/en/4.0/ref/utils/#django.utils.timezone.now
+        # The default for created is an aware datetime in UTC
+        # This does that, just manually, with a fixed date
+        local_create_date = timezone.datetime(
+            2020,
+            12,
+            25,
+            tzinfo=zoneinfo.ZoneInfo("Europe/Berlin"),
+        )
+
+        utc_create_date = local_create_date.astimezone(zoneinfo.ZoneInfo("UTC"))
+
+        self.assertEqual(utc_create_date.date().day, 24)
 
         doc = Document(
             mime_type="application/pdf",
             title="test",
-            created=timezone.datetime(
-                2020,
-                12,
-                25,
-                0,
-                0,
-                0,
-                0,
-                zoneinfo.ZoneInfo("Europe/Berlin"),
-            ),
+            created=utc_create_date,
         )
+
         self.assertEqual(doc.get_public_filename(), "2020-12-25 test.pdf")
 
     def test_file_name_jpg(self):
@@ -83,7 +92,7 @@ class TestDocument(TestCase):
         doc = Document(
             mime_type="image/jpeg",
             title="test",
-            created=timezone.datetime(2020, 12, 25),
+            created=timezone.datetime(2020, 12, 25, tzinfo=zoneinfo.ZoneInfo("UTC")),
         )
         self.assertEqual(doc.get_public_filename(), "2020-12-25 test.jpg")
 
@@ -92,7 +101,7 @@ class TestDocument(TestCase):
         doc = Document(
             mime_type="application/zip",
             title="test",
-            created=timezone.datetime(2020, 12, 25),
+            created=timezone.datetime(2020, 12, 25, tzinfo=zoneinfo.ZoneInfo("UTC")),
         )
         self.assertEqual(doc.get_public_filename(), "2020-12-25 test.zip")
 
@@ -101,6 +110,6 @@ class TestDocument(TestCase):
         doc = Document(
             mime_type="image/jpegasd",
             title="test",
-            created=timezone.datetime(2020, 12, 25),
+            created=timezone.datetime(2020, 12, 25, tzinfo=zoneinfo.ZoneInfo("UTC")),
         )
         self.assertEqual(doc.get_public_filename(), "2020-12-25 test")

--- a/src/documents/tests/test_document_model.py
+++ b/src/documents/tests/test_document_model.py
@@ -77,7 +77,24 @@ class TestDocument(TestCase):
 
         utc_create_date = local_create_date.astimezone(zoneinfo.ZoneInfo("UTC"))
 
+        doc = Document(
+            mime_type="application/pdf",
+            title="test",
+            created=utc_create_date,
+        )
+
+        # Ensure the create date would cause an off by 1 if not properly created above
         self.assertEqual(utc_create_date.date().day, 24)
+        self.assertEqual(doc.get_public_filename(), "2020-12-25 test.pdf")
+
+        local_create_date = timezone.datetime(
+            2020,
+            1,
+            1,
+            tzinfo=zoneinfo.ZoneInfo("Europe/Berlin"),
+        )
+
+        utc_create_date = local_create_date.astimezone(zoneinfo.ZoneInfo("UTC"))
 
         doc = Document(
             mime_type="application/pdf",
@@ -85,7 +102,9 @@ class TestDocument(TestCase):
             created=utc_create_date,
         )
 
-        self.assertEqual(doc.get_public_filename(), "2020-12-25 test.pdf")
+        # Ensure the create date would cause an off by 1 in the year if not properly created above
+        self.assertEqual(utc_create_date.date().year, 2019)
+        self.assertEqual(doc.get_public_filename(), "2020-01-01 test.pdf")
 
     def test_file_name_jpg(self):
 


### PR DESCRIPTION
## Proposed change

This PR fixes it so the filename of a document, both during a rename, save or export, will use the local time zone, instead of UTC time zone, which can, depending on the local time zone, result in an off by one in the date.

Dates being very hard, here's an example:
Document creation date: `2012-12-12 00:00:00+01:00` (Europe/Berlin)
Saved in database as `2012-12-11 23:00:00` (UTC)

Previously, the UTC time would be used to build an ISO format date like `2012-12-11` during document renaming, exporting and generally saving a document.  But then a user looks at the date in the web ui, sees `2012-12-12` (or the equivalent), and wonders why the date is off.

So all this really does it take the UTC date and convert back to local time zone, before using it to build a document filename.  I confirmed the filename is now matching local time zone for the initial consume, after changing the date in the web ui and when exported.

Fixes #926

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
