### PR TITLE
Add "Created" as additional (optional) parameter for post_documents 

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -240,10 +240,12 @@ be instructed to consume the document from there.
 The endpoint supports the following optional form fields:
 
 *   ``title``: Specify a title that the consumer should use for the document.
+*   ``created``: Specify a DateTime where the document was created (e.g. "2016-04-19" or "2016-04-19 06:15:00+02:00").
 *   ``correspondent``: Specify the ID of a correspondent that the consumer should use for the document.
 *   ``document_type``: Similar to correspondent.
 *   ``tags``: Similar to correspondent. Specify this multiple times to have multiple tags added
     to the document.
+
 
 The endpoint will immediately return "OK" if the document consumption process
 was started successfully. No additional status information about the consumption

--- a/src/documents/consumer.py
+++ b/src/documents/consumer.py
@@ -189,7 +189,7 @@ class Consumer(LoggingMixin):
         override_document_type_id=None,
         override_tag_ids=None,
         task_id=None,
-        override_created=None
+        override_created=None,
     ) -> Document:
         """
         Return the document object if it was successfully created.
@@ -398,7 +398,9 @@ class Consumer(LoggingMixin):
 
         if self.override_created is not None:
             create_date = self.override_created
-            self.log("debug", f"Creation date from post_documents parameter: {create_date}")
+            self.log(
+                "debug", f"Creation date from post_documents parameter: {create_date}"
+            )
         elif file_info.created is not None:
             create_date = file_info.created
             self.log("debug", f"Creation date from FileInfo: {create_date}")

--- a/src/documents/consumer.py
+++ b/src/documents/consumer.py
@@ -399,7 +399,8 @@ class Consumer(LoggingMixin):
         if self.override_created is not None:
             create_date = self.override_created
             self.log(
-                "debug", f"Creation date from post_documents parameter: {create_date}",
+                "debug",
+                f"Creation date from post_documents parameter: {create_date}",
             )
         elif file_info.created is not None:
             create_date = file_info.created

--- a/src/documents/consumer.py
+++ b/src/documents/consumer.py
@@ -189,6 +189,7 @@ class Consumer(LoggingMixin):
         override_document_type_id=None,
         override_tag_ids=None,
         task_id=None,
+        override_created=None
     ) -> Document:
         """
         Return the document object if it was successfully created.
@@ -201,6 +202,7 @@ class Consumer(LoggingMixin):
         self.override_document_type_id = override_document_type_id
         self.override_tag_ids = override_tag_ids
         self.task_id = task_id or str(uuid.uuid4())
+        self.override_created = override_created
 
         self._send_progress(0, 100, "STARTING", MESSAGE_NEW_FILE)
 
@@ -394,6 +396,7 @@ class Consumer(LoggingMixin):
 
         self.log("debug", "Saving record to database")
 
+<<<<<<< HEAD
         if file_info.created is not None:
             create_date = file_info.created
             self.log("debug", f"Creation date from FileInfo: {create_date}")
@@ -406,6 +409,14 @@ class Consumer(LoggingMixin):
                 datetime.datetime.fromtimestamp(stats.st_mtime),
             )
             self.log("debug", f"Creation date from st_mtime: {create_date}")
+=======
+        created = (
+            self.override_created
+            or file_info.created
+            or date
+            or timezone.make_aware(datetime.datetime.fromtimestamp(stats.st_mtime))
+        )
+>>>>>>> 51d322e1 (Added "created" as optional parameter for post_documents.)
 
         storage_type = Document.STORAGE_TYPE_UNENCRYPTED
 

--- a/src/documents/consumer.py
+++ b/src/documents/consumer.py
@@ -396,8 +396,10 @@ class Consumer(LoggingMixin):
 
         self.log("debug", "Saving record to database")
 
-<<<<<<< HEAD
-        if file_info.created is not None:
+        if self.override_created is not None:
+            create_date = self.override_created
+            self.log("debug", f"Creation date from post_documents parameter: {create_date}")
+        elif file_info.created is not None:
             create_date = file_info.created
             self.log("debug", f"Creation date from FileInfo: {create_date}")
         elif date is not None:
@@ -409,14 +411,6 @@ class Consumer(LoggingMixin):
                 datetime.datetime.fromtimestamp(stats.st_mtime),
             )
             self.log("debug", f"Creation date from st_mtime: {create_date}")
-=======
-        created = (
-            self.override_created
-            or file_info.created
-            or date
-            or timezone.make_aware(datetime.datetime.fromtimestamp(stats.st_mtime))
-        )
->>>>>>> 51d322e1 (Added "created" as optional parameter for post_documents.)
 
         storage_type = Document.STORAGE_TYPE_UNENCRYPTED
 

--- a/src/documents/consumer.py
+++ b/src/documents/consumer.py
@@ -399,7 +399,7 @@ class Consumer(LoggingMixin):
         if self.override_created is not None:
             create_date = self.override_created
             self.log(
-                "debug", f"Creation date from post_documents parameter: {create_date}"
+                "debug", f"Creation date from post_documents parameter: {create_date}",
             )
         elif file_info.created is not None:
             create_date = file_info.created

--- a/src/documents/serialisers.py
+++ b/src/documents/serialisers.py
@@ -416,6 +416,7 @@ class PostDocumentSerializer(serializers.Serializer):
         label="Created",
         allow_null=True,
         write_only=True,
+        required=False,
     )
 
     document = serializers.FileField(

--- a/src/documents/serialisers.py
+++ b/src/documents/serialisers.py
@@ -412,6 +412,12 @@ class BulkEditSerializer(DocumentListSerializer):
 
 class PostDocumentSerializer(serializers.Serializer):
 
+    created = serializers.DateTimeField(
+        label="Created",
+        allow_null=True,
+        write_only=True,
+    )
+
     document = serializers.FileField(
         label="Document",
         write_only=True,

--- a/src/documents/tasks.py
+++ b/src/documents/tasks.py
@@ -223,6 +223,7 @@ def consume_file(
     override_document_type_id=None,
     override_tag_ids=None,
     task_id=None,
+    override_created=None
 ):
 
     # check for separators in current document
@@ -303,6 +304,7 @@ def consume_file(
         override_document_type_id=override_document_type_id,
         override_tag_ids=override_tag_ids,
         task_id=task_id,
+        override_created=override_created
     )
 
     if document:

--- a/src/documents/tasks.py
+++ b/src/documents/tasks.py
@@ -223,7 +223,7 @@ def consume_file(
     override_document_type_id=None,
     override_tag_ids=None,
     task_id=None,
-    override_created=None
+    override_created=None,
 ):
 
     # check for separators in current document
@@ -304,7 +304,7 @@ def consume_file(
         override_document_type_id=override_document_type_id,
         override_tag_ids=override_tag_ids,
         task_id=task_id,
-        override_created=override_created
+        override_created=override_created,
     )
 
     if document:

--- a/src/documents/tests/test_api.py
+++ b/src/documents/tests/test_api.py
@@ -801,7 +801,6 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
                 {"document": f, "title": "", "correspondent": "", "document_type": ""},
             )
 
-        print(response.content)
         self.assertEqual(response.status_code, 200)
 
         m.assert_called_once()

--- a/src/documents/tests/test_api.py
+++ b/src/documents/tests/test_api.py
@@ -33,9 +33,6 @@ from rest_framework.test import APITestCase
 from whoosh.writing import AsyncWriter
 
 
-@override_settings(
-    DEBUG=True,
-)
 class TestDocumentApi(DirectoriesMixin, APITestCase):
     def setUp(self):
         super().setUp()

--- a/src/documents/tests/test_api.py
+++ b/src/documents/tests/test_api.py
@@ -9,6 +9,11 @@ import zipfile
 from unittest import mock
 from unittest.mock import MagicMock
 
+try:
+    import zoneinfo
+except ImportError:
+    import backports.zoneinfo as zoneinfo
+
 import pytest
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -28,6 +33,9 @@ from rest_framework.test import APITestCase
 from whoosh.writing import AsyncWriter
 
 
+@override_settings(
+    DEBUG=True,
+)
 class TestDocumentApi(DirectoriesMixin, APITestCase):
     def setUp(self):
         super().setUp()
@@ -796,6 +804,7 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
                 {"document": f, "title": "", "correspondent": "", "document_type": ""},
             )
 
+        print(response.content)
         self.assertEqual(response.status_code, 200)
 
         m.assert_called_once()
@@ -954,6 +963,34 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
         self.assertEqual(response.status_code, 400)
 
         async_task.assert_not_called()
+
+    @mock.patch("documents.views.async_task")
+    def test_upload_with_created(self, async_task):
+        created = datetime.datetime(
+            2022,
+            5,
+            12,
+            0,
+            0,
+            0,
+            0,
+            tzinfo=zoneinfo.ZoneInfo("America/Los_Angeles"),
+        )
+        with open(
+            os.path.join(os.path.dirname(__file__), "samples", "simple.pdf"),
+            "rb",
+        ) as f:
+            response = self.client.post(
+                "/api/documents/post_document/",
+                {"document": f, "created": created},
+            )
+        self.assertEqual(response.status_code, 200)
+
+        async_task.assert_called_once()
+
+        args, kwargs = async_task.call_args
+
+        self.assertEqual(kwargs["override_created"], created)
 
     def test_get_metadata(self):
         doc = Document.objects.create(

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -504,6 +504,7 @@ class PostDocumentView(GenericAPIView):
         document_type_id = serializer.validated_data.get("document_type")
         tag_ids = serializer.validated_data.get("tags")
         title = serializer.validated_data.get("title")
+        created = serializer.validated_data.get("created")
 
         t = int(mktime(datetime.now().timetuple()))
 
@@ -530,6 +531,7 @@ class PostDocumentView(GenericAPIView):
             override_tag_ids=tag_ids,
             task_id=task_id,
             task_name=os.path.basename(doc_name)[:100],
+            override_created=created
         )
 
         return Response("OK")

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -531,7 +531,7 @@ class PostDocumentView(GenericAPIView):
             override_tag_ids=tag_ids,
             task_id=task_id,
             task_name=os.path.basename(doc_name)[:100],
-            override_created=created
+            override_created=created,
         )
 
         return Response("OK")


### PR DESCRIPTION
## Proposed change

I need to import my ecodms-database and I spend much effort on manually tagging all the "created" dates on the documents. But now, while migrating to paperless with a self written import client, I had no option to migrate the "create" date as well.

So I added the possibility...

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [X] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [X] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.

Some needed Checklist-Boxes are unchecked. My change is very minimal and I tested it with a docker-compose instance manually for my import. Would someone from the dev team do the tests and have a second look over the changes?