### PR TITLE
Change npm --no-optional to --omit=optional

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ COPY ./src-ui /src/src-ui
 WORKDIR /src/src-ui
 RUN set -eux \
   && npm update npm -g \
-  && npm ci --no-optional
+  && npm ci --omit=optional
 RUN set -eux \
   && ./node_modules/.bin/ng build --configuration production
 

--- a/docker-builders/Dockerfile.frontend
+++ b/docker-builders/Dockerfile.frontend
@@ -9,6 +9,6 @@ COPY ./src-ui /src/src-ui
 WORKDIR /src/src-ui
 RUN set -eux \
   && npm update npm -g \
-  && npm ci --no-optional
+  && npm ci --omit=optional
 RUN set -eux \
   && ./node_modules/.bin/ng build --configuration production


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

This PR fixes an issue pointed out by @stumpylog that the `--no-optional` flag for `npm ci` now [presents a warning](https://github.com/paperless-ngx/paperless-ngx/runs/6495127492?check_suite_focus=true#step:9:578) (just a warning, not really breaking or anything). Its hard to find documentation of this but I verified using the latest npm and did find this commit: https://github.com/npm/cli/commit/6598bfe8697439e827d84981f8504febca64a55a . I tested this to make sure and it does in fact keep things as intended so no functional change here (only current optional dep is cypress).

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [] ~~If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.~~
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] ~~I have made corresponding changes to the documentation as needed.~~
- [x] I have checked my modifications for any breaking changes.
