### PR TITLE
Allow line breaks in tags

### DIFF
--- a/src-ui/src/app/components/common/tag/tag.component.scss
+++ b/src-ui/src/app/components/common/tag/tag.component.scss
@@ -1,3 +1,6 @@
 a {
     cursor: pointer;
+    white-space: normal;
+    word-break: break-word;
+    text-align: end;
 }

--- a/src-ui/src/app/components/document-list/document-card-small/document-card-small.component.html
+++ b/src-ui/src/app/components/document-list/document-card-small/document-card-small.component.html
@@ -10,10 +10,8 @@
         </div>
       </div>
 
-      <div style="top: 0; right: 0; font-size: large" class="text-end position-absolute me-1">
-        <div *ngFor="let t of getTagsLimited$() | async">
-          <app-tag [tag]="t" (click)="clickTag.emit(t.id);$event.stopPropagation()" [clickable]="true" linkTitle="Filter by tag" i18n-linkTitle></app-tag>
-        </div>
+      <div class="tags d-flex flex-column text-end position-absolute me-1 fs-6">
+        <app-tag *ngFor="let t of getTagsLimited$() | async" [tag]="t" (click)="clickTag.emit(t.id);$event.stopPropagation()" [clickable]="true" linkTitle="Filter by tag" i18n-linkTitle></app-tag>
         <div *ngIf="moreTags">
           <span class="badge badge-secondary">+ {{moreTags}}</span>
         </div>

--- a/src-ui/src/app/components/document-list/document-card-small/document-card-small.component.scss
+++ b/src-ui/src/app/components/document-list/document-card-small/document-card-small.component.scss
@@ -78,3 +78,11 @@
 a {
   cursor: pointer;
 }
+
+.tags {
+  top: 0;
+  right: 0;
+  max-width: 80%;
+  row-gap: .2rem;
+  line-height: 1;
+}

--- a/src-ui/src/styles.scss
+++ b/src-ui/src/styles.scss
@@ -497,6 +497,8 @@ table.table {
 // Bootstrap 5 tweaks
 a.badge {
   text-decoration: none;
+  word-break: initial;
+  white-space: initial;
 }
 
 .btn-link {

--- a/src-ui/src/styles.scss
+++ b/src-ui/src/styles.scss
@@ -497,8 +497,6 @@ table.table {
 // Bootstrap 5 tweaks
 a.badge {
   text-decoration: none;
-  word-break: initial;
-  white-space: initial;
 }
 
 .btn-link {


### PR DESCRIPTION
## Proposed change

Long tags overflow to the left currently and are displayed above of other document cards in the grid view. In my opinion allowing word breaking looks nicer.

Before:
![image](https://user-images.githubusercontent.com/26360562/169874936-b6a1b0d2-58b1-4e5d-95dc-45715cbf8bc8.png)

After:
![image](https://user-images.githubusercontent.com/26360562/169874963-77a50e30-6bed-41b0-9ebd-8eeda423ac2d.png)



## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Other (Improvement)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
