### PR TITLE
Feature: Fork django-q to update dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -169,6 +169,7 @@ COPY requirements.txt ../
 # dependencies
 ARG BUILD_PACKAGES="\
   build-essential \
+  git \
   python3-dev"
 
 RUN set -eux \

--- a/Pipfile
+++ b/Pipfile
@@ -14,7 +14,7 @@ django = "~=4.0"
 django-cors-headers = "*"
 django-extensions = "*"
 django-filter = "~=21.1"
-django-q = "~=1.3"
+django-q = {editable = true, ref = "relock-deps", git = "https://github.com/stumpylog/django-q.git"}
 djangorestframework = "~=3.13"
 filelock = "*"
 fuzzywuzzy = {extras = ["speedup"], version = "*"}

--- a/Pipfile
+++ b/Pipfile
@@ -14,7 +14,7 @@ django = "~=4.0"
 django-cors-headers = "*"
 django-extensions = "*"
 django-filter = "~=21.1"
-django-q = {editable = true, ref = "relock-deps", git = "https://github.com/stumpylog/django-q.git"}
+django-q = {editable = true, ref = "paperless-main", git = "https://github.com/paperless-ngx/django-q.git"}
 djangorestframework = "~=3.13"
 filelock = "*"
 fuzzywuzzy = {extras = ["speedup"], version = "*"}
@@ -23,13 +23,11 @@ imap-tools = "*"
 langdetect = "*"
 pathvalidate = "*"
 pillow = "~=9.1"
-# Any version update to pikepdf requires a base image update
 pikepdf = "~=5.1"
 python-gnupg = "*"
 python-dotenv = "*"
 python-dateutil = "*"
 python-magic = "*"
-# Any version update to psycopg2 requires a base image update
 psycopg2 = "*"
 redis = "*"
 # Pinned because aarch64 wheels and updates cause warnings when loading the classifier model.

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "1d3e45af4ae34722d55a93f3255fc60f5f95b2671d46fb97e4f06323bf8667c4"
+            "sha256": "5eb8d3dd2f13d65f3f334413f6905f1a7badc42adc79d34c8f8c8c61525aff59"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -322,8 +322,8 @@
         },
         "django-q": {
             "editable": true,
-            "git": "https://github.com/stumpylog/django-q.git",
-            "ref": "20aa962739d41ea187540267e92bc01539c914d6"
+            "git": "https://github.com/paperless-ngx/django-q.git",
+            "ref": "71abc78fdaec029cf71e9849a3b0fa084a1678f7"
         },
         "djangorestframework": {
             "hashes": [
@@ -1695,9 +1695,7 @@
             "version": "==0.4.4"
         },
         "coverage": {
-            "extras": [
-                "toml"
-            ],
+            "extras": [],
             "hashes": [
                 "sha256:01c5615d13f3dd3aa8543afc069e5319cfa0c7d712f6e04b920431e5c564a749",
                 "sha256:106c16dfe494de3193ec55cac9640dd039b66e196e4641fa8ac396181578b982",

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "416f74762bd0d17c4b9543a61d1153adbd330cda8c6654e35fdbfeaf5955d5e5"
+            "sha256": "1d3e45af4ae34722d55a93f3255fc60f5f95b2671d46fb97e4f06323bf8667c4"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -272,6 +272,14 @@
             "index": "pypi",
             "version": "==1.1.1"
         },
+        "deprecated": {
+            "hashes": [
+                "sha256:43ac5335da90c31c24ba028af536a91d41d53f9e6901ddb021bcc572ce44e38d",
+                "sha256:64756e3e14c8c5eea9795d93c524551432a0be75629f8f29e67ab8caf076c76d"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.2.13"
+        },
         "django": {
             "hashes": [
                 "sha256:502ae42b6ab1b612c933fb50d5ff850facf858a4c212f76946ecd8ea5b3bf2d9",
@@ -313,12 +321,9 @@
             "version": "==3.0.1"
         },
         "django-q": {
-            "hashes": [
-                "sha256:1b74ce3a8931990b136903e3a7bc9b07243282a2b5355117246f05ed5d076e68",
-                "sha256:5c6b4d530aa3aabf9c6aa57376da1ca2abf89a1562b77038b7a04e52a4a0a91b"
-            ],
-            "index": "pypi",
-            "version": "==1.3.9"
+            "editable": true,
+            "git": "https://github.com/stumpylog/django-q.git",
+            "ref": "20aa962739d41ea187540267e92bc01539c914d6"
         },
         "djangorestframework": {
             "hashes": [
@@ -997,11 +1002,11 @@
         },
         "redis": {
             "hashes": [
-                "sha256:0e7e0cfca8660dea8b7d5cd8c4f6c5e29e11f31158c0b0ae91a397f00e5a05a2",
-                "sha256:432b788c4530cfe16d8d943a09d40ca6c16149727e4afe8c2c9d5580c59d9f24"
+                "sha256:2f7a57cf4af15cd543c4394bcbe2b9148db2606a37edba755368836e3a1d053e",
+                "sha256:f57f8df5d238a8ecf92f499b6b21467bfee6c13d89953c27edf1e2bc673622e7"
             ],
             "index": "pypi",
-            "version": "==3.5.3"
+            "version": "==4.3.3"
         },
         "regex": {
             "hashes": [
@@ -1459,6 +1464,76 @@
             ],
             "index": "pypi",
             "version": "==2.7.4"
+        },
+        "wrapt": {
+            "hashes": [
+                "sha256:00b6d4ea20a906c0ca56d84f93065b398ab74b927a7a3dbd470f6fc503f95dc3",
+                "sha256:01c205616a89d09827986bc4e859bcabd64f5a0662a7fe95e0d359424e0e071b",
+                "sha256:02b41b633c6261feff8ddd8d11c711df6842aba629fdd3da10249a53211a72c4",
+                "sha256:07f7a7d0f388028b2df1d916e94bbb40624c59b48ecc6cbc232546706fac74c2",
+                "sha256:11871514607b15cfeb87c547a49bca19fde402f32e2b1c24a632506c0a756656",
+                "sha256:1b376b3f4896e7930f1f772ac4b064ac12598d1c38d04907e696cc4d794b43d3",
+                "sha256:21ac0156c4b089b330b7666db40feee30a5d52634cc4560e1905d6529a3897ff",
+                "sha256:257fd78c513e0fb5cdbe058c27a0624c9884e735bbd131935fd49e9fe719d310",
+                "sha256:2b39d38039a1fdad98c87279b48bc5dce2c0ca0d73483b12cb72aa9609278e8a",
+                "sha256:2cf71233a0ed05ccdabe209c606fe0bac7379fdcf687f39b944420d2a09fdb57",
+                "sha256:2fe803deacd09a233e4762a1adcea5db5d31e6be577a43352936179d14d90069",
+                "sha256:3232822c7d98d23895ccc443bbdf57c7412c5a65996c30442ebe6ed3df335383",
+                "sha256:34aa51c45f28ba7f12accd624225e2b1e5a3a45206aa191f6f9aac931d9d56fe",
+                "sha256:36f582d0c6bc99d5f39cd3ac2a9062e57f3cf606ade29a0a0d6b323462f4dd87",
+                "sha256:380a85cf89e0e69b7cfbe2ea9f765f004ff419f34194018a6827ac0e3edfed4d",
+                "sha256:40e7bc81c9e2b2734ea4bc1aceb8a8f0ceaac7c5299bc5d69e37c44d9081d43b",
+                "sha256:43ca3bbbe97af00f49efb06e352eae40434ca9d915906f77def219b88e85d907",
+                "sha256:4fcc4649dc762cddacd193e6b55bc02edca674067f5f98166d7713b193932b7f",
+                "sha256:5a0f54ce2c092aaf439813735584b9537cad479575a09892b8352fea5e988dc0",
+                "sha256:5a9a0d155deafd9448baff28c08e150d9b24ff010e899311ddd63c45c2445e28",
+                "sha256:5b02d65b9ccf0ef6c34cba6cf5bf2aab1bb2f49c6090bafeecc9cd81ad4ea1c1",
+                "sha256:60db23fa423575eeb65ea430cee741acb7c26a1365d103f7b0f6ec412b893853",
+                "sha256:642c2e7a804fcf18c222e1060df25fc210b9c58db7c91416fb055897fc27e8cc",
+                "sha256:6a9a25751acb379b466ff6be78a315e2b439d4c94c1e99cb7266d40a537995d3",
+                "sha256:6b1a564e6cb69922c7fe3a678b9f9a3c54e72b469875aa8018f18b4d1dd1adf3",
+                "sha256:6d323e1554b3d22cfc03cd3243b5bb815a51f5249fdcbb86fda4bf62bab9e164",
+                "sha256:6e743de5e9c3d1b7185870f480587b75b1cb604832e380d64f9504a0535912d1",
+                "sha256:709fe01086a55cf79d20f741f39325018f4df051ef39fe921b1ebe780a66184c",
+                "sha256:7b7c050ae976e286906dd3f26009e117eb000fb2cf3533398c5ad9ccc86867b1",
+                "sha256:7d2872609603cb35ca513d7404a94d6d608fc13211563571117046c9d2bcc3d7",
+                "sha256:7ef58fb89674095bfc57c4069e95d7a31cfdc0939e2a579882ac7d55aadfd2a1",
+                "sha256:80bb5c256f1415f747011dc3604b59bc1f91c6e7150bd7db03b19170ee06b320",
+                "sha256:81b19725065dcb43df02b37e03278c011a09e49757287dca60c5aecdd5a0b8ed",
+                "sha256:833b58d5d0b7e5b9832869f039203389ac7cbf01765639c7309fd50ef619e0b1",
+                "sha256:88bd7b6bd70a5b6803c1abf6bca012f7ed963e58c68d76ee20b9d751c74a3248",
+                "sha256:8ad85f7f4e20964db4daadcab70b47ab05c7c1cf2a7c1e51087bfaa83831854c",
+                "sha256:8c0ce1e99116d5ab21355d8ebe53d9460366704ea38ae4d9f6933188f327b456",
+                "sha256:8d649d616e5c6a678b26d15ece345354f7c2286acd6db868e65fcc5ff7c24a77",
+                "sha256:903500616422a40a98a5a3c4ff4ed9d0066f3b4c951fa286018ecdf0750194ef",
+                "sha256:9736af4641846491aedb3c3f56b9bc5568d92b0692303b5a305301a95dfd38b1",
+                "sha256:988635d122aaf2bdcef9e795435662bcd65b02f4f4c1ae37fbee7401c440b3a7",
+                "sha256:9cca3c2cdadb362116235fdbd411735de4328c61425b0aa9f872fd76d02c4e86",
+                "sha256:9e0fd32e0148dd5dea6af5fee42beb949098564cc23211a88d799e434255a1f4",
+                "sha256:9f3e6f9e05148ff90002b884fbc2a86bd303ae847e472f44ecc06c2cd2fcdb2d",
+                "sha256:a85d2b46be66a71bedde836d9e41859879cc54a2a04fad1191eb50c2066f6e9d",
+                "sha256:a9a52172be0b5aae932bef82a79ec0a0ce87288c7d132946d645eba03f0ad8a8",
+                "sha256:aa31fdcc33fef9eb2552cbcbfee7773d5a6792c137b359e82879c101e98584c5",
+                "sha256:b014c23646a467558be7da3d6b9fa409b2c567d2110599b7cf9a0c5992b3b471",
+                "sha256:b21bb4c09ffabfa0e85e3a6b623e19b80e7acd709b9f91452b8297ace2a8ab00",
+                "sha256:b5901a312f4d14c59918c221323068fad0540e34324925c8475263841dbdfe68",
+                "sha256:b9b7a708dd92306328117d8c4b62e2194d00c365f18eff11a9b53c6f923b01e3",
+                "sha256:d1967f46ea8f2db647c786e78d8cc7e4313dbd1b0aca360592d8027b8508e24d",
+                "sha256:d52a25136894c63de15a35bc0bdc5adb4b0e173b9c0d07a2be9d3ca64a332735",
+                "sha256:d77c85fedff92cf788face9bfa3ebaa364448ebb1d765302e9af11bf449ca36d",
+                "sha256:d79d7d5dc8a32b7093e81e97dad755127ff77bcc899e845f41bf71747af0c569",
+                "sha256:dbcda74c67263139358f4d188ae5faae95c30929281bc6866d00573783c422b7",
+                "sha256:ddaea91abf8b0d13443f6dac52e89051a5063c7d014710dcb4d4abb2ff811a59",
+                "sha256:dee0ce50c6a2dd9056c20db781e9c1cfd33e77d2d569f5d1d9321c641bb903d5",
+                "sha256:dee60e1de1898bde3b238f18340eec6148986da0455d8ba7848d50470a7a32fb",
+                "sha256:e2f83e18fe2f4c9e7db597e988f72712c0c3676d337d8b101f6758107c42425b",
+                "sha256:e3fb1677c720409d5f671e39bac6c9e0e422584e5f518bfd50aa4cbbea02433f",
+                "sha256:ee2b1b1769f6707a8a445162ea16dddf74285c3964f605877a20e38545c3c462",
+                "sha256:ee6acae74a2b91865910eef5e7de37dc6895ad96fa23603d1d27ea69df545015",
+                "sha256:ef3f72c9666bba2bab70d2a8b79f2c6d2c1a42a7f7e2b0ec83bb2f9e383950af"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==1.14.1"
         },
         "zipp": {
             "hashes": [

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@
 
 -i https://pypi.python.org/simple
 --extra-index-url https://www.piwheels.org/simple
--e git+https://github.com/stumpylog/django-q.git@20aa962739d41ea187540267e92bc01539c914d6#egg=django-q
+-e git+https://github.com/paperless-ngx/django-q.git@71abc78fdaec029cf71e9849a3b0fa084a1678f7#egg=django-q
 aioredis==1.3.1
 anyio==3.6.1; python_full_version >= '3.6.2'
 arrow==1.2.2; python_version >= '3.6'

--- a/requirements.txt
+++ b/requirements.txt
@@ -83,7 +83,8 @@ pyyaml==6.0
 pyzbar==0.1.9
 redis==4.3.3
 regex==2022.3.2; python_version >= '3.6'
-reportlab==3.6.10; python_version >= '3.7' and python_version < '4'
+# Manual downgrade until piwheel is working with this package again
+reportlab==3.6.9; python_version >= '3.7' and python_version < '4'
 requests==2.27.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
 scikit-learn==1.0.2
 scipy==1.8.1; python_version < '3.11' and python_version >= '3.8'

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@
 
 -i https://pypi.python.org/simple
 --extra-index-url https://www.piwheels.org/simple
+-e git+https://github.com/stumpylog/django-q.git@20aa962739d41ea187540267e92bc01539c914d6#egg=django-q
 aioredis==1.3.1
 anyio==3.6.1; python_full_version >= '3.6.2'
 arrow==1.2.2; python_version >= '3.6'
@@ -29,11 +30,11 @@ constantly==15.1.0
 cryptography==37.0.2; python_version >= '3.6'
 daphne==3.0.2; python_version >= '3.6'
 dateparser==1.1.1
+deprecated==1.2.13; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 django-cors-headers==3.13.0
 django-extensions==3.1.5
 django-filter==21.1
 django-picklefield==3.0.1; python_version >= '3'
-django-q==1.3.9
 django==4.0.5
 djangorestframework==3.13.1
 filelock==3.7.1
@@ -80,10 +81,9 @@ pytz-deprecation-shim==0.1.0.post0; python_version >= '2.7' and python_version n
 pytz==2022.1
 pyyaml==6.0
 pyzbar==0.1.9
-redis==3.5.3
+redis==4.3.3
 regex==2022.3.2; python_version >= '3.6'
-# WARNING: Temporary manual change as piwheels build failed for 3.6.10
-reportlab==3.6.9; python_version >= '3.7' and python_version < '4'
+reportlab==3.6.10; python_version >= '3.7' and python_version < '4'
 requests==2.27.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
 scikit-learn==1.0.2
 scipy==1.8.1; python_version < '3.11' and python_version >= '3.8'
@@ -109,5 +109,6 @@ wcwidth==0.2.5
 websockets==10.3
 whitenoise==6.2.0
 whoosh==2.7.4
+wrapt==1.14.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 zipp==3.8.0; python_version < '3.9'
 zope.interface==5.4.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'


### PR DESCRIPTION
## Proposed change

I'm opening this up as a discussion point around `django-q`, which is the library used for running the time consuming tasks in the background.  At least as of this time, the library hasn't been updated in around 11 months.  The author also hasn't had anything activity [in their profile](https://github.com/Koed00) since then.

I propose forking the repo into paperless-ngx, not to fully maintain (bug fixing, etc), but to allow its dependencies to be updated to more recent versions.  I've done a prototype of this work [here](https://github.com/stumpylog/django-q/compare/master...stumpylog:relock-deps).

### Advantages

- `redis-py` updates from version 3 to version 4
  - many bug fixes and improvements ([changelog](https://github.com/redis/redis-py/blob/master/CHANGES))
- Confirms `hiredis` 2.0.0 support
- resolves numerous warnings in our test suite
- Minor modernization of the library code
- In the future, could allow adding new features or fixing issues with the library

### Disadvantages

- More code to maintain

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
