### PR TITLE
Enhancement: Alphabetize tags by default

### DIFF
--- a/src-ui/src/app/services/rest/document.service.ts
+++ b/src-ui/src/app/services/rest/document.service.ts
@@ -6,7 +6,7 @@ import { HttpClient, HttpParams } from '@angular/common/http'
 import { Observable } from 'rxjs'
 import { Results } from 'src/app/data/results'
 import { FilterRule } from 'src/app/data/filter-rule'
-import { map } from 'rxjs/operators'
+import { map, tap } from 'rxjs/operators'
 import { CorrespondentService } from './correspondent.service'
 import { DocumentTypeService } from './document-type.service'
 import { TagService } from './tag.service'
@@ -70,7 +70,13 @@ export class DocumentService extends AbstractPaperlessService<PaperlessDocument>
       doc.document_type$ = this.documentTypeService.getCached(doc.document_type)
     }
     if (doc.tags) {
-      doc.tags$ = this.tagService.getCachedMany(doc.tags)
+      doc.tags$ = this.tagService
+        .getCachedMany(doc.tags)
+        .pipe(
+          tap((tags) =>
+            tags.sort((tagA, tagB) => tagA.name.localeCompare(tagB.name))
+          )
+        )
     }
     if (doc.storage_path) {
       doc.storage_path$ = this.storagePathService.getCached(doc.storage_path)


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

This PR alphabetizes the tags when displayed on a document in the UI. Currently they are sorted by id which as pointed out in the linked issue is not really predictable even if it is reproducible. I did consider other sorting but in the end kept coming back to this making the most sense. Though I am still not able to reproduce the problem in the linked issue, this should fix it anyway.

Fixes #927 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] ~~I have made corresponding changes to the documentation as needed.~~
- [x] I have checked my modifications for any breaking changes.
