### PR TITLE
Bugfix: Better sanity check messages

### DIFF
--- a/src/documents/sanity_checker.py
+++ b/src/documents/sanity_checker.py
@@ -137,7 +137,7 @@ def check_sanity(progress=False) -> SanityCheckMessages:
 
         # other document checks
         if not doc.content:
-            messages.info(doc.pk, "Document has no content.")
+            messages.info(doc.pk, "Document contains no OCR data")
 
     for extra_file in present_files:
         messages.warning(None, f"Orphaned file in media dir: {extra_file}")

--- a/src/documents/sanity_checker.py
+++ b/src/documents/sanity_checker.py
@@ -38,7 +38,10 @@ class SanityCheckMessages:
             for doc_pk in self._messages:
                 if doc_pk is not None:
                     doc = all_docs.get(pk=doc_pk)
-                    logger.info(f"Document: {doc.pk}, title: {doc.title}")
+                    logger.info(
+                        f"Detected following issue(s) with document #{doc.pk},"
+                        f" titled {doc.title}",
+                    )
                 for msg in self._messages[doc_pk]:
                     logger.log(msg["level"], msg["message"])
 

--- a/src/documents/tasks.py
+++ b/src/documents/tasks.py
@@ -338,9 +338,9 @@ def sanity_check():
 
     messages.log_messages()
 
-    if messages.has_error():
+    if messages.has_error:
         raise SanityCheckFailedException("Sanity check failed with errors. See log.")
-    elif messages.has_warning():
+    elif messages.has_warning:
         return "Sanity check exited with warnings. See log."
     elif len(messages) > 0:
         return "Sanity check exited with infos. See log."

--- a/src/documents/tests/test_management.py
+++ b/src/documents/tests/test_management.py
@@ -238,5 +238,5 @@ class TestSanityChecker(DirectoriesMixin, TestCase):
         with self.assertLogs() as capture:
             call_command("document_sanity_checker")
 
-        self.assertEqual(len(capture.output), 1)
-        self.assertIn("Checksum mismatch of document", capture.output[0])
+        self.assertEqual(len(capture.output), 2)
+        self.assertIn("Checksum mismatch. Stored: abc, actual:", capture.output[1])

--- a/src/documents/tests/test_management_exporter.py
+++ b/src/documents/tests/test_management_exporter.py
@@ -6,7 +6,6 @@ import tempfile
 from pathlib import Path
 from unittest import mock
 
-import pytest
 from django.core.management import call_command
 from django.test import override_settings
 from django.test import TestCase

--- a/src/documents/tests/test_management_exporter.py
+++ b/src/documents/tests/test_management_exporter.py
@@ -6,6 +6,7 @@ import tempfile
 from pathlib import Path
 from unittest import mock
 
+import pytest
 from django.core.management import call_command
 from django.test import override_settings
 from django.test import TestCase
@@ -190,7 +191,7 @@ class TestExportImport(DirectoriesMixin, TestCase):
             self.assertEqual(Document.objects.get(id=self.d4.id).title, "wow_dec")
             messages = check_sanity()
             # everything is alright after the test
-            self.assertEqual(len(messages), 0, str([str(m) for m in messages]))
+            self.assertEqual(len(messages), 0)
 
     def test_exporter_with_filename_format(self):
         shutil.rmtree(os.path.join(self.dirs.media_dir, "documents"))

--- a/src/documents/tests/test_sanity_check.py
+++ b/src/documents/tests/test_sanity_check.py
@@ -8,60 +8,7 @@ from django.conf import settings
 from django.test import TestCase
 from documents.models import Document
 from documents.sanity_checker import check_sanity
-from documents.sanity_checker import SanityCheckMessages
 from documents.tests.utils import DirectoriesMixin
-
-
-class TestSanityCheckMessages(TestCase):
-    def test_no_messages(self):
-        messages = SanityCheckMessages()
-        self.assertEqual(len(messages), 0)
-        self.assertFalse(messages.has_error())
-        self.assertFalse(messages.has_warning())
-        with self.assertLogs() as capture:
-            messages.log_messages()
-            self.assertEqual(len(capture.output), 1)
-            self.assertEqual(capture.records[0].levelno, logging.INFO)
-            self.assertEqual(
-                capture.records[0].message,
-                "Sanity checker detected no issues.",
-            )
-
-    def test_info(self):
-        messages = SanityCheckMessages()
-        messages.info("Something might be wrong")
-        self.assertEqual(len(messages), 1)
-        self.assertFalse(messages.has_error())
-        self.assertFalse(messages.has_warning())
-        with self.assertLogs() as capture:
-            messages.log_messages()
-            self.assertEqual(len(capture.output), 1)
-            self.assertEqual(capture.records[0].levelno, logging.INFO)
-            self.assertEqual(capture.records[0].message, "Something might be wrong")
-
-    def test_warning(self):
-        messages = SanityCheckMessages()
-        messages.warning("Something is wrong")
-        self.assertEqual(len(messages), 1)
-        self.assertFalse(messages.has_error())
-        self.assertTrue(messages.has_warning())
-        with self.assertLogs() as capture:
-            messages.log_messages()
-            self.assertEqual(len(capture.output), 1)
-            self.assertEqual(capture.records[0].levelno, logging.WARNING)
-            self.assertEqual(capture.records[0].message, "Something is wrong")
-
-    def test_error(self):
-        messages = SanityCheckMessages()
-        messages.error("Something is seriously wrong")
-        self.assertEqual(len(messages), 1)
-        self.assertTrue(messages.has_error())
-        self.assertFalse(messages.has_warning())
-        with self.assertLogs() as capture:
-            messages.log_messages()
-            self.assertEqual(len(capture.output), 1)
-            self.assertEqual(capture.records[0].levelno, logging.ERROR)
-            self.assertEqual(capture.records[0].message, "Something is seriously wrong")
 
 
 class TestSanityCheck(DirectoriesMixin, TestCase):
@@ -111,10 +58,30 @@ class TestSanityCheck(DirectoriesMixin, TestCase):
             archive_filename="0000001.pdf",
         )
 
-    def assertSanityError(self, messageRegex):
+    def assertSanityError(self, doc: Document, messageRegex):
         messages = check_sanity()
-        self.assertTrue(messages.has_error())
-        self.assertRegex(messages[0]["message"], messageRegex)
+        self.assertTrue(messages.has_error)
+        with self.assertLogs() as capture:
+            messages.log_messages()
+            self.assertRegex(
+                capture.records[0].message,
+                f"Document: {doc.pk}, title: {doc.title}",
+            )
+            self.assertRegex(capture.records[1].message, messageRegex)
+
+    def test_no_issues(self):
+        self.make_test_data()
+        messages = check_sanity()
+        self.assertFalse(messages.has_error)
+        self.assertFalse(messages.has_warning)
+        with self.assertLogs() as capture:
+            messages.log_messages()
+            self.assertEqual(len(capture.output), 1)
+            self.assertEqual(capture.records[0].levelno, logging.INFO)
+            self.assertEqual(
+                capture.records[0].message,
+                "Sanity checker detected no issues.",
+            )
 
     def test_no_docs(self):
         self.assertEqual(len(check_sanity()), 0)
@@ -126,75 +93,79 @@ class TestSanityCheck(DirectoriesMixin, TestCase):
     def test_no_thumbnail(self):
         doc = self.make_test_data()
         os.remove(doc.thumbnail_path)
-        self.assertSanityError("Thumbnail of document .* does not exist")
+        self.assertSanityError(doc, "Thumbnail of document does not exist")
 
     def test_thumbnail_no_access(self):
         doc = self.make_test_data()
         os.chmod(doc.thumbnail_path, 0o000)
-        self.assertSanityError("Cannot read thumbnail file of document")
+        self.assertSanityError(doc, "Cannot read thumbnail file of document")
         os.chmod(doc.thumbnail_path, 0o777)
 
     def test_no_original(self):
         doc = self.make_test_data()
         os.remove(doc.source_path)
-        self.assertSanityError("Original of document .* does not exist.")
+        self.assertSanityError(doc, "Original of document does not exist.")
 
     def test_original_no_access(self):
         doc = self.make_test_data()
         os.chmod(doc.source_path, 0o000)
-        self.assertSanityError("Cannot read original file of document")
+        self.assertSanityError(doc, "Cannot read original file of document")
         os.chmod(doc.source_path, 0o777)
 
     def test_original_checksum_mismatch(self):
         doc = self.make_test_data()
         doc.checksum = "WOW"
         doc.save()
-        self.assertSanityError("Checksum mismatch of document")
+        self.assertSanityError(doc, "Checksum mismatch. Stored: WOW, actual: ")
 
     def test_no_archive(self):
         doc = self.make_test_data()
         os.remove(doc.archive_path)
-        self.assertSanityError("Archived version of document .* does not exist.")
+        self.assertSanityError(doc, "Archived version of document does not exist.")
 
     def test_archive_no_access(self):
         doc = self.make_test_data()
         os.chmod(doc.archive_path, 0o000)
-        self.assertSanityError("Cannot read archive file of document")
+        self.assertSanityError(doc, "Cannot read archive file of document")
         os.chmod(doc.archive_path, 0o777)
 
     def test_archive_checksum_mismatch(self):
         doc = self.make_test_data()
         doc.archive_checksum = "WOW"
         doc.save()
-        self.assertSanityError("Checksum mismatch of archived document")
+        self.assertSanityError(doc, "Checksum mismatch of archived document")
 
     def test_empty_content(self):
         doc = self.make_test_data()
         doc.content = ""
         doc.save()
         messages = check_sanity()
-        self.assertFalse(messages.has_error())
-        self.assertFalse(messages.has_warning())
+        self.assertFalse(messages.has_error)
+        self.assertFalse(messages.has_warning)
         self.assertEqual(len(messages), 1)
-        self.assertRegex(messages[0]["message"], "Document .* has no content.")
+        self.assertRegex(messages[doc.pk][0]["message"], "Document has no content.")
 
     def test_orphaned_file(self):
         doc = self.make_test_data()
         Path(self.dirs.originals_dir, "orphaned").touch()
         messages = check_sanity()
-        self.assertFalse(messages.has_error())
-        self.assertTrue(messages.has_warning())
-        self.assertEqual(len(messages), 1)
-        self.assertRegex(messages[0]["message"], "Orphaned file in media dir")
+        self.assertTrue(messages.has_warning)
+        self.assertRegex(
+            messages._messages[None][0]["message"],
+            "Orphaned file in media dir",
+        )
 
     def test_archive_filename_no_checksum(self):
         doc = self.make_test_data()
         doc.archive_checksum = None
         doc.save()
-        self.assertSanityError("has an archive file, but its checksum is missing.")
+        self.assertSanityError(doc, "has an archive file, but its checksum is missing.")
 
     def test_archive_checksum_no_filename(self):
         doc = self.make_test_data()
         doc.archive_filename = None
         doc.save()
-        self.assertSanityError("has an archive file checksum, but no archive filename.")
+        self.assertSanityError(
+            doc,
+            "has an archive file checksum, but no archive filename.",
+        )

--- a/src/documents/tests/test_sanity_check.py
+++ b/src/documents/tests/test_sanity_check.py
@@ -143,7 +143,7 @@ class TestSanityCheck(DirectoriesMixin, TestCase):
         self.assertFalse(messages.has_error)
         self.assertFalse(messages.has_warning)
         self.assertEqual(len(messages), 1)
-        self.assertRegex(messages[doc.pk][0]["message"], "Document has no content.")
+        self.assertRegex(messages[doc.pk][0]["message"], "Document contains no OCR data.")
 
     def test_orphaned_file(self):
         doc = self.make_test_data()

--- a/src/documents/tests/test_sanity_check.py
+++ b/src/documents/tests/test_sanity_check.py
@@ -63,9 +63,9 @@ class TestSanityCheck(DirectoriesMixin, TestCase):
         self.assertTrue(messages.has_error)
         with self.assertLogs() as capture:
             messages.log_messages()
-            self.assertRegex(
+            self.assertEqual(
                 capture.records[0].message,
-                f"Document: {doc.pk}, title: {doc.title}",
+                f"Detected following issue(s) with document #{doc.pk}, titled {doc.title}",
             )
             self.assertRegex(capture.records[1].message, messageRegex)
 

--- a/src/documents/tests/test_sanity_check.py
+++ b/src/documents/tests/test_sanity_check.py
@@ -143,7 +143,10 @@ class TestSanityCheck(DirectoriesMixin, TestCase):
         self.assertFalse(messages.has_error)
         self.assertFalse(messages.has_warning)
         self.assertEqual(len(messages), 1)
-        self.assertRegex(messages[doc.pk][0]["message"], "Document contains no OCR data.")
+        self.assertRegex(
+            messages[doc.pk][0]["message"],
+            "Document contains no OCR data",
+        )
 
     def test_orphaned_file(self):
         doc = self.make_test_data()

--- a/src/documents/tests/test_tasks.py
+++ b/src/documents/tests/test_tasks.py
@@ -538,7 +538,7 @@ class TestTasks(DirectoriesMixin, TestCase):
     @mock.patch("documents.tasks.sanity_checker.check_sanity")
     def test_sanity_check_error(self, m):
         messages = SanityCheckMessages()
-        messages.error("Some error")
+        messages.error(None, "Some error")
         m.return_value = messages
         self.assertRaises(SanityCheckFailedException, tasks.sanity_check)
         m.assert_called_once()
@@ -546,7 +546,7 @@ class TestTasks(DirectoriesMixin, TestCase):
     @mock.patch("documents.tasks.sanity_checker.check_sanity")
     def test_sanity_check_warning(self, m):
         messages = SanityCheckMessages()
-        messages.warning("Some warning")
+        messages.warning(None, "Some warning")
         m.return_value = messages
         self.assertEqual(
             tasks.sanity_check(),
@@ -557,7 +557,7 @@ class TestTasks(DirectoriesMixin, TestCase):
     @mock.patch("documents.tasks.sanity_checker.check_sanity")
     def test_sanity_check_info(self, m):
         messages = SanityCheckMessages()
-        messages.info("Some info")
+        messages.info(None, "Some info")
         m.return_value = messages
         self.assertEqual(
             tasks.sanity_check(),


### PR DESCRIPTION
## Proposed change

With this PR, the messages from the sanity_checker will include some more helpful information in the output.  Instead of only outputting the document primary key, the title will also be output.  This can help the user locate the document, without needing to know the primary key can be put in the URL or understand the API.

Messages are now grouped by the document, so multiple issues with a single document will be together.  For issues not related to a particular document, they will be output together.  Currently, this is only for extra files in the media directory.

Fixes #1041

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
