### PR TITLE
Bugfix: Don't assume the document has a title set

### DIFF
--- a/src/documents/models.py
+++ b/src/documents/models.py
@@ -233,10 +233,13 @@ class Document(models.Model):
         # Convert UTC database time to local time
         created = datetime.date.isoformat(timezone.localdate(self.created))
 
-        if self.correspondent and self.title:
-            return f"{created} {self.correspondent} {self.title}"
-        else:
-            return f"{created} {self.title}"
+        res = f"{created}"
+
+        if self.correspondent:
+            res += f" {self.correspondent}"
+        if self.title:
+            res += f" {self.title}"
+        return res
 
     @property
     def source_path(self):


### PR DESCRIPTION
## Proposed change

When constructing the public filename of a document, don't assume the document will have a non-empty title.  Instead, check directly for each part which builds up the final name.

Fixes #1052

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
