### PR TITLE
Bugfix: Don't assume default Docker folders

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -28,7 +28,9 @@ initialize() {
 	# Check for overrides of certain folders
 	map_folders
 
-	for dir in "${DATA_DIR}" "${DATA_DIR}/index" "${MEDIA_ROOT_DIR}" "${MEDIA_ROOT_DIR}/documents" "${MEDIA_ROOT_DIR}/documents/originals" "${MEDIA_ROOT_DIR}/documents/thumbnails"; do
+	local export_dir="/usr/src/paperless/export"
+
+	for dir in "${export_dir}" "${DATA_DIR}" "${DATA_DIR}/index" "${MEDIA_ROOT_DIR}" "${MEDIA_ROOT_DIR}/documents" "${MEDIA_ROOT_DIR}/documents/originals" "${MEDIA_ROOT_DIR}/documents/thumbnails"; do
 		if [[ ! -d "${dir}" ]]; then
 			echo "Creating directory ${dir}"
 			mkdir "${dir}"
@@ -42,7 +44,7 @@ initialize() {
 	set +e
 	echo "Adjusting permissions of paperless files. This may take a while."
 	chown -R paperless:paperless ${tmp_dir}
-	for dir in "${DATA_DIR}" "${MEDIA_ROOT_DIR}"; do
+	for dir in "${export_dir}" "${DATA_DIR}" "${MEDIA_ROOT_DIR}"; do
 		find "${dir}" -not \( -user paperless -and -group paperless \) -exec chown paperless:paperless {} +
 	done
 	set -e

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -28,7 +28,7 @@ initialize() {
 	# Check for overrides of certain folders
 	map_folders
 
-	for dir in ${DATA_DIR} ${DATA_DIR}/index ${MEDIA_ROOT_DIR} ${MEDIA_ROOT_DIR}/documents ${MEDIA_ROOT_DIR}/documents/originals ${MEDIA_ROOT_DIR}/documents/thumbnails; do
+	for dir in "${DATA_DIR}" "${DATA_DIR}/index" "${MEDIA_ROOT_DIR}" "${MEDIA_ROOT_DIR}/documents" "${MEDIA_ROOT_DIR}/documents/originals" "${MEDIA_ROOT_DIR}/documents/thumbnails"; do
 		if [[ ! -d "${dir}" ]]; then
 			echo "Creating directory ${dir}"
 			mkdir "${dir}"
@@ -42,7 +42,7 @@ initialize() {
 	set +e
 	echo "Adjusting permissions of paperless files. This may take a while."
 	chown -R paperless:paperless ${tmp_dir}
-	for dir in ${DATA_DIR} ${MEDIA_ROOT_DIR}; do
+	for dir in "${DATA_DIR}" "${MEDIA_ROOT_DIR}"; do
 		find "${dir}" -not \( -user paperless -and -group paperless \) -exec chown paperless:paperless {} +
 	done
 	set -e

--- a/docker/docker-prepare.sh
+++ b/docker/docker-prepare.sh
@@ -3,16 +3,17 @@
 set -e
 
 wait_for_postgres() {
-	attempt_num=1
-	max_attempts=5
+	local attempt_num=1
+	local max_attempts=5
 
 	echo "Waiting for PostgreSQL to start..."
 
-	host="${PAPERLESS_DBHOST:=localhost}"
-	port="${PAPERLESS_DBPORT:=5432}"
+	local host="${PAPERLESS_DBHOST:-localhost}"
+	local port="${PAPERLESS_DBPORT:-5432}"
 
-
-	while [ ! "$(pg_isready -h $host -p $port)" ]; do
+	# Disable warning, host and port can't have spaces
+	# shellcheck disable=SC2086
+	while [ ! "$(pg_isready -h ${host} -p ${port})" ]; do
 
 		if [ $attempt_num -eq $max_attempts ]; then
 			echo "Unable to connect to database."
@@ -43,17 +44,18 @@ migrations() {
 		flock 200
 		echo "Apply database migrations..."
 		python3 manage.py migrate
-	) 200>/usr/src/paperless/data/migration_lock
+	) 200>"${DATA_DIR}/migration_lock"
 }
 
 search_index() {
-	index_version=1
-	index_version_file=/usr/src/paperless/data/.index_version
 
-	if [[ (! -f "$index_version_file") || $(<$index_version_file) != "$index_version" ]]; then
+	local index_version=1
+	local index_version_file=${DATA_DIR}/.index_version
+
+	if [[ (! -f "${index_version_file}") || $(<"${index_version_file}") != "$index_version" ]]; then
 		echo "Search index out of date. Updating..."
 		python3 manage.py document_index reindex --no-progress-bar
-		echo $index_version | tee $index_version_file >/dev/null
+		echo ${index_version} | tee "${index_version_file}" >/dev/null
 	fi
 }
 


### PR DESCRIPTION
## Proposed change

When the Docker entry point script runs, it sets up the media and data folders and changes permissions on them.  It previously assumed these folders would be subfolders of `/usr/src/paperless`.  However, a user can override these in the environment.  With this change, the maybe user defined settings will be taken into account, falling back to the defaults it nothing is set.

This change also means the search index will not be "out of date" on every startup if a user has overridden DATA_DIR.

Example of 1.7:
```
Creating directory ../data/index
Creating directory ../media/documents
Creating directory ../media/documents/originals
Creating directory ../media/documents/thumbnails
```

Example defaults:
```
Creating directory /usr/src/paperless/data/index
Creating directory /usr/src/paperless/media/documents
Creating directory /usr/src/paperless/media/documents/originals
Creating directory /usr/src/paperless/media/documents/thumbnails
```

Example if `PAPERLESS_DATA_DIR` and `PAPERLESS_MEDIA_ROOT` are set:
```
Creating directory /data/index
Creating directory /media/documents
Creating directory /media/documents/originals
Creating directory /media/documents/thumbnails
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
