### PR TITLE
Longer (5 vs 0.2s) guard_cycle for Django-Q

### DIFF
--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -458,6 +458,7 @@ PAPERLESS_WORKER_RETRY: Final[int] = __get_int(
 
 Q_CLUSTER = {
     "name": "paperless",
+    "guard_cycle": 5,
     "catch_up": False,
     "recycle": 1,
     "retry": PAPERLESS_WORKER_RETRY,


### PR DESCRIPTION
## Proposed change
To reduce average CPU load. Given paperless is mostly idling and when not, just spawns long-running operations (e.g., OCR), a 0.2s health-check of the Django-Q cluster is unnecessary. See also #1084

Partially fixes #1084

## Type of change

- [X] Other (please explain)

Config change

## Checklist:

- [X] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [X] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [X] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [X] I have checked my modifications for any breaking changes.
