### PR TITLE
Feature: CI/Image Library Speed Improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,20 +260,19 @@ jobs:
       -
         name: Compile messages
         run: |
-          ls -ahl
           cd src/
-          ls -ahl
-          pipenv run manage.py compilemessages
+          pipenv run python3 manage.py compilemessages
       -
         name: Collect static files
         run: |
           cd src/
-          pipenv run manage.py collectstatic --no-input
+          pipenv run python3 manage.py collectstatic --no-input
       -
         name: Move files
         run: |
           mkdir dist
           mkdir dist/paperless-ngx
+          mkdir dist/paperless-ngx/static
           mkdir dist/paperless-ngx/scripts
           cp .dockerignore .env Dockerfile Pipfile Pipfile.lock LICENSE README.md requirements.txt dist/paperless-ngx/
           cp paperless.conf.example dist/paperless-ngx/paperless.conf
@@ -282,12 +281,11 @@ jobs:
           cp scripts/*.service scripts/*.sh dist/paperless-ngx/scripts/
           cp src/ dist/paperless-ngx/src -r
           cp docs/_build/html/ dist/paperless-ngx/docs -r
-
+          cp -r static dist/paperless-ngx
       -
         name: Make release package
         run: |
           cd dist
-          find . -name __pycache__ | xargs rm -r
           tar -cJf paperless-ngx.tar.xz paperless-ngx/
       -
         name: Upload release artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,17 +230,21 @@ jobs:
         name: Checkout
         uses: actions/checkout@v3
       -
+        name: Install pipenv
+        run: pipx install pipenv
+      -
         name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: 3.9
+          python-version: "3.9"
+          cache: "pipenv"
+          cache-dependency-path: 'Pipfile.lock'
       -
         name: Install dependencies
         run: |
           sudo apt-get update -qq
           sudo apt-get install -qq --no-install-recommends gettext liblept5
-          pip3 install --upgrade pip setuptools wheel
-          pip3 install -r requirements.txt
+          pipenv sync --dev
       -
         name: Download frontend artifact
         uses: actions/download-artifact@v3
@@ -254,6 +258,18 @@ jobs:
           name: documentation
           path: docs/_build/html/
       -
+        name: Compile messages
+        run: |
+          ls -ahl
+          cd src/
+          ls -ahl
+          pipenv run manage.py compilemessages
+      -
+        name: Collect static files
+        run: |
+          cd src/
+          pipenv run manage.py collectstatic --no-input
+      -
         name: Move files
         run: |
           mkdir dist
@@ -266,16 +282,7 @@ jobs:
           cp scripts/*.service scripts/*.sh dist/paperless-ngx/scripts/
           cp src/ dist/paperless-ngx/src -r
           cp docs/_build/html/ dist/paperless-ngx/docs -r
-      -
-        name: Compile messages
-        run: |
-          cd dist/paperless-ngx/src
-          python3 manage.py compilemessages
-      -
-        name: Collect static files
-        run: |
-          cd dist/paperless-ngx/src
-          python3 manage.py collectstatic --no-input
+
       -
         name: Make release package
         run: |

--- a/.github/workflows/installer-library.yml
+++ b/.github/workflows/installer-library.yml
@@ -71,6 +71,17 @@ jobs:
           echo ${build_json}
 
           echo ::set-output name=pikepdf-json::${build_json}
+
+      -
+        name: Setup lxml image
+        id: lxml-setup
+        run: |
+          build_json=$(python ${GITHUB_WORKSPACE}/.github/scripts/get-build-json.py lxml)
+
+          echo ${build_json}
+
+          echo ::set-output name=lxml-json::${build_json}
+
       -
         name: Setup jbig2enc image
         id: jbig2enc-setup
@@ -86,6 +97,8 @@ jobs:
       qpdf-json: ${{ steps.qpdf-setup.outputs.qpdf-json }}
 
       pikepdf-json: ${{ steps.pikepdf-setup.outputs.pikepdf-json }}
+
+      lxml-json: ${{ steps.lxml-setup.outputs.lxml-json }}
 
       psycopg2-json: ${{ steps.psycopg2-setup.outputs.psycopg2-json }}
 
@@ -124,11 +137,23 @@ jobs:
       build-args: |
         PSYCOPG2_VERSION=${{ fromJSON(needs.prepare-docker-build.outputs.psycopg2-json).version }}
 
+  build-lxml-wheel:
+    name: lxml
+    needs:
+      - prepare-docker-build
+    uses: ./.github/workflows/reusable-workflow-builder.yml
+    with:
+      dockerfile: ./docker-builders/Dockerfile.lxml
+      build-json: ${{ needs.prepare-docker-build.outputs.lxml-json }}
+      build-args: |
+        LXML_VERSION=${{ fromJSON(needs.prepare-docker-build.outputs.lxml-json).version }}
+
   build-pikepdf-wheel:
     name: pikepdf
     needs:
       - prepare-docker-build
       - build-qpdf-debs
+      - build-lxml-wheel
     uses: ./.github/workflows/reusable-workflow-builder.yml
     with:
       dockerfile: ./docker-builders/Dockerfile.pikepdf
@@ -136,4 +161,5 @@ jobs:
       build-args: |
         REPO=${{ github.repository }}
         QPDF_VERSION=${{ fromJSON(needs.prepare-docker-build.outputs.qpdf-json).version }}
+        LXML_VERSION=${{ fromJSON(needs.prepare-docker-build.outputs.lxml-json).version }}
         PIKEPDF_VERSION=${{ fromJSON(needs.prepare-docker-build.outputs.pikepdf-json).version }}

--- a/docker-builders/Dockerfile.lxml
+++ b/docker-builders/Dockerfile.lxml
@@ -1,0 +1,54 @@
+# This Dockerfile builds the lxml wheel
+# Inputs:
+#    - LXML_VERSION - Version of lxml to build wheel for
+
+# Default to pulling from the main repo registry when manually building
+ARG REPO="paperless-ngx/paperless-ngx"
+
+FROM python:3.9-slim-bullseye as main
+
+LABEL org.opencontainers.image.description="A intermediate image with lxml wheel built"
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+ARG BUILD_PACKAGES="\
+  build-essential \
+  python3-dev \
+  python3-pip \
+  # lxml requrements - https://lxml.de/installation.html
+  libxml2-dev \
+  libxslt1-dev"
+
+WORKDIR /usr/src
+
+# As this is an base image for a multi-stage final image
+# the added size of the install is basically irrelevant
+
+RUN set -eux \
+  && apt-get update --quiet \
+  && apt-get install --yes --quiet --no-install-recommends ${BUILD_PACKAGES} \
+  && python3 -m pip install --no-cache-dir --upgrade \
+    pip \
+    wheel \
+  && rm -rf /var/lib/apt/lists/*
+
+# Layers after this point change according to required version
+# For better caching, seperate the basic installs from
+# the building
+
+ARG LXML_VERSION
+
+RUN set -eux \
+  && echo "Building lxml wheel ${LXML_VERSION}" \
+  && mkdir wheels \
+  && python3 -m pip wheel \
+    # Build the package at the required version
+    lxml==${LXML_VERSION} \
+    # Output the *.whl into this directory
+    --wheel-dir wheels \
+    # Do not use a binary packge for the package being built
+    --no-binary=lxml \
+    # Do use binary packages for dependencies
+    --prefer-binary \
+    --no-cache-dir \
+  && ls -ahl wheels

--- a/docker-builders/Dockerfile.pikepdf
+++ b/docker-builders/Dockerfile.pikepdf
@@ -8,7 +8,9 @@
 ARG REPO="paperless-ngx/paperless-ngx"
 
 ARG QPDF_VERSION
+ARG LXML_VERSION
 FROM ghcr.io/${REPO}/builder/qpdf:${QPDF_VERSION} as qpdf-builder
+FROM ghcr.io/${REPO}/builder/lxml:${LXML_VERSION} as lxml-builder
 
 # This does nothing, except provide a name for a copy below
 
@@ -24,9 +26,6 @@ ARG BUILD_PACKAGES="\
   python3-pip \
   # qpdf requirement - https://github.com/qpdf/qpdf#crypto-providers
   libgnutls28-dev \
-  # lxml requrements - https://lxml.de/installation.html
-  libxml2-dev \
-  libxslt1-dev \
   # Pillow requirements - https://pillow.readthedocs.io/en/stable/installation.html#external-libraries
   # JPEG functionality
   libjpeg62-turbo-dev \
@@ -50,6 +49,7 @@ ARG BUILD_PACKAGES="\
 WORKDIR /usr/src
 
 COPY --from=qpdf-builder /usr/src/qpdf/*.deb ./
+COPY --from=lxml-builder /usr/src/wheels/*.whl ./
 
 # As this is an base image for a multi-stage final image
 # the added size of the install is basically irrelevant
@@ -85,4 +85,6 @@ RUN set -eux \
     # Do use binary packages for dependencies
     --prefer-binary \
     --no-cache-dir \
+    # Use current directory to locate lxml wheel
+    --find-links=. \
   && ls -ahl wheels


### PR DESCRIPTION
## Proposed change

Two pretty small changes for small improvements to CI speed.

Fairly small change to pre-build the lxml wheel, which pikepdf needs.  This doesn't change too often, and accounts for ~20 minutes of the pikepdf build.  Using the already established procedure, build the wheel ahead of time.

And for the release dist making, use the pipenv cache, instead of installing from `requirements.txt`.  This sheds a minute or two from this step. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
