### PR TITLE
Fix: Prevent duplicate api calls on text filtering

### DIFF
--- a/src-ui/src/app/components/document-list/filter-editor/filter-editor.component.ts
+++ b/src-ui/src/app/components/document-list/filter-editor/filter-editor.component.ts
@@ -16,7 +16,7 @@ import { debounceTime, distinctUntilChanged, filter } from 'rxjs/operators'
 import { DocumentTypeService } from 'src/app/services/rest/document-type.service'
 import { TagService } from 'src/app/services/rest/tag.service'
 import { CorrespondentService } from 'src/app/services/rest/correspondent.service'
-import { FilterRule } from 'src/app/data/filter-rule'
+import { filterRulesDiffer, FilterRule } from 'src/app/data/filter-rule'
 import {
   FILTER_ADDED_AFTER,
   FILTER_ADDED_BEFORE,
@@ -204,7 +204,10 @@ export class FilterEditorComponent implements OnInit, OnDestroy {
   @Input()
   set unmodifiedFilterRules(value: FilterRule[]) {
     this._unmodifiedFilterRules = value
-    this.checkIfRulesHaveChanged()
+    this.rulesModified = filterRulesDiffer(
+      this._unmodifiedFilterRules,
+      this._filterRules
+    )
   }
 
   get unmodifiedFilterRules(): FilterRule[] {
@@ -330,7 +333,10 @@ export class FilterEditorComponent implements OnInit, OnDestroy {
           break
       }
     })
-    this.checkIfRulesHaveChanged()
+    this.rulesModified = filterRulesDiffer(
+      this._unmodifiedFilterRules,
+      this._filterRules
+    )
   }
 
   get filterRules(): FilterRule[] {
@@ -472,31 +478,6 @@ export class FilterEditorComponent implements OnInit, OnDestroy {
   filterRulesChange = new EventEmitter<FilterRule[]>()
 
   rulesModified: boolean = false
-
-  private checkIfRulesHaveChanged() {
-    let modified = false
-    if (this._unmodifiedFilterRules.length != this._filterRules.length) {
-      modified = true
-    } else {
-      modified = this._unmodifiedFilterRules.some((rule) => {
-        return (
-          this._filterRules.find(
-            (fri) => fri.rule_type == rule.rule_type && fri.value == rule.value
-          ) == undefined
-        )
-      })
-
-      if (!modified) {
-        // only check other direction if we havent already determined is modified
-        modified = this._filterRules.some((rule) => {
-          this._unmodifiedFilterRules.find(
-            (fr) => fr.rule_type == rule.rule_type && fr.value == rule.value
-          ) == undefined
-        })
-      }
-    }
-    this.rulesModified = modified
-  }
 
   updateRules() {
     this.filterRulesChange.next(this.filterRules)

--- a/src-ui/src/app/data/filter-rule.ts
+++ b/src-ui/src/app/data/filter-rule.ts
@@ -25,6 +25,34 @@ export function isFullTextFilterRule(filterRules: FilterRule[]): boolean {
   )
 }
 
+export function filterRulesDiffer(
+  filterRulesA: FilterRule[],
+  filterRulesB: FilterRule[]
+): boolean {
+  let modified = false
+  if (filterRulesA.length != filterRulesB.length) {
+    modified = true
+  } else {
+    modified = filterRulesA.some((rule) => {
+      return (
+        filterRulesB.find(
+          (fri) => fri.rule_type == rule.rule_type && fri.value == rule.value
+        ) == undefined
+      )
+    })
+
+    if (!modified) {
+      // only check other direction if we havent already determined is modified
+      modified = filterRulesB.some((rule) => {
+        filterRulesA.find(
+          (fr) => fr.rule_type == rule.rule_type && fr.value == rule.value
+        ) == undefined
+      })
+    }
+  }
+  return modified
+}
+
 export interface FilterRule {
   rule_type: number
   value: string

--- a/src-ui/src/app/data/filter-rule.ts
+++ b/src-ui/src/app/data/filter-rule.ts
@@ -29,28 +29,19 @@ export function filterRulesDiffer(
   filterRulesA: FilterRule[],
   filterRulesB: FilterRule[]
 ): boolean {
-  let modified = false
+  let differ = false
   if (filterRulesA.length != filterRulesB.length) {
-    modified = true
+    differ = true
   } else {
-    modified = filterRulesA.some((rule) => {
+    differ = filterRulesA.some((rule) => {
       return (
         filterRulesB.find(
           (fri) => fri.rule_type == rule.rule_type && fri.value == rule.value
         ) == undefined
       )
     })
-
-    if (!modified) {
-      // only check other direction if we havent already determined is modified
-      modified = filterRulesB.some((rule) => {
-        filterRulesA.find(
-          (fr) => fr.rule_type == rule.rule_type && fr.value == rule.value
-        ) == undefined
-      })
-    }
   }
-  return modified
+  return differ
 }
 
 export interface FilterRule {


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

This PR attempts to address the fact that text filtering causes duplicate calls to the API from the frontend. See videos before / after.

https://user-images.githubusercontent.com/4887959/173458948-502d718e-de73-4f5a-b531-e3a38201976d.mov

https://user-images.githubusercontent.com/4887959/173458954-b67a32b1-1cfa-4e8f-a56d-4b6c3e5c3b5b.mov


Fixes #1131

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] ~~I have made corresponding changes to the documentation as needed.~~
- [x] I have checked my modifications for any breaking changes.
