### PR TITLE
Feature use env vars in pre post scripts

### DIFF
--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -161,6 +161,9 @@ into paperless. It receives the following environment variables:
 
 * ``DOCUMENT_ID``
 * ``DOCUMENT_FILE_NAME``
+* ``DOCUMENT_CREATED``
+* ``DOCUMENT_MODIFIED``
+* ``DOCUMENT_ADDED``
 * ``DOCUMENT_SOURCE_PATH``
 * ``DOCUMENT_THUMBNAIL_PATH``
 * ``DOCUMENT_DOWNLOAD_URL``

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -165,6 +165,7 @@ into paperless. It receives the following environment variables:
 * ``DOCUMENT_MODIFIED``
 * ``DOCUMENT_ADDED``
 * ``DOCUMENT_SOURCE_PATH``
+* ``DOCUMENT_ARCHIVE_PATH``
 * ``DOCUMENT_THUMBNAIL_PATH``
 * ``DOCUMENT_DOWNLOAD_URL``
 * ``DOCUMENT_THUMBNAIL_URL``

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -121,10 +121,10 @@ Pre-consumption script
 ======================
 
 Executed after the consumer sees a new document in the consumption folder, but
-before any processing of the document is performed. This script receives exactly
-one argument:
+before any processing of the document is performed. This script can access the
+following relevant environment variables set:
 
-* Document file name
+* ``DOCUMENT_SOURCE_PATH``
 
 A simple but common example for this would be creating a simple script like
 this:
@@ -134,7 +134,7 @@ this:
 .. code:: bash
 
     #!/usr/bin/env bash
-    pdf2pdfocr.py -i ${1}
+    pdf2pdfocr.py -i ${DOCUMENT_SOURCE_PATH}
 
 ``/etc/paperless.conf``
 
@@ -157,16 +157,16 @@ Post-consumption script
 =======================
 
 Executed after the consumer has successfully processed a document and has moved it
-into paperless. It receives the following arguments:
+into paperless. It receives the following environment variables:
 
-* Document id
-* Generated file name
-* Source path
-* Thumbnail path
-* Download URL
-* Thumbnail URL
-* Correspondent
-* Tags
+* ``DOCUMENT_ID``
+* ``DOCUMENT_FILE_NAME``
+* ``DOCUMENT_SOURCE_PATH``
+* ``DOCUMENT_THUMBNAIL_PATH``
+* ``DOCUMENT_DOWNLOAD_URL``
+* ``DOCUMENT_THUMBNAIL_URL``
+* ``DOCUMENT_CORRESPONDENT``
+* ``DOCUMENT_TAGS``
 
 The script can be in any language, but for a simple shell script
 example, you can take a look at `post-consumption-example.sh`_ in this project.

--- a/scripts/post-consumption-example.sh
+++ b/scripts/post-consumption-example.sh
@@ -7,6 +7,9 @@ following additional information about it:
 
 * Generated File Name: ${DOCUMENT_FILE_NAME}
 * Source Path: ${DOCUMENT_SOURCE_PATH}
+* Created: ${DOCUMENT_CREATED}
+* Added: ${DOCUMENT_ADDED}
+* Modified: ${DOCUMENT_MODIFIED}
 * Thumbnail Path: ${DOCUMENT_THUMBNAIL_PATH}
 * Download URL: ${DOCUMENT_DOWNLOAD_URL}
 * Thumbnail URL: ${DOCUMENT_THUMBNAIL_URL}

--- a/scripts/post-consumption-example.sh
+++ b/scripts/post-consumption-example.sh
@@ -1,14 +1,5 @@
 #!/usr/bin/env bash
 
-DOCUMENT_ID=${1}
-DOCUMENT_FILE_NAME=${2}
-DOCUMENT_SOURCE_PATH=${3}
-DOCUMENT_THUMBNAIL_PATH=${4}
-DOCUMENT_DOWNLOAD_URL=${5}
-DOCUMENT_THUMBNAIL_URL=${6}
-DOCUMENT_CORRESPONDENT=${7}
-DOCUMENT_TAGS=${8}
-
 echo "
 
 A document with an id of ${DOCUMENT_ID} was just consumed.  I know the

--- a/scripts/post-consumption-example.sh
+++ b/scripts/post-consumption-example.sh
@@ -6,6 +6,7 @@ A document with an id of ${DOCUMENT_ID} was just consumed.  I know the
 following additional information about it:
 
 * Generated File Name: ${DOCUMENT_FILE_NAME}
+* Archive Path: ${DOCUMENT_ARCHIVE_PATH}
 * Source Path: ${DOCUMENT_SOURCE_PATH}
 * Created: ${DOCUMENT_CREATED}
 * Added: ${DOCUMENT_ADDED}

--- a/src/documents/consumer.py
+++ b/src/documents/consumer.py
@@ -165,6 +165,9 @@ class Consumer(LoggingMixin):
         script_env = os.environ.copy()
 
         script_env["DOCUMENT_ID"] = str(document.pk)
+        script_env["DOCUMENT_CREATED"] = str(document.created)
+        script_env["DOCUMENT_MODIFIED"] = str(document.modified)
+        script_env["DOCUMENT_ADDED"] = str(document.added)
         script_env["DOCUMENT_FILE_NAME"] = document.get_public_filename()
         script_env["DOCUMENT_SOURCE_PATH"] = os.path.normpath(document.source_path)
         script_env["DOCUMENT_THUMBNAIL_PATH"] = os.path.normpath(

--- a/src/documents/consumer.py
+++ b/src/documents/consumer.py
@@ -170,6 +170,7 @@ class Consumer(LoggingMixin):
         script_env["DOCUMENT_ADDED"] = str(document.added)
         script_env["DOCUMENT_FILE_NAME"] = document.get_public_filename()
         script_env["DOCUMENT_SOURCE_PATH"] = os.path.normpath(document.source_path)
+        script_env["DOCUMENT_ARCHIVE_PATH"] = os.path.normpath(str(document.archive_path))
         script_env["DOCUMENT_THUMBNAIL_PATH"] = os.path.normpath(
             document.thumbnail_path
         )

--- a/src/documents/consumer.py
+++ b/src/documents/consumer.py
@@ -134,11 +134,19 @@ class Consumer(LoggingMixin):
 
         self.log("info", f"Executing pre-consume script {settings.PRE_CONSUME_SCRIPT}")
 
+        filepath_arg = os.path.normpath(self.path)
+
         script_env = os.environ.copy()
-        script_env["DOCUMENT_SOURCE_PATH"] = os.path.normpath(self.path)
+        script_env["DOCUMENT_SOURCE_PATH"] = filepath_arg
 
         try:
-            Popen(settings.PRE_CONSUME_SCRIPT, env=script_env).wait()
+            Popen(
+                (
+                    settings.PRE_CONSUME_SCRIPT,
+                    filepath_arg,
+                ),
+                env=script_env,
+            ).wait()
         except Exception as e:
             self._fail(
                 MESSAGE_PRE_CONSUME_SCRIPT_ERROR,
@@ -170,24 +178,38 @@ class Consumer(LoggingMixin):
         script_env["DOCUMENT_ADDED"] = str(document.added)
         script_env["DOCUMENT_FILE_NAME"] = document.get_public_filename()
         script_env["DOCUMENT_SOURCE_PATH"] = os.path.normpath(document.source_path)
-        script_env["DOCUMENT_ARCHIVE_PATH"] = os.path.normpath(str(document.archive_path))
+        script_env["DOCUMENT_ARCHIVE_PATH"] = os.path.normpath(
+            str(document.archive_path),
+        )
         script_env["DOCUMENT_THUMBNAIL_PATH"] = os.path.normpath(
-            document.thumbnail_path
+            document.thumbnail_path,
         )
         script_env["DOCUMENT_DOWNLOAD_URL"] = reverse(
-            "document-download", kwargs={"pk": document.pk}
+            "document-download",
+            kwargs={"pk": document.pk},
         )
         script_env["DOCUMENT_THUMBNAIL_URL"] = reverse(
-            "document-thumb", kwargs={"pk": document.pk}
+            "document-thumb",
+            kwargs={"pk": document.pk},
         )
         script_env["DOCUMENT_CORRESPONDENT"] = str(document.correspondent)
         script_env["DOCUMENT_TAGS"] = str(
-            ",".join(document.tags.all().values_list("name", flat=True))
+            ",".join(document.tags.all().values_list("name", flat=True)),
         )
 
         try:
             Popen(
-                settings.POST_CONSUME_SCRIPT,
+                (
+                    settings.POST_CONSUME_SCRIPT,
+                    str(document.pk),
+                    document.get_public_filename(),
+                    os.path.normpath(document.source_path),
+                    os.path.normpath(document.thumbnail_path),
+                    reverse("document-download", kwargs={"pk": document.pk}),
+                    reverse("document-thumb", kwargs={"pk": document.pk}),
+                    str(document.correspondent),
+                    str(",".join(document.tags.all().values_list("name", flat=True))),
+                ),
                 env=script_env,
             ).wait()
         except Exception as e:


### PR DESCRIPTION
## Proposed change

This PR changes the pre- and post-consumption script invokation to not use positional script arguments but named environment variables. 

It also adds the documents relevant dates: `added`, `created` and `modified` to complete the available metadata provided to the post-consumption script 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ x ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

scripts that used the positional arguments will have to be changed, see the diff for the provided example script

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
