### PR TITLE
Enable rootless container w/ CI tweaks/bugfixes

### DIFF
--- a/.github/scripts/common.py
+++ b/.github/scripts/common.py
@@ -11,7 +11,7 @@ def get_image_tag(
     """
     Returns a string representing the normal image for a given package
     """
-    return f"ghcr.io/{repo_name}/builder/{pkg_name}:{pkg_version}"
+    return f"ghcr.io/{repo_name.lower()}/builder/{pkg_name}:{pkg_version}"
 
 
 def get_cache_image_tag(
@@ -26,7 +26,7 @@ def get_cache_image_tag(
     Registry type caching is utilized for the builder images, to allow fast
     rebuilds, generally almost instant for the same version
     """
-    return f"ghcr.io/{repo_name}/builder/cache/{pkg_name}:{pkg_version}"
+    return f"ghcr.io/{repo_name.lower()}/builder/cache/{pkg_name}:{pkg_version}"
 
 
 def get_log_level(args) -> int:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,8 +69,8 @@ jobs:
       - ci-frontend
     steps:
       -
-        name: Set gchr repository name
-        id: set-ghrc-repository
+        name: Set ghcr repository name
+        id: set-ghcr-repository
         run: |
           ghcr_name=$(echo "${GITHUB_REPOSITORY}" | awk '{ print tolower($0) }')
           echo ::set-output name=repository::${ghcr_name}
@@ -121,7 +121,7 @@ jobs:
 
     outputs:
 
-      ghcr-repository: ${{ steps.set-ghrc-repository.outputs.repository }}
+      ghcr-repository: ${{ steps.set-ghcr-repository.outputs.repository }}
 
       qpdf-json: ${{ steps.qpdf-setup.outputs.qpdf-json }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,12 @@ jobs:
       - ci-frontend
     steps:
       -
+        name: Set gchr repository name
+        id: set-ghrc-repository
+        run: |
+          ghcr_name=$(echo "${GITHUB_REPOSITORY}" | awk '{ print tolower($0) }')
+          echo ::set-output name=repository::${ghcr_name}
+      -
         name: Checkout
         uses: actions/checkout@v3
       -
@@ -115,6 +121,8 @@ jobs:
 
     outputs:
 
+      ghcr-repository: ${{ steps.set-ghrc-repository.outputs.repository }}
+
       qpdf-json: ${{ steps.qpdf-setup.outputs.qpdf-json }}
 
       pikepdf-json: ${{ steps.pikepdf-setup.outputs.pikepdf-json }}
@@ -142,7 +150,7 @@ jobs:
         #  a tag
         # Otherwise forks would require a Docker Hub account and secrets setup
         run: |
-          if [[ ${{ github.repository }} == "paperless-ngx/paperless-ngx" && ( ${{ github.ref_name }} == "main" || ${{ github.ref_name }} == "dev" || ${{ github.ref_name }} == "beta" || ${{ startsWith(github.ref, 'refs/tags/v') }} == "true" ) ]] ; then
+          if [[ ${{ needs.prepare-docker-build.outputs.ghcr-repository }} == "paperless-ngx/paperless-ngx" && ( ${{ github.ref_name }} == "main" || ${{ github.ref_name }} == "dev" || ${{ github.ref_name }} == "beta" || ${{ startsWith(github.ref, 'refs/tags/v') }} == "true" ) ]] ; then
             echo "Enabling DockerHub image push"
             echo ::set-output name=enable::"true"
           else
@@ -155,7 +163,7 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: |
-            ghcr.io/${{ github.repository }}
+            ghcr.io/${{ needs.prepare-docker-build.outputs.ghcr-repository }}
             name=paperlessngx/paperless-ngx,enable=${{ steps.docker-hub.outputs.enable }}
           tags: |
             # Tag branches with branch name
@@ -206,11 +214,11 @@ jobs:
           # Get cache layers from this branch, then dev, then main
           # This allows new branches to get at least some cache benefits, generally from dev
           cache-from: |
-            type=registry,ref=ghcr.io/${{ github.repository }}/builder/cache/app:${{ github.ref_name }}
-            type=registry,ref=ghcr.io/${{ github.repository }}/builder/cache/app:dev
-            type=registry,ref=ghcr.io/${{ github.repository }}/builder/cache/app:main
+            type=registry,ref=ghcr.io/${{ needs.prepare-docker-build.outputs.ghcr-repository }}/builder/cache/app:${{ github.ref_name }}
+            type=registry,ref=ghcr.io/${{ needs.prepare-docker-build.outputs.ghcr-repository }}/builder/cache/app:dev
+            type=registry,ref=ghcr.io/${{ needs.prepare-docker-build.outputs.ghcr-repository }}/builder/cache/app:main
           cache-to: |
-            type=registry,mode=max,ref=ghcr.io/${{ github.repository }}/builder/cache/app:${{ github.ref_name }}
+            type=registry,mode=max,ref=ghcr.io/${{ needs.prepare-docker-build.outputs.ghcr-repository }}/builder/cache/app:${{ github.ref_name }}
       -
         name: Inspect image
         run: |

--- a/.github/workflows/installer-library.yml
+++ b/.github/workflows/installer-library.yml
@@ -37,8 +37,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       -
-        name: Set gchr repository name
-        id: set-ghrc-repository
+        name: Set ghcr repository name
+        id: set-ghcr-repository
         run: |
           ghcr_name=$(echo "${GITHUB_REPOSITORY}" | awk '{ print tolower($0) }')
           echo ::set-output name=repository::${ghcr_name}
@@ -89,7 +89,7 @@ jobs:
 
     outputs:
 
-      ghcr-repository: ${{ steps.set-ghrc-repository.outputs.repository }}
+      ghcr-repository: ${{ steps.set-ghcr-repository.outputs.repository }}
 
       qpdf-json: ${{ steps.qpdf-setup.outputs.qpdf-json }}
 

--- a/.github/workflows/installer-library.yml
+++ b/.github/workflows/installer-library.yml
@@ -37,6 +37,12 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       -
+        name: Set gchr repository name
+        id: set-ghrc-repository
+        run: |
+          ghcr_name=$(echo "${GITHUB_REPOSITORY}" | awk '{ print tolower($0) }')
+          echo ::set-output name=repository::${ghcr_name}
+      -
         name: Checkout
         uses: actions/checkout@v3
       -
@@ -82,6 +88,8 @@ jobs:
           echo ::set-output name=jbig2enc-json::${build_json}
 
     outputs:
+
+      ghcr-repository: ${{ steps.set-ghrc-repository.outputs.repository }}
 
       qpdf-json: ${{ steps.qpdf-setup.outputs.qpdf-json }}
 
@@ -134,6 +142,6 @@ jobs:
       dockerfile: ./docker-builders/Dockerfile.pikepdf
       build-json: ${{ needs.prepare-docker-build.outputs.pikepdf-json }}
       build-args: |
-        REPO=${{ github.repository }}
+        REPO=${{ needs.prepare-docker-build.outputs.ghcr-repository }}
         QPDF_VERSION=${{ fromJSON(needs.prepare-docker-build.outputs.qpdf-json).version }}
         PIKEPDF_VERSION=${{ fromJSON(needs.prepare-docker-build.outputs.pikepdf-json).version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -120,19 +120,29 @@ COPY gunicorn.conf.py .
 ARG DOCKER_SRC=/usr/src/paperless/src/docker/
 WORKDIR ${DOCKER_SRC}
 
-RUN --mount=type=bind,readwrite,source=docker,target=${DOCKER_SRC} \
-  set -eux \
+COPY [ \
+	"docker/imagemagick-policy.xml", \
+	"docker/supervisord.conf", \
+	"docker/docker-entrypoint.sh", \
+	"docker/docker-prepare.sh", \
+	"docker/wait-for-redis.py", \
+	"docker/management_script.sh", \
+	"docker/install_management_commands.sh", \
+	"${DOCKER_SRC}" \
+]
+
+RUN set -eux \
   && echo "Configuring ImageMagick" \
-    && cp imagemagick-policy.xml /etc/ImageMagick-6/policy.xml \
+    && mv imagemagick-policy.xml /etc/ImageMagick-6/policy.xml \
   && echo "Configuring supervisord" \
     && mkdir /var/log/supervisord /var/run/supervisord \
-    && cp supervisord.conf /etc/supervisord.conf \
+    && mv supervisord.conf /etc/supervisord.conf \
   && echo "Setting up Docker scripts" \
-    && cp docker-entrypoint.sh /sbin/docker-entrypoint.sh \
+    && mv docker-entrypoint.sh /sbin/docker-entrypoint.sh \
     && chmod 755 /sbin/docker-entrypoint.sh \
-    && cp docker-prepare.sh /sbin/docker-prepare.sh \
+    && mv docker-prepare.sh /sbin/docker-prepare.sh \
     && chmod 755 /sbin/docker-prepare.sh \
-    && cp wait-for-redis.py /sbin/wait-for-redis.py \
+    && mv wait-for-redis.py /sbin/wait-for-redis.py \
     && chmod 755 /sbin/wait-for-redis.py \
   && echo "Installing managment commands" \
     && chmod +x install_management_commands.sh \

--- a/Dockerfile
+++ b/Dockerfile
@@ -117,9 +117,10 @@ COPY gunicorn.conf.py .
 # setup docker-specific things
 # Use mounts to avoid copying installer files into the image
 # These change sometimes, but rarely
-WORKDIR /usr/src/paperless/src/docker/
+ARG DOCKER_SRC=/usr/src/paperless/src/docker/
+WORKDIR ${DOCKER_SRC}
 
-RUN --mount=type=bind,readwrite,source=docker,target=./ \
+RUN --mount=type=bind,readwrite,source=docker,target=${DOCKER_SRC} \
   set -eux \
   && echo "Configuring ImageMagick" \
     && cp imagemagick-policy.xml /etc/ImageMagick-6/policy.xml \

--- a/Dockerfile
+++ b/Dockerfile
@@ -125,6 +125,7 @@ COPY [ \
 	"docker/supervisord.conf", \
 	"docker/docker-entrypoint.sh", \
 	"docker/docker-prepare.sh", \
+	"docker/paperless_cmd.sh", \
 	"docker/wait-for-redis.py", \
 	"docker/management_script.sh", \
 	"docker/install_management_commands.sh", \
@@ -144,6 +145,8 @@ RUN set -eux \
     && chmod 755 /sbin/docker-prepare.sh \
     && mv wait-for-redis.py /sbin/wait-for-redis.py \
     && chmod 755 /sbin/wait-for-redis.py \
+    && mv paperless_cmd.sh /usr/local/bin/paperless_cmd.sh \
+    && chmod 755 /usr/local/bin/paperless_cmd.sh \
   && echo "Installing managment commands" \
     && chmod +x install_management_commands.sh \
     && ./install_management_commands.sh
@@ -222,4 +225,4 @@ ENTRYPOINT ["/sbin/docker-entrypoint.sh"]
 
 EXPOSE 8000
 
-CMD ["/usr/local/bin/supervisord", "-c", "/etc/supervisord.conf"]
+CMD ["/usr/local/bin/paperless_cmd.sh"]

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -95,7 +95,11 @@ initialize() {
 	done
 	set -e
 
-	gosu paperless /sbin/docker-prepare.sh
+	if [ $(id -u) == $(id -u paperless) ]; then
+		/sbin/docker-prepare.sh
+	else
+		gosu paperless /sbin/docker-prepare.sh
+	fi
 }
 
 install_languages() {

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -95,11 +95,7 @@ initialize() {
 	done
 	set -e
 
-	if [ $(id -u) == $(id -u paperless) ]; then
-		/sbin/docker-prepare.sh
-	else
-		gosu paperless /sbin/docker-prepare.sh
-	fi
+	${gosu_cmd[@]} /sbin/docker-prepare.sh
 }
 
 install_languages() {
@@ -141,6 +137,11 @@ install_languages() {
 
 echo "Paperless-ngx docker container starting..."
 
+gosu_cmd=(gosu paperless)
+if [ $(id -u) == $(id -u paperless) ]; then
+	gosu_cmd=()
+fi
+
 # Install additional languages if specified
 if [[ -n "$PAPERLESS_OCR_LANGUAGES" ]]; then
 	install_languages "$PAPERLESS_OCR_LANGUAGES"
@@ -150,7 +151,7 @@ initialize
 
 if [[ "$1" != "/"* ]]; then
 	echo Executing management command "$@"
-	exec gosu paperless python3 manage.py "$@"
+	exec ${gosu_cmd[@]} python3 manage.py "$@"
 else
 	echo Executing "$@"
 	exec "$@"

--- a/docker/paperless_cmd.sh
+++ b/docker/paperless_cmd.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+rootless_args=()
+if [ $(id -u) == $(id -u paperless) ]; then
+	rootless_args=(
+		--user
+		paperless
+		--logfile
+		supervisord.log
+		--pidfile
+		supervisord.pid
+	)
+fi
+
+/usr/local/bin/supervisord -c /etc/supervisord.conf ${rootless_args[@]}

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -184,6 +184,29 @@ Install Paperless from Docker Hub
     port 8000. Modifying the part before the colon will map requests on another
     port to the webserver running on the default port.
 
+    **Rootless**
+
+    If you want to run Paperless as a rootless container, you will need to:
+
+    - set the ``user`` running the container to map to the ``paperless`` user in the
+      container.
+      See ``USERMAP_UID`` and ``USERMAP_GID`` :ref:`here <configuration-polling>`.
+
+    - override some of the ``supervisord`` defaults by setting the ``command`` to:
+
+     .. code::
+
+        command:
+          - "/usr/local/bin/supervisord"
+          - "-c"
+          - "/etc/supervisord.conf"
+          - "--user"
+          - "paperless"
+          - "--logfile"
+          - "supervisord.log"
+          - "--pidfile"
+          - "supervisord.pid"
+
 5.  Modify ``docker-compose.env``, following the comments in the file. The
     most important change is to set ``USERMAP_UID`` and ``USERMAP_GID``
     to the uid and gid of your user on the host system. Use ``id -u`` and

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -186,26 +186,35 @@ Install Paperless from Docker Hub
 
     **Rootless**
 
-    If you want to run Paperless as a rootless container, you will need to:
+    If you want to run Paperless as a rootless container, you will need to add the
+    following to your ``docker-compose.yml``:
 
     - set the ``user`` running the container to map to the ``paperless`` user in the
       container.
-      See ``USERMAP_UID`` and ``USERMAP_GID`` :ref:`here <configuration-polling>`.
+      This value (``user_id`` below), should be the same id that ``USERMAP_UID`` and
+      ``USERMAP_GID`` are set to in the next step.
+      See ``USERMAP_UID`` and ``USERMAP_GID`` :ref:`here <configuration-docker>`.
 
-    - override some of the ``supervisord`` defaults by setting the ``command`` to:
+    - override some of the ``supervisord`` defaults by setting the docker ``command``
+      (`see here <https://docs.docker.com/compose/compose-file/#command>`_) to:
+
+    Your ``docker-compose.yml`` entry for Paperless will look something like:
 
      .. code::
 
-        command:
-          - "/usr/local/bin/supervisord"
-          - "-c"
-          - "/etc/supervisord.conf"
-          - "--user"
-          - "paperless"
-          - "--logfile"
-          - "supervisord.log"
-          - "--pidfile"
-          - "supervisord.pid"
+        webserver:
+          image: ghcr.io/paperless-ngx/paperless-ngx:latest
+          user: <user_id>
+          command:
+            - "/usr/local/bin/supervisord"
+            - "-c"
+            - "/etc/supervisord.conf"
+            - "--user"
+            - "paperless"
+            - "--logfile"
+            - "supervisord.log"
+            - "--pidfile"
+            - "supervisord.pid"
 
 5.  Modify ``docker-compose.env``, following the comments in the file. The
     most important change is to set ``USERMAP_UID`` and ``USERMAP_GID``

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -186,8 +186,8 @@ Install Paperless from Docker Hub
 
     **Rootless**
 
-    If you want to run Paperless as a rootless container, you will need to add the
-    following to your ``docker-compose.yml``:
+    If you want to run Paperless as a rootless container, you will need to do the
+    following in your ``docker-compose.yml``:
 
     - set the ``user`` running the container to map to the ``paperless`` user in the
       container.
@@ -195,26 +195,13 @@ Install Paperless from Docker Hub
       ``USERMAP_GID`` are set to in the next step.
       See ``USERMAP_UID`` and ``USERMAP_GID`` :ref:`here <configuration-docker>`.
 
-    - override some of the ``supervisord`` defaults by setting the docker ``command``
-      (`see here <https://docs.docker.com/compose/compose-file/#command>`_) to:
-
-    Your ``docker-compose.yml`` entry for Paperless will look something like:
+    Your entry for Paperless should contain something like:
 
      .. code::
 
         webserver:
           image: ghcr.io/paperless-ngx/paperless-ngx:latest
           user: <user_id>
-          command:
-            - "/usr/local/bin/supervisord"
-            - "-c"
-            - "/etc/supervisord.conf"
-            - "--user"
-            - "paperless"
-            - "--logfile"
-            - "supervisord.log"
-            - "--pidfile"
-            - "supervisord.pid"
 
 5.  Modify ``docker-compose.env``, following the comments in the file. The
     most important change is to set ``USERMAP_UID`` and ``USERMAP_GID``


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Enables running the container as rootless by setting the running user to be the `paperless` user (configurable by `USERMAP_UID`).
Also fixes three other issues:
* building fails on selinux enabled systems unless relabeling is enabled for the bind-mounted host directory
  * `COPY`-ing the files into the container instead works around this problem without requiring relabeling 
* `podman build` fails on non-absolute mount points
  * fixed by  setting the workdir to an argument and reusing that argument in the mount
* builds using github actions failed if the running repository contains any capital letters
  * container registries require all lowercase repo name
  * fixed by ensuring that we coerce the repository name to lowercase

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
