### PR TITLE
Feature: Don't push feature development branches to DockerHub

### DIFF
--- a/.github/scripts/cleanup-tags.py
+++ b/.github/scripts/cleanup-tags.py
@@ -21,12 +21,17 @@ class GithubContainerRegistry:
         self._session: requests.Session = session
         self._token = token
         self._owner_or_org = owner_or_org
+        # https://docs.github.com/en/rest/branches/branches
         self._BRANCHES_ENDPOINT = "https://api.github.com/repos/{OWNER}/{REPO}/branches"
         if self._owner_or_org == "paperless-ngx":
+            # https://docs.github.com/en/rest/packages#get-all-package-versions-for-a-package-owned-by-an-organization
             self._PACKAGES_VERSIONS_ENDPOINT = "https://api.github.com/orgs/{ORG}/packages/{PACKAGE_TYPE}/{PACKAGE_NAME}/versions"
+            # https://docs.github.com/en/rest/packages#delete-package-version-for-an-organization
             self._PACKAGE_VERSION_DELETE_ENDPOINT = "https://api.github.com/orgs/{ORG}/packages/{PACKAGE_TYPE}/{PACKAGE_NAME}/versions/{PACKAGE_VERSION_ID}"
         else:
+            # https://docs.github.com/en/rest/packages#get-all-package-versions-for-a-package-owned-by-the-authenticated-user
             self._PACKAGES_VERSIONS_ENDPOINT = "https://api.github.com/user/packages/{PACKAGE_TYPE}/{PACKAGE_NAME}/versions"
+            # https://docs.github.com/en/rest/packages#delete-a-package-version-for-the-authenticated-user
             self._PACKAGE_VERSION_DELETE_ENDPOINT = "https://api.github.com/user/packages/{PACKAGE_TYPE}/{PACKAGE_NAME}/versions/{PACKAGE_VERSION_ID}"
 
     def __enter__(self):

--- a/.github/scripts/cleanup-tags.py
+++ b/.github/scripts/cleanup-tags.py
@@ -135,23 +135,6 @@ class GithubContainerRegistry:
             )
 
 
-class DockerHubContainerRegistery:
-    def __init__(self):
-        pass
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        pass
-
-    def get_image_versions(self) -> List:
-        return []
-
-    def delete_image_version(self):
-        pass
-
-
 def _main():
     parser = ArgumentParser(
         description="Using the GitHub API locate and optionally delete container"
@@ -253,15 +236,6 @@ def _main():
                                 package_name,
                                 to_delete_version,
                             )
-
-        with DockerHubContainerRegistery() as dh_api:
-            docker_hub_image_version = dh_api.get_image_versions()
-
-            # TODO
-            docker_hub_to_delete = []
-
-            for x in docker_hub_to_delete:
-                dh_api.delete_image_version()
 
 
 if __name__ == "__main__":

--- a/.github/scripts/cleanup-tags.py
+++ b/.github/scripts/cleanup-tags.py
@@ -222,13 +222,18 @@ def _main():
                 for tag_to_delete in to_delete:
                     package_version_info = packages_tagged_feature[tag_to_delete]
 
-                    logger.info(
-                        f"Deleting {tag_to_delete} (id {package_version_info['id']})",
-                    )
                     if args.delete:
+                        logger.info(
+                            f"Deleting {tag_to_delete} (id {package_version_info['id']})",
+                        )
                         gh_api.delete_package_version(
                             package_name,
                             package_version_info,
+                        )
+
+                    else:
+                        logger.info(
+                            f"Would delete {tag_to_delete} (id {package_version_info['id']})",
                         )
 
                 if args.untagged:
@@ -241,6 +246,8 @@ def _main():
                                 package_name,
                                 to_delete_version,
                             )
+                else:
+                    logger.info("Leaving untagged images untouched")
 
 
 if __name__ == "__main__":

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,12 +135,18 @@ jobs:
       -
         name: Check pushing to Docker Hub
         id: docker-hub
-        # Only push to Dockerhub from the main repo
+        # Only push to Dockerhub from the main repo AND the ref is either:
+        #  main
+        #  dev
+        #  beta
+        #  a tag
         # Otherwise forks would require a Docker Hub account and secrets setup
         run: |
-          if [[ ${{ github.repository }} == "paperless-ngx/paperless-ngx" ]] ; then
+          if [[ ${{ github.repository }} == "paperless-ngx/paperless-ngx" && ( ${{ github.ref_name }} == "main" || ${{ github.ref_name }} == "dev" || ${{ github.ref_name }} == "beta" || ${{ startsWith(github.ref, 'refs/tags/v') }} == "true" ) ]] ; then
+            echo "Enabling DockerHub image push"
             echo ::set-output name=enable::"true"
           else
+            echo "Not pushing to DockerHub"
             echo ::set-output name=enable::"false"
           fi
       -

--- a/.github/workflows/cleanup-tags.yml
+++ b/.github/workflows/cleanup-tags.yml
@@ -45,4 +45,4 @@ jobs:
       -
         name: Cleanup feature tags
         run: |
-          python ${GITHUB_WORKSPACE}/.github/scripts/cleanup-tags.py --loglevel info
+          python ${GITHUB_WORKSPACE}/.github/scripts/cleanup-tags.py --loglevel info --delete

--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ target/
 .virtualenv
 virtualenv
 /venv
+.venv/
 /docker-compose.env
 /docker-compose.yml
 


### PR DESCRIPTION
## Proposed change

After looking into the responses from the DockerHub API, deletion of versions was reported as being a paid feature, unlike Github.

So this PR removes the stub for deletion through the API and instead only enables pushing to there for a subset of branches (`main`, `dev`, `beta`) and for tags.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
