### PR TITLE
Bugfix: Include the actual OSError string when a file can't be opened for consumption

### DIFF
--- a/src/documents/management/commands/document_consumer.py
+++ b/src/documents/management/commands/document_consumer.py
@@ -67,17 +67,19 @@ def _consume(filepath):
 
     read_try_count = 0
     file_open_ok = False
+    os_error_str = None
 
     while (read_try_count < os_error_retry_count) and not file_open_ok:
         try:
             with open(filepath, "rb"):
                 file_open_ok = True
-        except OSError:
+        except OSError as e:
             read_try_count += 1
+            os_error_str = str(e)
             sleep(os_error_retry_wait)
 
     if read_try_count >= os_error_retry_count:
-        logger.warning(f"Not consuming file {filepath}: OS reports file as busy still")
+        logger.warning(f"Not consuming file {filepath}: OS reports {os_error_str}")
         return
 
     tag_ids = None


### PR DESCRIPTION
## Proposed change

When trying to open the file before consuming (as part of the prechecks and validations), store and potentially output the OSError message, if the file open fails.

Fixes #1149

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
