### PR TITLE
Bugfix: Adds pngquant and jbig2dec to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,6 +90,10 @@ ARG RUNTIME_PACKAGES="\
   tesseract-ocr-fra \
   tesseract-ocr-ita \
   tesseract-ocr-spa \
+  # Suggested for OCRmyPDF
+  pngquant \
+  # Suggested for pikepdf
+  jbig2dec \
   tzdata \
   unpaper \
   # Mime type detection

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -339,7 +339,7 @@ writing. Windows is not and will never be supported.
     *   ``qpdf``
     *   ``liblept5``
     *   ``libxml2``
-    *   ``pngquant``
+    *   ``pngquant`` (suggested for certain PDF image optimizations)
     *   ``zlib1g``
     *   ``tesseract-ocr`` >= 4.0.0 for OCR
     *   ``tesseract-ocr`` language packs (``tesseract-ocr-eng``, ``tesseract-ocr-deu``, etc)


### PR DESCRIPTION
## Proposed change

Resolves a new (?) warning from pikepdf concerning jbig2 decoder:

`UserWarning: pikepdf is missing some specialized decoders (probably JBIG2) so not all stream contents can be tested.`

Adds back the pngquant tool, which was removed by the WebP pull request, but is [suggested here](https://ocrmypdf.readthedocs.io/en/latest/cookbook.html#pdf-optimization) for PDF optimization tasks.  Fixes part of a warning like:
```
2022-07-18 10:08:52,841] [WARNING] [ocrmypdf._validation] The output file size is 1.45× larger than the input file.
Possible reasons for this include:
The argument --deskew was issued, causing transcoding.
The optional dependency 'pngquant' was not found, so some image optimizations could not be attempted.
```

Fixes # (issue)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
