### PR TITLE
Chore: Normalize and make settings paths absolute

### DIFF
--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -4,6 +4,7 @@ import math
 import multiprocessing
 import os
 import re
+import tempfile
 from typing import Final
 from typing import Optional
 from typing import Set
@@ -56,6 +57,13 @@ def __get_float(key: str, default: float) -> float:
     return float(os.getenv(key, default))
 
 
+def __get_path(key: str, default: str) -> str:
+    """
+    Return a normalized, absolute path based on the environment variable or a default
+    """
+    return os.path.abspath(os.path.normpath(os.environ.get(key, default)))
+
+
 # NEVER RUN WITH DEBUG IN PRODUCTION.
 DEBUG = __get_boolean("PAPERLESS_DEBUG", "NO")
 
@@ -66,14 +74,14 @@ DEBUG = __get_boolean("PAPERLESS_DEBUG", "NO")
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-STATIC_ROOT = os.getenv("PAPERLESS_STATICDIR", os.path.join(BASE_DIR, "..", "static"))
+STATIC_ROOT = __get_path("PAPERLESS_STATICDIR", os.path.join(BASE_DIR, "..", "static"))
 
-MEDIA_ROOT = os.getenv("PAPERLESS_MEDIA_ROOT", os.path.join(BASE_DIR, "..", "media"))
+MEDIA_ROOT = __get_path("PAPERLESS_MEDIA_ROOT", os.path.join(BASE_DIR, "..", "media"))
 ORIGINALS_DIR = os.path.join(MEDIA_ROOT, "documents", "originals")
 ARCHIVE_DIR = os.path.join(MEDIA_ROOT, "documents", "archive")
 THUMBNAIL_DIR = os.path.join(MEDIA_ROOT, "documents", "thumbnails")
 
-DATA_DIR = os.getenv("PAPERLESS_DATA_DIR", os.path.join(BASE_DIR, "..", "data"))
+DATA_DIR = __get_path("PAPERLESS_DATA_DIR", os.path.join(BASE_DIR, "..", "data"))
 
 TRASH_DIR = os.getenv("PAPERLESS_TRASH_DIR")
 
@@ -83,15 +91,18 @@ MEDIA_LOCK = os.path.join(MEDIA_ROOT, "media.lock")
 INDEX_DIR = os.path.join(DATA_DIR, "index")
 MODEL_FILE = os.path.join(DATA_DIR, "classification_model.pickle")
 
-LOGGING_DIR = os.getenv("PAPERLESS_LOGGING_DIR", os.path.join(DATA_DIR, "log"))
+LOGGING_DIR = __get_path("PAPERLESS_LOGGING_DIR", os.path.join(DATA_DIR, "log"))
 
-CONSUMPTION_DIR = os.getenv(
+CONSUMPTION_DIR = __get_path(
     "PAPERLESS_CONSUMPTION_DIR",
     os.path.join(BASE_DIR, "..", "consume"),
 )
 
 # This will be created if it doesn't exist
-SCRATCH_DIR = os.getenv("PAPERLESS_SCRATCH_DIR", "/tmp/paperless")
+SCRATCH_DIR = __get_path(
+    "PAPERLESS_SCRATCH_DIR",
+    os.path.join(tempfile.gettempdir(), "paperless"),
+)
 
 ###############################################################################
 # Application Definition                                                      #


### PR DESCRIPTION
## Proposed change

Minor quality of life change to normalize and make all the paths in the settings absolute.  This should eliminate any `..` showing up in logs.  I always find it a little annoying to remove those while looking at logs.

Also a minor change to use the `tempfile` provided temporary directory, just in case that isn't `/tmp`.

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
