### PR TITLE
Fix: dropdown selected items not visible again

### DIFF
--- a/src-ui/src/styles.scss
+++ b/src-ui/src/styles.scss
@@ -215,8 +215,6 @@ a, a:hover, .btn-link, .btn-link:hover {
       top: 7px;
     }
 
-    .paperless-input-select .ng-select .ng-select-container
-
     .ng-dropdown-panel .ng-dropdown-panel-items .ng-option.ng-option-marked {
       background-color: var(--pngx-bg-darker) !important;
       color: var(--pngx-body-color-accent) !important;


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

This PR fixes a visual bug where the selected (hovered, keyboard) item in dropdowns is not visible again. I think it was just a merge error in the CSS as this was fixed before in #933

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] ~~I have made corresponding changes to the documentation as needed.~~
- [x] I have checked my modifications for any breaking changes.
