### PR TITLE
Bugfix: Adds configuration for database timeout, fixing database locked error

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -31,7 +31,7 @@ PAPERLESS_REDIS=<url>
 
 PAPERLESS_DBHOST=<hostname>
     By default, sqlite is used as the database backend. This can be changed here.
-    Set PAPERLESS_DBHOST and PostgreSQL will be used instead of mysql.
+    Set PAPERLESS_DBHOST and PostgreSQL will be used instead of sqlite.
 
 PAPERLESS_DBPORT=<port>
     Adjust port if necessary.
@@ -59,6 +59,13 @@ PAPERLESS_DBSSLMODE=<mode>
     See `the official documentation about sslmode <https://www.postgresql.org/docs/current/libpq-ssl.html>`_.
 
     Default is ``prefer``.
+
+PAPERLESS_DB_TIMEOUT=<float>
+    Amount of time for a database connection to wait for the database to unlock.
+    Mostly applicable for an sqlite based installation, consider changing to postgresql
+    if you need to increase this.
+
+    Defaults to unset, keeping the Django defaults.
 
 Paths and folders
 #################

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -309,7 +309,7 @@ You might find messages like these in your log files:
 
 .. code::
 
-    [WARNING] [paperless.management.consumer] Not consuming file /usr/src/paperless/src/../consume/SCN_0001.pdf: OS reports file as busy still
+    [ERROR] [paperless.management.consumer] Creating PaperlessTask failed: db locked
 
 You are likely using an sqlite based installation, with an increased number of workers and are running into sqlite's concurrency limitations.
 Uploading or consuming multiple files at once results in many workers attempting to access the database simultaneously.

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -301,3 +301,19 @@ try adjusting the :ref:`polling configuration <configuration-polling>`.
 
     The user will need to manually move the file out of the consume folder and
     back in, for the initial failing file to be consumed.
+
+Log reports "Creating PaperlessTask failed".
+#########################################################
+
+You might find messages like these in your log files:
+
+.. code::
+
+    [WARNING] [paperless.management.consumer] Not consuming file /usr/src/paperless/src/../consume/SCN_0001.pdf: OS reports file as busy still
+
+You are likely using an sqlite based installation, with an increased number of workers and are running into sqlite's concurrency limitations.
+Uploading or consuming multiple files at once results in many workers attempting to access the database simultaneously.
+
+Consider changing to the PostgreSQL database if you will be processing many documents at once often.  Otherwise,
+try tweaking the ``PAPERLESS_DB_TIMEOUT`` setting to allow more time for the database to unlock.  This may have
+minor performance implications.

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -327,6 +327,13 @@ if os.getenv("PAPERLESS_DBHOST"):
     if os.getenv("PAPERLESS_DBPORT"):
         DATABASES["default"]["PORT"] = os.getenv("PAPERLESS_DBPORT")
 
+if os.getenv("PAPERLESS_DB_TIMEOUT") is not None:
+    _new_opts = {"timeout": float(os.getenv("PAPERLESS_DB_TIMEOUT"))}
+    if "OPTIONS" in DATABASES["default"]:
+        DATABASES["default"]["OPTIONS"].update(_new_opts)
+    else:
+        DATABASES["default"]["OPTIONS"] = _new_opts
+
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
 ###############################################################################


### PR DESCRIPTION
## Proposed change

Adds a new configuration option, `PAPERLESS_DB_TIMEOUT`, which sets the Django database timeout option, if it is set.  This allows a user to resolve issues where an sqlite database especially might be locked, when multiple documents are being consumed at once, resulting in many workers accessing the database for writing at once.

To be safer, the possible `OperationalError` in the signal handler is now caught and an error logged.  This allows consumption to continue.  The later signals are also updated to `get_or_create`, just in case the first signal handler didn't create the task.

Finally, documentation is updated for the new option, and a troubleshooting section was added, with some suggestions for tuning or upgrading to Postgres.

Requires:

1. sqlite database almost certainly
2. More than the default 1 worker
3. Many documents either uploaded or being consumed.

Fixes #1246

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
