### PR TITLE
[CI] Fix release drafter issues

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -25,6 +25,7 @@ include-labels:
   - 'deployment'
   - 'translation'
   - 'dependencies'
+  - 'documentation'
 replacers: # Changes "Feature: Update checker" to "Update checker"
   - search: '/Feature:|Feat:|\[feature\]/gi'
     replace: ''

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -35,11 +35,8 @@ include-labels:
   - 'frontend'
   - 'backend'
   - 'ci-cd'
-replacers: # Changes "Feature: Update checker" to "Update checker"
-  - search: '/Feature:?|Feat:?|\[feature\]/gi'
-    replace: ''
 category-template: '### $TITLE'
-change-template: '- $TITLE [@$AUTHOR](https://github.com/$AUTHOR) ([#$NUMBER]($URL))'
+change-template: '- $TITLE @$AUTHOR ([#$NUMBER]($URL))'
 change-title-escapes: '\<*_&#@'
 template: |
   ## paperless-ngx $RESOLVED_VERSION

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -15,9 +15,15 @@ categories:
       - 'chore'
       - 'deployment'
       - 'translation'
+      - 'ci-cd'
   - title: 'Dependencies'
     collapse-after: 3
     label: 'dependencies'
+  - title: 'All App Changes'
+    labels:
+      - 'frontend'
+      - 'backend'
+    collapse-after: 0
 include-labels:
   - 'enhancement'
   - 'bug'
@@ -26,8 +32,11 @@ include-labels:
   - 'translation'
   - 'dependencies'
   - 'documentation'
+  - 'frontend'
+  - 'backend'
+  - 'ci-cd'
 replacers: # Changes "Feature: Update checker" to "Update checker"
-  - search: '/Feature:|Feat:|\[feature\]/gi'
+  - search: '/Feature:?|Feat:?|\[feature\]/gi'
     replace: ''
 category-template: '### $TITLE'
 change-template: '- $TITLE [@$AUTHOR](https://github.com/$AUTHOR) ([#$NUMBER]($URL))'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,6 +372,8 @@ jobs:
           git branch ${{ needs.publish-release.outputs.version }}-changelog
           git checkout ${{ needs.publish-release.outputs.version }}-changelog
           echo -e "# Changelog\n\n${{ needs.publish-release.outputs.changelog }}\n" > changelog-new.md
+          echo "Manually linking usernames"
+          sed -i -r 's|@(.+?) \(\[#|[@\1](https://github.com/\1) ([#|ig' changelog-new.md
           CURRENT_CHANGELOG=`tail --lines +2 changelog.md`
           echo -e "$CURRENT_CHANGELOG" >> changelog-new.md
           mv changelog-new.md changelog.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -332,7 +332,7 @@ jobs:
       -
         name: Create Release and Changelog
         id: create-release
-        uses: release-drafter/release-drafter@v5
+        uses: paperless-ngx/release-drafter@master
         with:
           name: Paperless-ngx ${{ steps.get_version.outputs.version }}
           tag: ${{ steps.get_version.outputs.version }}


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

As discussed in #1298 there are a few issues with how the [release-drafter action](https://github.com/release-drafter/release-drafter) interacts with our betas. I don't have time right now but should before next release.

Changelog issues:

- [x] The majority of the PRs were not included in v1.8.0 because they [were drafted in the pre-release](https://github.com/paperless-ngx/paperless-ngx/releases/tag/v1.8.0-beta.rc1). ~~[This line](https://github.com/paperless-ngx/paperless-ngx/pull/1249/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR310) might have to be conditional (only include changelog on releases to `main`). Should test for comprehensive changelog on private repo, _warning_ `release-drafter` might still omit PRs if they're in pre-releases, regardless of what changelog was generated.~~
    - [Fixed in 18a2a41682274d870c9a935feb4b8a20381e29f2]
- [x] Manual name linking causing the missing contributors section. One thing we could do is regex replace the @'s with manual md links for the **appended changelog only**, and let github link usernames in the release notes.
  - [Fixed in a4c4b81297445365602f2c460b617dffa3a63f2b]
- [x] Missing PRs when their only label is documentation, which [isn't included](https://github.com/paperless-ngx/paperless-ngx/blob/20671c718e2620ea8dbca2e37efe6371b65fd12f/.github/release-drafter.yml#L21-L27). 
  - [Fixed in df7e664692c53ff5b6ae13926d7c6fdec62a4b67]

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
