### PR TITLE
Bugfix: Interaction between barcode and directories as tags

### DIFF
--- a/src/documents/tasks.py
+++ b/src/documents/tasks.py
@@ -87,6 +87,8 @@ def consume_file(
     override_created=None,
 ):
 
+    path = Path(path).resolve()
+
     # check for separators in current document
     if settings.CONSUMER_ENABLE_BARCODES:
 
@@ -122,7 +124,11 @@ def consume_file(
                         newname = f"{str(n)}_" + override_filename
                     else:
                         newname = None
-                    barcodes.save_to_dir(document, newname=newname)
+                    barcodes.save_to_dir(
+                        document,
+                        newname=newname,
+                        target_dir=path.parent,
+                    )
 
                 # if we got here, the document was successfully split
                 # and can safely be deleted


### PR DESCRIPTION
## Proposed change

When a barcode file containing file is split, previously the newly created files were placed into the `CONSUMPTION_DIR`.  However, if the consumer is working recursively and tagging documents based on the path of the barcode document, this means the split files won't have the correct tags.

This PR fixes the behavior by placing new split files into the same directory as the original file was.

Fixes #1294

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
