### PR TITLE
Fix: missing tooltip translation & filter editor wrapping

### DIFF
--- a/src-ui/messages.xlf
+++ b/src-ui/messages.xlf
@@ -513,6 +513,10 @@
         <source>Suggest an idea</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/app-frame/app-frame.component.html</context>
+          <context context-type="linenumber">192</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/app-frame/app-frame.component.html</context>
           <context context-type="linenumber">196</context>
         </context-group>
       </trans-unit>

--- a/src-ui/src/app/components/app-frame/app-frame.component.html
+++ b/src-ui/src/app/components/app-frame/app-frame.component.html
@@ -189,7 +189,7 @@
                   <use xlink:href="assets/bootstrap-icons.svg#github" />
                 </svg>&nbsp;<ng-container i18n>GitHub</ng-container>
               </a>
-              <a class="nav-link-additional small text-muted ms-3" target="_blank" rel="noopener noreferrer" href="https://github.com/paperless-ngx/paperless-ngx/discussions/categories/feature-requests" title="Suggest an idea">
+              <a class="nav-link-additional small text-muted ms-3" target="_blank" rel="noopener noreferrer" href="https://github.com/paperless-ngx/paperless-ngx/discussions/categories/feature-requests" title="Suggest an idea" i18n-title>
                 <svg xmlns="http://www.w3.org/2000/svg" width="1.1em" height="1.1em" fill="currentColor" class="me-1" viewBox="0 0 16 16">
                   <use xlink:href="assets/bootstrap-icons.svg#lightbulb" />
                 </svg>

--- a/src-ui/src/app/components/document-list/filter-editor/filter-editor.component.html
+++ b/src-ui/src/app/components/document-list/filter-editor/filter-editor.component.html
@@ -1,5 +1,5 @@
 <div class="row flex-wrap">
-   <div class="col mb-2 mb-xl-0">
+   <div class="col mb-2 mb-xxl-0">
      <div class="form-inline d-flex align-items-center">
          <div class="input-group input-group-sm flex-fill w-auto flex-nowrap">
            <div ngbDropdown>
@@ -15,10 +15,10 @@
          </div>
      </div>
   </div>
-  <div class="w-100 d-xl-none"></div>
+  <div class="w-100 d-xxl-none"></div>
     <div class="col col-xl-auto">
       <div class="d-flex flex-wrap">
-        <div class="d-flex flex-wrap mb-2 mb-lg-0">
+        <div class="d-flex flex-wrap mb-2 mb-xxl-0">
           <app-filterable-dropdown class="flex-fill" title="Tags" icon="tag-fill" i18n-title
             filterPlaceholder="Filter tags" i18n-filterPlaceholder
             [items]="tags"
@@ -63,7 +63,7 @@
         </div>
      </div>
    </div>
-   <div class="w-100 d-xl-none"></div>
+   <div class="w-100 d-xxl-none"></div>
    <div class="col col-xl-auto ps-0">
      <button class="btn btn-link btn-sm px-0" [disabled]="!rulesModified" (click)="resetSelected()">
        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-x me-1" fill="currentColor" xmlns="http://www.w3.org/2000/svg">

--- a/src-ui/src/app/components/document-list/filter-editor/filter-editor.component.scss
+++ b/src-ui/src/app/components/document-list/filter-editor/filter-editor.component.scss
@@ -17,3 +17,7 @@
 .d-flex.flex-wrap {
   column-gap: 0.7rem;
 }
+
+input[type="text"] {
+  min-width: 120px;
+}


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

This small PR addresses two (unrelated) issues reported in 1.8.0, the first a missing translation string and the second the fact that the filter editor text field can become too short on certain screen sizes. Regarding the second issue, fix was to increase the breakpoint at which everything goes to one line from 1200 --> 1400 px (e.g. at user's screen size things will now be on two lines). Screenshot below is new minimum width to illustrate, its still small but acceptable I think.

<img width="1396" alt="Screen Shot 2022-07-29 at 2 42 02 PM" src="https://user-images.githubusercontent.com/4887959/181847483-0a39929b-af1c-4e08-85c9-eb62df43313f.png">

Fixes #1299
Fixes #1300

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] ~~I have made corresponding changes to the documentation as needed.~~
- [x] I have checked my modifications for any breaking changes.
