### PR TITLE
Info about installing on subpath

### DIFF
--- a/docker/compose/docker-compose.env
+++ b/docker/compose/docker-compose.env
@@ -37,45 +37,6 @@
 # documents are written in.
 #PAPERLESS_OCR_LANGUAGE=eng
 
-# The UID and GID of the user used to run paperless in the container. Set this
-# to your UID and GID on the host so that you have write access to the
-# consumption directory.
-#USERMAP_UID=1000
-#USERMAP_GID=1000
-
-# Additional languages to install for text recognition, separated by a
-# whitespace. Note that this is
-# different from PAPERLESS_OCR_LANGUAGE (default=eng), which defines the
-# language used for OCR.
-# The container installs English, German, Italian, Spanish and French by
-# default.
-# See https://packages.debian.org/search?keywords=tesseract-ocr-&searchon=names&suite=buster
-# for available languages.
-#PAPERLESS_OCR_LANGUAGES=tur ces
-
-###############################################################################
-# Paperless-specific settings                                                 #
-###############################################################################
-
-# All settings defined in the paperless.conf.example can be used here. The
-# Docker setup does not use the configuration file.
-# A few commonly adjusted settings are provided below.
-
-# This is required if you will be exposing Paperless-ngx on a public domain
-# (if doing so please consider security measures such as reverse proxy)
-#PAPERLESS_URL=https://paperless.example.com
-
-# Adjust this key if you plan to make paperless available publicly. It should
-# be a very long sequence of random characters. You don't need to remember it.
-#PAPERLESS_SECRET_KEY=change-me
-
-# Use this variable to set a timezone for the Paperless Docker containers. If not specified, defaults to UTC.
-#PAPERLESS_TIME_ZONE=America/Los_Angeles
-
-# The default language to use for OCR. Set this to the language most of your
-# documents are written in.
-#PAPERLESS_OCR_LANGUAGE=eng
-
 # Use this to extend the basepath of paperless when using a reverse-proxy like traefik or nginx
 # you will thus access paperless from http(s)://yourdomain/PATHPREFIX
 #PAPERLESS_FORCE_SCRIPT_NAME=/PATHPREFIX

--- a/docker/compose/docker-compose.env
+++ b/docker/compose/docker-compose.env
@@ -37,7 +37,6 @@
 # documents are written in.
 #PAPERLESS_OCR_LANGUAGE=eng
 
-# Use this to extend the basepath of paperless when using a reverse-proxy like traefik or nginx
-# you will thus access paperless from http(s)://yourdomain/PATHPREFIX
+# Set if accessing paperless via a domain subpath e.g. https://domain.com/PATHPREFIX and using a reverse-proxy like traefik or nginx
 #PAPERLESS_FORCE_SCRIPT_NAME=/PATHPREFIX
-#PAPERLESS_STATIC_URL=/PATHPREFIX/static/ # leave a trailing slash, otherwise paperless will not start
+#PAPERLESS_STATIC_URL=/PATHPREFIX/static/ # trailing slash required

--- a/docker/compose/docker-compose.env
+++ b/docker/compose/docker-compose.env
@@ -36,3 +36,47 @@
 # The default language to use for OCR. Set this to the language most of your
 # documents are written in.
 #PAPERLESS_OCR_LANGUAGE=eng
+
+# The UID and GID of the user used to run paperless in the container. Set this
+# to your UID and GID on the host so that you have write access to the
+# consumption directory.
+#USERMAP_UID=1000
+#USERMAP_GID=1000
+
+# Additional languages to install for text recognition, separated by a
+# whitespace. Note that this is
+# different from PAPERLESS_OCR_LANGUAGE (default=eng), which defines the
+# language used for OCR.
+# The container installs English, German, Italian, Spanish and French by
+# default.
+# See https://packages.debian.org/search?keywords=tesseract-ocr-&searchon=names&suite=buster
+# for available languages.
+#PAPERLESS_OCR_LANGUAGES=tur ces
+
+###############################################################################
+# Paperless-specific settings                                                 #
+###############################################################################
+
+# All settings defined in the paperless.conf.example can be used here. The
+# Docker setup does not use the configuration file.
+# A few commonly adjusted settings are provided below.
+
+# This is required if you will be exposing Paperless-ngx on a public domain
+# (if doing so please consider security measures such as reverse proxy)
+#PAPERLESS_URL=https://paperless.example.com
+
+# Adjust this key if you plan to make paperless available publicly. It should
+# be a very long sequence of random characters. You don't need to remember it.
+#PAPERLESS_SECRET_KEY=change-me
+
+# Use this variable to set a timezone for the Paperless Docker containers. If not specified, defaults to UTC.
+#PAPERLESS_TIME_ZONE=America/Los_Angeles
+
+# The default language to use for OCR. Set this to the language most of your
+# documents are written in.
+#PAPERLESS_OCR_LANGUAGE=eng
+
+# Use this to extend the basepath of paperless when using a reverse-proxy like traefik or nginx
+# you will thus access paperless from http(s)://yourdomain/PATHPREFIX
+#PAPERLESS_FORCE_SCRIPT_NAME=/PATHPREFIX
+#PAPERLESS_STATIC_URL=/PATHPREFIX/static/ # leave a trailing slash, otherwise paperless will not start

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -215,18 +215,16 @@ PAPERLESS_FORCE_SCRIPT_NAME=<path>
 PAPERLESS_STATIC_URL=<path>
     Override the STATIC_URL here.  Unless you're hosting Paperless off a
     subdomain like /paperless/, you probably don't need to change this.
-    When you do, change it for e.g. to /paperless/static/  Trailing slash!
+    If you do change it, be sure to include the trailing slash.
 
     Defaults to "/static/".
-.. note::
-    When hosting paperless behind a reverse proxy like Traefik or Nginx at 
-    the root of a subdomain like paperless.example.com/ one needs not to change 
-    the config. However using a subpath for example paperless.example.com/paperlessngx
-    you will need to change
-      PAPERLESS_FORCE_SCRIPT_NAME=/paperlessngx
 
-      PAPERLESS_STATIC_URL=/paperlessngx/static/
-    
+    .. note::
+
+        When hosting paperless behind a reverse proxy like Traefik or Nginx at a subpath e.g.
+        example.com/paperlessngx you will also need to set ``PAPERLESS_FORCE_SCRIPT_NAME``
+        (see above).
+
 PAPERLESS_AUTO_LOGIN_USERNAME=<username>
     Specify a username here so that paperless will automatically perform login
     with the selected user.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -215,9 +215,18 @@ PAPERLESS_FORCE_SCRIPT_NAME=<path>
 PAPERLESS_STATIC_URL=<path>
     Override the STATIC_URL here.  Unless you're hosting Paperless off a
     subdomain like /paperless/, you probably don't need to change this.
+    When you do, change it for e.g. to /paperless/static/  Trailing slash!
 
     Defaults to "/static/".
+.. note::
+    When hosting paperless behind a reverse proxy like Traefik or Nginx at 
+    the root of a subdomain like paperless.example.com/ one needs not to change 
+    the config. However using a subpath for example paperless.example.com/paperlessngx
+    you will need to change
+      PAPERLESS_FORCE_SCRIPT_NAME=/paperlessngx
 
+      PAPERLESS_STATIC_URL=/paperlessngx/static/
+    
 PAPERLESS_AUTO_LOGIN_USERNAME=<username>
     Specify a username here so that paperless will automatically perform login
     with the selected user.


### PR DESCRIPTION
## Proposed change

In my setup I want to use traefik as a reverse proxy. This works without problems on a subdomain, subdomain.example.com. Trying to make this work on a subpath, like subdomain.example.com/paperless fails. I could not get useful information just by searching. 
The standard way would be to setup Traefik to respond to subdomain.example.com/paperless, strip the pathprefix and send the query to paperless-ngx which waits on the root path and is unknowing of the domain it serves on. This however is not working as intended. 
The other way was to change the basepath, but this is very scarcely documented and it contains some errors like subdomain instead of subpath

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ x ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
