### PR TITLE
Bugfix: Chain exceptions during exception handling

### DIFF
--- a/src/documents/classifier.py
+++ b/src/documents/classifier.py
@@ -101,8 +101,8 @@ class DocumentClassifier:
                         self.correspondent_classifier = pickle.load(f)
                         self.document_type_classifier = pickle.load(f)
                         self.storage_path_classifier = pickle.load(f)
-                    except Exception:
-                        raise ClassifierModelCorruptError()
+                    except Exception as err:
+                        raise ClassifierModelCorruptError() from err
 
             # Check for the warning about unpickling from differing versions
             # and consider it incompatible

--- a/src/documents/consumer.py
+++ b/src/documents/consumer.py
@@ -78,10 +78,16 @@ class Consumer(LoggingMixin):
             {"type": "status_update", "data": payload},
         )
 
-    def _fail(self, message, log_message=None, exc_info=None):
+    def _fail(
+        self,
+        message,
+        log_message=None,
+        exc_info=None,
+        exception: Optional[Exception] = None,
+    ):
         self._send_progress(100, 100, "FAILED", message)
         self.log("error", log_message or message, exc_info=exc_info)
-        raise ConsumerError(f"{self.filename}: {log_message or message}")
+        raise ConsumerError(f"{self.filename}: {log_message or message}") from exception
 
     def __init__(self):
         super().__init__()
@@ -152,6 +158,7 @@ class Consumer(LoggingMixin):
                 MESSAGE_PRE_CONSUME_SCRIPT_ERROR,
                 f"Error while executing pre-consume script: {e}",
                 exc_info=True,
+                exception=e,
             )
 
     def run_post_consume_script(self, document):
@@ -217,6 +224,7 @@ class Consumer(LoggingMixin):
                 MESSAGE_POST_CONSUME_SCRIPT_ERROR,
                 f"Error while executing post-consume script: {e}",
                 exc_info=True,
+                exception=e,
             )
 
     def try_consume_file(
@@ -331,6 +339,7 @@ class Consumer(LoggingMixin):
                 str(e),
                 f"Error while consuming document {self.filename}: {e}",
                 exc_info=True,
+                exception=e,
             )
 
         # Prepare the document classifier.
@@ -415,6 +424,7 @@ class Consumer(LoggingMixin):
                 f"The following error occurred while consuming "
                 f"{self.filename}: {e}",
                 exc_info=True,
+                exception=e,
             )
         finally:
             document_parser.cleanup()

--- a/src/paperless_mail/mail.py
+++ b/src/paperless_mail/mail.py
@@ -197,12 +197,14 @@ class MailAccountHandler(LoggingMixin):
 
                         # Need to transition out of AUTH state to SELECTED
                         M.folder.set("INBOX")
-                    except Exception:
+                    except Exception as err:
                         self.log(
                             "error",
                             "Unable to authenticate with mail server using AUTH=PLAIN",
                         )
-                        raise MailError(f"Error while authenticating account {account}")
+                        raise MailError(
+                            f"Error while authenticating account {account}",
+                        ) from err
                 except Exception as e:
                     self.log(
                         "error",
@@ -245,7 +247,7 @@ class MailAccountHandler(LoggingMixin):
 
         try:
             M.folder.set(rule.folder)
-        except MailboxFolderSelectError:
+        except MailboxFolderSelectError as err:
 
             self.log(
                 "error",
@@ -264,7 +266,7 @@ class MailAccountHandler(LoggingMixin):
             raise MailError(
                 f"Rule {rule}: Folder {rule.folder} "
                 f"does not exist in account {rule.account}",
-            )
+            ) from err
 
         criterias = make_criterias(rule)
 
@@ -279,8 +281,10 @@ class MailAccountHandler(LoggingMixin):
                 mark_seen=False,
                 charset=rule.account.character_set,
             )
-        except Exception:
-            raise MailError(f"Rule {rule}: Error while fetching folder {rule.folder}")
+        except Exception as err:
+            raise MailError(
+                f"Rule {rule}: Error while fetching folder {rule.folder}",
+            ) from err
 
         post_consume_messages = []
 
@@ -320,7 +324,7 @@ class MailAccountHandler(LoggingMixin):
         except Exception as e:
             raise MailError(
                 f"Rule {rule}: Error while processing post-consume actions: " f"{e}",
-            )
+            ) from e
 
         return total_processed_files
 

--- a/src/paperless_tesseract/parsers.py
+++ b/src/paperless_tesseract/parsers.py
@@ -323,11 +323,11 @@ class RasterisedDocumentParser(DocumentParser):
 
             except Exception as e:
                 # If this fails, we have a serious issue at hand.
-                raise ParseError(f"{e.__class__.__name__}: {str(e)}")
+                raise ParseError(f"{e.__class__.__name__}: {str(e)}") from e
 
         except Exception as e:
             # Anything else is probably serious.
-            raise ParseError(f"{e.__class__.__name__}: {str(e)}")
+            raise ParseError(f"{e.__class__.__name__}: {str(e)}") from e
 
         # As a last resort, if we still don't have any text for any reason,
         # try to extract the text from the original document.

--- a/src/paperless_tika/parsers.py
+++ b/src/paperless_tika/parsers.py
@@ -57,7 +57,7 @@ class TikaDocumentParser(DocumentParser):
             raise ParseError(
                 f"Could not parse {document_path} with tika server at "
                 f"{tika_server}: {err}",
-            )
+            ) from err
 
         self.text = parsed["content"].strip()
 
@@ -90,7 +90,9 @@ class TikaDocumentParser(DocumentParser):
                 response = requests.post(url, files=files, headers=headers)
                 response.raise_for_status()  # ensure we notice bad responses
             except Exception as err:
-                raise ParseError(f"Error while converting document to PDF: {err}")
+                raise ParseError(
+                    f"Error while converting document to PDF: {err}",
+                ) from err
 
         with open(pdf_path, "wb") as file:
             file.write(response.content)


### PR DESCRIPTION
## Proposed change

A minor change so that during exception handling, if the action is to raise an exception of a different type, use the `from` keyword so the exceptions are chained for better clarity.  This means the message will change from "During handling of the above exception, another exception occurred:" to "The above exception was the direct cause of the following exception:"

The docs claim this happens automatically if an exception is raised inside `except` or `finally`, but I don't see that happening in logs (for example #900), so I'm making it explicit.

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (please explain) - qol

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
