### PR TITLE
Bugfix: Allow webserver bind address to be configured

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -808,6 +808,13 @@ PAPERLESS_WEBSERVER_WORKERS=<num>
 
     Defaults to 1.
 
+PAPERLESS_BIND_ADDR=<ip address>
+    The IP address the webserver will listen on inside the container. There are
+    special setups where you may need to configure this value to restrict the
+    Ip address or interface the webserver listens on.
+
+    Defaults to [::], meaning all interfaces, including IPv6.
+
 PAPERLESS_PORT=<port>
     The port number the webserver will listen on inside the container. There are
     special setups where you may need this to avoid collisions with other

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,6 +1,6 @@
 import os
 
-bind = f'[::]:{os.getenv("PAPERLESS_PORT", 8000)}'
+bind = f'{os.getenv("PAPERLESS_BIND_ADDR", "[::]")}:{os.getenv("PAPERLESS_PORT", 8000)}'
 workers = int(os.getenv("PAPERLESS_WEBSERVER_WORKERS", 1))
 worker_class = "paperless.workers.ConfigurableWorker"
 timeout = 120


### PR DESCRIPTION
## Proposed change

Allows the IP address that gunicorn will bind to to be configurable via the environment.  Should allow hosts with no IPv6 support at all to still function, and may have other uses (I think I saw feature requests for this in discussions)

Fixes #1356

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
