### PR TITLE
Fix: correct date pasting with other formats

### DIFF
--- a/src-ui/src/app/components/common/input/date/date.component.ts
+++ b/src-ui/src/app/components/common/input/date/date.component.ts
@@ -1,8 +1,10 @@
 import { Component, forwardRef, OnInit } from '@angular/core'
 import { NG_VALUE_ACCESSOR } from '@angular/forms'
-import { NgbDateParserFormatter } from '@ng-bootstrap/ng-bootstrap'
+import {
+  NgbDateAdapter,
+  NgbDateParserFormatter,
+} from '@ng-bootstrap/ng-bootstrap'
 import { SettingsService } from 'src/app/services/settings.service'
-import { LocalizedDateParserFormatter } from 'src/app/utils/ngb-date-parser-formatter'
 import { AbstractInputComponent } from '../abstract-input'
 
 @Component({
@@ -23,7 +25,8 @@ export class DateComponent
 {
   constructor(
     private settings: SettingsService,
-    private ngbDateParserFormatter: NgbDateParserFormatter
+    private ngbDateParserFormatter: NgbDateParserFormatter,
+    private isoDateAdapter: NgbDateAdapter<string>
   ) {
     super()
   }
@@ -43,9 +46,10 @@ export class DateComponent
       let pastedText = clipboardData.getData('text')
       pastedText = pastedText.replace(/[\sa-z#!$%\^&\*;:{}=\-_`~()]+/g, '')
       const parsedDate = this.ngbDateParserFormatter.parse(pastedText)
-      const formattedDate = this.ngbDateParserFormatter.format(parsedDate)
-      this.writeValue(formattedDate)
-      this.onChange(formattedDate)
+      if (parsedDate) {
+        this.writeValue(this.isoDateAdapter.toModel(parsedDate))
+        this.onChange(this.value)
+      }
     }
   }
 


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Ah dates. This PR (hopefully) fixes some problems with pasting dates reported in the linked issue. In that user's case he was unable to paste a date like `26.07.2022` and the german d-m-y format was incorrectly being reversed when pasting e.g. `06.08.2022`. Both fixes are shown in video with date set to German format.

https://user-images.githubusercontent.com/4887959/183274584-65714a15-001c-4be5-868f-f673af67e216.mov

Closes #1365

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] ~~I have made corresponding changes to the documentation as needed.~~
- [x] I have checked my modifications for any breaking changes.
