### PR TITLE
Fix: saved view page parameter

### DIFF
--- a/src-ui/src/app/components/document-list/document-list.component.html
+++ b/src-ui/src/app/components/document-list/document-list.component.html
@@ -91,7 +91,7 @@
         <span i18n *ngIf="list.selected.size == 0">{list.collectionSize, plural, =1 {One document} other {{{list.collectionSize || 0}} documents}}</span>&nbsp;<span i18n *ngIf="isFiltered">(filtered)</span>
       </ng-container>
     </p>
-    <ngb-pagination [pageSize]="list.currentPageSize" [collectionSize]="list.collectionSize" (pageChange)="setPage($event)" [page]="list.currentPage" [maxSize]="5"
+    <ngb-pagination *ngIf="list.collectionSize" [pageSize]="list.currentPageSize" [collectionSize]="list.collectionSize" [(page)]="list.currentPage" [maxSize]="5"
     [rotate]="true" aria-label="Default pagination"></ngb-pagination>
   </div>
 </ng-template>

--- a/src-ui/src/app/components/document-list/document-list.component.ts
+++ b/src-ui/src/app/components/document-list/document-list.component.ts
@@ -6,7 +6,7 @@ import {
   ViewChild,
   ViewChildren,
 } from '@angular/core'
-import { ActivatedRoute, Router } from '@angular/router'
+import { ActivatedRoute, convertToParamMap, Router } from '@angular/router'
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap'
 import { filter, first, map, Subject, switchMap, takeUntil } from 'rxjs'
 import { FilterRule, isFullTextFilterRule } from 'src/app/data/filter-rule'
@@ -126,7 +126,11 @@ export class DocumentListComponent implements OnInit, OnDestroy {
           this.router.navigate(['404'])
           return
         }
-        this.list.activateSavedView(view)
+
+        this.list.activateSavedViewWithQueryParams(
+          view,
+          convertToParamMap(this.route.snapshot.queryParams)
+        )
         this.list.reload()
         this.unmodifiedFilterRules = view.filter_rules
       })
@@ -139,7 +143,13 @@ export class DocumentListComponent implements OnInit, OnDestroy {
       .subscribe((queryParams) => {
         if (queryParams.has('view')) {
           // loading a saved view on /documents
-          this.loadViewConfig(parseInt(queryParams.get('view')))
+          this.savedViewService
+            .getCached(parseInt(queryParams.get('view')))
+            .pipe(first())
+            .subscribe((view) => {
+              this.list.activateSavedView(view)
+              this.list.reload()
+            })
         } else {
           this.list.activateSavedView(null)
           this.list.loadFromQueryParams(queryParams)
@@ -152,16 +162,6 @@ export class DocumentListComponent implements OnInit, OnDestroy {
     // unsubscribes all
     this.unsubscribeNotifier.next(this)
     this.unsubscribeNotifier.complete()
-  }
-
-  loadViewConfig(viewId: number) {
-    this.savedViewService
-      .getCached(viewId)
-      .pipe(first())
-      .subscribe((view) => {
-        this.list.activateSavedView(view)
-        this.list.reload()
-      })
   }
 
   saveViewConfig() {

--- a/src-ui/src/app/components/document-list/document-list.component.ts
+++ b/src-ui/src/app/components/document-list/document-list.component.ts
@@ -87,10 +87,6 @@ export class DocumentListComponent implements OnInit, OnDestroy {
     this.list.setSort(event.column, event.reverse)
   }
 
-  setPage(page: number) {
-    this.list.currentPage = page
-  }
-
   get isBulkEditing(): boolean {
     return this.list.selected.size > 0
   }

--- a/src-ui/src/app/services/document-list-view.service.ts
+++ b/src-ui/src/app/services/document-list-view.service.ts
@@ -147,6 +147,15 @@ export class DocumentListViewService {
     }
   }
 
+  activateSavedViewWithQueryParams(
+    view: PaperlessSavedView,
+    queryParams: ParamMap
+  ) {
+    let params = parseParams(queryParams)
+    this.activateSavedView(view)
+    this.activeListViewState.currentPage = params.currentPage
+  }
+
   loadSavedView(view: PaperlessSavedView, closeCurrentView: boolean = false) {
     if (closeCurrentView) {
       this._activeSavedViewId = null
@@ -212,11 +221,15 @@ export class DocumentListViewService {
           this.isReloading = false
           activeListViewState.collectionSize = result.count
           activeListViewState.documents = result.results
-
           if (updateQueryParams && !this._activeSavedViewId) {
             let base = ['/documents']
             this.router.navigate(base, {
               queryParams: generateParams(activeListViewState),
+            })
+          } else if (this._activeSavedViewId) {
+            this.router.navigate([], {
+              queryParams: generateParams(activeListViewState, true),
+              queryParamsHandling: 'merge',
             })
           }
 
@@ -305,7 +318,6 @@ export class DocumentListViewService {
 
   set currentPage(page: number) {
     if (this.activeListViewState.currentPage == page) return
-    this._activeSavedViewId = null
     this.activeListViewState.currentPage = page
     this.reload()
     this.saveDocumentListView()

--- a/src-ui/src/app/services/document-list-view.service.ts
+++ b/src-ui/src/app/services/document-list-view.service.ts
@@ -11,7 +11,7 @@ import { PaperlessDocument } from '../data/paperless-document'
 import { PaperlessSavedView } from '../data/paperless-saved-view'
 import { SETTINGS_KEYS } from '../data/paperless-uisettings'
 import { DOCUMENT_LIST_SERVICE } from '../data/storage-keys'
-import { generateParams, parseParams } from '../utils/query-params'
+import { paramsFromViewState, paramsToViewState } from '../utils/query-params'
 import { DocumentService, DOCUMENT_SORT_FIELDS } from './rest/document.service'
 import { SettingsService } from './settings.service'
 
@@ -151,9 +151,9 @@ export class DocumentListViewService {
     view: PaperlessSavedView,
     queryParams: ParamMap
   ) {
-    let params = parseParams(queryParams)
+    const viewState = paramsToViewState(queryParams)
     this.activateSavedView(view)
-    this.activeListViewState.currentPage = params.currentPage
+    this.currentPage = viewState.currentPage
   }
 
   loadSavedView(view: PaperlessSavedView, closeCurrentView: boolean = false) {
@@ -180,7 +180,7 @@ export class DocumentListViewService {
   loadFromQueryParams(queryParams: ParamMap) {
     const paramsEmpty: boolean = queryParams.keys.length == 0
     let newState: ListViewState = this.listViewStates.get(null)
-    if (!paramsEmpty) newState = parseParams(queryParams)
+    if (!paramsEmpty) newState = paramsToViewState(queryParams)
     if (newState == undefined) newState = this.defaultListViewState() // if nothing in local storage
 
     // only reload if things have changed
@@ -224,11 +224,11 @@ export class DocumentListViewService {
           if (updateQueryParams && !this._activeSavedViewId) {
             let base = ['/documents']
             this.router.navigate(base, {
-              queryParams: generateParams(activeListViewState),
+              queryParams: paramsFromViewState(activeListViewState),
             })
           } else if (this._activeSavedViewId) {
             this.router.navigate([], {
-              queryParams: generateParams(activeListViewState, true),
+              queryParams: paramsFromViewState(activeListViewState, true),
               queryParamsHandling: 'merge',
             })
           }

--- a/src-ui/src/app/services/document-list-view.service.ts
+++ b/src-ui/src/app/services/document-list-view.service.ts
@@ -225,6 +225,7 @@ export class DocumentListViewService {
             let base = ['/documents']
             this.router.navigate(base, {
               queryParams: paramsFromViewState(activeListViewState),
+              replaceUrl: !this.router.routerState.snapshot.url.includes('?'), // in case navigating from params-less /documents
             })
           } else if (this._activeSavedViewId) {
             this.router.navigate([], {

--- a/src-ui/src/app/utils/query-params.ts
+++ b/src-ui/src/app/utils/query-params.ts
@@ -7,7 +7,7 @@ const SORT_FIELD_PARAMETER = 'sort'
 const SORT_REVERSE_PARAMETER = 'reverse'
 const PAGE_PARAMETER = 'page'
 
-export function generateParams(
+export function paramsFromViewState(
   viewState: ListViewState,
   pageOnly: boolean = false
 ): Params {
@@ -22,7 +22,7 @@ export function generateParams(
   return params
 }
 
-export function parseParams(queryParams: ParamMap): ListViewState {
+export function paramsToViewState(queryParams: ParamMap): ListViewState {
   let filterRules = filterRulesFromQueryParams(queryParams)
   let sortField = queryParams.get(SORT_FIELD_PARAMETER)
   let sortReverse =

--- a/src-ui/src/app/utils/query-params.ts
+++ b/src-ui/src/app/utils/query-params.ts
@@ -7,13 +7,18 @@ const SORT_FIELD_PARAMETER = 'sort'
 const SORT_REVERSE_PARAMETER = 'reverse'
 const PAGE_PARAMETER = 'page'
 
-export function generateParams(viewState: ListViewState): Params {
+export function generateParams(
+  viewState: ListViewState,
+  pageOnly: boolean = false
+): Params {
   let params = queryParamsFromFilterRules(viewState.filterRules)
   params[SORT_FIELD_PARAMETER] = viewState.sortField
   params[SORT_REVERSE_PARAMETER] = viewState.sortReverse ? 1 : undefined
+  if (pageOnly) params = {}
   params[PAGE_PARAMETER] = isNaN(viewState.currentPage)
     ? 1
     : viewState.currentPage
+  if (pageOnly && viewState.currentPage == 1) params[PAGE_PARAMETER] = null
   return params
 }
 


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

This PR fixes an issue where the user is unable to navigate past page 1 of a saved view. Incidentally I also fixed an issue where navigating to /documents effectively "breaks" the back button. Video of primary fix in this PR is attached

https://user-images.githubusercontent.com/4887959/183360911-93e56746-37d4-49ce-9475-a1ca0e476839.mov

Closes #1363

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
