### PR TITLE
Bugfix: Catch all exceptions during the task signals

### DIFF
--- a/src/documents/signals/handlers.py
+++ b/src/documents/signals/handlers.py
@@ -11,7 +11,6 @@ from django.contrib.contenttypes.models import ContentType
 from django.db import DatabaseError
 from django.db import models
 from django.db.models import Q
-from django.db.utils import OperationalError
 from django.dispatch import receiver
 from django.utils import termcolors
 from django.utils import timezone
@@ -514,7 +513,9 @@ def init_paperless_task(sender, task, **kwargs):
             paperless_task.name = task["name"]
             paperless_task.created = task["started"]
             paperless_task.save()
-        except OperationalError as e:
+        except Exception as e:
+            # Don't let an exception in the signal handlers prevent
+            # a document from being consumed.
             logger.error(f"Creating PaperlessTask failed: {e}")
 
 
@@ -527,10 +528,10 @@ def paperless_task_started(sender, task, **kwargs):
             )
             paperless_task.started = timezone.now()
             paperless_task.save()
-    except OperationalError as e:
-        logger.error(f"Creating PaperlessTask failed: {e}")
     except PaperlessTask.DoesNotExist:
         pass
+    except Exception as e:
+        logger.error(f"Creating PaperlessTask failed: {e}")
 
 
 @receiver(models.signals.post_save, sender=django_q.models.Task)
@@ -542,7 +543,7 @@ def update_paperless_task(sender, instance, **kwargs):
             )
             paperless_task.attempted_task = instance
             paperless_task.save()
-    except OperationalError as e:
-        logger.error(f"Creating PaperlessTask failed: {e}")
     except PaperlessTask.DoesNotExist:
         pass
+    except Exception as e:
+        logger.error(f"Creating PaperlessTask failed: {e}")


### PR DESCRIPTION
## Proposed change

During the signals used to create a PaperlessTask for the frontend visibility into tasks, catch all the possible exception so the task can still run (and raise up its own issues if needed).  Given we've had a number of database problems in this section, it seems prudent to catch everything.

I think a more "correct" fix is in paperless-ngx/django-q/pull/1 regarding the specific error.

Fixes #1355

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
