### PR TITLE
Chore: Add `autolabeler` to label PRs based on `ref` and title

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,3 +1,14 @@
+autolabeler:
+  - label: "bug"
+    branch:
+      - '/^fix/'
+    title:
+      - "/^fix/i"
+  - label: "enhancement"
+    branch:
+      - '/^feature/'
+    title:
+      - "/^feature/i"
 categories:
   - title: 'Breaking Changes'
     labels:

--- a/.github/workflows/project-actions.yml
+++ b/.github/workflows/project-actions.yml
@@ -13,6 +13,9 @@ on:
       - main
       - dev
 
+permissions:
+  contents: read
+
 env:
   todo: Todo
   done: Done
@@ -35,6 +38,9 @@ jobs:
   pr_opened_or_reopened:
     name: pr_opened_or_reopened
     runs-on: ubuntu-latest
+    permissions:
+      # write permission is required for autolabeler
+      pull-requests: write
     if: github.event_name == 'pull_request_target' && (github.event.action == 'opened' || github.event.action == 'reopened')
     steps:
       - name: Set PR status to ${{ env.in_progress }}
@@ -45,3 +51,7 @@ jobs:
           project_id: 2
           resource_node_id: ${{ github.event.pull_request.node_id }}
           status_value: ${{ env.in_progress }} # Target status
+      - name: Label PR with release-drafter
+        uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Small QoL change: this should identify PRs with Title/Branch ref starting with `fix*` or `feature*` and label them appropriately.

Some examples (note the Github Actions applied label):

- [`ref` == "fix*"](https://github.com/qcasey/paperless-ngx/pull/70)
- [`ref` == "feature*"](https://github.com/qcasey/paperless-ngx/pull/60)
- [Title == "fix*"](https://github.com/qcasey/paperless-ngx/pull/62)
- [Title == "feature*"](https://github.com/qcasey/paperless-ngx/pull/61)

This will help automate our changelogs by fixing the misattributed PRs as I [described here](https://github.com/paperless-ngx/paperless-ngx/pull/1301#issuecomment-1207441834). Most bug fix / feature PRs we see follow at least one of the above 4 patterns. 

Supersedes https://github.com/paperless-ngx/secretary/pull/8

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
