### PR TITLE
Chore: Exclude dependabot PRs from Project, set status to "Needs Review"

### DIFF
--- a/.github/workflows/project-actions.yml
+++ b/.github/workflows/project-actions.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'issues' && (github.event.action == 'opened' || github.event.action == 'reopened')
     steps:
-      - name: Set issue status to ${{ env.todo }}
+      - name: Add issue to project and set status to ${{ env.todo }}
         uses: leonsteinhaeuser/project-beta-automations@v1.2.1
         with:
           gh_token: ${{ secrets.GH_TOKEN }}
@@ -43,14 +43,14 @@ jobs:
       pull-requests: write
     if: github.event_name == 'pull_request_target' && (github.event.action == 'opened' || github.event.action == 'reopened') && github.event.pull_request.user.login != "dependabot"
     steps:
-      - name: Set PR status to ${{ env.in_progress }}
+      - name: Add PR to project and set status to "Needs Review"
         uses: leonsteinhaeuser/project-beta-automations@v1.2.1
         with:
           gh_token: ${{ secrets.GH_TOKEN }}
           organization: paperless-ngx
           project_id: 2
           resource_node_id: ${{ github.event.pull_request.node_id }}
-          status_value: ${{ env.in_progress }} # Target status
+          status_value: "Needs Review" # Target status
       - name: Label PR with release-drafter
         uses: release-drafter/release-drafter@v5
         env:

--- a/.github/workflows/project-actions.yml
+++ b/.github/workflows/project-actions.yml
@@ -41,7 +41,7 @@ jobs:
     permissions:
       # write permission is required for autolabeler
       pull-requests: write
-    if: github.event_name == 'pull_request_target' && (github.event.action == 'opened' || github.event.action == 'reopened')
+    if: github.event_name == 'pull_request_target' && (github.event.action == 'opened' || github.event.action == 'reopened') && github.event.pull_request.user.login != "dependabot"
     steps:
       - name: Set PR status to ${{ env.in_progress }}
         uses: leonsteinhaeuser/project-beta-automations@v1.2.1


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

I expect this change will exclude dependabot PRs from the [Project Board](https://github.com/orgs/paperless-ngx/projects/2). They pollute the "No Priority" section and we never promote them up the board, so those PRs need to be removed by hand each time.

If a dependabot PR needs to be on the board for whatever reason it can still be added from the sidebar. 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
