### PR TITLE
PAPERLESS_REDIS may be set via docker secrets

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -62,7 +62,8 @@ initialize() {
 		PAPERLESS_AUTO_LOGIN_USERNAME \
 		PAPERLESS_ADMIN_USER \
 		PAPERLESS_ADMIN_MAIL \
-		PAPERLESS_ADMIN_PASSWORD; do
+		PAPERLESS_ADMIN_PASSWORD \
+		PAPERLESS_REDIS; do
 		# Check for a version of this var with _FILE appended
 		# and convert the contents to the env var value
 		file_env ${env_var}

--- a/docker/wait-for-redis.py
+++ b/docker/wait-for-redis.py
@@ -7,7 +7,6 @@ a certain number of times, waiting a little bit in between
 import os
 import sys
 import time
-import re
 from typing import Final
 
 from redis import Redis
@@ -18,14 +17,8 @@ if __name__ == "__main__":
     RETRY_SLEEP_SECONDS: Final[int] = 5
 
     REDIS_URL: Final[str] = os.getenv("PAPERLESS_REDIS", "redis://localhost:6379")
-    matches = re.match(r"(?P<protocol>.*//)(?P<credentials>.*\@)?(?P<host>.*)", REDIS_URL)
 
-    credentials=""
-    if (matches.group("credentials") is not None):
-        credentials="xxx:xxx@"
-    redisurl="{0}{1}{2}".format(matches.group("protocol"), credentials, matches.group("host"))
-
-    print(f"Waiting for Redis: {redisurl}", flush=True)
+    print(f"Waiting for Redis...", flush=True)
 
     attempt = 0
     with Redis.from_url(url=REDIS_URL) as client:
@@ -44,8 +37,8 @@ if __name__ == "__main__":
                 attempt += 1
 
     if attempt >= MAX_RETRY_COUNT:
-        print(f"Failed to connect to: {redisurl}")
+        print(f"Failed to connect to redis using environment variable PAPERLESS_REDIS.")
         sys.exit(os.EX_UNAVAILABLE)
     else:
-        print(f"Connected to Redis broker: {redisurl}")
+        print(f"Connected to Redis broker.")
         sys.exit(os.EX_OK)


### PR DESCRIPTION
## Proposed change

Best practice is for redis to be at least password protected: https://redis.io/docs/getting-started/.

Paperless uses `Redis.from_url` to establish a connection to redis which already enables us to use username/password, e.g. `redis://username:password@redis:6379`.
https://github.com/paperless-ngx/paperless-ngx/blob/5fe435048bc6eb77f9473afc11588427846456ab/docker/wait-for-redis.py#L24

The redis connection string therefore is a secret and needs to be able to leverage docker secrets, hence this PR.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
