### PR TITLE
Fix: `created_date` should not be required

### DIFF
--- a/src/documents/serialisers.py
+++ b/src/documents/serialisers.py
@@ -240,7 +240,8 @@ class DocumentSerializer(DynamicFieldsModelSerializer):
             )
             instance.created = new_datetime
             instance.save()
-        validated_data.pop("created_date")
+        if "created_date" in validated_data:
+            validated_data.pop("created_date")
         super().update(instance, validated_data)
         return instance
 


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

This tiny PR fixes an issue reported with 1.8.0 API is requiring `created_date`

Fixes #1411 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
