### PR TITLE
Fix: dev backend testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,9 @@ jobs:
         uses: actions/checkout@v3
       -
         name: Install pipenv
-        run: pipx install pipenv
+        run: |
+          pipx install pipenv==2022.8.5
+          pipenv --version
       -
         name: Set up Python
         uses: actions/setup-python@v4
@@ -55,6 +57,10 @@ jobs:
         name: Install dependencies
         run: |
           pipenv sync --dev
+      -
+        name: List installed Python dependencies
+        run: |
+          pipenv run pip list
       -
         name: Make documentation
         run: |
@@ -84,7 +90,9 @@ jobs:
           fetch-depth: 2
       -
         name: Install pipenv
-        run: pipx install pipenv
+        run: |
+          pipx install pipenv==2022.8.5
+          pipenv --version
       -
         name: Set up Python
         uses: actions/setup-python@v4
@@ -101,6 +109,10 @@ jobs:
         name: Install Python dependencies
         run: |
           pipenv sync --dev
+      -
+        name: List installed Python dependencies
+        run: |
+          pipenv run pip list
       -
         name: Tests
         run: |


### PR DESCRIPTION
## Proposed change

This fixes the backend testing by locking pipenv to a last known working version.  We're running into pypa/pipenv/issues/5247 and pypa/pipenv/issues/5254 at the moment.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
