### PR TITLE
Update redis image

### DIFF
--- a/docker/compose/docker-compose.portainer.yml
+++ b/docker/compose/docker-compose.portainer.yml
@@ -31,7 +31,7 @@
 version: "3.4"
 services:
   broker:
-    image: docker.io/library/redis:6.0
+    image: docker.io/library/redis:7
     restart: unless-stopped
     volumes:
       - redisdata:/data

--- a/docker/compose/docker-compose.postgres-tika.yml
+++ b/docker/compose/docker-compose.postgres-tika.yml
@@ -33,7 +33,7 @@
 version: "3.4"
 services:
   broker:
-    image: docker.io/library/redis:6.0
+    image: docker.io/library/redis:7
     restart: unless-stopped
     volumes:
       - redisdata:/data

--- a/docker/compose/docker-compose.postgres.yml
+++ b/docker/compose/docker-compose.postgres.yml
@@ -29,7 +29,7 @@
 version: "3.4"
 services:
   broker:
-    image: docker.io/library/redis:6.0
+    image: docker.io/library/redis:7
     restart: unless-stopped
     volumes:
       - redisdata:/data

--- a/docker/compose/docker-compose.sqlite-tika.yml
+++ b/docker/compose/docker-compose.sqlite-tika.yml
@@ -33,7 +33,7 @@
 version: "3.4"
 services:
   broker:
-    image: docker.io/library/redis:6.0
+    image: docker.io/library/redis:7
     restart: unless-stopped
     volumes:
       - redisdata:/data

--- a/docker/compose/docker-compose.sqlite.yml
+++ b/docker/compose/docker-compose.sqlite.yml
@@ -26,7 +26,7 @@
 version: "3.4"
 services:
   broker:
-    image: docker.io/library/redis:6.0
+    image: docker.io/library/redis:7
     restart: unless-stopped
     volumes:
       - redisdata:/data


### PR DESCRIPTION
## Proposed change

We are currently using the `6.0` tag from redis, which [is unsupported](https://redis.io/docs/about/releases/). I don't think we have a reason to do this except that this is how it was done historically. The version was introduced by [this commit](https://github.com/paperless-ngx/paperless-ngx/commit/af254fb9704f2558cd26194cd447eb1c3727f061) back in November 2020.

I propose to change this to :7 (the latest major version), which is consistent with what we are doing with the postgres image.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Other (please explain)

## Checklist:

- [X] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [X] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [X] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [X] I have checked my modifications for any breaking changes.
