### PR TITLE
Feature: Adds storage paths to re-tagger command

### DIFF
--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -310,6 +310,7 @@ there are tools for it.
     -c, --correspondent
     -T, --tags
     -t, --document_type
+    -s, --storage_path
     -i, --inbox-only
     --use-first
     -f, --overwrite
@@ -318,7 +319,7 @@ Run this after changing or adding matching rules. It'll loop over all
 of the documents in your database and attempt to match documents
 according to the new rules.
 
-Specify any combination of ``-c``, ``-T`` and ``-t`` to have the
+Specify any combination of ``-c``, ``-T``, ``-t`` and ``-s`` to have the
 retagger perform matching of the specified metadata type. If you don't
 specify any of these options, the document retagger won't do anything.
 

--- a/src/documents/management/commands/document_retagger.py
+++ b/src/documents/management/commands/document_retagger.py
@@ -7,6 +7,7 @@ from documents.models import Document
 
 from ...signals.handlers import set_correspondent
 from ...signals.handlers import set_document_type
+from ...signals.handlers import set_storage_path
 from ...signals.handlers import set_tags
 
 
@@ -29,6 +30,7 @@ class Command(BaseCommand):
         parser.add_argument("-c", "--correspondent", default=False, action="store_true")
         parser.add_argument("-T", "--tags", default=False, action="store_true")
         parser.add_argument("-t", "--document_type", default=False, action="store_true")
+        parser.add_argument("-s", "--storage_path", default=False, action="store_true")
         parser.add_argument("-i", "--inbox-only", default=False, action="store_true")
         parser.add_argument(
             "--use-first",
@@ -108,6 +110,17 @@ class Command(BaseCommand):
                     document=document,
                     classifier=classifier,
                     replace=options["overwrite"],
+                    suggest=options["suggest"],
+                    base_url=options["base_url"],
+                    color=color,
+                )
+            if options["storage_path"]:
+                set_storage_path(
+                    sender=None,
+                    document=document,
+                    classifier=classifier,
+                    replace=options["overwrite"],
+                    use_first=options["use_first"],
                     suggest=options["suggest"],
                     base_url=options["base_url"],
                     color=color,

--- a/src/documents/signals/handlers.py
+++ b/src/documents/signals/handlers.py
@@ -291,7 +291,7 @@ def set_storage_path(
                     )
                     + f" [{document.pk}]",
                 )
-            print(f"Sugest storage directory {selected}")
+            print(f"Suggest storage directory {selected}")
         else:
             logger.info(
                 f"Assigning storage path {selected} to {document}",

--- a/src/documents/tests/test_management_retagger.py
+++ b/src/documents/tests/test_management_retagger.py
@@ -3,12 +3,34 @@ from django.test import TestCase
 from documents.models import Correspondent
 from documents.models import Document
 from documents.models import DocumentType
+from documents.models import StoragePath
 from documents.models import Tag
 from documents.tests.utils import DirectoriesMixin
 
 
 class TestRetagger(DirectoriesMixin, TestCase):
     def make_models(self):
+
+        self.sp1 = StoragePath.objects.create(
+            name="dummy a",
+            path="{created_data}/{title}",
+            match="auto document",
+            matching_algorithm=StoragePath.MATCH_LITERAL,
+        )
+        self.sp2 = StoragePath.objects.create(
+            name="dummy b",
+            path="{title}",
+            match="^first|^unrelated",
+            matching_algorithm=StoragePath.MATCH_REGEX,
+        )
+
+        self.sp3 = StoragePath.objects.create(
+            name="dummy c",
+            path="{title}",
+            match="^blah",
+            matching_algorithm=StoragePath.MATCH_REGEX,
+        )
+
         self.d1 = Document.objects.create(
             checksum="A",
             title="A",
@@ -23,6 +45,7 @@ class TestRetagger(DirectoriesMixin, TestCase):
             checksum="C",
             title="C",
             content="unrelated document",
+            storage_path=self.sp3,
         )
         self.d4 = Document.objects.create(
             checksum="D",
@@ -146,15 +169,15 @@ class TestRetagger(DirectoriesMixin, TestCase):
         call_command("document_retagger", "--document_type", "--suggest")
         d_first, d_second, d_unrelated, d_auto = self.get_updated_docs()
 
-        self.assertEqual(d_first.document_type, None)
-        self.assertEqual(d_second.document_type, None)
+        self.assertIsNone(d_first.document_type)
+        self.assertIsNone(d_second.document_type)
 
     def test_add_correspondent_suggest(self):
         call_command("document_retagger", "--correspondent", "--suggest")
         d_first, d_second, d_unrelated, d_auto = self.get_updated_docs()
 
-        self.assertEqual(d_first.correspondent, None)
-        self.assertEqual(d_second.correspondent, None)
+        self.assertIsNone(d_first.correspondent)
+        self.assertIsNone(d_second.correspondent)
 
     def test_add_tags_suggest_url(self):
         call_command(
@@ -178,8 +201,8 @@ class TestRetagger(DirectoriesMixin, TestCase):
         )
         d_first, d_second, d_unrelated, d_auto = self.get_updated_docs()
 
-        self.assertEqual(d_first.document_type, None)
-        self.assertEqual(d_second.document_type, None)
+        self.assertIsNone(d_first.document_type)
+        self.assertIsNone(d_second.document_type)
 
     def test_add_correspondent_suggest_url(self):
         call_command(
@@ -190,5 +213,48 @@ class TestRetagger(DirectoriesMixin, TestCase):
         )
         d_first, d_second, d_unrelated, d_auto = self.get_updated_docs()
 
-        self.assertEqual(d_first.correspondent, None)
-        self.assertEqual(d_second.correspondent, None)
+        self.assertIsNone(d_first.correspondent)
+        self.assertIsNone(d_second.correspondent)
+
+    def test_add_storage_path(self):
+        """
+        GIVEN:
+            - 2 storage paths with documents which match them
+            - 1 document which matches but has a storage path
+        WHEN:
+            - document retagger is called
+        THEN:
+            - Matching document's storage paths updated
+            - Non-matching documents have no storage path
+            - Existing storage patch left unchanged
+        """
+        call_command(
+            "document_retagger",
+            "--storage_path",
+        )
+        d_first, d_second, d_unrelated, d_auto = self.get_updated_docs()
+
+        self.assertEqual(d_first.storage_path, self.sp2)
+        self.assertEqual(d_auto.storage_path, self.sp1)
+        self.assertIsNone(d_second.storage_path)
+        self.assertEqual(d_unrelated.storage_path, self.sp3)
+
+    def test_overwrite_storage_path(self):
+        """
+        GIVEN:
+            - 2 storage paths with documents which match them
+            - 1 document which matches but has a storage path
+        WHEN:
+            - document retagger is called with overwrite
+        THEN:
+            - Matching document's storage paths updated
+            - Non-matching documents have no storage path
+            - Existing storage patch overwritten
+        """
+        call_command("document_retagger", "--storage_path", "--overwrite")
+        d_first, d_second, d_unrelated, d_auto = self.get_updated_docs()
+
+        self.assertEqual(d_first.storage_path, self.sp2)
+        self.assertEqual(d_auto.storage_path, self.sp1)
+        self.assertIsNone(d_second.storage_path)
+        self.assertEqual(d_unrelated.storage_path, self.sp2)


### PR DESCRIPTION
## Proposed change

As noticed and requested in #1439, storage paths weren't included alongside most other matching fields as an option.  This PR adds storage paths as an option to re-matched.

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
