### PR TITLE
Fix actions button in tasks table

### DIFF
--- a/src-ui/src/app/components/manage/tasks/tasks.component.html
+++ b/src-ui/src/app/components/manage/tasks/tasks.component.html
@@ -55,7 +55,7 @@
         </th>
         <td class="overflow-auto">{{ task.name }}</td>
         <td class="d-none d-lg-table-cell">{{ task.created | customDate:'short' }}</td>
-        <td class="d-none d-lg-table-cell" *ngIf="activeTab != 'incomplete'">
+        <td class="d-none d-lg-table-cell" *ngIf="activeTab != 'started' && activeTab != 'queued'">
           <div *ngIf="task.result.length > 50" class="result" (click)="expandTask(task); $event.stopPropagation();"
             [ngbPopover]="resultPopover" popoverClass="shadow small mobile" triggers="mouseenter:mouseleave" container="body">
             <span class="small d-none d-md-inline-block font-monospace text-muted">{{ task.result | slice:0:50 }}&hellip;</span>


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

This tiny PR fixes a small visual issue I noted in 1.8.0 where 'Started' and 'Queued' tasks break the table column layout, see screenshot.

<img width="764" alt="Screen Shot 2022-08-31 at 12 38 43 PM" src="https://user-images.githubusercontent.com/4887959/187767902-4bce0ec8-6849-4d9f-ab2a-b505fac15007.png">
<img width="1373" alt="Screen Shot 2022-08-31 at 12 30 46 PM" src="https://user-images.githubusercontent.com/4887959/187767899-944f679e-2667-4ac3-a8e7-13f8377d793b.png">

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] ~~I have made corresponding changes to the documentation as needed.~~
- [x] I have checked my modifications for any breaking changes.
