### PR TITLE
Bugfix: Better gunicorn settings for workers

### DIFF
--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,9 +1,17 @@
 import os
 
+# See https://docs.gunicorn.org/en/stable/settings.html for
+# explanations of settings
+
 bind = f'{os.getenv("PAPERLESS_BIND_ADDR", "[::]")}:{os.getenv("PAPERLESS_PORT", 8000)}'
+
 workers = int(os.getenv("PAPERLESS_WEBSERVER_WORKERS", 1))
 worker_class = "paperless.workers.ConfigurableWorker"
 timeout = 120
+preload_app = True
+
+# https://docs.gunicorn.org/en/stable/faq.html#blocking-os-fchmod
+worker_tmp_dir = "/dev/shm"
 
 
 def pre_fork(server, worker):


### PR DESCRIPTION
## Proposed change

This PR introduces two tweaks to the gunicorn settings.

1. If `PAPERLESS_WEBSERVER_WORKERS` is set to 1, the worker will timeout after 120s and get respawned.  During this time, it is blocking and the login page won't load at all.  After the timeout, everything functions normally.  To fix this, the worker temporary directory, which is used for worker heartbeats, is changed to be in shared memory
2. I also added the `preload_app` setting, which notes it can increase startup speed and decrease memory usage slightly.  Compared to a fresh 1.8 container, I saw ~40 MB less usage.  This is at the expense of reloading workers, which isn't something being done anyway.

Fixes #1481

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
