### PR TITLE
Chore: Smaller library images

### DIFF
--- a/docker-builders/Dockerfile.jbig2enc
+++ b/docker-builders/Dockerfile.jbig2enc
@@ -7,6 +7,7 @@ FROM debian:bullseye-slim as main
 LABEL org.opencontainers.image.description="A intermediate image with jbig2enc built"
 
 ARG DEBIAN_FRONTEND=noninteractive
+ARG JBIG2ENC_VERSION
 
 ARG BUILD_PACKAGES="\
   build-essential \
@@ -19,21 +20,16 @@ ARG BUILD_PACKAGES="\
 
 WORKDIR /usr/src/jbig2enc
 
-# As this is an base image for a multi-stage final image
-# the added size of the install is basically irrelevant
-RUN apt-get update --quiet \
-  && apt-get install --yes --quiet --no-install-recommends ${BUILD_PACKAGES} \
-  && rm -rf /var/lib/apt/lists/*
-
-# Layers after this point change according to required version
-# For better caching, seperate the basic installs from
-# the building
-
-ARG JBIG2ENC_VERSION
-
 RUN set -eux \
-  && git clone --quiet --branch $JBIG2ENC_VERSION https://github.com/agl/jbig2enc .
-RUN set -eux \
-  && ./autogen.sh
-RUN set -eux \
-  && ./configure && make
+  && echo "Installing build tools" \
+    && apt-get update --quiet \
+    && apt-get install --yes --quiet --no-install-recommends ${BUILD_PACKAGES} \
+  && echo "Building jbig2enc" \
+    && git clone --quiet --branch $JBIG2ENC_VERSION https://github.com/agl/jbig2enc . \
+    && ./autogen.sh \
+    && ./configure \
+    && make \
+  && echo "Cleaning up image" \
+    && apt-get -y purge ${BUILD_PACKAGES} \
+    && apt-get -y autoremove --purge \
+    && rm -rf /var/lib/apt/lists/*

--- a/docker-builders/Dockerfile.pikepdf
+++ b/docker-builders/Dockerfile.pikepdf
@@ -17,6 +17,7 @@ FROM python:3.9-slim-bullseye as main
 LABEL org.opencontainers.image.description="A intermediate image with pikepdf wheel built"
 
 ARG DEBIAN_FRONTEND=noninteractive
+ARG PIKEPDF_VERSION
 
 ARG BUILD_PACKAGES="\
   build-essential \
@@ -55,34 +56,33 @@ COPY --from=qpdf-builder /usr/src/qpdf/*.deb ./
 # the added size of the install is basically irrelevant
 
 RUN set -eux \
-  && apt-get update --quiet \
-  && apt-get install --yes --quiet --no-install-recommends $BUILD_PACKAGES \
-  && dpkg --install libqpdf28_*.deb \
-  && dpkg --install libqpdf-dev_*.deb \
-  && python3 -m pip install --no-cache-dir --upgrade \
-    pip \
-    wheel \
-    # https://pikepdf.readthedocs.io/en/latest/installation.html#requirements
-    pybind11 \
-  && rm -rf /var/lib/apt/lists/*
-
-# Layers after this point change according to required version
-# For better caching, seperate the basic installs from
-# the building
-
-ARG PIKEPDF_VERSION
-
-RUN set -eux \
+  && echo "Installing build tools" \
+    && apt-get update --quiet \
+    && apt-get install --yes --quiet --no-install-recommends ${BUILD_PACKAGES} \
+  && echo "Installing qpdf" \
+    && dpkg --install libqpdf28_*.deb \
+    && dpkg --install libqpdf-dev_*.deb \
+  && echo "Installing Python tools" \
+    && python3 -m pip install --no-cache-dir --upgrade \
+      pip \
+      wheel \
+      # https://pikepdf.readthedocs.io/en/latest/installation.html#requirements
+      pybind11 \
   && echo "Building pikepdf wheel ${PIKEPDF_VERSION}" \
-  && mkdir wheels \
-  && python3 -m pip wheel \
-    # Build the package at the required version
-    pikepdf==${PIKEPDF_VERSION} \
-    # Output the *.whl into this directory
-    --wheel-dir wheels \
-    # Do not use a binary packge for the package being built
-    --no-binary=pikepdf \
-    # Do use binary packages for dependencies
-    --prefer-binary \
-    --no-cache-dir \
-  && ls -ahl wheels
+    && mkdir wheels \
+    && python3 -m pip wheel \
+      # Build the package at the required version
+      pikepdf==${PIKEPDF_VERSION} \
+      # Output the *.whl into this directory
+      --wheel-dir wheels \
+      # Do not use a binary packge for the package being built
+      --no-binary=pikepdf \
+      # Do use binary packages for dependencies
+      --prefer-binary \
+      # Don't cache build files
+      --no-cache-dir \
+    && ls -ahl wheels \
+  && echo "Cleaning up image" \
+    && apt-get -y purge ${BUILD_PACKAGES} \
+    && apt-get -y autoremove --purge \
+    && rm -rf /var/lib/apt/lists/*

--- a/docker-builders/Dockerfile.psycopg2
+++ b/docker-builders/Dockerfile.psycopg2
@@ -6,6 +6,7 @@ FROM python:3.9-slim-bullseye as main
 
 LABEL org.opencontainers.image.description="A intermediate image with psycopg2 wheel built"
 
+ARG PSYCOPG2_VERSION
 ARG DEBIAN_FRONTEND=noninteractive
 
 ARG BUILD_PACKAGES="\
@@ -21,29 +22,27 @@ WORKDIR /usr/src
 # the added size of the install is basically irrelevant
 
 RUN set -eux \
-  && apt-get update --quiet \
-  && apt-get install --yes --quiet --no-install-recommends $BUILD_PACKAGES \
-  && rm -rf /var/lib/apt/lists/* \
-  && python3 -m pip install --no-cache-dir --upgrade pip wheel
-
-# Layers after this point change according to required version
-# For better caching, seperate the basic installs from
-# the building
-
-ARG PSYCOPG2_VERSION
-
-RUN set -eux \
+  && echo "Installing build tools" \
+    && apt-get update --quiet \
+    && apt-get install --yes --quiet --no-install-recommends ${BUILD_PACKAGES} \
+  && echo "Installing Python tools" \
+    && python3 -m pip install --no-cache-dir --upgrade pip wheel \
   && echo "Building psycopg2 wheel ${PSYCOPG2_VERSION}" \
-  && cd /usr/src \
-  && mkdir wheels \
-  && python3 -m pip wheel \
-    # Build the package at the required version
-    psycopg2==${PSYCOPG2_VERSION} \
-    # Output the *.whl into this directory
-    --wheel-dir wheels \
-    # Do not use a binary packge for the package being built
-    --no-binary=psycopg2 \
-    # Do use binary packages for dependencies
-    --prefer-binary \
-    --no-cache-dir \
-  && ls -ahl wheels/
+    && cd /usr/src \
+    && mkdir wheels \
+    && python3 -m pip wheel \
+      # Build the package at the required version
+      psycopg2==${PSYCOPG2_VERSION} \
+      # Output the *.whl into this directory
+      --wheel-dir wheels \
+      # Do not use a binary packge for the package being built
+      --no-binary=psycopg2 \
+      # Do use binary packages for dependencies
+      --prefer-binary \
+      # Don't cache build files
+      --no-cache-dir \
+    && ls -ahl wheels/ \
+  && echo "Cleaning up image" \
+    && apt-get -y purge ${BUILD_PACKAGES} \
+    && apt-get -y autoremove --purge \
+    && rm -rf /var/lib/apt/lists/*

--- a/docker-builders/Dockerfile.qpdf
+++ b/docker-builders/Dockerfile.qpdf
@@ -1,8 +1,15 @@
+# This Dockerfile compiles the jbig2enc library
+# Inputs:
+#    - QPDF_VERSION - the version of qpdf to build a .deb.
+#                     Must be preset as a deb-src
+
 FROM debian:bullseye-slim as main
 
 LABEL org.opencontainers.image.description="A intermediate image with qpdf built"
 
 ARG DEBIAN_FRONTEND=noninteractive
+# This must match to pikepdf's minimum at least
+ARG QPDF_VERSION
 
 ARG BUILD_PACKAGES="\
   build-essential \
@@ -23,31 +30,23 @@ WORKDIR /usr/src
 # the added size of the install is basically irrelevant
 
 RUN set -eux \
-  && apt-get update --quiet \
-  && apt-get install --yes --quiet --no-install-recommends $BUILD_PACKAGES \
-  && rm -rf /var/lib/apt/lists/*
-
-# Layers after this point change according to required version
-# For better caching, seperate the basic installs from
-# the building
-
-# This must match to pikepdf's minimum at least
-ARG QPDF_VERSION
-
-# In order to get the required version of qpdf, it is backported from bookwork
-# and then built from source
-RUN set -eux \
+  && echo "Installing build tools" \
+    && apt-get update --quiet \
+    && apt-get install --yes --quiet --no-install-recommends $BUILD_PACKAGES \
   && echo "Building qpdf" \
-  && echo "deb-src http://deb.debian.org/debian/ bookworm main" > /etc/apt/sources.list.d/bookworm-src.list \
-  && apt-get update \
-  && mkdir qpdf \
-  && cd qpdf \
-  && apt-get source --yes --quiet qpdf=${QPDF_VERSION}-1/bookworm \
-  && rm -rf /var/lib/apt/lists/* \
-  && cd qpdf-$QPDF_VERSION \
-  # We don't need to build the tests (also don't run them)
-  && rm -rf libtests \
-  && DEBEMAIL=hello@paperless-ngx.com debchange --bpo \
-  && export DEB_BUILD_OPTIONS="terse nocheck nodoc parallel=2" \
-  && dpkg-buildpackage --build=binary --unsigned-source --unsigned-changes \
-  && ls -ahl ../*.deb
+    && echo "deb-src http://deb.debian.org/debian/ bookworm main" > /etc/apt/sources.list.d/bookworm-src.list \
+    && apt-get update \
+    && mkdir qpdf \
+    && cd qpdf \
+    && apt-get source --yes --quiet qpdf=${QPDF_VERSION}-1/bookworm \
+    && cd qpdf-$QPDF_VERSION \
+    # We don't need to build the tests (also don't run them)
+    && rm -rf libtests \
+    && DEBEMAIL=hello@paperless-ngx.com debchange --bpo \
+    && export DEB_BUILD_OPTIONS="terse nocheck nodoc parallel=2" \
+    && dpkg-buildpackage --build=binary --unsigned-source --unsigned-changes --post-clean \
+    && ls -ahl ../*.deb \
+  && echo "Cleaning up image" \
+    && apt-get -y purge ${BUILD_PACKAGES} \
+    && apt-get -y autoremove --purge \
+    && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Proposed change

When I initially created the Dockerfiles for the library of installer images, I mistakenly thought there would be better caching if the layer of installing build tools and the actual building were split.  That was not correct, we can get as good caching with an image which is cleaned up more.

So, with this change, the installer images are now cleaned up and generally smaller.  The changes have no effect on the final built item nor the final image.  it's only about reducing network usage and storage usage so we can be more efficient overall.

Comparing uncompressed sizes for amd64, psycopg2 is about 31% of the size, pikepdf is 27% and qpdf a rather whopping 11%.  I forgot check jbig2enc, but it no doubt shrunk as well.

```
ghcr.io/stumpylog/paperless-ngx/builder/pikepdf        5.5.0     1b97e7cf498a   55 minutes ago   175MB
ghcr.io/stumpylog/paperless-ngx/builder/qpdf           10.6.3    1c59e67adfaf   2 hours ago      169MB
ghcr.io/stumpylog/paperless-ngx/builder/psycopg2       2.9.3     f887668bc79f   2 hours ago      141MB
ghcr.io/paperless-ngx/paperless-ngx/builder/pikepdf    5.5.0     ab5d326545cd   13 days ago      632MB
ghcr.io/paperless-ngx/paperless-ngx/builder/qpdf       10.6.3    26f3f2f87874   13 days ago      1.46GB
ghcr.io/paperless-ngx/paperless-ngx/builder/psycopg2   2.9.3     82c5d4f8889b   13 days ago      454MB
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (please explain) - build improvements

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
