### PR TITLE
Fix: Include storage paths in document exporter

### DIFF
--- a/src/documents/management/commands/document_exporter.py
+++ b/src/documents/management/commands/document_exporter.py
@@ -18,6 +18,7 @@ from documents.models import Document
 from documents.models import DocumentType
 from documents.models import SavedView
 from documents.models import SavedViewFilterRule
+from documents.models import StoragePath
 from documents.models import Tag
 from documents.models import UiSettings
 from documents.settings import EXPORTER_ARCHIVE_NAME
@@ -114,8 +115,8 @@ class Command(BaseCommand):
                 map(lambda f: os.path.abspath(os.path.join(root, f)), files),
             )
 
-        # 2. Create manifest, containing all correspondents, types, tags,
-        # documents and ui_settings
+        # 2. Create manifest, containing all correspondents, types, tags, storage paths
+        # comments, documents and ui_settings
         with transaction.atomic():
             manifest = json.loads(
                 serializers.serialize("json", Correspondent.objects.all()),
@@ -125,6 +126,10 @@ class Command(BaseCommand):
 
             manifest += json.loads(
                 serializers.serialize("json", DocumentType.objects.all()),
+            )
+
+            manifest += json.loads(
+                serializers.serialize("json", StoragePath.objects.all()),
             )
 
             manifest += json.loads(

--- a/src/documents/tests/test_management_exporter.py
+++ b/src/documents/tests/test_management_exporter.py
@@ -14,6 +14,7 @@ from documents.models import Comment
 from documents.models import Correspondent
 from documents.models import Document
 from documents.models import DocumentType
+from documents.models import StoragePath
 from documents.models import Tag
 from documents.models import User
 from documents.sanity_checker import check_sanity
@@ -70,11 +71,14 @@ class TestExportImport(DirectoriesMixin, TestCase):
         self.t1 = Tag.objects.create(name="t")
         self.dt1 = DocumentType.objects.create(name="dt")
         self.c1 = Correspondent.objects.create(name="c")
+        self.sp1 = StoragePath.objects.create(path="{created_year}-{title}")
 
         self.d1.tags.add(self.t1)
         self.d1.correspondent = self.c1
         self.d1.document_type = self.dt1
         self.d1.save()
+        self.d4.storage_path = self.sp1
+        self.d4.save()
         super().setUp()
 
     def _get_document_from_manifest(self, manifest, id):
@@ -120,7 +124,7 @@ class TestExportImport(DirectoriesMixin, TestCase):
 
         manifest = self._do_export(use_filename_format=use_filename_format)
 
-        self.assertEqual(len(manifest), 10)
+        self.assertEqual(len(manifest), 11)
         self.assertEqual(
             len(list(filter(lambda e: e["model"] == "documents.document", manifest))),
             4,
@@ -199,6 +203,7 @@ class TestExportImport(DirectoriesMixin, TestCase):
             self.assertEqual(Tag.objects.count(), 1)
             self.assertEqual(Correspondent.objects.count(), 1)
             self.assertEqual(DocumentType.objects.count(), 1)
+            self.assertEqual(StoragePath.objects.count(), 1)
             self.assertEqual(Document.objects.get(id=self.d1.id).title, "wow1")
             self.assertEqual(Document.objects.get(id=self.d2.id).title, "wow2")
             self.assertEqual(Document.objects.get(id=self.d3.id).title, "wow2")


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

This PR adds the new storage paths feature to the `document_exporter` command

Fixes #1554 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] ~~If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.~~
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] ~~I have made corresponding changes to the documentation as needed.~~
- [x] I have checked my modifications for any breaking changes.
