### PR TITLE
Fix document comments not updating on document navigation

### DIFF
--- a/src-ui/src/app/components/app-frame/app-frame.component.html
+++ b/src-ui/src/app/components/app-frame/app-frame.component.html
@@ -21,7 +21,7 @@
   </div>
   <ul ngbNav class="order-sm-3">
     <li ngbDropdown class="nav-item dropdown">
-      <button class="btn" id="userDropdown" ngbDropdownToggle>
+      <button class="btn border-0" id="userDropdown" ngbDropdownToggle>
         <span class="small me-2 d-none d-sm-inline">
           {{this.settingsService.displayName}}
         </span>

--- a/src-ui/src/app/components/document-comments/document-comments.component.html
+++ b/src-ui/src/app/components/document-comments/document-comments.component.html
@@ -6,7 +6,8 @@
                 Please enter a comment.
             </div>
         </div>
-        <div class="form-group mt-2 d-flex justify-content-end">
+        <div class="form-group mt-2 d-flex justify-content-end align-items-center">
+            <div *ngIf="networkActive" class="spinner-border spinner-border-sm fw-normal me-auto" role="status"></div>
             <button type="button" class="btn btn-primary btn-sm" [disabled]="networkActive" (click)="addComment()" i18n>Add comment</button>
         </div>
     </form>


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

This PR fixes an issue in the 1.9.0 beta where comments weren't correctly updating when navigating between documents (without closing). I also included an unrelated visual fix for an unwanted border on the user dropdown (resultant from recent bootstrap update). Video included for reference

https://user-images.githubusercontent.com/4887959/189696115-c9fa7270-1921-4932-8b90-8d38d2250b87.mov

Fixes #1564

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] ~~I have made corresponding changes to the documentation as needed.~~
- [x] I have checked my modifications for any breaking changes.
