### PR TITLE
Fix: Parsing Tika documents fails with AttributeError

### DIFF
--- a/src/paperless_tika/parsers.py
+++ b/src/paperless_tika/parsers.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 import dateutil.parser
 import requests
@@ -28,6 +29,11 @@ class TikaDocumentParser(DocumentParser):
 
     def extract_metadata(self, document_path, mime_type):
         tika_server = settings.TIKA_ENDPOINT
+
+        # tika does not support a PathLike, only strings
+        # ensure this is a string
+        document_path = str(document_path)
+
         try:
             parsed = parser.from_file(document_path, tika_server)
         except Exception as e:
@@ -47,9 +53,13 @@ class TikaDocumentParser(DocumentParser):
             for key in parsed["metadata"]
         ]
 
-    def parse(self, document_path, mime_type, file_name=None):
+    def parse(self, document_path: Path, mime_type, file_name=None):
         self.log("info", f"Sending {document_path} to Tika server")
         tika_server = settings.TIKA_ENDPOINT
+
+        # tika does not support a PathLike, only strings
+        # ensure this is a string
+        document_path = str(document_path)
 
         try:
             parsed = parser.from_file(document_path, tika_server)


### PR DESCRIPTION
## Proposed change

The tika library expects a string value for the document path, which is then provided to `urllib.parse.urlparse` for decoding.  It was getting a Path object instead.  With this PR, the Path is converted to a string for tika functions.

Fixes #1583

Side note/future idea, at least in the CI, we could spin up containers and test against the actual service better.  Skipping if the environ doesn't include a URL to a tika server.  It would have caught this.  Working on this for the future in feature-live-tika-testing

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
