### PR TITLE
Feature: add redis sentinel support

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -63,7 +63,8 @@ initialize() {
 		PAPERLESS_ADMIN_USER \
 		PAPERLESS_ADMIN_MAIL \
 		PAPERLESS_ADMIN_PASSWORD \
-		PAPERLESS_REDIS; do
+		PAPERLESS_REDIS \
+		PAPERLESS_REDIS_SENTINEL; do
 		# Check for a version of this var with _FILE appended
 		# and convert the contents to the env var value
 		file_env ${env_var}

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -27,10 +27,33 @@ PAPERLESS_REDIS=<url>
     This is required for processing scheduled tasks such as email fetching, index
     optimization and for training the automatic document matcher.
 
-    Sentinel is supported, using `redis+sentinel` scheme, for example
-    `redis+sentinel://localhost:26379/0?mastername=mymaster&sentinelusername=user&sentinelpassword=pass`
+    Sentinel is supported, using `sentinel` scheme, with hosts separated by
+    semicolon, for example:
+    `sentinel://localhost:26379;sentinel://localhost:26380;sentinel://localhost:26381`
 
     Defaults to redis://localhost:6379.
+
+PAPERLESS_REDIS_SENTINEL=<query params formatted string>
+
+    This are extra options for sentinel configuration, formatted as query
+    string, for example:
+    `master_name=mymaster&ssl=true&sentinel_password=mypass&ssl_cert_reqs=none`
+
+    Supported parameters are:
+
+    * `master_name` - sentinel master name, defaults to `mymaster`
+    * `redis_db` - db number for underlying redis instances, defaults to `0`
+    * `redis_password` - password for underlying redis instances, empty by
+      default
+    * `redis_username` - username for underlying redis instances, empty by
+      default
+    * `sentinel_password` - password for sentinel, empty by default
+    * `sentinel_username` - username for sentinel, empty by default
+    * `ssl` - use SSL when connecting to both redis and sentinel, every value
+      different than `false` expands to `true` - default is `true`
+    * `ssl_cert_reqs` - for ssl only, strict certificate verification config -
+      allowed options are `required`, `optional` or `none` - default is
+      `required`
 
 PAPERLESS_DBENGINE=<engine_name>
     Optional, gives the ability to choose Postgres or MariaDB for database engine.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -27,6 +27,9 @@ PAPERLESS_REDIS=<url>
     This is required for processing scheduled tasks such as email fetching, index
     optimization and for training the automatic document matcher.
 
+    Sentinel is supported, using `redis+sentinel` scheme, for example
+    `redis+sentinel://localhost:26379/0?mastername=mymaster&sentinelusername=user&sentinelpassword=pass`
+
     Defaults to redis://localhost:6379.
 
 PAPERLESS_DBENGINE=<engine_name>

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -232,6 +232,7 @@ Install Paperless from Docker Hub
           * PAPERLESS_ADMIN_MAIL
           * PAPERLESS_ADMIN_PASSWORD
           * PAPERLESS_REDIS
+          * PAPERLESS_REDIS_SENTINEL
 
     .. caution::
 

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -231,6 +231,7 @@ Install Paperless from Docker Hub
           * PAPERLESS_ADMIN_USER
           * PAPERLESS_ADMIN_MAIL
           * PAPERLESS_ADMIN_PASSWORD
+          * PAPERLESS_REDIS
 
     .. caution::
 

--- a/src/paperless/brokers.py
+++ b/src/paperless/brokers.py
@@ -1,0 +1,115 @@
+from urllib.parse import parse_qs
+from urllib.parse import urlparse
+
+import redis
+from django_q.brokers.redis_broker import Redis as RedisBroker
+from django_q.conf import Conf
+from redis import Redis
+from redis import Sentinel
+
+
+class RedisSentinelBroker(RedisBroker):
+    def enqueue(self, task):
+        try:
+            return super().enqueue(task)
+        except redis.ConnectionError:
+            self.connection = self.get_connection()
+            return super().enqueue(task)
+
+    def dequeue(self):
+        try:
+            return super().dequeue()
+        except redis.ConnectionError:
+            self.connection = self.get_connection()
+            return super().dequeue()
+
+    def queue_size(self):
+        try:
+            return super().queue_size()
+        except redis.ConnectionError:
+            self.connection = self.get_connection()
+            return super().queue_size()
+
+    def delete_queue(self):
+        try:
+            return super().delete_queue()
+        except redis.ConnectionError:
+            self.connection = self.get_connection()
+            return super().delete_queue()
+
+    def purge_queue(self):
+        try:
+            return super().purge_queue()
+        except redis.ConnectionError:
+            self.connection = self.get_connection()
+            return super().purge_queue()
+
+    def ping(self) -> bool:
+        try:
+            return super().ping()
+        except redis.ConnectionError:
+            self.connection = self.get_connection()
+            return super().ping()
+
+    def info(self) -> str:
+        try:
+            return super().info()
+        except redis.ConnectionError:
+            self.connection = self.get_connection()
+            return super().info()
+
+    def set_stat(self, key: str, value: str, timeout: int):
+        try:
+            return super().set_stat(key, value, timeout)
+        except redis.ConnectionError:
+            self.connection = self.get_connection()
+            return super().set_stat(key, value, timeout)
+
+    def get_stat(self, key: str):
+        try:
+            return super().get_stat(key)
+        except redis.ConnectionError:
+            self.connection = self.get_connection()
+            return super().get_stat(key)
+
+    def get_stats(self, pattern: str):
+        try:
+            return super().get_stats(pattern)
+        except redis.ConnectionError:
+            self.connection = self.get_connection()
+            return super().get_stats(pattern)
+
+    @staticmethod
+    def get_connection(list_key: str = Conf.PREFIX) -> Redis:
+        if not isinstance(Conf.REDIS, str):
+            return RedisBroker.get_connection(list_key)
+
+        url = urlparse(Conf.REDIS)
+        scheme_split = url.scheme.split("+")
+        if "sentinel" not in scheme_split:
+            return RedisBroker.get_connection(list_key)
+
+        query = parse_qs(url.query)
+        connection_kwargs = {
+            "username": url.username,  # redis node username
+            "password": url.password,  # redis node password
+            "ssl": ("rediss" in scheme_split),
+            "db": url.path[1:],
+        }
+        if "rediss" in scheme_split:
+            connection_kwargs["ssl_cert_reqs"] = query.get(
+                "ssl_cert_reqs",
+                ["required"],
+            )[0]
+
+        sentinel = Sentinel(
+            [(url.hostname, url.port)],
+            sentinel_kwargs={
+                "username": query.get("sentinelusername", [""])[0],
+                "password": query.get("sentinelpassword", [""])[0],
+                "ssl": ("rediss" in scheme_split),
+                "ssl_cert_reqs": query.get("ssl_cert_reqs", ["required"])[0],
+            },
+            **connection_kwargs,
+        )
+        return sentinel.master_for(query.get("mastername", ["mymaster"])[0])

--- a/src/paperless/helpers.py
+++ b/src/paperless/helpers.py
@@ -1,0 +1,54 @@
+from urllib.parse import parse_qs
+from urllib.parse import urlparse
+
+from redis import Redis
+from redis.sentinel import Sentinel
+
+
+def build_redis_client(
+    paperless_redis: str,
+    paperless_redis_sentinel: str = "",
+) -> Redis:
+    redis_urls = list(map(str.strip, paperless_redis.split(";")))
+
+    if len(redis_urls) == 1 and redis_urls[0][:8] != "sentinel":
+        return Redis.from_url(url=redis_urls[0])
+
+    if any(r[:8] != "sentinel" for r in redis_urls):
+        raise ValueError(
+            "when providing multiple redis urls, "
+            "all of them need to follow sentinel:// scheme",
+        )
+
+    sentinels = []
+    for redis_url in redis_urls:
+        url = urlparse(redis_url)
+        sentinels.append((url.hostname, url.port))
+
+    query = parse_qs(paperless_redis_sentinel)
+    ssl = query.get("ssl", ["true"])[0] != "false"
+
+    connection_kwargs = {
+        "username": query.get("redis_username", [""])[0],
+        "password": query.get("redis_password", [""])[0],
+        "ssl": ssl,
+        "db": url.path[1:],
+    }
+
+    sentinel_kwargs = {
+        "username": query.get("sentinel_username", [""])[0],
+        "password": query.get("sentinel_password", [""])[0],
+        "ssl": ssl,
+    }
+
+    if ssl:
+        ssl_cert_reqs = query.get("ssl_cert_reqs", ["required"])[0]
+        connection_kwargs["ssl_cert_reqs"] = ssl_cert_reqs
+        sentinel_kwargs["ssl_cert_reqs"] = ssl_cert_reqs
+
+    sentinel = Sentinel(
+        sentinels,
+        sentinel_kwargs=sentinel_kwargs,
+        **connection_kwargs,
+    )
+    return sentinel.master_for(query.get("master_name", ["mymaster"])[0])


### PR DESCRIPTION
## Proposed change

This PR adds support for Redis Sentinel, which enables paperless to be deployed in High-Availability environments (like kubernetes). It should be backwards compatible with current redis uri schemas.

P.S. I'm not a python developer, so I couldn't set up working environment to run tests ~~and pre-commit hooks~~, I'm relying on github actions, that PR is fine. Is it possible to build dev env via docker somehow?

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
