### PR TITLE
Fix reset button padding on small screens

### DIFF
--- a/src-ui/src/app/components/document-list/filter-editor/filter-editor.component.html
+++ b/src-ui/src/app/components/document-list/filter-editor/filter-editor.component.html
@@ -64,9 +64,9 @@
      </div>
    </div>
    <div class="w-100 d-xxl-none"></div>
-   <div class="col col-xl-auto ps-0">
+   <div class="col col-xl-auto ps-xxl-0">
      <button class="btn btn-link btn-sm px-0" [disabled]="!rulesModified" (click)="resetSelected()">
-       <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-x me-1" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+       <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-x me-1 ms-n1" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
          <path fill-rule="evenodd" d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708z"/>
        </svg><ng-container i18n>Reset filters</ng-container>
      </button>


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

This tiny PR fixes a visual bug I noted with the filter editor 'Reset' button in 1.9.0 so figured can sneak it into 1.9.1 bugfix release. Before/after screenshot below

![after](https://user-images.githubusercontent.com/4887959/192346901-473dda18-118a-4cf3-9abe-8eaf1b15afab.jpg)

![PNG image](https://user-images.githubusercontent.com/4887959/192346538-1e43b49e-b219-4903-bbf6-de9afce39baf.png)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] ~~I have made corresponding changes to the documentation as needed.~~
- [x] I have checked my modifications for any breaking changes.
