### PR TITLE
Bugfix: Set MySql charset

### DIFF
--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -319,6 +319,7 @@ DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.sqlite3",
         "NAME": os.path.join(DATA_DIR, "db.sqlite3"),
+        "OPTIONS": {},
     },
 }
 
@@ -340,21 +341,18 @@ if os.getenv("PAPERLESS_DBHOST"):
     # Leave room for future extensibility
     if os.getenv("PAPERLESS_DBENGINE") == "mariadb":
         engine = "django.db.backends.mysql"
-        options = {"read_default_file": "/etc/mysql/my.cnf"}
+        options = {"read_default_file": "/etc/mysql/my.cnf", "charset": "utf8mb4"}
     else:  # Default to PostgresDB
         engine = "django.db.backends.postgresql_psycopg2"
         options = {"sslmode": os.getenv("PAPERLESS_DBSSLMODE", "prefer")}
 
     DATABASES["default"]["ENGINE"] = engine
-    for key, value in options.items():
-        DATABASES["default"]["OPTIONS"][key] = value
+    DATABASES["default"]["OPTIONS"].update(options)
 
 if os.getenv("PAPERLESS_DB_TIMEOUT") is not None:
-    _new_opts = {"timeout": float(os.getenv("PAPERLESS_DB_TIMEOUT"))}
-    if "OPTIONS" in DATABASES["default"]:
-        DATABASES["default"]["OPTIONS"].update(_new_opts)
-    else:
-        DATABASES["default"]["OPTIONS"] = _new_opts
+    DATABASES["default"]["OPTIONS"].update(
+        {"timeout": float(os.getenv("PAPERLESS_DB_TIMEOUT"))},
+    )
 
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 


### PR DESCRIPTION
## Proposed change

This sets the MySql/MariaDB options to change the charset to allow 4 byte UTF8, instead of only 3-byte UTF8.  There's a long open Django bug to make this the default (https://code.djangoproject.com/ticket/18392) but  nothing appears to have been actually fixed.

With this change, I can consume the sample file (https://www.ukmt.org.uk/sites/default/files/ukmt/SMC_2021_paper.pdf)

Fixes #1668

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
