### PR TITLE
Fix: allow preview for .csv files

### DIFF
--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -261,6 +261,9 @@ class DocumentViewSet(
             file_handle = doc.source_file
             filename = doc.get_public_filename()
             mime_type = doc.mime_type
+            # Support browser previewing csv files by using text mime type
+            if mime_type in {"application/csv", "text/csv"} and disposition == "inline":
+                mime_type = "text/plain"
 
         if doc.storage_type == Document.STORAGE_TYPE_GPG:
             file_handle = GnuPG.decrypted(file_handle)


### PR DESCRIPTION
Co-Authored-By: bin101 <12427722+bin101@users.noreply.github.com>

<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

This PR implements a fix for the preview of csv files by passing the `text/plain` mime type when returning the inline file for the api `preview` endpoint when a csv is detected. Browsers do not support displaying csv so currently the preview button actually forces a download of a csv file but with this change it will show the text contents just fine. Screenshot below.

Of course if folks have issues with this solution, feel free to shoot it down =)

<img width="543" alt="Screen Shot 2022-10-04 at 11 15 50 AM" src="https://user-images.githubusercontent.com/4887959/193896589-935c64ab-118a-4f43-a7f2-1386547c5530.png">

Fixes #1725 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] ~~I have made corresponding changes to the documentation as needed.~~
- [x] I have checked my modifications for any breaking changes.
