### PR TITLE
Bugfix: Fix email labeling for non-Gmail servers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,12 @@ jobs:
         ports:
           - "3000:3000/tcp"
     env:
+      # Enable Tika end to end testing
       TIKA_LIVE: 1
+      # Enable paperless_mail testing against real server
+      PAPERLESS_MAIL_TEST_HOST: ${{ secrets.TEST_MAIL_HOST }}
+      PAPERLESS_MAIL_TEST_USER: ${{ secrets.TEST_MAIL_USER }}
+      PAPERLESS_MAIL_TEST_PASSWD: ${{ secrets.TEST_MAIL_PASSWD }}
     steps:
       -
         name: Checkout

--- a/src/paperless_mail/mail.py
+++ b/src/paperless_mail/mail.py
@@ -4,6 +4,7 @@ import tempfile
 from datetime import date
 from datetime import timedelta
 from fnmatch import fnmatch
+from typing import Dict
 
 import magic
 import pathvalidate
@@ -30,7 +31,7 @@ class MailError(Exception):
 
 
 class BaseMailAction:
-    def get_criteria(self):
+    def get_criteria(self) -> Dict:
         return {}
 
     def post_consume(self, M, message_uids, parameter):
@@ -78,7 +79,7 @@ class TagMailAction(BaseMailAction):
             M.flag(message_uids, [self.keyword], True)
 
 
-def get_rule_action(rule):
+def get_rule_action(rule) -> BaseMailAction:
     if rule.action == MailRule.MailAction.FLAG:
         return FlagMailAction()
     elif rule.action == MailRule.MailAction.DELETE:
@@ -108,7 +109,7 @@ def make_criterias(rule):
     return {**criterias, **get_rule_action(rule).get_criteria()}
 
 
-def get_mailbox(server, port, security):
+def get_mailbox(server, port, security) -> MailBox:
     if security == MailAccount.ImapSecurity.NONE:
         mailbox = MailBoxUnencrypted(server, port)
     elif security == MailAccount.ImapSecurity.STARTTLS:
@@ -167,7 +168,7 @@ class MailAccountHandler(LoggingMixin):
                 "Unknown correspondent selector",
             )  # pragma: nocover
 
-    def handle_mail_account(self, account):
+    def handle_mail_account(self, account: MailAccount):
 
         self.renew_logging_group()
 
@@ -181,7 +182,14 @@ class MailAccountHandler(LoggingMixin):
                 account.imap_security,
             ) as M:
 
+                supports_gmail_labels = "X-GM-EXT-1" in M.client.capabilities
+                supports_auth_plain = "AUTH=PLAIN" in M.client.capabilities
+
+                self.log("debug", f"GMAIL Label Support: {supports_gmail_labels}")
+                self.log("debug", f"AUTH=PLAIN Support: {supports_auth_plain}")
+
                 try:
+
                     M.login(account.username, account.password)
 
                 except UnicodeEncodeError:
@@ -215,7 +223,11 @@ class MailAccountHandler(LoggingMixin):
 
                 for rule in account.rules.order_by("order"):
                     try:
-                        total_processed_files += self.handle_mail_rule(M, rule)
+                        total_processed_files += self.handle_mail_rule(
+                            M,
+                            rule,
+                            supports_gmail_labels,
+                        )
                     except Exception as e:
                         self.log(
                             "error",
@@ -233,7 +245,12 @@ class MailAccountHandler(LoggingMixin):
 
         return total_processed_files
 
-    def handle_mail_rule(self, M: MailBox, rule):
+    def handle_mail_rule(
+        self,
+        M: MailBox,
+        rule: MailRule,
+        supports_gmail_labels: bool = False,
+    ):
 
         self.log("debug", f"Rule {rule}: Selecting folder {rule.folder}")
 
@@ -261,11 +278,19 @@ class MailAccountHandler(LoggingMixin):
             ) from err
 
         criterias = make_criterias(rule)
-        criterias_imap = AND(**criterias)
+
+        # Deal with the Gmail label extension
         if "gmail_label" in criterias:
+
             gmail_label = criterias["gmail_label"]
             del criterias["gmail_label"]
-            criterias_imap = AND(NOT(gmail_label=gmail_label), **criterias)
+
+            if not supports_gmail_labels:
+                criterias_imap = AND(**criterias)
+            else:
+                criterias_imap = AND(NOT(gmail_label=gmail_label), **criterias)
+        else:
+            criterias_imap = AND(**criterias)
 
         self.log(
             "debug",

--- a/src/paperless_mail/tests/test_live_mail.py
+++ b/src/paperless_mail/tests/test_live_mail.py
@@ -1,0 +1,70 @@
+import os
+
+import pytest
+from django.test import TestCase
+from paperless_mail.mail import MailAccountHandler
+from paperless_mail.mail import MailError
+from paperless_mail.models import MailAccount
+from paperless_mail.models import MailRule
+
+# Only run if the environment is setup
+# And the environment is not empty (forks, I think)
+@pytest.mark.skipif(
+    "PAPERLESS_MAIL_TEST_HOST" not in os.environ
+    or not len(os.environ["PAPERLESS_MAIL_TEST_HOST"]),
+    reason="Live server testing not enabled",
+)
+class TestMailLiveServer(TestCase):
+    def setUp(self) -> None:
+
+        self.mail_account_handler = MailAccountHandler()
+        self.account = MailAccount.objects.create(
+            name="test",
+            imap_server=os.environ["PAPERLESS_MAIL_TEST_HOST"],
+            username=os.environ["PAPERLESS_MAIL_TEST_USER"],
+            password=os.environ["PAPERLESS_MAIL_TEST_PASSWD"],
+            imap_port=993,
+        )
+
+        return super().setUp()
+
+    def tearDown(self) -> None:
+        self.account.delete()
+        return super().tearDown()
+
+    def test_process_non_gmail_server_flag(self):
+
+        try:
+            rule1 = MailRule.objects.create(
+                name="testrule",
+                account=self.account,
+                action=MailRule.MailAction.FLAG,
+            )
+
+            self.mail_account_handler.handle_mail_account(self.account)
+
+            rule1.delete()
+
+        except MailError as e:
+            self.fail(f"Failure: {e}")
+        except Exception as e:
+            pass
+
+    def test_process_non_gmail_server_tag(self):
+
+        try:
+
+            rule2 = MailRule.objects.create(
+                name="testrule",
+                account=self.account,
+                action=MailRule.MailAction.TAG,
+            )
+
+            self.mail_account_handler.handle_mail_account(self.account)
+
+            rule2.delete()
+
+        except MailError as e:
+            self.fail(f"Failure: {e}")
+        except Exception as e:
+            pass

--- a/src/paperless_mail/tests/test_mail.py
+++ b/src/paperless_mail/tests/test_mail.py
@@ -47,14 +47,15 @@ class BogusFolderManager:
 
 
 class BogusClient:
+    def __init__(self, messages):
+        self.messages: List[MailMessage] = messages
+        self.capabilities: List[str] = []
+
     def __enter__(self):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         pass
-
-    def __init__(self, messages):
-        self.messages: List[MailMessage] = messages
 
     def authenticate(self, mechanism, authobject):
         # authobject must be a callable object
@@ -80,18 +81,18 @@ class BogusMailBox(ContextManager):
     # Note the non-ascii characters here
     UTF_PASSWORD: str = "w57äöüw4b6huwb6nhu"
 
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        pass
-
     def __init__(self):
         self.messages: List[MailMessage] = []
         self.messages_spam: List[MailMessage] = []
         self.folder = BogusFolderManager()
         self.client = BogusClient(self.messages)
         self._host = ""
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass
 
     def updateClient(self):
         self.client = BogusClient(self.messages)
@@ -648,6 +649,7 @@ class TestMail(DirectoriesMixin, TestCase):
 
     def test_handle_mail_account_tag_gmail(self):
         self.bogus_mailbox._host = "imap.gmail.com"
+        self.bogus_mailbox.client.capabilities = ["X-GM-EXT-1"]
 
         account = MailAccount.objects.create(
             name="test",


### PR DESCRIPTION
## Proposed change

Check the server capabilities for `X-GM-EXT-1` and never send the GMail specific criteria if it is not supported.

To further ensure catching of this sort of thing, I created a new test which can, if configured via the environment (and secrets), connect to a real server and account for processing.  The account doesn't really have emails in it to process, but it would catch this sort of thing anyway.

Fixes #1753

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
