### PR TITLE
Documentation: Tweak LinuxServer

### DIFF
--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -664,7 +664,7 @@ are translatable to Docker commands as well.
 6.  Update media paths
 
     a) Set the environment variable ``PAPERLESS_MEDIA_ROOT``
-       to ``/data``
+       to ``/data/media``
 
 7.  Update timezone
 


### PR DESCRIPTION
## Proposed change

Very minor docs tweask.  LSIO sets the media root one level deeper than i guessed from their image docs.

https://github.com/linuxserver/docker-paperless-ngx/blob/main/Dockerfile#L11

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (please explain) - docs only update

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
