### PR TITLE
Bugfix: Files containing barcodes uploaded via web are not consumed after splitting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
       -
         name: Install pipenv
         run: |
-          pipx install pipenv
+          pipx install pipenv==2022.10.4
           pipenv --version
       -
         name: Set up Python

--- a/src/documents/tasks.py
+++ b/src/documents/tasks.py
@@ -117,9 +117,11 @@ def consume_file(
                     # Move it to consume directory to be picked up
                     # Otherwise, use the current parent to keep possible tags
                     # from subdirectories
-                    if path.is_relative_to(settings.SCRATCH_DIR):
+                    try:
+                        # is_relative_to would be nicer, but new in 3.9
+                        _ = path.relative_to(settings.SCRATCH_DIR)
                         save_to_dir = settings.CONSUMPTION_DIR
-                    else:
+                    except ValueError:
                         save_to_dir = path.parent
 
                     barcodes.save_to_dir(

--- a/src/documents/tasks.py
+++ b/src/documents/tasks.py
@@ -112,10 +112,20 @@ def consume_file(
                         newname = f"{str(n)}_" + override_filename
                     else:
                         newname = None
+
+                    # If the file is an upload, it's in the scratch directory
+                    # Move it to consume directory to be picked up
+                    # Otherwise, use the current parent to keep possible tags
+                    # from subdirectories
+                    if path.is_relative_to(settings.SCRATCH_DIR):
+                        save_to_dir = settings.CONSUMPTION_DIR
+                    else:
+                        save_to_dir = path.parent
+
                     barcodes.save_to_dir(
                         document,
                         newname=newname,
-                        target_dir=path.parent,
+                        target_dir=save_to_dir,
                     )
 
                 # Delete the PDF file which was split


### PR DESCRIPTION
## Proposed change

When a file is uploaded via the UI, barcodes are detected, but the split files are placed into the same directory as the original file, which is probably the temporary directory.  With this PR, the split files will go to the consumption directory root if they  were in temp or into the parent directory (for those files already in the consume dir)

Fixes #1758

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
