### PR TITLE
Chore: Updates Gotenberg versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
         ports:
           - "9998:9998/tcp"
       gotenberg:
-        image: docker.io/gotenberg/gotenberg:7.4
+        image: docker.io/gotenberg/gotenberg:7.6
         ports:
           - "3000:3000/tcp"
     env:

--- a/docker/compose/docker-compose.mariadb-tika.yml
+++ b/docker/compose/docker-compose.mariadb-tika.yml
@@ -85,10 +85,11 @@ services:
       PAPERLESS_TIKA_ENDPOINT: http://tika:9998
 
   gotenberg:
-    image: docker.io/gotenberg/gotenberg:7.4
+    image: docker.io/gotenberg/gotenberg:7.6
     restart: unless-stopped
-    environment:
-      CHROMIUM_DISABLE_ROUTES: 1
+    command:
+      - "gotenberg"
+      - "--chromium-disable-routes=true"
 
   tika:
     image: ghcr.io/paperless-ngx/tika:latest

--- a/docker/compose/docker-compose.postgres-tika.yml
+++ b/docker/compose/docker-compose.postgres-tika.yml
@@ -77,7 +77,7 @@ services:
       PAPERLESS_TIKA_ENDPOINT: http://tika:9998
 
   gotenberg:
-    image: docker.io/gotenberg/gotenberg:7.4
+    image: docker.io/gotenberg/gotenberg:7.6
     restart: unless-stopped
     command:
       - "gotenberg"

--- a/docker/compose/docker-compose.sqlite-tika.yml
+++ b/docker/compose/docker-compose.sqlite-tika.yml
@@ -65,7 +65,7 @@ services:
       PAPERLESS_TIKA_ENDPOINT: http://tika:9998
 
   gotenberg:
-    image: docker.io/gotenberg/gotenberg:7.4
+    image: docker.io/gotenberg/gotenberg:7.6
     restart: unless-stopped
     command:
       - "gotenberg"

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -538,7 +538,7 @@ requires are as follows:
         # ...
 
         gotenberg:
-            image: gotenberg/gotenberg:7.4
+            image: gotenberg/gotenberg:7.6
             restart: unless-stopped
             command:
                 - "gotenberg"

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -125,7 +125,7 @@ If using docker-compose, this is achieved by the following configuration change 
 .. code:: yaml
 
     gotenberg:
-        image: gotenberg/gotenberg:7.4
+        image: gotenberg/gotenberg:7.6
         restart: unless-stopped
         command:
             - "gotenberg"

--- a/scripts/start_services.sh
+++ b/scripts/start_services.sh
@@ -2,5 +2,5 @@
 
 docker run -p 5432:5432 -e POSTGRES_PASSWORD=password -v paperless_pgdata:/var/lib/postgresql/data -d postgres:13
 docker run -d -p 6379:6379 redis:latest
-docker run -p 3000:3000 -d gotenberg/gotenberg:7.4
+docker run -p 3000:3000 -d gotenberg/gotenberg:7.6
 docker run -p 9998:9998 -d ghcr.io/paperless-ngx/tika:latest


### PR DESCRIPTION
## Proposed change

This PR updates the Gotenberg container version from 7.4 to 7.6 (see [their releases](https://github.com/gotenberg/gotenberg/releases) for details).

This also appears to fix whatever is happening with the testing from #1757.  Despite [having run it 5 times](https://github.com/paperless-ngx/paperless-ngx/actions/runs/3206167645) it now naturally wants to fail on almost every run due to a segmentation fault in Gotenberg.  I haven't yet seen this happening with 7.6 (fingers crossed)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (please explain) - version updates

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ x I have made corresponding changes to the documentation as needed.
- [ x I have checked my modifications for any breaking changes.
