### PR TITLE
Feature: Allow running custom container initialization scripts

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -13,6 +13,7 @@ body:
         - [The troubleshooting documentation](https://paperless-ngx.readthedocs.io/en/latest/troubleshooting.html).
         - [The installation instructions](https://paperless-ngx.readthedocs.io/en/latest/setup.html#installation).
         - [Existing issues and discussions](https://github.com/paperless-ngx/paperless-ngx/search?q=&type=issues).
+        - Disable any customer container initialization scripts, if using any
 
         If you encounter issues while installing or configuring Paperless-ngx, please post in the ["Support" section of the discussions](https://github.com/paperless-ngx/paperless-ngx/discussions/new?category=support).
   - type: textarea

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -9,8 +9,8 @@ set -e
 # fill in the value of "$XYZ_DB_PASSWORD" from a file, especially for Docker's
 # secrets feature
 file_env() {
-	local var="$1"
-	local fileVar="${var}_FILE"
+	local -r var="$1"
+	local -r fileVar="${var}_FILE"
 
 	# Basic validation
 	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
@@ -35,14 +35,14 @@ file_env() {
 
 # Source: https://github.com/sameersbn/docker-gitlab/
 map_uidgid() {
-	USERMAP_ORIG_UID=$(id -u paperless)
-	USERMAP_ORIG_GID=$(id -g paperless)
-	USERMAP_NEW_UID=${USERMAP_UID:-$USERMAP_ORIG_UID}
-	USERMAP_NEW_GID=${USERMAP_GID:-${USERMAP_ORIG_GID:-$USERMAP_NEW_UID}}
-	if [[ ${USERMAP_NEW_UID} != "${USERMAP_ORIG_UID}" || ${USERMAP_NEW_GID} != "${USERMAP_ORIG_GID}" ]]; then
-		echo "Mapping UID and GID for paperless:paperless to $USERMAP_NEW_UID:$USERMAP_NEW_GID"
-		usermod -o -u "${USERMAP_NEW_UID}" paperless
-		groupmod -o -g "${USERMAP_NEW_GID}" paperless
+	local -r usermap_original_uid=$(id -u paperless)
+	local -r usermap_original_gid=$(id -g paperless)
+	local -r usermap_new_uid=${USERMAP_UID:-$usermap_original_uid}
+	local -r usermap_new_gid=${USERMAP_GID:-${usermap_original_gid:-$usermap_new_uid}}
+	if [[ ${usermap_new_uid} != "${usermap_original_uid}" || ${usermap_new_gid} != "${usermap_original_gid}" ]]; then
+		echo "Mapping UID and GID for paperless:paperless to $usermap_new_uid:$usermap_new_gid"
+		usermod -o -u "${usermap_new_uid}" paperless
+		groupmod -o -g "${usermap_new_gid}" paperless
 	fi
 }
 
@@ -55,8 +55,8 @@ map_folders() {
 
 nltk_data () {
 	# Store the NLTK data outside the Docker container
-	local nltk_data_dir="${DATA_DIR}/nltk"
-	readonly truthy_things=("yes y 1 t true")
+	local -r nltk_data_dir="${DATA_DIR}/nltk"
+	local -r truthy_things=("yes y 1 t true")
 
 	# If not set, or it looks truthy
 	if [[ -z "${PAPERLESS_ENABLE_NLTK}" ]] || [[ "${truthy_things[*]}" =~ ${PAPERLESS_ENABLE_NLTK,} ]]; then
@@ -100,7 +100,7 @@ initialize() {
 	# Check for overrides of certain folders
 	map_folders
 
-	local export_dir="/usr/src/paperless/export"
+	local -r export_dir="/usr/src/paperless/export"
 
 	for dir in \
 		"${export_dir}" \
@@ -113,7 +113,7 @@ initialize() {
 		fi
 	done
 
-	local tmp_dir="/tmp/paperless"
+	local -r tmp_dir="/tmp/paperless"
 	echo "Creating directory ${tmp_dir}"
 	mkdir -p "${tmp_dir}"
 
@@ -137,7 +137,7 @@ initialize() {
 install_languages() {
 	echo "Installing languages..."
 
-	local langs="$1"
+	local -r langs="$1"
 	read -ra langs <<<"$langs"
 
 	# Check that it is not empty

--- a/docker/docker-prepare.sh
+++ b/docker/docker-prepare.sh
@@ -89,7 +89,7 @@ superuser() {
 	fi
 }
 
-customer_container_init() {
+custom_container_init() {
 	# Mostly borrowed from the LinuxServer.io base image
 	# https://github.com/linuxserver/docker-baseimage-ubuntu/tree/bionic/root/etc/cont-init.d
 	readonly custom_script_dir="/custom-cont-init.d"
@@ -145,7 +145,7 @@ do_work() {
 	superuser
 
 	# Leave this last thing
-	customer_container_init
+	custom_container_init
 
 }
 

--- a/docker/docker-prepare.sh
+++ b/docker/docker-prepare.sh
@@ -109,7 +109,7 @@ customer_container_init() {
 		fi
 
 		# Make sure custom init directory has files in it
-		if [ -n "$(/bin/ls -A "${custom_script_dir} "2>/dev/null)" ]; then
+		if [ -n "$(/bin/ls -A "${custom_script_dir}" 2>/dev/null)" ]; then
 			echo "[custom-init] files found in ${custom_script_dir} executing"
 			# Loop over files in the directory
 			for SCRIPT in "${custom_script_dir}"/*; do

--- a/docker/docker-prepare.sh
+++ b/docker/docker-prepare.sh
@@ -109,14 +109,14 @@ custom_container_init() {
 		fi
 
 		# Make sure custom init directory has files in it
-		if [ -n "$(/usr/bin/ls -A "${custom_script_dir}" 2>/dev/null)" ]; then
+		if [ -n "$(/bin/ls -A "${custom_script_dir}" 2>/dev/null)" ]; then
 			echo "[custom-init] files found in ${custom_script_dir} executing"
 			# Loop over files in the directory
 			for SCRIPT in "${custom_script_dir}"/*; do
 				NAME="$(basename "${SCRIPT}")"
 				if [ -f "${SCRIPT}" ]; then
 					echo "[custom-init] ${NAME}: executing..."
-					/usr/bin/bash "${SCRIPT}"
+					/bin/bash "${SCRIPT}"
 					echo "[custom-init] ${NAME}: exited $?"
 				elif [ ! -f "${SCRIPT}" ]; then
 					echo "[custom-init] ${NAME}: is not a file"

--- a/docker/docker-prepare.sh
+++ b/docker/docker-prepare.sh
@@ -4,12 +4,12 @@ set -e
 
 wait_for_postgres() {
 	local attempt_num=1
-	local max_attempts=5
+	local -r max_attempts=5
 
 	echo "Waiting for PostgreSQL to start..."
 
-	local host="${PAPERLESS_DBHOST:-localhost}"
-	local port="${PAPERLESS_DBPORT:-5432}"
+	local -r host="${PAPERLESS_DBHOST:-localhost}"
+	local -r port="${PAPERLESS_DBPORT:-5432}"
 
 	# Disable warning, host and port can't have spaces
 	# shellcheck disable=SC2086
@@ -31,11 +31,11 @@ wait_for_postgres() {
 wait_for_mariadb() {
 	echo "Waiting for MariaDB to start..."
 
-	host="${PAPERLESS_DBHOST:=localhost}"
-	port="${PAPERLESS_DBPORT:=3306}"
+	local -r host="${PAPERLESS_DBHOST:=localhost}"
+	local -r port="${PAPERLESS_DBPORT:=3306}"
 
-	attempt_num=1
-	max_attempts=5
+	local attempt_num=1
+	local -r max_attempts=5
 
 	while ! true > /dev/tcp/$host/$port; do
 
@@ -73,8 +73,8 @@ migrations() {
 
 search_index() {
 
-	local index_version=1
-	local index_version_file=${DATA_DIR}/.index_version
+	local -r index_version=1
+	local -r index_version_file=${DATA_DIR}/.index_version
 
 	if [[ (! -f "${index_version_file}") || $(<"${index_version_file}") != "$index_version" ]]; then
 		echo "Search index out of date. Updating..."
@@ -92,31 +92,31 @@ superuser() {
 custom_container_init() {
 	# Mostly borrowed from the LinuxServer.io base image
 	# https://github.com/linuxserver/docker-baseimage-ubuntu/tree/bionic/root/etc/cont-init.d
-	readonly custom_script_dir="/custom-cont-init.d"
+	local -r custom_script_dir="/custom-cont-init.d"
 	# Tamper checking.
 	# Don't run files which are owned by anyone except root
 	# Don't run files which are writeable by others
 	if [ -d "${custom_script_dir}" ]; then
-		if [ -n "$(find "${custom_script_dir}" ! -user root)" ]; then
+		if [ -n "$(/usr/bin/find "${custom_script_dir}" ! -user root)" ]; then
 			echo "**** Potential tampering with custom scripts detected ****"
 			echo "**** The folder '${custom_script_dir}' must be owned by root ****"
 			return 0
 		fi
-		if [ -n "$(find "${custom_script_dir}" -perm -o+w)" ]; then
+		if [ -n "$(/usr/bin/find "${custom_script_dir}" -perm -o+w)" ]; then
 			echo "**** The folder '${custom_script_dir}' or some of contents have write permissions for others, which is a security risk. ****"
 			echo "**** Please review the permissions and their contents to make sure they are owned by root, and can only be modified by root. ****"
 			return 0
 		fi
 
 		# Make sure custom init directory has files in it
-		if [ -n "$(/bin/ls -A "${custom_script_dir}" 2>/dev/null)" ]; then
+		if [ -n "$(/usr/bin/ls -A "${custom_script_dir}" 2>/dev/null)" ]; then
 			echo "[custom-init] files found in ${custom_script_dir} executing"
 			# Loop over files in the directory
 			for SCRIPT in "${custom_script_dir}"/*; do
 				NAME="$(basename "${SCRIPT}")"
 				if [ -f "${SCRIPT}" ]; then
 					echo "[custom-init] ${NAME}: executing..."
-					/bin/bash "${SCRIPT}"
+					/usr/bin/bash "${SCRIPT}"
 					echo "[custom-init] ${NAME}: exited $?"
 				elif [ ! -f "${SCRIPT}" ]; then
 					echo "[custom-init] ${NAME}: is not a file"

--- a/docker/docker-prepare.sh
+++ b/docker/docker-prepare.sh
@@ -89,6 +89,46 @@ superuser() {
 	fi
 }
 
+customer_container_init() {
+	# Mostly borrowed from the LinuxServer.io base image
+	# https://github.com/linuxserver/docker-baseimage-ubuntu/tree/bionic/root/etc/cont-init.d
+	readonly custom_script_dir="/custom-cont-init.d"
+	# Tamper checking.
+	# Don't run files which are owned by anyone except root
+	# Don't run files which are writeable by others
+	if [ -d "${custom_script_dir}" ]; then
+		if [ -n "$(find "${custom_script_dir}" ! -user root)" ]; then
+			echo "**** Potential tampering with custom scripts detected ****"
+			echo "**** The folder '${custom_script_dir}' must be owned by root ****"
+			return 0
+		fi
+		if [ -n "$(find "${custom_script_dir}" -perm -o+w)" ]; then
+			echo "**** The folder '${custom_script_dir}' or some of contents have write permissions for others, which is a security risk. ****"
+			echo "**** Please review the permissions and their contents to make sure they are owned by root, and can only be modified by root. ****"
+			return 0
+		fi
+
+		# Make sure custom init directory has files in it
+		if [ -n "$(/bin/ls -A "${custom_script_dir} "2>/dev/null)" ]; then
+			echo "[custom-init] files found in ${custom_script_dir} executing"
+			# Loop over files in the directory
+			for SCRIPT in "${custom_script_dir}"/*; do
+				NAME="$(basename "${SCRIPT}")"
+				if [ -f "${SCRIPT}" ]; then
+					echo "[custom-init] ${NAME}: executing..."
+					/bin/bash "${SCRIPT}"
+					echo "[custom-init] ${NAME}: exited $?"
+				elif [ ! -f "${SCRIPT}" ]; then
+					echo "[custom-init] ${NAME}: is not a file"
+				fi
+			done
+		else
+			echo "[custom-init] no custom files found exiting..."
+		fi
+
+	fi
+}
+
 do_work() {
 	if [[ "${PAPERLESS_DBENGINE}" == "mariadb" ]]; then
 		wait_for_mariadb
@@ -103,6 +143,9 @@ do_work() {
 	search_index
 
 	superuser
+
+	# Leave this last thing
+	customer_container_init
 
 }
 

--- a/docker/docker-prepare.sh
+++ b/docker/docker-prepare.sh
@@ -97,12 +97,12 @@ custom_container_init() {
 	# Don't run files which are owned by anyone except root
 	# Don't run files which are writeable by others
 	if [ -d "${custom_script_dir}" ]; then
-		if [ -n "$(/usr/bin/find "${custom_script_dir}" ! -user root)" ]; then
+		if [ -n "$(/usr/bin/find "${custom_script_dir}" -maxdepth 1 ! -user root)" ]; then
 			echo "**** Potential tampering with custom scripts detected ****"
 			echo "**** The folder '${custom_script_dir}' must be owned by root ****"
 			return 0
 		fi
-		if [ -n "$(/usr/bin/find "${custom_script_dir}" -perm -o+w)" ]; then
+		if [ -n "$(/usr/bin/find "${custom_script_dir}" -maxdepth 1 -perm -o+w)" ]; then
 			echo "**** The folder '${custom_script_dir}' or some of contents have write permissions for others, which is a security risk. ****"
 			echo "**** Please review the permissions and their contents to make sure they are owned by root, and can only be modified by root. ****"
 			return 0

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -386,3 +386,28 @@ a Docker installation, you can use volumes to accomplish this:
         # ...
         volumes:
           - /path/to/my/flowerconfig.py:/usr/src/paperless/src/paperless/flowerconfig.py:ro
+
+Custom Container Initialization
+###############################
+
+The Docker image includes the ability to run custom user scripts during startup.  This could be
+utilized for installing additional tools or Python packages, for example.
+
+To utilize this, mount a folder containing your scripts to the custom initialization directory, `/custom-cont-init.d`
+and place scripts you wish to run inside.  For security, the folder and its contents must be owned by `root`.
+Additionally, scripts must only be writable by `root`.
+
+Your scripts will be run directly before the webserver completes startup.  Scripts will be run by the `root` user.
+This is an advanced functionality with which you could break functionality or lose data.
+
+For example, using Docker Compose:
+
+
+.. code:: yaml
+
+    services:
+      # ...
+      webserver:
+        # ...
+        volumes:
+          - /path/to/my/scripts:/custom-cont-init.d:ro


### PR DESCRIPTION
## Proposed change

This is all essentially exactly how the LinuxServer.io base image handles running custom scripts at container startup.  For security, the folder and files must be owned by `root` and cannot be writable by the world.

Using it is as simple at adding a new mount to your image, something like:

```yaml
    volumes:
...
      - ./scripts:/custom-cont-init.d:ro
```

![image](https://user-images.githubusercontent.com/797416/197098849-b8d5e73b-f3fa-404c-99d3-213a848b551c.png)

Informing the user that the directory must be root owned, and not executing the files in the folder.

![image](https://user-images.githubusercontent.com/797416/197098786-3a48a80b-5b0a-45f9-98fd-f9319bb1db0d.png)

An empty folder, but it exists.

![image](https://user-images.githubusercontent.com/797416/197099226-c6af8b98-f71d-44e4-baa1-9e3c6f51a953.png)

Running a couple of example scripts.

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
