### PR TITLE
Fix: frontend relative date searches

### DIFF
--- a/src-ui/src/app/components/common/date-dropdown/date-dropdown.component.html
+++ b/src-ui/src/app/components/common/date-dropdown/date-dropdown.component.html
@@ -1,10 +1,18 @@
   <div class="btn-group w-100" ngbDropdown role="group">
   <button class="btn btn-sm" id="dropdown{{title}}" ngbDropdownToggle [ngClass]="dateBefore || dateAfter ? 'btn-primary' : 'btn-outline-primary'">
     {{title}}
+    <div *ngIf="isActive" class="position-absolute top-0 start-100 p-2 translate-middle badge bg-secondary border border-light rounded-circle">
+      <span class="visually-hidden">selected</span>
+    </div>
   </button>
   <div class="dropdown-menu date-dropdown shadow pt-0" ngbDropdownMenu attr.aria-labelledby="dropdown{{title}}">
     <div class="list-group list-group-flush">
-        <button *ngFor="let qf of quickFilters" class="list-group-item small list-goup list-group-item-action d-flex p-2 ps-3" role="menuitem" (click)="setDateQuickFilter(qf.id)">
+        <button *ngFor="let qf of quickFilters" class="list-group-item small list-goup list-group-item-action d-flex p-2" role="menuitem" (click)="setDateQuickFilter(qf.id)">
+          <div _ngcontent-hga-c166="" class="selected-icon me-1">
+            <svg *ngIf="quickFilter === qf.id" xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" fill="currentColor" class="bi bi-check" viewBox="0 0 16 16">
+              <path d="M10.97 4.97a.75.75 0 0 1 1.07 1.05l-3.99 4.99a.75.75 0 0 1-1.08.02L4.324 8.384a.75.75 0 1 1 1.06-1.06l2.094 2.093 3.473-4.425a.267.267 0 0 1 .02-.022z"/>
+            </svg>
+          </div>
           {{qf.name}}
         </button>
         <div class="list-group-item d-flex flex-column align-items-start" role="menuitem">

--- a/src-ui/src/app/components/common/date-dropdown/date-dropdown.component.html
+++ b/src-ui/src/app/components/common/date-dropdown/date-dropdown.component.html
@@ -7,13 +7,13 @@
   </button>
   <div class="dropdown-menu date-dropdown shadow pt-0" ngbDropdownMenu attr.aria-labelledby="dropdown{{title}}">
     <div class="list-group list-group-flush">
-        <button *ngFor="let qf of quickFilters" class="list-group-item small list-goup list-group-item-action d-flex p-2" role="menuitem" (click)="setDateQuickFilter(qf.id)">
+        <button *ngFor="let rd of relativeDates" class="list-group-item small list-goup list-group-item-action d-flex p-2" role="menuitem" (click)="setRelativeDate(rd.date)">
           <div _ngcontent-hga-c166="" class="selected-icon me-1">
-            <svg *ngIf="quickFilter === qf.id" xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" fill="currentColor" class="bi bi-check" viewBox="0 0 16 16">
+            <svg *ngIf="relativeDate === rd.date" xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" fill="currentColor" class="bi bi-check" viewBox="0 0 16 16">
               <path d="M10.97 4.97a.75.75 0 0 1 1.07 1.05l-3.99 4.99a.75.75 0 0 1-1.08.02L4.324 8.384a.75.75 0 1 1 1.06-1.06l2.094 2.093 3.473-4.425a.267.267 0 0 1 .02-.022z"/>
             </svg>
           </div>
-          {{qf.name}}
+          {{rd.name}}
         </button>
         <div class="list-group-item d-flex flex-column align-items-start" role="menuitem">
 

--- a/src-ui/src/app/components/common/date-dropdown/date-dropdown.component.scss
+++ b/src-ui/src/app/components/common/date-dropdown/date-dropdown.component.scss
@@ -5,3 +5,8 @@
     line-height: 1;
   }
 }
+
+.selected-icon {
+  min-width: 1em;
+  min-height: 1em;
+}

--- a/src-ui/src/app/components/common/date-dropdown/date-dropdown.component.ts
+++ b/src-ui/src/app/components/common/date-dropdown/date-dropdown.component.ts
@@ -16,19 +16,15 @@ import { ISODateAdapter } from 'src/app/utils/ngb-iso-date-adapter'
 export interface DateSelection {
   before?: string
   after?: string
-  dateQuery?: string
+  relativeDateID?: number
 }
 
-interface QuickFilter {
-  id: number
-  name: string
-  dateQuery: string
+export enum RelativeDate {
+  LAST_7_DAYS = 0,
+  LAST_MONTH = 1,
+  LAST_3_MONTHS = 2,
+  LAST_YEAR = 3,
 }
-
-const LAST_7_DAYS = 0
-const LAST_MONTH = 1
-const LAST_3_MONTHS = 2
-const LAST_YEAR = 3
 
 @Component({
   selector: 'app-date-dropdown',
@@ -41,23 +37,23 @@ export class DateDropdownComponent implements OnInit, OnDestroy {
     this.datePlaceHolder = settings.getLocalizedDateInputFormat()
   }
 
-  quickFilters: Array<QuickFilter> = [
+  relativeDates = [
     {
-      id: LAST_7_DAYS,
+      date: RelativeDate.LAST_7_DAYS,
       name: $localize`Last 7 days`,
-      dateQuery: '-1 week to now',
     },
     {
-      id: LAST_MONTH,
+      date: RelativeDate.LAST_MONTH,
       name: $localize`Last month`,
-      dateQuery: '-1 month to now',
     },
     {
-      id: LAST_3_MONTHS,
+      date: RelativeDate.LAST_3_MONTHS,
       name: $localize`Last 3 months`,
-      dateQuery: '-3 month to now',
     },
-    { id: LAST_YEAR, name: $localize`Last year`, dateQuery: '-1 year to now' },
+    {
+      date: RelativeDate.LAST_YEAR,
+      name: $localize`Last year`,
+    },
   ]
 
   datePlaceHolder: string
@@ -74,21 +70,11 @@ export class DateDropdownComponent implements OnInit, OnDestroy {
   @Output()
   dateAfterChange = new EventEmitter<string>()
 
-  quickFilter: number
-
   @Input()
-  set dateQuery(query: string) {
-    this.quickFilter = this.quickFilters.find((qf) => qf.dateQuery == query)?.id
-  }
-
-  get dateQuery(): string {
-    return (
-      this.quickFilters.find((qf) => qf.id == this.quickFilter)?.dateQuery ?? ''
-    )
-  }
+  relativeDate: RelativeDate
 
   @Output()
-  dateQueryChange = new EventEmitter<string>()
+  relativeDateChange = new EventEmitter<number>()
 
   @Input()
   title: string
@@ -98,7 +84,7 @@ export class DateDropdownComponent implements OnInit, OnDestroy {
 
   get isActive(): boolean {
     return (
-      this.quickFilter > -1 ||
+      this.relativeDate !== null ||
       this.dateAfter?.length > 0 ||
       this.dateBefore?.length > 0
     )
@@ -120,30 +106,26 @@ export class DateDropdownComponent implements OnInit, OnDestroy {
     }
   }
 
-  setDateQuickFilter(qf: number) {
+  setRelativeDate(rd: RelativeDate) {
     this.dateBefore = null
     this.dateAfter = null
-    this.quickFilter = this.quickFilter == qf ? null : qf
+    this.relativeDate = this.relativeDate == rd ? null : rd
     this.onChange()
-  }
-
-  qfIsSelected(qf: number) {
-    return this.quickFilter == qf
   }
 
   onChange() {
     this.dateBeforeChange.emit(this.dateBefore)
     this.dateAfterChange.emit(this.dateAfter)
-    this.dateQueryChange.emit(this.dateQuery)
+    this.relativeDateChange.emit(this.relativeDate)
     this.datesSet.emit({
       after: this.dateAfter,
       before: this.dateBefore,
-      dateQuery: this.dateQuery,
+      relativeDateID: this.relativeDate,
     })
   }
 
   onChangeDebounce() {
-    this.dateQuery = null
+    this.relativeDate = null
     this.datesSetDebounce$.next({
       after: this.dateAfter,
       before: this.dateBefore,

--- a/src-ui/src/app/components/document-list/filter-editor/filter-editor.component.html
+++ b/src-ui/src/app/components/document-list/filter-editor/filter-editor.component.html
@@ -55,13 +55,13 @@
             (datesSet)="updateRules()"
             [(dateBefore)]="dateCreatedBefore"
             [(dateAfter)]="dateCreatedAfter"
-            [(dateQuery)]="dateCreatedQuery"></app-date-dropdown>
+            [(relativeDate)]="dateCreatedRelativeDate"></app-date-dropdown>
           <app-date-dropdown class="mb-2 mb-xl-0"
             title="Added" i18n-title
             (datesSet)="updateRules()"
             [(dateBefore)]="dateAddedBefore"
             [(dateAfter)]="dateAddedAfter"
-            [(dateQuery)]="dateAddedQuery"></app-date-dropdown>
+            [(relativeDate)]="dateAddedRelativeDate"></app-date-dropdown>
         </div>
      </div>
    </div>

--- a/src-ui/src/app/components/document-list/filter-editor/filter-editor.component.html
+++ b/src-ui/src/app/components/document-list/filter-editor/filter-editor.component.html
@@ -54,12 +54,14 @@
             title="Created" i18n-title
             (datesSet)="updateRules()"
             [(dateBefore)]="dateCreatedBefore"
-            [(dateAfter)]="dateCreatedAfter"></app-date-dropdown>
+            [(dateAfter)]="dateCreatedAfter"
+            [(dateQuery)]="dateCreatedQuery"></app-date-dropdown>
           <app-date-dropdown class="mb-2 mb-xl-0"
+            title="Added" i18n-title
+            (datesSet)="updateRules()"
             [(dateBefore)]="dateAddedBefore"
             [(dateAfter)]="dateAddedAfter"
-            title="Added" i18n-title
-            (datesSet)="updateRules()"></app-date-dropdown>
+            [(dateQuery)]="dateAddedQuery"></app-date-dropdown>
         </div>
      </div>
    </div>

--- a/src-ui/src/app/components/document-list/filter-editor/filter-editor.component.ts
+++ b/src-ui/src/app/components/document-list/filter-editor/filter-editor.component.ts
@@ -300,8 +300,10 @@ export class FilterEditorComponent implements OnInit, OnDestroy {
               queryArgs.splice(queryArgs.indexOf(arg), 1)
             }
           })
-          this._textFilter = queryArgs.join(',')
-          this.textFilterTarget = TEXT_FILTER_TARGET_FULLTEXT_QUERY
+          if (queryArgs.length) {
+            this._textFilter = queryArgs.join(',')
+            this.textFilterTarget = TEXT_FILTER_TARGET_FULLTEXT_QUERY
+          }
           break
         case FILTER_FULLTEXT_MORELIKE:
           this._moreLikeId = +rule.value

--- a/src-ui/src/styles.scss
+++ b/src-ui/src/styles.scss
@@ -372,6 +372,10 @@ textarea,
   &:hover, &:focus {
     background-color: var(--bs-body-bg);
   }
+
+  &:focus {
+    color: var(--bs-body-color);
+  }
 }
 
 .dropdown-menu {


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

This one has always bugged me, this PR adds support for relative date querying to the frontend, updating the "Last Month" etc. date filters to use this. Because it has to be passed as part of a whoosh query there is some slight quirkiness, for example a `title_content` search gets ignored if you pass `query` too so those get 'converted' to an advanced search, which unfortunately isnt 1:1. Still overall I think this is an improvement. The other thing about this is that people's existing saved views wont benefit from this.

The alternative to this, I suppose, would be to specifically add support for this ourselves, something like `created__within` or whatever but in some ways that sounded potentially more complicated.

In general this doesnt look much different though I did add badges and checkmarks to the date dropdown as part of this. The biggest difference will be for saved views that use it. The first video demonstrates changing the date on my machine and (upon reload) the "last 7 days" filter correctly shows 3 documents. In the current version that wouldn't work because "last 7 days" actually just sets `created__date__gt=2022-10-18`

Honestly, this was a bit tricky to implement, hope I've got it licked though.

https://user-images.githubusercontent.com/4887959/197898035-610e8110-dd89-4667-af0a-26175f990c33.mov

https://user-images.githubusercontent.com/4887959/197896130-76ec3ff0-c54f-4fda-aa8e-59daad413014.mov

Fixes #1847 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] ~~I have made corresponding changes to the documentation as needed.~~
- [x] I have checked my modifications for any breaking changes.
