### PR TITLE
Django error W003 - MariaDB may not allow unique CharFields to have a max_length > 255.

### DIFF
--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -347,6 +347,11 @@ if os.getenv("PAPERLESS_DBHOST"):
     if os.getenv("PAPERLESS_DBENGINE") == "mariadb":
         engine = "django.db.backends.mysql"
         options = {"read_default_file": "/etc/mysql/my.cnf", "charset": "utf8mb4"}
+        #Silence Django erros on old MariaDB versions where VARCHAR were limited to 255 chars.
+        #https://docs.djangoproject.com/en/4.1/ref/checks/#database
+        #https://mariadb.com/kb/en/innodb-system-variables/#innodb_large_prefix
+        SILENCED_SYSTEM_CHECKS = ["mysql.W003"]
+
     else:  # Default to PostgresDB
         engine = "django.db.backends.postgresql_psycopg2"
         options = {"sslmode": os.getenv("PAPERLESS_DBSSLMODE", "prefer")}

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -347,9 +347,10 @@ if os.getenv("PAPERLESS_DBHOST"):
     if os.getenv("PAPERLESS_DBENGINE") == "mariadb":
         engine = "django.db.backends.mysql"
         options = {"read_default_file": "/etc/mysql/my.cnf", "charset": "utf8mb4"}
-        #Silence Django erros on old MariaDB versions where VARCHAR were limited to 255 chars.
-        #https://docs.djangoproject.com/en/4.1/ref/checks/#database
-        #https://mariadb.com/kb/en/innodb-system-variables/#innodb_large_prefix
+
+        # Silence Django erros on old MariaDB versions where VARCHAR were limited to 255 chars.
+        # https://docs.djangoproject.com/en/4.1/ref/checks/#database
+        # https://mariadb.com/kb/en/innodb-system-variables/#innodb_large_prefix
         SILENCED_SYSTEM_CHECKS = ["mysql.W003"]
 
     else:  # Default to PostgresDB

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -348,7 +348,8 @@ if os.getenv("PAPERLESS_DBHOST"):
         engine = "django.db.backends.mysql"
         options = {"read_default_file": "/etc/mysql/my.cnf", "charset": "utf8mb4"}
 
-        # Silence Django erros on old MariaDB versions where VARCHAR were limited to 255 chars.
+        # Silence Django error on old MariaDB versions.
+        # VARCHAR can support > 255 in modern versions
         # https://docs.djangoproject.com/en/4.1/ref/checks/#database
         # https://mariadb.com/kb/en/innodb-system-variables/#innodb_large_prefix
         SILENCED_SYSTEM_CHECKS = ["mysql.W003"]


### PR DESCRIPTION

## Proposed change

Django gives system error when using MariaDB when using VARCHARs longer than 255 chars. This was a limitation in older versions of mysql. Meaning: You cannot even run Paperless-NGX on older version were this limitation were present, meaning Django plays it extremely safe by giving an error on this. This fixes this problem.

Fixes # (issue)
Django error W003, which is not relevant for Paperless-NGX.

[Django documentation on systemchecks](https://docs.djangoproject.com/en/4.1/ref/checks/#database)

Below a few lines from the log:

```
documents.Document.archive_filename: (mysql.W003) MariaDB may not allow unique CharFields to have a max_length > 255.
paperless_mail.MailRule.name: (mysql.W003) MariaDB may not allow unique CharFields to have a max_length > 255.

```

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [X] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
