### PR TITLE
Bugfix: Unintentional deletion of feature tagged Docker images

### DIFF
--- a/.github/scripts/cleanup-tags.py
+++ b/.github/scripts/cleanup-tags.py
@@ -249,10 +249,12 @@ class MainImageTagsCleaner(RegistryTagsCleaner):
         will be removed, if the corresponding branch no longer exists.
         """
 
+        # Default to everything gets kept still
+        super().decide_what_tags_to_keep()
+
         # Locate the feature branches
         feature_branches = {}
         for branch in self.branch_api.get_branches(
-            owner=self.repo_owner,
             repo=self.repo_name,
         ):
             if branch.name.startswith("feature-"):
@@ -260,6 +262,10 @@ class MainImageTagsCleaner(RegistryTagsCleaner):
                 feature_branches[branch.name] = branch
 
         logger.info(f"Located {len(feature_branches)} feature branches")
+
+        if not len(feature_branches):
+            # Our work here is done, delete nothing
+            return
 
         # Filter to packages which are tagged with feature-*
         packages_tagged_feature: List[ContainerPackage] = []

--- a/.github/workflows/cleanup-tags.yml
+++ b/.github/workflows/cleanup-tags.yml
@@ -64,9 +64,9 @@ jobs:
         with:
           python-version: "3.10"
       -
-        name: Install requests
+        name: Install httpx
         run: |
-          python -m pip install requests
+          python -m pip install httpx
       #
       # Clean up primary package
       #


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

My local version of the GHA environment wasn't quite right.  The run was getting [404 errors](https://github.com/paperless-ngx/paperless-ngx/actions/runs/3340803651/jobs/5531317182#step:6:14) when trying to retrieve branches.  That then [deleted feature images](https://github.com/paperless-ngx/paperless-ngx/actions/runs/3340803651/jobs/5531317182#step:6:18) which shouldn't have been.

- non-standard HTTP responses will raise an exception instead of just logging
- if the branch API returns no branches or no feature branches, a bunch of API calls get skipped and everything is kept
- Switches to httpx instead of requests


## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
