### PR TITLE
Bugfix: Prevent file handling from running with stale data

### DIFF
--- a/src/documents/consumer.py
+++ b/src/documents/consumer.py
@@ -405,6 +405,7 @@ class Consumer(LoggingMixin):
 
                 # Don't save with the lock active. Saving will cause the file
                 # renaming logic to acquire the lock as well.
+                # This triggers things like file renaming
                 document.save()
 
                 # Delete the file only if it was successfully consumed
@@ -437,6 +438,9 @@ class Consumer(LoggingMixin):
         self.log("info", f"Document {document} consumption finished")
 
         self._send_progress(100, 100, "SUCCESS", MESSAGE_FINISHED, document.id)
+
+        # Return the most up to date fields
+        document.refresh_from_db()
 
         return document
 

--- a/src/documents/signals/handlers.py
+++ b/src/documents/signals/handlers.py
@@ -400,6 +400,13 @@ def update_filename_and_move_files(sender, instance, **kwargs):
 
     with FileLock(settings.MEDIA_LOCK):
         try:
+
+            # If this was waiting for the lock, the filename or archive_filename
+            # of this document may have been updated.  This happens if multiple updates
+            # get queued from the UI for the same document
+            # So freshen up the data before doing anything
+            instance.refresh_from_db()
+
             old_filename = instance.filename
             old_source_path = instance.source_path
 


### PR DESCRIPTION
## Proposed change

If multiple updates are made to the same document from the UI and the updates actually take long enough to encounter the file lock which prevents concurrent renaming, the handling could operate against outdated information.

It takes a decently special set of steps:

1. Queue update to many documents (I used 1k), setting type, for example
2. Queue another update to the same models (adding a tag)
3. Update 1 will run in a task, taking some time (maybe a minute)
4. Update 2 will run, blocking on FileLock
5. Update 1 will complete and update the database
6. Update 2 will unblock, but the Document instance isn't current, due to Update 1
7. Update 2 tries to find files where they aren't and fails

The solution is actually simple enough, refresh the instance from the DB before doing anything in the handler.

This also found a small issue in the testing, where the Document instance was using a non-refreshed instance but instead using the old date, instead of the DB UTC date.  I hate dates.

Fixes #1779 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
