### PR TITLE
Bugfix: Don't allow exceptions during date parsing to fail consume

### DIFF
--- a/src/documents/consumer.py
+++ b/src/documents/consumer.py
@@ -444,7 +444,12 @@ class Consumer(LoggingMixin):
 
         return document
 
-    def _store(self, text, date, mime_type) -> Document:
+    def _store(
+        self,
+        text: str,
+        date: Optional[datetime.datetime],
+        mime_type: str,
+    ) -> Document:
 
         # If someone gave us the original filename, use it instead of doc.
 

--- a/src/documents/parsers.py
+++ b/src/documents/parsers.py
@@ -260,7 +260,7 @@ def parse_date_generator(filename, text) -> Iterator[datetime.datetime]:
 
         try:
             date = __parser(date_string, date_order)
-        except (TypeError, ValueError):
+        except Exception:
             # Skip all matches that do not parse to a proper date
             date = None
 


### PR DESCRIPTION
## Proposed change

Simple enough, catch everything when trying to wrangle a date out of some string which looks date-like.  I tried adding testing with various large and small date string, but could never trigger the OverflowError.

Fixes #1993

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
