### PR TITLE
Feature: Allow bulk download API to follow file name formatting

### DIFF
--- a/src-ui/src/app/components/document-list/bulk-editor/bulk-editor.component.html
+++ b/src-ui/src/app/components/document-list/bulk-editor/bulk-editor.component.html
@@ -66,7 +66,6 @@
   </div>
   <div class="col-auto ms-auto mb-2 mb-xl-0 d-flex">
     <div class="btn-group btn-group-sm me-2">
-
       <div ngbDropdown class="me-2 d-flex">
         <button class="btn btn-sm btn-outline-primary" id="dropdownSelect" ngbDropdownToggle>
           <svg class="toolbaricon" fill="currentColor">
@@ -75,26 +74,57 @@
           <div class="d-none d-sm-inline">&nbsp;<ng-container i18n>Actions</ng-container></div>
         </button>
         <div ngbDropdownMenu aria-labelledby="dropdownSelect" class="shadow">
-          <button ngbDropdownItem [disabled]="awaitingDownload" (click)="downloadSelected()" i18n>
-            Download
-            <div *ngIf="awaitingDownload" class="spinner-border spinner-border-sm" role="status">
-              <span class="visually-hidden">Preparing download...</span>
-            </div>
-          </button>
-          <button ngbDropdownItem [disabled]="awaitingDownload" (click)="downloadSelected('originals')" i18n>
-            Download originals
-            <div *ngIf="awaitingDownload" class="spinner-border spinner-border-sm" role="status">
-              <span class="visually-hidden">Preparing download...</span>
-            </div>
-          </button>
           <button ngbDropdownItem (click)="redoOcrSelected()" i18n>Redo OCR</button>
         </div>
       </div>
+    </div>
 
-    <button type="button" class="btn btn-sm btn-outline-danger" (click)="applyDelete()">
-      <svg width="1em" height="1em" viewBox="0 0 16 16" fill="currentColor">
-        <use xlink:href="assets/bootstrap-icons.svg#trash" />
-      </svg>&nbsp;<ng-container i18n>Delete</ng-container>
-    </button>
+    <div class="btn-group btn-group-sm me-2">
+      <button class="btn btn-sm btn-outline-primary" [disabled]="awaitingDownload" (click)="downloadSelected()">
+        <svg *ngIf="!awaitingDownload" class="toolbaricon" fill="currentColor">
+          <use xlink:href="assets/bootstrap-icons.svg#arrow-down" />
+        </svg>
+        <div *ngIf="awaitingDownload" class="spinner-border spinner-border-sm" role="status">
+          <span class="visually-hidden">Preparing download...</span>
+        </div>
+        <div class="d-none d-sm-inline">&nbsp;<ng-container i18n>Download</ng-container></div>
+      </button>
+      <div ngbDropdown class="me-2 d-flex btn-group" role="group">
+        <button type="button" class="btn btn-sm btn-outline-primary dropdown-toggle-split rounded-end" ngbDropdownToggle></button>
+        <div ngbDropdownMenu aria-labelledby="dropdownSelect" class="shadow">
+					<form [formGroup]="downloadForm" class="px-3 py-1">
+            <p class="mb-1" i18n>Include:</p>
+            <div class="form-group ps-3 mb-2">
+              <div class="form-check">
+                <input type="checkbox" class="form-check-input" id="downloadFileType_archive" formControlName="downloadFileTypeArchive" />
+                <label class="form-check-label" for="downloadFileType_archive" i18n>
+                  Archived files
+                </label>
+              </div>
+              <div class="form-check">
+                <input type="checkbox" class="form-check-input" id="downloadFileType_originals" formControlName="downloadFileTypeOriginals" />
+                <label class="form-check-label" for="downloadFileType_originals" i18n>
+                  Original files
+                </label>
+              </div>
+            </div>
+            <div class="form-check">
+              <input type="checkbox" class="form-check-input" id="downloadUseFormatting" formControlName="downloadUseFormatting" />
+              <label class="form-check-label" for="downloadUseFormatting" i18n>
+                Use formatted filename
+              </label>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+
+    <div class="btn-group btn-group-sm me-2">
+      <button type="button" class="btn btn-sm btn-outline-danger" (click)="applyDelete()">
+        <svg width="1em" height="1em" viewBox="0 0 16 16" fill="currentColor">
+          <use xlink:href="assets/bootstrap-icons.svg#trash" />
+        </svg>&nbsp;<ng-container i18n>Delete</ng-container>
+      </button>
+    </div>
   </div>
 </div>

--- a/src-ui/src/app/components/document-list/bulk-editor/bulk-editor.component.scss
+++ b/src-ui/src/app/components/document-list/bulk-editor/bulk-editor.component.scss
@@ -1,0 +1,7 @@
+.dropdown-toggle-split {
+    --bs-border-radius: .25rem;
+}
+
+.dropdown-menu{
+    --bs-dropdown-min-width: 12rem;
+}

--- a/src-ui/src/app/services/rest/document.service.ts
+++ b/src-ui/src/app/services/rest/document.service.ts
@@ -174,10 +174,18 @@ export class DocumentService extends AbstractPaperlessService<PaperlessDocument>
     )
   }
 
-  bulkDownload(ids: number[], content = 'both') {
+  bulkDownload(
+    ids: number[],
+    content = 'both',
+    useFilenameFormatting: boolean = false
+  ) {
     return this.http.post(
       this.getResourceUrl(null, 'bulk_download'),
-      { documents: ids, content: content },
+      {
+        documents: ids,
+        content: content,
+        follow_formatting: useFilenameFormatting,
+      },
       { responseType: 'blob' }
     )
   }

--- a/src-ui/src/theme.scss
+++ b/src-ui/src/theme.scss
@@ -203,8 +203,12 @@ $form-check-radio-checked-bg-image-dark: url("data:image/svg+xml,<svg xmlns='htt
   .toast,
   .toast .toast-header,
   .toast .btn,
-  .toast .btn-close, {
+  .toast .btn-close {
     color: var(--pngx-primary-text-contrast);
+  }
+
+  .dropdown-menu {
+    --bs-dropdown-color: var(--bs-body-color);
   }
 }
 

--- a/src/documents/bulk_download.py
+++ b/src/documents/bulk_download.py
@@ -1,18 +1,29 @@
+import os
 from zipfile import ZipFile
 
 from documents.models import Document
 
 
 class BulkArchiveStrategy:
-    def __init__(self, zipf: ZipFile):
+    def __init__(self, zipf: ZipFile, follow_formatting: bool = False):
         self.zipf = zipf
+        if follow_formatting:
+            self.make_unique_filename = self._formatted_filepath
+        else:
+            self.make_unique_filename = self._filename_only
 
-    def make_unique_filename(
+    def _filename_only(
         self,
         doc: Document,
         archive: bool = False,
         folder: str = "",
     ):
+        """
+        Constructs a unique name for the given document to be used inside the
+        zip file.
+
+        The filename might not be unique enough, so a counter is appended if needed
+        """
         counter = 0
         while True:
             filename = folder + doc.get_public_filename(archive, counter)
@@ -20,6 +31,25 @@ class BulkArchiveStrategy:
                 counter += 1
             else:
                 return filename
+
+    def _formatted_filepath(
+        self,
+        doc: Document,
+        archive: bool = False,
+        folder: str = "",
+    ):
+        """
+        Constructs a full file path for the given document to be used inside
+        the zipfile.
+
+        The path is already unique, as handled when a document is consumed or updated
+        """
+        if archive and doc.has_archive_version:
+            in_archive_path = os.path.join(folder, doc.archive_filename)
+        else:
+            in_archive_path = os.path.join(folder, doc.filename)
+
+        return in_archive_path
 
     def add_document(self, doc: Document):
         raise NotImplementedError()  # pragma: no cover
@@ -31,9 +61,6 @@ class OriginalsOnlyStrategy(BulkArchiveStrategy):
 
 
 class ArchiveOnlyStrategy(BulkArchiveStrategy):
-    def __init__(self, zipf):
-        super().__init__(zipf)
-
     def add_document(self, doc: Document):
         if doc.has_archive_version:
             self.zipf.write(

--- a/src/documents/models.py
+++ b/src/documents/models.py
@@ -287,6 +287,9 @@ class Document(models.Model):
         return open(self.archive_path, "rb")
 
     def get_public_filename(self, archive=False, counter=0, suffix=None) -> str:
+        """
+        Returns a sanitized filename for the document, not including any paths.
+        """
         result = str(self)
 
         if counter:

--- a/src/documents/serialisers.py
+++ b/src/documents/serialisers.py
@@ -551,6 +551,10 @@ class BulkDownloadSerializer(DocumentListSerializer):
         default="none",
     )
 
+    follow_formatting = serializers.BooleanField(
+        default=False,
+    )
+
     def validate_compression(self, compression):
         import zipfile
 

--- a/src/documents/tests/test_api.py
+++ b/src/documents/tests/test_api.py
@@ -2329,6 +2329,9 @@ class TestBulkEdit(DirectoriesMixin, APITestCase):
 
 
 class TestBulkDownload(DirectoriesMixin, APITestCase):
+
+    ENDPOINT = "/api/documents/bulk_download/"
+
     def setUp(self):
         super().setUp()
 
@@ -2379,7 +2382,7 @@ class TestBulkDownload(DirectoriesMixin, APITestCase):
 
     def test_download_originals(self):
         response = self.client.post(
-            "/api/documents/bulk_download/",
+            self.ENDPOINT,
             json.dumps(
                 {"documents": [self.doc2.id, self.doc3.id], "content": "originals"},
             ),
@@ -2402,7 +2405,7 @@ class TestBulkDownload(DirectoriesMixin, APITestCase):
 
     def test_download_default(self):
         response = self.client.post(
-            "/api/documents/bulk_download/",
+            self.ENDPOINT,
             json.dumps({"documents": [self.doc2.id, self.doc3.id]}),
             content_type="application/json",
         )
@@ -2423,7 +2426,7 @@ class TestBulkDownload(DirectoriesMixin, APITestCase):
 
     def test_download_both(self):
         response = self.client.post(
-            "/api/documents/bulk_download/",
+            self.ENDPOINT,
             json.dumps({"documents": [self.doc2.id, self.doc3.id], "content": "both"}),
             content_type="application/json",
         )
@@ -2457,7 +2460,7 @@ class TestBulkDownload(DirectoriesMixin, APITestCase):
 
     def test_filename_clashes(self):
         response = self.client.post(
-            "/api/documents/bulk_download/",
+            self.ENDPOINT,
             json.dumps({"documents": [self.doc2.id, self.doc2b.id]}),
             content_type="application/json",
         )
@@ -2479,12 +2482,144 @@ class TestBulkDownload(DirectoriesMixin, APITestCase):
 
     def test_compression(self):
         response = self.client.post(
-            "/api/documents/bulk_download/",
+            self.ENDPOINT,
             json.dumps(
                 {"documents": [self.doc2.id, self.doc2b.id], "compression": "lzma"},
             ),
             content_type="application/json",
         )
+
+    @override_settings(FILENAME_FORMAT="{correspondent}/{title}")
+    def test_formatted_download_originals(self):
+
+        c = Correspondent.objects.create(name="test")
+        c2 = Correspondent.objects.create(name="a space name")
+
+        self.doc2.correspondent = c
+        self.doc2.title = "This is Doc 2"
+        self.doc2.save()
+
+        self.doc3.correspondent = c2
+        self.doc3.title = "Title 2 - Doc 3"
+        self.doc3.save()
+
+        response = self.client.post(
+            self.ENDPOINT,
+            json.dumps(
+                {
+                    "documents": [self.doc2.id, self.doc3.id],
+                    "content": "originals",
+                    "follow_formatting": True,
+                },
+            ),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "application/zip")
+
+        with zipfile.ZipFile(io.BytesIO(response.content)) as zipf:
+            self.assertEqual(len(zipf.filelist), 2)
+            self.assertIn("a space name/Title 2 - Doc 3.jpg", zipf.namelist())
+            self.assertIn("test/This is Doc 2.pdf", zipf.namelist())
+
+            with self.doc2.source_file as f:
+                self.assertEqual(f.read(), zipf.read("test/This is Doc 2.pdf"))
+
+            with self.doc3.source_file as f:
+                self.assertEqual(
+                    f.read(),
+                    zipf.read("a space name/Title 2 - Doc 3.jpg"),
+                )
+
+    @override_settings(FILENAME_FORMAT="somewhere/{title}")
+    def test_formatted_download_archive(self):
+
+        self.doc2.title = "This is Doc 2"
+        self.doc2.save()
+
+        self.doc3.title = "Title 2 - Doc 3"
+        self.doc3.save()
+        print(self.doc3.archive_path)
+        print(self.doc3.archive_filename)
+
+        response = self.client.post(
+            self.ENDPOINT,
+            json.dumps(
+                {
+                    "documents": [self.doc2.id, self.doc3.id],
+                    "follow_formatting": True,
+                },
+            ),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "application/zip")
+
+        with zipfile.ZipFile(io.BytesIO(response.content)) as zipf:
+            self.assertEqual(len(zipf.filelist), 2)
+            self.assertIn("somewhere/This is Doc 2.pdf", zipf.namelist())
+            self.assertIn("somewhere/Title 2 - Doc 3.pdf", zipf.namelist())
+
+            with self.doc2.source_file as f:
+                self.assertEqual(f.read(), zipf.read("somewhere/This is Doc 2.pdf"))
+
+            with self.doc3.archive_file as f:
+                self.assertEqual(f.read(), zipf.read("somewhere/Title 2 - Doc 3.pdf"))
+
+    @override_settings(FILENAME_FORMAT="{document_type}/{title}")
+    def test_formatted_download_both(self):
+
+        dc1 = DocumentType.objects.create(name="bill")
+        dc2 = DocumentType.objects.create(name="statement")
+
+        self.doc2.document_type = dc1
+        self.doc2.title = "This is Doc 2"
+        self.doc2.save()
+
+        self.doc3.document_type = dc2
+        self.doc3.title = "Title 2 - Doc 3"
+        self.doc3.save()
+
+        response = self.client.post(
+            self.ENDPOINT,
+            json.dumps(
+                {
+                    "documents": [self.doc2.id, self.doc3.id],
+                    "content": "both",
+                    "follow_formatting": True,
+                },
+            ),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "application/zip")
+
+        with zipfile.ZipFile(io.BytesIO(response.content)) as zipf:
+            self.assertEqual(len(zipf.filelist), 3)
+            self.assertIn("originals/bill/This is Doc 2.pdf", zipf.namelist())
+            self.assertIn("archive/statement/Title 2 - Doc 3.pdf", zipf.namelist())
+            self.assertIn("originals/statement/Title 2 - Doc 3.jpg", zipf.namelist())
+
+            with self.doc2.source_file as f:
+                self.assertEqual(
+                    f.read(),
+                    zipf.read("originals/bill/This is Doc 2.pdf"),
+                )
+
+            with self.doc3.archive_file as f:
+                self.assertEqual(
+                    f.read(),
+                    zipf.read("archive/statement/Title 2 - Doc 3.pdf"),
+                )
+
+            with self.doc3.source_file as f:
+                self.assertEqual(
+                    f.read(),
+                    zipf.read("originals/statement/Title 2 - Doc 3.jpg"),
+                )
 
 
 class TestApiAuth(DirectoriesMixin, APITestCase):

--- a/src/documents/tests/test_api.py
+++ b/src/documents/tests/test_api.py
@@ -2491,6 +2491,15 @@ class TestBulkDownload(DirectoriesMixin, APITestCase):
 
     @override_settings(FILENAME_FORMAT="{correspondent}/{title}")
     def test_formatted_download_originals(self):
+        """
+        GIVEN:
+            - Defined file naming format
+        WHEN:
+            - Bulk download request for original documents
+            - Bulk download request requests to follow format
+        THEN:
+            - Files defined in resulting zipfile are formatted
+        """
 
         c = Correspondent.objects.create(name="test")
         c2 = Correspondent.objects.create(name="a space name")
@@ -2534,6 +2543,15 @@ class TestBulkDownload(DirectoriesMixin, APITestCase):
 
     @override_settings(FILENAME_FORMAT="somewhere/{title}")
     def test_formatted_download_archive(self):
+        """
+        GIVEN:
+            - Defined file naming format
+        WHEN:
+            - Bulk download request for archive documents
+            - Bulk download request requests to follow format
+        THEN:
+            - Files defined in resulting zipfile are formatted
+        """
 
         self.doc2.title = "This is Doc 2"
         self.doc2.save()
@@ -2570,6 +2588,15 @@ class TestBulkDownload(DirectoriesMixin, APITestCase):
 
     @override_settings(FILENAME_FORMAT="{document_type}/{title}")
     def test_formatted_download_both(self):
+        """
+        GIVEN:
+            - Defined file naming format
+        WHEN:
+            - Bulk download request for original documents and archive documents
+            - Bulk download request requests to follow format
+        THEN:
+            - Files defined in resulting zipfile are formatted
+        """
 
         dc1 = DocumentType.objects.create(name="bill")
         dc2 = DocumentType.objects.create(name="statement")

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -745,6 +745,7 @@ class BulkDownloadView(GenericAPIView):
         ids = serializer.validated_data.get("documents")
         compression = serializer.validated_data.get("compression")
         content = serializer.validated_data.get("content")
+        follow_filename_format = serializer.validated_data.get("follow_formatting")
 
         os.makedirs(settings.SCRATCH_DIR, exist_ok=True)
         temp = tempfile.NamedTemporaryFile(
@@ -761,7 +762,7 @@ class BulkDownloadView(GenericAPIView):
             strategy_class = ArchiveOnlyStrategy
 
         with zipfile.ZipFile(temp.name, "w", compression) as zipf:
-            strategy = strategy_class(zipf)
+            strategy = strategy_class(zipf, follow_filename_format)
             for id in ids:
                 doc = Document.objects.get(id=id)
                 strategy.add_document(doc)


### PR DESCRIPTION
## Proposed change

Adds a new optional parameter to the bulk download API endpoint to indicate a request to follow the defined filename format when creating the zipfile.  It defaults to false, matching the existing behavior.

If set true, the filename inside the zipfile will use the constructed path name for each document.

TBD: How or if to expose this in the UI

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
