### PR TITLE
Documentation: Update MariaDB docs to note some potential issues

### DIFF
--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -424,3 +424,24 @@ For example, using Docker Compose:
         # ...
         volumes:
           - /path/to/my/scripts:/custom-cont-init.d:ro
+
+.. _advanced-mysql-caveats:
+
+MySQL Caveats
+#############
+
+Case Sensitivity
+================
+
+The database interface does not provide a method to configure a MySQL database to
+be case sensitive.  This would prevent a user from creating a tag ``Name`` and ``NAME``
+as they are considered the same.
+
+Per Django documentation, to enable this requires manual intervention.  To enable
+case sensetive tables, you can execute the following command against each table:
+
+``ALTER TABLE <table_name> CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;``
+
+You can also set the default for new tables (this does NOT affect existing tables) with:
+
+``ALTER DATABASE <db_name> CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;``

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -38,7 +38,13 @@ PAPERLESS_REDIS=<url>
 PAPERLESS_DBENGINE=<engine_name>
     Optional, gives the ability to choose Postgres or MariaDB for database engine.
     Available options are `postgresql` and `mariadb`.
+
     Default is `postgresql`.
+
+    .. warning::
+
+      Using MariaDB comes with some caveats.  See :ref:`advanced-mysql-caveats` for details.
+
 
 PAPERLESS_DBHOST=<hostname>
     By default, sqlite is used as the database backend. This can be changed here.

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -649,7 +649,7 @@ Migration to paperless-ngx is then performed in a few simple steps:
 
 
 Migrating from LinuxServer.io Docker Image
-========================
+==========================================
 
 As with any upgrades and large changes, it is highly recommended to create a backup before
 starting.  This assumes the image was running using Docker Compose, but the instructions
@@ -663,7 +663,7 @@ are translatable to Docker commands as well.
         to step 4.
     b)  Otherwise, in the ``docker-compose.yml`` add a new service for Redis,
         following `the example compose files <https://github.com/paperless-ngx/paperless-ngx/tree/main/docker/compose>`_
-    b)  Set the environment variable ``PAPERLESS_REDIS`` so it points to the new Redis container
+    c)  Set the environment variable ``PAPERLESS_REDIS`` so it points to the new Redis container
 
 4.  Update user mapping
 
@@ -692,11 +692,12 @@ are translatable to Docker commands as well.
 
 .. _setup-sqlite_to_psql:
 
-Moving data from SQLite to PostgreSQL
-=====================================
+Moving data from SQLite to PostgreSQL or MySQL/MariaDB
+======================================================
 
-Moving your data from SQLite to PostgreSQL is done via executing a series of django
-management commands as below.
+Moving your data from SQLite to PostgreSQL or MySQL/MariaDB is done via executing a series of django
+management commands as below.  The commands below use PostgreSQL, but are applicable to MySQL/MariaDB
+with the
 
 .. caution::
 
@@ -712,6 +713,11 @@ management commands as below.
     (128 characters), names of document types, tags and correspondents (128 characters),
     and filenames (1024 characters). If you have data in these fields that surpasses these
     limits, migration to PostgreSQL is not possible and will fail with an error.
+
+.. warning::
+
+    MySQL is case insensitive by default, treating values like "Name" and "NAME" as identical.
+    See :ref:`advanced-mysql-caveats` for details.
 
 
 1.  Stop paperless, if it is running.


### PR DESCRIPTION
## Proposed change

This PR adds some documentation about issues a user may encounter with MariaDB.  At this point, the biggest is MariaDB defaults to being case insensitive (`text == TEXT`), where SQLite and Postgres default to being case sensitive.  If a user is transitioning from one to the other, they may encounter issues.

It is possible to fix this, but it requires manual intervention.  Django and mysqlclient don't provide a portable way to set what's known as the database collation.  So the docs now provide the manual commands to run and a warning under the DB configuration about this case.  It's the best solution I can think of.

Fixes #2011, #2010

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (please explain) - Docs update

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
