### PR TITLE
Bugfix: Fix created_date being a string

### DIFF
--- a/src/documents/tasks.py
+++ b/src/documents/tasks.py
@@ -3,6 +3,7 @@ import logging
 import os
 import shutil
 import uuid
+from datetime import datetime
 from pathlib import Path
 from typing import Type
 
@@ -97,6 +98,14 @@ def consume_file(
 ):
 
     path = Path(path).resolve()
+
+    # Celery converts this to a string, but everything expects a datetime
+    # Long term solution is to not use JSON for the serializer but pickle instead
+    if override_created is not None and isinstance(override_created, str):
+        try:
+            override_created = datetime.fromisoformat(override_created)
+        except Exception:
+            pass
 
     # check for separators in current document
     if settings.CONSUMER_ENABLE_BARCODES:


### PR DESCRIPTION
## Proposed change

The task serializer for Celery defaults to JSON, which is fine for anything except a `datetime` object, which gets converted to an ISO format string.  Check for that and coerce it back to a datetime so everything else downstream works.

The long term fix is changing the serializer to pickle, which can handle almost every kind of Python object directly.  That would also have prevented what was fixed in #1942.  But it's a larger change and I don't want to potentially reduce the stability of the beta with it.

Fixes #2019

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
