### PR TITLE
Bugfix: Some tesseract languages aren't detected as installed.

### DIFF
--- a/src/paperless_tesseract/checks.py
+++ b/src/paperless_tesseract/checks.py
@@ -1,3 +1,4 @@
+import shutil
 import subprocess
 
 from django.conf import settings
@@ -7,10 +8,16 @@ from django.core.checks import Warning
 
 
 def get_tesseract_langs():
-    with subprocess.Popen(["tesseract", "--list-langs"], stdout=subprocess.PIPE) as p:
-        stdout, stderr = p.communicate()
+    proc = subprocess.run(
+        [shutil.which("tesseract"), "--list-langs"],
+        capture_output=True,
+    )
 
-    return stdout.decode().strip().split("\n")[1:]
+    # Decode bytes to string, split on newlines, trim out the header
+    proc_lines = proc.stdout.decode("utf8", errors="ignore").strip().split("\n")[1:]
+
+    # Replace _ with - to convert two part languages to the expected code
+    return [x.replace("_", "-") for x in proc_lines]
 
 
 @register()


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

The language pack is installed as `tesseract-ocr-chi-sim` but lists as `chi_sim` when the check calls `tesseract --list-langs`.  Simple fix, replace the `_` with a `-` so they match up.

Fixes #2044

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
