### PR TITLE
Bugfix: Don't silence an exception when trying to handle file naming

### DIFF
--- a/src/documents/signals/handlers.py
+++ b/src/documents/signals/handlers.py
@@ -447,7 +447,8 @@ def update_filename_and_move_files(sender, instance, **kwargs):
                 archive_filename=instance.archive_filename,
             )
 
-        except (OSError, DatabaseError, CannotMoveFilesException):
+        except (OSError, DatabaseError, CannotMoveFilesException) as e:
+            logger.warn(f"Exception during file handling: {e}")
             # This happens when either:
             #  - moving the files failed due to file system errors
             #  - saving to the database failed due to database errors
@@ -456,9 +457,11 @@ def update_filename_and_move_files(sender, instance, **kwargs):
             # Try to move files to their original location.
             try:
                 if move_original and os.path.isfile(instance.source_path):
+                    logger.info("Restoring previous original path")
                     os.rename(instance.source_path, old_source_path)
 
                 if move_archive and os.path.isfile(instance.archive_path):
+                    logger.info("Restoring previous archive path")
                     os.rename(instance.archive_path, old_archive_path)
 
             except Exception:
@@ -468,7 +471,7 @@ def update_filename_and_move_files(sender, instance, **kwargs):
                 #  issue that's going to get caught by the santiy checker.
                 #  All files remain in place and will never be overwritten,
                 #  so this is not the end of the world.
-                # B: if moving the orignal file failed, nothing has changed
+                # B: if moving the original file failed, nothing has changed
                 #  anyway.
                 pass
 


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Simple change to make the user aware of why a rename during file handling didn't work.  Now the logs will have something like `Exception during file handling: [Errno 36] File name too long` if that happens.

Fixes #2053

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
