### PR TITLE
Bugfix: Add libatomic for armv7 compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -127,7 +127,9 @@ ARG RUNTIME_PACKAGES="\
   zlib1g \
   # Barcode splitter
   libzbar0 \
-  poppler-utils"
+  poppler-utils \
+  # RapidFuzz on armv7
+  libatomic1"
 
 # Install basic runtime packages.
 # These change very infrequently

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,34 +72,37 @@ COPY --from=jbig2enc-builder /usr/src/jbig2enc/src/*.h /usr/local/include/
 
 # Packages need for running
 ARG RUNTIME_PACKAGES="\
+  # Python
+  python3 \
+  python3-pip \
+  python3-setuptools \
+  # General utils
   curl \
-  file \
+  # Docker specific
+  gosu \
+  # Timezones support
+  tzdata \
   # fonts for text file thumbnail generation
   fonts-liberation \
   gettext \
   ghostscript \
   gnupg \
-  gosu \
   icc-profiles-free \
   imagemagick \
-  media-types \
+  # Image processing
   liblept5 \
-  libpq5 \
-  libxml2 \
   liblcms2-2 \
   libtiff5 \
-  libxslt1.1 \
   libfreetype6 \
   libwebp6 \
   libopenjp2-7 \
   libimagequant0 \
   libraqm0 \
-  libgnutls30 \
   libjpeg62-turbo \
-  python3 \
-  python3-pip \
-  python3-setuptools \
+  # PostgreSQL
+  libpq5 \
   postgresql-client \
+  # MySQL / MariaDB
   mariadb-client \
   # For Numpy
   libatlas3-base \
@@ -110,13 +113,17 @@ ARG RUNTIME_PACKAGES="\
   tesseract-ocr-fra \
   tesseract-ocr-ita \
   tesseract-ocr-spa \
-  # Suggested for OCRmyPDF
-  pngquant \
-  # Suggested for pikepdf
-  jbig2dec \
-  tzdata \
   unpaper \
+  pngquant \
+  # pikepdf / qpdf
+  jbig2dec \
+  libxml2 \
+  libxslt1.1 \
+  libgnutls30 \
   # Mime type detection
+  file \
+  libmagic1 \
+  media-types \
   zlib1g \
   # Barcode splitter
   libzbar0 \


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

The ARMv7 wheel built by piwheels differs somehow from the official amd64 and aarch64, in that it needs libatomic installed.  So install it in the image (for all arches).

I also took the opportunity to group up things in the packages. 

Fixes #2052

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
