### PR TITLE
Chore: Use exact arguments when doing live tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,7 @@ jobs:
         name: Stop containers
         if: always()
         run: |
+          docker compose --file ${GITHUB_WORKSPACE}/docker/compose/docker-compose.ci-test.yml logs
           docker compose --file ${GITHUB_WORKSPACE}/docker/compose/docker-compose.ci-test.yml down
 
   tests-frontend:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,15 +81,6 @@ jobs:
       matrix:
         python-version: ['3.8', '3.9', '3.10']
       fail-fast: false
-    services:
-      tika:
-        image: ghcr.io/paperless-ngx/tika:latest
-        ports:
-          - "9998:9998/tcp"
-      gotenberg:
-        image: docker.io/gotenberg/gotenberg:7.6
-        ports:
-          - "3000:3000/tcp"
     env:
       # Enable Tika end to end testing
       TIKA_LIVE: 1
@@ -103,6 +94,11 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      -
+        name: Start containers
+        run: |
+          docker compose --file ${GITHUB_WORKSPACE}/docker/compose/docker-compose.ci-test.yml pull --quiet
+          docker compose --file ${GITHUB_WORKSPACE}/docker/compose/docker-compose.ci-test.yml up --detach
       -
         name: Install pipenv
         run: |
@@ -154,6 +150,11 @@ jobs:
         run: |
           cd src/
           pipenv run coveralls --service=github
+      -
+        name: Stop containers
+        if: always()
+        run: |
+          docker compose --file ${GITHUB_WORKSPACE}/docker/compose/docker-compose.ci-test.yml down
 
   tests-frontend:
     name: "Tests Frontend"

--- a/docker/compose/docker-compose.ci-test.yml
+++ b/docker/compose/docker-compose.ci-test.yml
@@ -1,0 +1,22 @@
+# docker-compose file for running paperless testing with actual gotenberg
+# and Tika containers for a more end to end test of the Tika related functionality
+# Can be used locally or by the CI to start the nessecary containers with the
+# correct networking for the tests
+
+version: "3.7"
+services:
+  gotenberg:
+    image: docker.io/gotenberg/gotenberg:7.6
+    hostname: gotenberg
+    container_name: gotenberg
+    network_mode: host
+    restart: unless-stopped
+    command:
+      - "gotenberg"
+      - "--chromium-disable-routes=true"
+  tika:
+    image: ghcr.io/paperless-ngx/tika:latest
+    hostname: tika
+    container_name: tika
+    network_mode: host
+    restart: unless-stopped


### PR DESCRIPTION
## Proposed change

It always bothered me the Github action service containers don't allow overriding the container command.  So skip using that, and use normal `docker compose` ourselves.  That way, we can exactly match the commands we tell users to use.  It's actually pretty simple.

This will also help @p-h-a-i-l with their test integrating.

Fixes # (issue)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (please explain) - CI improvement

## Checklist:

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
