### PR TITLE
Bugfix: Custom startup commands weren't run as root

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -77,6 +77,46 @@ nltk_data () {
 
 }
 
+custom_container_init() {
+	# Mostly borrowed from the LinuxServer.io base image
+	# https://github.com/linuxserver/docker-baseimage-ubuntu/tree/bionic/root/etc/cont-init.d
+	local -r custom_script_dir="/custom-cont-init.d"
+	# Tamper checking.
+	# Don't run files which are owned by anyone except root
+	# Don't run files which are writeable by others
+	if [ -d "${custom_script_dir}" ]; then
+		if [ -n "$(/usr/bin/find "${custom_script_dir}" -maxdepth 1 ! -user root)" ]; then
+			echo "**** Potential tampering with custom scripts detected ****"
+			echo "**** The folder '${custom_script_dir}' must be owned by root ****"
+			return 0
+		fi
+		if [ -n "$(/usr/bin/find "${custom_script_dir}" -maxdepth 1 -perm -o+w)" ]; then
+			echo "**** The folder '${custom_script_dir}' or some of contents have write permissions for others, which is a security risk. ****"
+			echo "**** Please review the permissions and their contents to make sure they are owned by root, and can only be modified by root. ****"
+			return 0
+		fi
+
+		# Make sure custom init directory has files in it
+		if [ -n "$(/bin/ls -A "${custom_script_dir}" 2>/dev/null)" ]; then
+			echo "[custom-init] files found in ${custom_script_dir} executing"
+			# Loop over files in the directory
+			for SCRIPT in "${custom_script_dir}"/*; do
+				NAME="$(basename "${SCRIPT}")"
+				if [ -f "${SCRIPT}" ]; then
+					echo "[custom-init] ${NAME}: executing..."
+					/bin/bash "${SCRIPT}"
+					echo "[custom-init] ${NAME}: exited $?"
+				elif [ ! -f "${SCRIPT}" ]; then
+					echo "[custom-init] ${NAME}: is not a file"
+				fi
+			done
+		else
+			echo "[custom-init] no custom files found exiting..."
+		fi
+
+	fi
+}
+
 initialize() {
 
 	# Setup environment from secrets before anything else
@@ -132,6 +172,10 @@ initialize() {
 	set -e
 
 	"${gosu_cmd[@]}" /sbin/docker-prepare.sh
+
+	# Leave this last thing
+	custom_container_init
+
 }
 
 install_languages() {

--- a/docker/docker-prepare.sh
+++ b/docker/docker-prepare.sh
@@ -89,46 +89,6 @@ superuser() {
 	fi
 }
 
-custom_container_init() {
-	# Mostly borrowed from the LinuxServer.io base image
-	# https://github.com/linuxserver/docker-baseimage-ubuntu/tree/bionic/root/etc/cont-init.d
-	local -r custom_script_dir="/custom-cont-init.d"
-	# Tamper checking.
-	# Don't run files which are owned by anyone except root
-	# Don't run files which are writeable by others
-	if [ -d "${custom_script_dir}" ]; then
-		if [ -n "$(/usr/bin/find "${custom_script_dir}" -maxdepth 1 ! -user root)" ]; then
-			echo "**** Potential tampering with custom scripts detected ****"
-			echo "**** The folder '${custom_script_dir}' must be owned by root ****"
-			return 0
-		fi
-		if [ -n "$(/usr/bin/find "${custom_script_dir}" -maxdepth 1 -perm -o+w)" ]; then
-			echo "**** The folder '${custom_script_dir}' or some of contents have write permissions for others, which is a security risk. ****"
-			echo "**** Please review the permissions and their contents to make sure they are owned by root, and can only be modified by root. ****"
-			return 0
-		fi
-
-		# Make sure custom init directory has files in it
-		if [ -n "$(/bin/ls -A "${custom_script_dir}" 2>/dev/null)" ]; then
-			echo "[custom-init] files found in ${custom_script_dir} executing"
-			# Loop over files in the directory
-			for SCRIPT in "${custom_script_dir}"/*; do
-				NAME="$(basename "${SCRIPT}")"
-				if [ -f "${SCRIPT}" ]; then
-					echo "[custom-init] ${NAME}: executing..."
-					/bin/bash "${SCRIPT}"
-					echo "[custom-init] ${NAME}: exited $?"
-				elif [ ! -f "${SCRIPT}" ]; then
-					echo "[custom-init] ${NAME}: is not a file"
-				fi
-			done
-		else
-			echo "[custom-init] no custom files found exiting..."
-		fi
-
-	fi
-}
-
 do_work() {
 	if [[ "${PAPERLESS_DBENGINE}" == "mariadb" ]]; then
 		wait_for_mariadb
@@ -143,9 +103,6 @@ do_work() {
 	search_index
 
 	superuser
-
-	# Leave this last thing
-	custom_container_init
 
 }
 

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -407,11 +407,14 @@ The Docker image includes the ability to run custom user scripts during startup.
 utilized for installing additional tools or Python packages, for example.
 
 To utilize this, mount a folder containing your scripts to the custom initialization directory, `/custom-cont-init.d`
-and place scripts you wish to run inside.  For security, the folder and its contents must be owned by `root`.
-Additionally, scripts must only be writable by `root`.
+and place scripts you wish to run inside.  For security, the folder must be owned by `root` and should have permissions
+of `a=rx`.  Additionally, scripts must only be writable by `root`.
 
 Your scripts will be run directly before the webserver completes startup.  Scripts will be run by the `root` user.
-This is an advanced functionality with which you could break functionality or lose data.
+If you would like to switch users, the utility `gosu` is available and preferred over `sudo`.
+
+This is an advanced functionality with which you could break functionality or lose data.  If you experience issues,
+please disable any custom scripts and try again before reporting an issue.
 
 For example, using Docker Compose:
 
@@ -424,6 +427,7 @@ For example, using Docker Compose:
         # ...
         volumes:
           - /path/to/my/scripts:/custom-cont-init.d:ro
+
 
 .. _advanced-mysql-caveats:
 


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

The custom startup commands were being run as `paperless`, not `root`, so something like installing a package would result in permission denied.  Move the function into the entry point and run it there as root.

Expands the docs about permissions setup to hopefully make that easier for people (me) to remember what to set.

Fixes # (issue)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
