### PR TITLE
Bugfix: Incompatible URL schemes for socket based Redis

### DIFF
--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -8,6 +8,7 @@ import tempfile
 from typing import Final
 from typing import Optional
 from typing import Set
+from typing import Tuple
 from urllib.parse import urlparse
 
 from celery.schedules import crontab
@@ -63,6 +64,34 @@ def __get_path(key: str, default: str) -> str:
     Return a normalized, absolute path based on the environment variable or a default
     """
     return os.path.abspath(os.path.normpath(os.environ.get(key, default)))
+
+
+def _parse_redis_url(env_redis: Optional[str]) -> Tuple[str]:
+    """
+    Gets the Redis information from the environment or a default and handles
+    converting from incompatible django_channels and celery formats.
+
+    Returns a tuple of (celery_url, channels_url)
+    """
+
+    # Not set, return a compatible default
+    if env_redis is None:
+        return ("redis://localhost:6379", "redis://localhost:6379")
+
+    _, path = env_redis.split(":")
+
+    if "unix" in env_redis.lower():
+        # channels_redis socket format, looks like:
+        # "unix:///path/to/redis.sock"
+        return (f"redis+socket:{path}", env_redis)
+
+    elif "+socket" in env_redis.lower():
+        # celery socket style, looks like:
+        # "redis+socket:///path/to/redis.sock"
+        return (env_redis, f"unix:{path}")
+
+    # Not a socket
+    return (env_redis, env_redis)
 
 
 # NEVER RUN WITH DEBUG IN PRODUCTION.
@@ -182,7 +211,9 @@ ASGI_APPLICATION = "paperless.asgi.application"
 STATIC_URL = os.getenv("PAPERLESS_STATIC_URL", BASE_URL + "static/")
 WHITENOISE_STATIC_PREFIX = "/static/"
 
-_REDIS_URL = os.getenv("PAPERLESS_REDIS", "redis://localhost:6379")
+_CELERY_REDIS_URL, _CHANNELS_REDIS_URL = _parse_redis_url(
+    os.getenv("PAPERLESS_REDIS", None),
+)
 
 # TODO: what is this used for?
 TEMPLATES = [
@@ -205,7 +236,7 @@ CHANNEL_LAYERS = {
     "default": {
         "BACKEND": "channels_redis.core.RedisChannelLayer",
         "CONFIG": {
-            "hosts": [_REDIS_URL],
+            "hosts": [_CHANNELS_REDIS_URL],
             "capacity": 2000,  # default 100
             "expiry": 15,  # default 60
         },
@@ -468,7 +499,7 @@ TASK_WORKERS = __get_int("PAPERLESS_TASK_WORKERS", 1)
 
 WORKER_TIMEOUT: Final[int] = __get_int("PAPERLESS_WORKER_TIMEOUT", 1800)
 
-CELERY_BROKER_URL = _REDIS_URL
+CELERY_BROKER_URL = _CELERY_REDIS_URL
 CELERY_TIMEZONE = TIME_ZONE
 
 CELERY_WORKER_HIJACK_ROOT_LOGGER = False
@@ -513,7 +544,7 @@ CELERY_BEAT_SCHEDULE_FILENAME = os.path.join(DATA_DIR, "celerybeat-schedule.db")
 CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.redis.RedisCache",
-        "LOCATION": _REDIS_URL,
+        "LOCATION": _CHANNELS_REDIS_URL,
     },
 }
 

--- a/src/paperless/tests/test_settings.py
+++ b/src/paperless/tests/test_settings.py
@@ -97,7 +97,9 @@ class TestIgnoreDateParsing(TestCase):
         """
 
         for input, expected in [
+            # Nothing is set
             (None, ("redis://localhost:6379", "redis://localhost:6379")),
+            # celery style
             (
                 "redis+socket:///run/redis/redis.sock",
                 (
@@ -105,11 +107,28 @@ class TestIgnoreDateParsing(TestCase):
                     "unix:///run/redis/redis.sock",
                 ),
             ),
+            # redis-py / channels-redis style
             (
                 "unix:///run/redis/redis.sock",
                 (
                     "redis+socket:///run/redis/redis.sock",
                     "unix:///run/redis/redis.sock",
+                ),
+            ),
+            # celery style with db
+            (
+                "redis+socket:///run/redis/redis.sock?virtual_host=5",
+                (
+                    "redis+socket:///run/redis/redis.sock?virtual_host=5",
+                    "unix:///run/redis/redis.sock?db=5",
+                ),
+            ),
+            # redis-py / channels-redis style with db
+            (
+                "unix:///run/redis/redis.sock?db=10",
+                (
+                    "redis+socket:///run/redis/redis.sock?virtual_host=10",
+                    "unix:///run/redis/redis.sock?db=10",
                 ),
             ),
         ]:


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

celery vs channels-redis use different URL schemes to specify using a socket.  Adds a decently simple layer to convert from one to the other, so both can work happily with a socket and user's don't need to think too much about which format.

Also supports translation of the DB number aka virtual host.

Fixes #2072

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://paperless-ngx.readthedocs.io/en/latest/extending.html#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
