### PR TITLE
Bugfix: Redis socket compatibility didn't handle URLs with ports

### DIFF
--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -78,11 +78,11 @@ def _parse_redis_url(env_redis: Optional[str]) -> Tuple[str]:
     if env_redis is None:
         return ("redis://localhost:6379", "redis://localhost:6379")
 
-    _, path = env_redis.split(":")
-
     if "unix" in env_redis.lower():
         # channels_redis socket format, looks like:
         # "unix:///path/to/redis.sock"
+        _, path = env_redis.split(":")
+        # Optionally setting a db number
         if "?db=" in env_redis:
             path, number = path.split("?db=")
             return (f"redis+socket:{path}?virtual_host={number}", env_redis)
@@ -92,6 +92,7 @@ def _parse_redis_url(env_redis: Optional[str]) -> Tuple[str]:
     elif "+socket" in env_redis.lower():
         # celery socket style, looks like:
         # "redis+socket:///path/to/redis.sock"
+        _, path = env_redis.split(":")
         if "?virtual_host=" in env_redis:
             # Virtual host (aka db number)
             path, number = path.split("?virtual_host=")

--- a/src/paperless/tests/test_settings.py
+++ b/src/paperless/tests/test_settings.py
@@ -131,6 +131,11 @@ class TestIgnoreDateParsing(TestCase):
                     "unix:///run/redis/redis.sock?db=10",
                 ),
             ),
+            # Just a host with a port
+            (
+                "redis://myredishost:6379",
+                ("redis://myredishost:6379", "redis://myredishost:6379"),
+            ),
         ]:
             result = _parse_redis_url(input)
             self.assertTupleEqual(expected, result)


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

Missed a pretty obvious test case, the parsing failed if the Redis URL included a port, which also used `:` as a separator, giving 3 values instead of the expected 2.  Fixes this.

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
