### PR TITLE
Bugfix: Language code checks around two part languages

### DIFF
--- a/src/paperless_tesseract/checks.py
+++ b/src/paperless_tesseract/checks.py
@@ -16,8 +16,7 @@ def get_tesseract_langs():
     # Decode bytes to string, split on newlines, trim out the header
     proc_lines = proc.stdout.decode("utf8", errors="ignore").strip().split("\n")[1:]
 
-    # Replace _ with - to convert two part languages to the expected code
-    return [x.replace("_", "-") for x in proc_lines]
+    return [x.strip() for x in proc_lines]
 
 
 @register()

--- a/src/paperless_tesseract/tests/test_checks.py
+++ b/src/paperless_tesseract/tests/test_checks.py
@@ -27,3 +27,40 @@ class TestChecks(TestCase):
         msgs = check_default_language_available(None)
         self.assertEqual(len(msgs), 1)
         self.assertEqual(msgs[0].level, ERROR)
+
+    @override_settings(OCR_LANGUAGE="chi_sim")
+    @mock.patch("paperless_tesseract.checks.get_tesseract_langs")
+    def test_multi_part_language(self, m):
+        """
+        GIVEN:
+            - An OCR language which is multi part (ie chi-sim)
+            - The language is correctly formatted
+        WHEN:
+            - Installed packages are checked
+        THEN:
+            - No errors are reported
+        """
+        m.return_value = ["chi_sim", "eng"]
+
+        msgs = check_default_language_available(None)
+
+        self.assertEqual(len(msgs), 0)
+
+    @override_settings(OCR_LANGUAGE="chi-sim")
+    @mock.patch("paperless_tesseract.checks.get_tesseract_langs")
+    def test_multi_part_language_bad_format(self, m):
+        """
+        GIVEN:
+            - An OCR language which is multi part (ie chi-sim)
+            - The language is correctly NOT formatted
+        WHEN:
+            - Installed packages are checked
+        THEN:
+            - No errors are reported
+        """
+        m.return_value = ["chi_sim", "eng"]
+
+        msgs = check_default_language_available(None)
+
+        self.assertEqual(len(msgs), 1)
+        self.assertEqual(msgs[0].level, ERROR)


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

Basically reverts #2057

I didn't read our own documentation closely enough.  The original "fix" wasn't correct.  As per the docs, languages like Chinese simplified are installed as `tesseract-ocr-chi-sim`.  It's then reported as `chi_sim`.  `chi_sim` is also what the docs tell folks to use for replacing a dash and that's also what OCRMyPDF expects a language code to look like.

Basically, `PAPERLESS_OCR_LANGUAGE` needs to match with tesseract and OCRMyPDF and `PAPERLESS_OCR_LANGUAGES` needs to match with the package manager name.

Sometime, a sort of compatibility layer could be made to catch and fix this for a user, similar to what I created for Redis sockets.

It's confusing, to be sure.

Fixes #2110

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
