### PR TITLE
Feature: Bake NLTK into Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -228,6 +228,10 @@ RUN set -eux \
     && python3 -m pip install --no-cache-dir --upgrade wheel \
   && echo "Installing Python requirements" \
     && python3 -m pip install --default-timeout=1000 --no-cache-dir --requirement requirements.txt \
+  && echo "Installing NLTK data" \
+    && python3 -W ignore::RuntimeWarning -m nltk.downloader -d "/usr/local/share/nltk_data" snowball_data \
+    && python3 -W ignore::RuntimeWarning -m nltk.downloader -d "/usr/local/share/nltk_data" stopwords \
+    && python3 -W ignore::RuntimeWarning -m nltk.downloader -d "/usr/local/share/nltk_data" punkt \
   && echo "Cleaning up image" \
     && apt-get -y purge ${BUILD_PACKAGES} \
     && apt-get -y autoremove --purge \

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -53,30 +53,6 @@ map_folders() {
 	export CONSUME_DIR="${PAPERLESS_CONSUMPTION_DIR:-/usr/src/paperless/consume}"
 }
 
-nltk_data () {
-	# Store the NLTK data outside the Docker container
-	local -r nltk_data_dir="${DATA_DIR}/nltk"
-	local -r truthy_things=("yes y 1 t true")
-
-	# If not set, or it looks truthy
-	if [[ -z "${PAPERLESS_ENABLE_NLTK}" ]] || [[ "${truthy_things[*]}" =~ ${PAPERLESS_ENABLE_NLTK,} ]]; then
-
-		# Download or update the snowball stemmer data
-		python3 -W ignore::RuntimeWarning -m nltk.downloader -d "${nltk_data_dir}" snowball_data
-
-		# Download or update the stopwords corpus
-		python3 -W ignore::RuntimeWarning -m nltk.downloader -d "${nltk_data_dir}" stopwords
-
-		# Download or update the punkt tokenizer data
-		python3 -W ignore::RuntimeWarning -m nltk.downloader -d "${nltk_data_dir}" punkt
-
-	else
-		echo "Skipping NLTK data download"
-
-	fi
-
-}
-
 custom_container_init() {
 	# Mostly borrowed from the LinuxServer.io base image
 	# https://github.com/linuxserver/docker-baseimage-ubuntu/tree/bionic/root/etc/cont-init.d
@@ -157,8 +133,6 @@ initialize() {
 	echo "Creating directory ${tmp_dir}"
 	mkdir -p "${tmp_dir}"
 
-	nltk_data
-
 	set +e
 	echo "Adjusting permissions of paperless files. This may take a while."
 	chown -R paperless:paperless ${tmp_dir}
@@ -191,10 +165,6 @@ install_languages() {
 
 	for lang in "${langs[@]}"; do
 		pkg="tesseract-ocr-$lang"
-		# English is installed by default
-		#if [[ "$lang" ==  "eng" ]]; then
-		#    continue
-		#fi
 
 		if dpkg -s "$pkg" &>/dev/null; then
 			echo "Package $pkg already installed!"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -177,6 +177,10 @@ processing, if you are using it. If you are using the Docker image,
 this should not be changed, as the data is included in the image
 already.
 
+Previously, the location defaulted to `PAPERLESS_DATA_DIR/nltk`.
+Unless you are using this in a bare metal install or other setup,
+this folder is no longer needed and can be removed manually.
+
 Defaults to `/usr/local/share/nltk_data`
 
 ## Logging

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -170,6 +170,15 @@ details.
 
     Defaults to "`PAPERLESS_DATA_DIR`/log/".
 
+`PAPERLESS_NLTK_DIR=<path>`
+
+: This is where paperless will search for the data required for NLTK
+processing, if you are using it. If you are using the Docker image,
+this should not be changed, as the data is included in the image
+already.
+
+Defaults to `/usr/local/share/nltk_data`
+
 ## Logging
 
 `PAPERLESS_LOGROTATE_MAX_SIZE=<num>`
@@ -697,6 +706,16 @@ less than the worker timeout.
 for details on how to set it.
 
     Defaults to UTC.
+
+`PAPERLESS_ENABLE_NLTK=<bool>`
+
+: Enables or disables the advanced natural language processing
+used during automatic classification. If disabled, paperless will
+still preform some basic text pre-processing before matching.
+
+See also `PAPERLESS_NLTK_DIR`.
+
+    Defaults to 1.
 
 ## Polling {#polling}
 

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -123,7 +123,7 @@ THUMBNAIL_DIR = os.path.join(MEDIA_ROOT, "documents", "thumbnails")
 
 DATA_DIR = __get_path("PAPERLESS_DATA_DIR", os.path.join(BASE_DIR, "..", "data"))
 
-NLTK_DIR = os.path.join(DATA_DIR, "nltk")
+NLTK_DIR = __get_path("PAPERLESS_NLTK_DIR", "/usr/local/share/nltk_data")
 
 TRASH_DIR = os.getenv("PAPERLESS_TRASH_DIR")
 


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

This changes the downloading on the NLTK data at startup into a downloading at image build time.  Initially, I didn't do this as I wasn't sure about how much it adds to the size.  It's actually around 60mb to the compressed image, so fairly small in the end.  NLTK usage can still be enabled or disabled if a user doesn't want to use it.

This will also resolve user's being unable to download the files at startup, either due to (so many) DNS issues or working in a completely offline environment.

Finally, it fixes the missing documentation on the enable/disable as well as location of data.

See #2061

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
