### PR TITLE
Chore: Apply live testing backoff logic to new mail tests

### DIFF
--- a/src/paperless_mail/tests/test_parsers_live.py
+++ b/src/paperless_mail/tests/test_parsers_live.py
@@ -165,7 +165,7 @@ class TestParserLive(TestCase):
 
         pdf_path = self.util_call_with_backoff(
             self.parser.generate_pdf,
-            os.path.join(self.SAMPLE_FILES, "html.eml"),
+            [os.path.join(self.SAMPLE_FILES, "html.eml")],
         )
         self.assertTrue(os.path.isfile(pdf_path))
 
@@ -194,7 +194,7 @@ class TestParserLive(TestCase):
 
         with open(pdf_path, "wb") as file:
             file.write(
-                self.util_call_with_backoff(self.parser.generate_pdf_from_mail, mail),
+                self.util_call_with_backoff(self.parser.generate_pdf_from_mail, [mail]),
             )
 
         extracted = extract_text(pdf_path)
@@ -225,7 +225,7 @@ class TestParserLive(TestCase):
 
         with open(pdf_path, "wb") as file:
             file.write(
-                self.util_call_with_backoff(self.parser.generate_pdf_from_mail, mail),
+                self.util_call_with_backoff(self.parser.generate_pdf_from_mail, [mail]),
             )
 
         converted = os.path.join(


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

Same change idea as #1922, try to isolate the CI runs from random failures in Gotenberg and/or Tika when doing mail related testing which uses those containers.  I've seen it happen once so far, but as usual a re-run fixed everything, so this simply always does some retry logic in case of exception.

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (please explain) - maintenance

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
