### PR TITLE
Chore: Prevent forks from having failing CI runs by default

### DIFF
--- a/.github/workflows/cleanup-tags.yml
+++ b/.github/workflows/cleanup-tags.yml
@@ -1,7 +1,9 @@
 # This workflow runs on certain conditions to check for and potentially
 # delete container images from the GHCR which no longer have an associated
 # code branch.
-# Requires a PAT with the correct scope set in the secrets
+# Requires a PAT with the correct scope set in the secrets.
+#
+# This workflow will not trigger runs on forked repos.
 
 name: Cleanup Image Tags
 
@@ -21,6 +23,7 @@ concurrency:
 jobs:
   cleanup-images:
     name: Cleanup Image Tags for ${{ matrix.primary-name }}
+    if: github.repository_owner == 'paperless-ngx'
     runs-on: ubuntu-22.04
     strategy:
       matrix:


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

Every fork ends up with regularly failing pipeline runs ~~from scheduled workflows~~ that require further setup or are very specific to the main repo to deploy stuff or interact with other services like GHCR.
I think those should not run by default on all forks.

Maybe worth configuring them even more restrictive to run only on the main repo out of the box:
```
if: github.repository == 'paperless-ngx/paperless-ngx'
```
The cleanup-tag workflow requires further setup to work on forks anyway (PAT setup). So maybe that's the way to go to prevent further unintentional failing runs on users forks?

What about the CodeQL workflow?

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (please explain): CI

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
