### PR TITLE
Docs: Fix leftover issues from conversion

### DIFF
--- a/docs/advanced_usage.md
+++ b/docs/advanced_usage.md
@@ -302,7 +302,7 @@ value.
 !!! tip
 
     You can affect how empty placeholders are treated by changing the
-    following setting to [true]{.title-ref}.
+    following setting to `true`.
 
     ```
     PAPERLESS_FILENAME_FORMAT_REMOVE_NONE=True
@@ -364,7 +364,7 @@ Insurances = Insurances/{correspondent}/{created_year}-{created_month}-{created_
 ```
 
 If you then map these storage paths to the documents, you might get the
-following result. For simplicity, [By Year]{.title-ref} defines the same
+following result. For simplicity, `By Year` defines the same
 structure as in the previous example above.
 
 ```text
@@ -435,7 +435,7 @@ by `root` and should have permissions of `a=rx`. Additionally, scripts
 must only be writable by `root`.
 
 Your scripts will be run directly before the webserver completes
-startup. Scripts will be run by the [root]{.title-ref} user.
+startup. Scripts will be run by the `root` user.
 If you would like to switch users, the utility `gosu` is available and
 preferred over `sudo`.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1315,9 +1315,9 @@ paperless.
   .doc, .odt and more.
   - See the [Tika settings](/configuration#tika) on how to enable this
     feature. This feature requires two additional services (one for
-	parsing Office documents and metadata extraction and another for
-	converting Office documents to PDF), and is therefore not enabled
-	on default installations.
+    parsing Office documents and metadata extraction and another for
+    converting Office documents to PDF), and is therefore not enabled
+    on default installations.
   - As with all other documents, paperless converts Office documents
     to PDF and stores both the original as well as the archived PDF.
 - Dark mode

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Take ownership of k8s-at-home Helm chart, [@alexander-bauer](https://github.com/alexander-bauer) ([#1947](https://github.com/paperless-ngx/paperless-ngx/pull/1947))
+- Take ownership of k8s-at-home Helm chart [@alexander-bauer](https://github.com/alexander-bauer) ([#1947](https://github.com/paperless-ngx/paperless-ngx/pull/1947))
 
 ### Bug Fixes
 
@@ -22,7 +22,7 @@
 
 ### Maintenance
 
-- Take ownership of k8s-at-home Helm chart, [@alexander-bauer](https://github.com/alexander-bauer) ([#1947](https://github.com/paperless-ngx/paperless-ngx/pull/1947))
+- Take ownership of k8s-at-home Helm chart [@alexander-bauer](https://github.com/alexander-bauer) ([#1947](https://github.com/paperless-ngx/paperless-ngx/pull/1947))
 
 ### All App Changes
 
@@ -991,11 +991,10 @@ This is a maintenance release.
 
 !!! note
 
-The changed to the full text searching require you to reindex your
-documents. _The docker image does this automatically, you don't need to
-do anything._ To do this, execute the `document_index reindex`
-management command (see `administration-index`{.interpreted-text
-role="ref"}).
+    The changed to the full text searching require you to reindex your
+    documents. _The docker image does this automatically, you don't need to
+    do anything._ To do this, execute the `document_index reindex`
+    management command (see [Managing the document search index](/administration#index)).
 
 ### paperless-ng 1.3.2
 
@@ -1034,8 +1033,7 @@ This release contains new database migrations.
 - Changes
   - The REST API is versioned from this point onwards. This will
     allow me to make changes without breaking existing clients. See
-    the documentation about `api-versioning`{.interpreted-text
-    role="ref"} for details.
+    the documentation about [API versioning](/api#api-versioning) for details.
   - Added a color picker for tag colors.
   - Added the ability to use the filter for searching the document
     content as well.
@@ -1069,7 +1067,7 @@ This release contains new database migrations.
 - Changes to the OCRmyPDF integration
   - Added support for deskewing and automatic rotation of
     incorrectly rotated pages. This is enabled by default, see
-    `configuration-ocr`{.interpreted-text role="ref"}.
+    [OCR settings](/configuration#ocr).
   - Better support for encrypted files.
   - Better support for various other PDF files: Paperless will now
     attempt to force OCR with safe options when OCR fails with the
@@ -1096,7 +1094,7 @@ This release contains new database migrations.
 
 - Added a docker-specific configuration option to adjust the number of
   worker processes of the web server. See
-  `configuration-docker`{.interpreted-text role="ref"}.
+  [Docker options](/configuration#docker).
 - Some more memory usage optimizations.
 - Don't show inbox statistics if no inbox tag is defined.
 
@@ -1105,8 +1103,7 @@ This release contains new database migrations.
 - Always show top left corner of thumbnails, even for extra wide
   documents.
 - Added a management command for executing the sanity checker
-  directly. See `utilities-sanity-checker`{.interpreted-text
-  role="ref"}.
+  directly. See [management utilities](/administration#sanity-checker).
 - The weekly sanity check now reports messages in the log files.
 - Fixed an issue with the metadata tab not reporting anything in case
   of missing files.
@@ -1140,7 +1137,7 @@ This release contains new database migrations.
   management commands, since these also ensure that they're always
   executed as the paperless user and you're less likely to run into
   permission issues. See
-  `utilities-management-commands`{.interpreted-text role="ref"}.
+  [management commands](/administration#management-commands).
 
 ### paperless-ng 1.1.0
 
@@ -1182,7 +1179,7 @@ This release contains new database migrations.
   status notifications.
 
   Apache `mod_wsgi` users, see
-  `this note <faq-mod_wsgi>`{.interpreted-text role="ref"}.
+  [this note](/faq#how-do-i-get-websocket-support-with-apache-mod_wsgi).
 
 - Paperless now offers suggestions for tags, correspondents and types
   on the document detail page.
@@ -1227,9 +1224,7 @@ bug reports coming in, I think that this is reasonably stable.
   - The document exporter locks the media directory and the database
     during execution to ensure that the resulting export is
     consistent.
-  - See the
-    `updated documentation <utilities-exporter>`{.interpreted-text
-    role="ref"} for more details.
+  - See the [updated documentation](/administration#exporter) for more details.
 - Other changes and additions
   - Added a language selector to the settings.
   - Added date format options to the settings.
@@ -1318,11 +1313,11 @@ paperless.
 - Thanks to [Jo Vandeginste](https://github.com/jovandeginste),
   Paperless has optional support for Office documents such as .docx,
   .doc, .odt and more.
-  - See the `configuration<configuration-tika>`{.interpreted-text
-    role="ref"} on how to enable this feature. This feature requires
-    two additional services (one for parsing Office documents and
-    metadata extraction and another for converting Office documents
-    to PDF), and is therefore not enabled on default installations.
+  - See the [Tika settings](/configuration#tika) on how to enable this
+    feature. This feature requires two additional services (one for
+	parsing Office documents and metadata extraction and another for
+	converting Office documents to PDF), and is therefore not enabled
+	on default installations.
   - As with all other documents, paperless converts Office documents
     to PDF and stores both the original as well as the archived PDF.
 - Dark mode
@@ -1398,15 +1393,14 @@ paperless.
 
 !!! note
 
-The bulk delete operations did not update the search index. Therefore,
-documents that you deleted remained in the index and caused the search
-to return messages about missing documents when searching. Further bulk
-operations will properly update the index.
+    The bulk delete operations did not update the search index. Therefore,
+    documents that you deleted remained in the index and caused the search
+    to return messages about missing documents when searching. Further bulk
+    operations will properly update the index.
 
-However, this change is not retroactive: If you used the delete method
-of the bulk editor, you need to reindex your search index by
-`running the management command document_index with the argument reindex <administration-index>`{.interpreted-text
-role="ref"}.
+    However, this change is not retroactive: If you used the delete method
+    of the bulk editor, you need to reindex your search index by
+    [running the management command `document_index` with the argument `reindex`](/administration#index).
 
 ### paperless-ng 0.9.9
 
@@ -1563,17 +1557,14 @@ primarily.
     edit page. If available, a dropdown menu will appear next to the
     download button.
   - Many of the configuration options regarding OCR have changed.
-    See `configuration-ocr`{.interpreted-text role="ref"} for
-    details.
+    See [OCR settings](/configuration#ocr) for details.
   - Paperless no longer guesses the language of your documents. It
     always uses the language that you specified with
     `PAPERLESS_OCR_LANGUAGE`. Be sure to set this to the language
     the majority of your documents are in. Multiple languages can be
     specified, but that requires more CPU time.
-  - The management command
-    `document_archiver <utilities-archiver>`{.interpreted-text
-    role="ref"} can be used to create archived versions for already
-    existing documents.
+  - The management command [`document_archiver`](/administration#archiver)
+    can be used to create archived versions for already existing documents.
 - Tags from consumption folder.
   - Thanks to [jayme-github](https://github.com/jayme-github),
     paperless now consumes files from sub folders in the consumption
@@ -1586,7 +1577,7 @@ primarily.
   - The endpoint for uploading documents now supports specifying
     custom titles, correspondents, tags and types. This can be used
     by clients to override the default behavior of paperless. See
-    `api-file_uploads`{.interpreted-text role="ref"}.
+    [POSTing documents](/api#file-uploads).
   - The document endpoint of API now serves documents in this form:
     - correspondents, document types and tags are referenced by
       their ID in the fields `correspondent`, `document_type` and
@@ -1620,16 +1611,14 @@ primarily.
   - Paperless now supports searching by tags, types and dates and
     correspondents. In order to have this applied to your existing
     documents, you need to perform a `document_index reindex`
-    management command (see `administration-index`{.interpreted-text
-    role="ref"}) that adds the data to the search index. You only
-    need to do this once, since the schema of the search index
-    changed. Paperless keeps the index updated after that whenever
-    something changes.
+    management command (see [document search index](/administration#index))
+    that adds the data to the search index. You only need to do this
+    once, since the schema of the search index changed. Paperless
+    keeps the index updated after that whenever something changes.
   - Paperless now has spelling corrections ("Did you mean") for
     miss-typed queries.
   - The documentation contains
-    `information about the query syntax <basic-searching>`{.interpreted-text
-    role="ref"}.
+    [information about the query syntax](/usage#basic-usage_searching).
 - Front end:
   - Clickable tags, correspondents and types allow quick filtering
     for related documents.
@@ -1748,7 +1737,7 @@ primarily.
     uses PostgreSQL instead of SQLite. Username, database and
     password all default to `paperless` if not specified.
 - **Modified \[breaking\]:** document_retagger management command
-  rework. See `utilities-retagger`{.interpreted-text role="ref"} for
+  rework. See [Document retagger](/administration#retagger) for
   details. Replaces `document_correspondents` management command.
 - **Removed \[breaking\]:** Reminders.
 - **Removed:** All customizations made to the django admin pages.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -328,8 +328,8 @@ supported.
 
     - `PAPERLESS_REDIS` should point to your redis server, such as
       <redis://localhost:6379>.
-    - `PAPERLESS_DBENGINE` optional, and should be one of [postgres,
-      mariadb, or sqlite]{.title-ref}
+    - `PAPERLESS_DBENGINE` optional, and should be one of `postgres`, 
+	  `mariadb`, or `sqlite`
     - `PAPERLESS_DBHOST` should be the hostname on which your
       PostgreSQL server is running. Do not configure this to use
       SQLite instead. Also configure port, database name, user and

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -328,8 +328,8 @@ supported.
 
     - `PAPERLESS_REDIS` should point to your redis server, such as
       <redis://localhost:6379>.
-    - `PAPERLESS_DBENGINE` optional, and should be one of `postgres`, 
-	  `mariadb`, or `sqlite`
+    - `PAPERLESS_DBENGINE` optional, and should be one of `postgres`,
+      `mariadb`, or `sqlite`
     - `PAPERLESS_DBHOST` should be the hostname on which your
       PostgreSQL server is running. Do not configure this to use
       SQLite instead. Also configure port, database name, user and

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -222,7 +222,7 @@ This might have multiple reasons.
     SENDFILE=0
     ```
 
-    to your [docker-compose.env]{.title-ref} file.
+    to your `docker-compose.env` file.
 
 ## Error while reading metadata
 
@@ -326,9 +326,9 @@ unlock. This may have minor performance implications.
 ## gunicorn fails to start with "is not a valid port number"
 
 You are likely running using Kubernetes, which automatically creates an
-environment variable named [\${serviceName}\_PORT]{.title-ref}. This is
+environment variable named `${serviceName}_PORT`. This is
 the same environment variable which is used by Paperless to optionally
 change the port gunicorn listens on.
 
-To fix this, set [PAPERLESS_PORT]{.title-ref} again to your desired
-port, or the default of 8000.
+To fix this, set `PAPERLESS_PORT` again to your desired port, or the
+default of 8000.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -195,7 +195,7 @@ configured on the 'Scheduled tasks' page in the admin.
 
 ### REST API
 
-You can also submit a document using the REST API, see [docs][api#file-uploads]
+You can also submit a document using the REST API, see [POSTing documents][/api#file-uploads]
 for details.
 
 ## Best practices {#basic-searching}


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

This resolves the `{.title-ref}` and `{.interpreted-text role="ref"}` leftovers.

I think that's how it should be, no 100% certain about the title-ref ones.
RTD doesn't seem to deploy from the branch with the archived docs any longer? I only get the redirects now.

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (please explain): Docs

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
