### PR TITLE
Chore: Changes qpdf to be cross compiled for large speed up

### DIFF
--- a/.github/workflows/installer-library.yml
+++ b/.github/workflows/installer-library.yml
@@ -127,6 +127,7 @@ jobs:
     uses: ./.github/workflows/reusable-workflow-builder.yml
     with:
       dockerfile: ./docker-builders/Dockerfile.qpdf
+      build-platforms: linux/amd64
       build-json: ${{ needs.prepare-docker-build.outputs.qpdf-json }}
       build-args: |
         QPDF_VERSION=${{ fromJSON(needs.prepare-docker-build.outputs.qpdf-json).version }}

--- a/.github/workflows/reusable-workflow-builder.yml
+++ b/.github/workflows/reusable-workflow-builder.yml
@@ -13,6 +13,10 @@ on:
         required: false
         default: ""
         type: string
+      build-platforms:
+        required: false
+        default: linux/amd64,linux/arm64,linux/arm/v7
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ fromJSON(inputs.build-json).name }}-${{ fromJSON(inputs.build-json).version }}
@@ -46,7 +50,7 @@ jobs:
           context: .
           file: ${{ inputs.dockerfile }}
           tags: ${{ fromJSON(inputs.build-json).image_tag }}
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: ${{ inputs.build-platforms }}
           build-args: ${{ inputs.build-args }}
           push: true
           cache-from: type=registry,ref=${{ fromJSON(inputs.build-json).cache_tag }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,12 @@ LABEL org.opencontainers.image.url="https://github.com/paperless-ngx/paperless-n
 LABEL org.opencontainers.image.licenses="GPL-3.0-only"
 
 ARG DEBIAN_FRONTEND=noninteractive
+# Buildx provided
+ARG TARGETARCH
+ARG TARGETVARIANT
+
+# Workflow provided
+ARG QPDF_VERSION
 
 #
 # Begin installation and configuration
@@ -194,8 +200,8 @@ RUN --mount=type=bind,from=qpdf-builder,target=/qpdf \
     --mount=type=bind,from=pikepdf-builder,target=/pikepdf \
   set -eux \
   && echo "Installing qpdf" \
-    && apt-get install --yes --no-install-recommends /qpdf/usr/src/qpdf/libqpdf29_*.deb \
-    && apt-get install --yes --no-install-recommends /qpdf/usr/src/qpdf/qpdf_*.deb \
+    && apt-get install --yes --no-install-recommends /qpdf/usr/src/qpdf/${QPDF_VERSION}/${TARGETARCH}${TARGETVARIANT}/libqpdf29_*.deb \
+    && apt-get install --yes --no-install-recommends /qpdf/usr/src/qpdf/${QPDF_VERSION}/${TARGETARCH}${TARGETVARIANT}/qpdf_*.deb \
   && echo "Installing pikepdf and dependencies" \
     && python3 -m pip install --no-cache-dir /pikepdf/usr/src/wheels/*.whl \
     && python3 -m pip list \

--- a/docker-builders/Dockerfile.pikepdf
+++ b/docker-builders/Dockerfile.pikepdf
@@ -16,7 +16,13 @@ FROM python:3.9-slim-bullseye as main
 
 LABEL org.opencontainers.image.description="A intermediate image with pikepdf wheel built"
 
+# Buildx provided
+ARG TARGETARCH
+ARG TARGETVARIANT
+
 ARG DEBIAN_FRONTEND=noninteractive
+# Workflow provided
+ARG QPDF_VERSION
 ARG PIKEPDF_VERSION
 # These are not used, but will still bust the cache if one changes
 # Otherwise, the main image will try to build thing (and fail)
@@ -54,7 +60,7 @@ ARG BUILD_PACKAGES="\
 
 WORKDIR /usr/src
 
-COPY --from=qpdf-builder /usr/src/qpdf/*.deb ./
+COPY --from=qpdf-builder /usr/src/qpdf/${QPDF_VERSION}/${TARGETARCH}${TARGETVARIANT}/*.deb ./
 
 # As this is an base image for a multi-stage final image
 # the added size of the install is basically irrelevant
@@ -88,6 +94,8 @@ RUN set -eux \
       # Don't cache build files
       --no-cache-dir \
     && ls -ahl wheels \
+  && echo "Gathering package data" \
+    && dpkg-query -f '${Package;-40}${Version}\n' -W > ./wheels/pkg-list.txt \
   && echo "Cleaning up image" \
     && apt-get -y purge ${BUILD_PACKAGES} \
     && apt-get -y autoremove --purge \

--- a/docker-builders/Dockerfile.psycopg2
+++ b/docker-builders/Dockerfile.psycopg2
@@ -42,6 +42,8 @@ RUN set -eux \
       # Don't cache build files
       --no-cache-dir \
     && ls -ahl wheels/ \
+  && echo "Gathering package data" \
+    && dpkg-query -f '${Package;-40}${Version}\n' -W > ./wheels/pkg-list.txt \
   && echo "Cleaning up image" \
     && apt-get -y purge ${BUILD_PACKAGES} \
     && apt-get -y autoremove --purge \

--- a/docker-builders/Dockerfile.qpdf
+++ b/docker-builders/Dockerfile.qpdf
@@ -1,48 +1,156 @@
-# This Dockerfile compiles the jbig2enc library
-# Inputs:
-#    - QPDF_VERSION - the version of qpdf to build a .deb.
-#                     Must be present as a deb-src in bookworm
+#
+# Stage: pre-build
+# Purpose:
+#  - Installs common packages
+#  - Sets common environment variables related to dpkg
+#  - Aquires the qpdf source from bookwork
+# Useful Links:
+#  - https://qpdf.readthedocs.io/en/stable/installation.html#system-requirements
+#  - https://wiki.debian.org/Multiarch/HOWTO
+#  - https://wiki.debian.org/CrossCompiling
+#
 
-FROM debian:bullseye-slim as main
+FROM debian:bullseye-slim as pre-build
 
-LABEL org.opencontainers.image.description="A intermediate image with qpdf built"
-
-ARG DEBIAN_FRONTEND=noninteractive
-# This must match to pikepdf's minimum at least
 ARG QPDF_VERSION
 
-ARG BUILD_PACKAGES="\
-  build-essential \
-  debhelper \
+ARG COMMON_BUILD_PACKAGES="\
+  cmake \
+  debhelper\
   debian-keyring \
   devscripts \
-  equivs  \
-  libtool \
-  # https://qpdf.readthedocs.io/en/stable/installation.html#system-requirements
-  libjpeg62-turbo-dev \
-  libgnutls28-dev \
+  dpkg-dev \
+  equivs \
   packaging-dev \
-  cmake \
-  zlib1g-dev"
+  libtool"
+
+ENV DEB_BUILD_OPTIONS="terse nocheck nodoc parallel=2"
 
 WORKDIR /usr/src
 
 RUN set -eux \
-  && echo "Installing build tools" \
+  && echo "Installing common packages" \
     && apt-get update --quiet \
-    && apt-get install --yes --quiet --no-install-recommends $BUILD_PACKAGES \
-  && echo "Getting qpdf src" \
+    && apt-get install --yes --quiet --no-install-recommends ${COMMON_BUILD_PACKAGES} \
+  && echo "Getting qpdf source" \
     && echo "deb-src http://deb.debian.org/debian/ bookworm main" > /etc/apt/sources.list.d/bookworm-src.list \
-    && apt-get update \
-    && mkdir qpdf \
-    && cd qpdf \
-    && apt-get source --yes --quiet qpdf=${QPDF_VERSION}-1/bookworm \
-  && echo "Building qpdf" \
-    && cd qpdf-$QPDF_VERSION \
-    && export DEB_BUILD_OPTIONS="terse nocheck nodoc parallel=2" \
-    && dpkg-buildpackage --build=binary --unsigned-source --unsigned-changes --post-clean \
-    && ls -ahl ../*.deb \
-  && echo "Cleaning up image" \
-    && apt-get -y purge ${BUILD_PACKAGES} \
-    && apt-get -y autoremove --purge \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get update --quiet \
+    && apt-get source --yes --quiet qpdf=${QPDF_VERSION}-1/bookworm
+
+#
+# Stage: amd64-builder
+# Purpose: Builds qpdf for x86_64 (native build)
+#
+FROM pre-build as amd64-builder
+
+ARG AMD64_BUILD_PACKAGES="\
+  build-essential \
+  libjpeg62-turbo-dev:amd64 \
+  libgnutls28-dev:amd64 \
+  zlib1g-dev:amd64"
+
+WORKDIR /usr/src/qpdf-${QPDF_VERSION}
+
+RUN set -eux \
+  && echo "Beginning amd64" \
+    && echo "Install amd64 packages" \
+      && apt-get update --quiet \
+      && apt-get install --yes --quiet --no-install-recommends ${AMD64_BUILD_PACKAGES} \
+    && echo "Building amd64" \
+      && dpkg-buildpackage --build=binary --unsigned-source --unsigned-changes --post-clean \
+    && echo "Removing debug files" \
+      && rm -f ../libqpdf29-dbgsym* \
+      && rm -f ../qpdf-dbgsym* \
+    && echo "Gathering package data" \
+      && dpkg-query -f '${Package;-40}${Version}\n' -W > ../pkg-list.txt
+#
+# Stage: armhf-builder
+# Purpose:
+#  - Sets armhf specific environment
+#  - Builds qpdf for armhf (cross compile)
+#
+FROM pre-build as armhf-builder
+
+ARG ARMHF_PACKAGES="\
+  crossbuild-essential-armhf \
+  libjpeg62-turbo-dev:armhf \
+  libgnutls28-dev:armhf \
+  zlib1g-dev:armhf"
+
+WORKDIR /usr/src/qpdf-${QPDF_VERSION}
+
+ENV CXX="/usr/bin/arm-linux-gnueabihf-g++" \
+    CC="/usr/bin/arm-linux-gnueabihf-gcc"
+
+RUN set -eux \
+  && echo "Beginning armhf" \
+    && echo "Install armhf packages" \
+      && dpkg --add-architecture armhf \
+      && apt-get update --quiet \
+      && apt-get install --yes --quiet --no-install-recommends ${ARMHF_PACKAGES} \
+    && echo "Building armhf" \
+      && dpkg-buildpackage --build=binary --unsigned-source --unsigned-changes --post-clean --host-arch armhf \
+    && echo "Removing debug files" \
+      && rm -f ../libqpdf29-dbgsym* \
+      && rm -f ../qpdf-dbgsym* \
+    && echo "Gathering package data" \
+      && dpkg-query -f '${Package;-40}${Version}\n' -W > ../pkg-list.txt
+
+#
+# Stage: aarch64-builder
+# Purpose:
+#  - Sets aarch64 specific environment
+#  - Builds qpdf for aarch64 (cross compile)
+#
+FROM pre-build as aarch64-builder
+
+ARG ARM64_PACKAGES="\
+  crossbuild-essential-arm64 \
+  libjpeg62-turbo-dev:arm64 \
+  libgnutls28-dev:arm64 \
+  zlib1g-dev:arm64"
+
+ENV CXX="/usr/bin/aarch64-linux-gnu-g++" \
+    CC="/usr/bin/aarch64-linux-gnu-gcc"
+
+WORKDIR /usr/src/qpdf-${QPDF_VERSION}
+
+RUN set -eux \
+  && echo "Beginning arm64" \
+    && echo "Install arm64 packages" \
+      && dpkg --add-architecture arm64 \
+      && apt-get update --quiet \
+      && apt-get install --yes --quiet --no-install-recommends ${ARM64_PACKAGES} \
+    && echo "Building arm64" \
+      && dpkg-buildpackage --build=binary --unsigned-source --unsigned-changes --post-clean --host-arch arm64 \
+    && echo "Removing debug files" \
+      && rm -f ../libqpdf29-dbgsym* \
+      && rm -f ../qpdf-dbgsym* \
+    && echo "Gathering package data" \
+      && dpkg-query -f '${Package;-40}${Version}\n' -W > ../pkg-list.txt
+
+#
+# Stage: package
+# Purpose: Holds the compiled .deb files in arch/variant specific folders
+#
+FROM alpine:3.17 as package
+
+LABEL org.opencontainers.image.description="A image with qpdf installers stored in architecture & version specific folders"
+
+ARG QPDF_VERSION
+
+WORKDIR /usr/src/qpdf/${QPDF_VERSION}/amd64
+
+COPY --from=amd64-builder /usr/src/*.deb ./
+COPY --from=amd64-builder /usr/src/pkg-list.txt ./
+
+# Note this is ${TARGETARCH}${TARGETVARIANT} for armv7
+WORKDIR /usr/src/qpdf/${QPDF_VERSION}/armv7
+
+COPY --from=armhf-builder /usr/src/*.deb ./
+COPY --from=armhf-builder /usr/src/pkg-list.txt ./
+
+WORKDIR /usr/src/qpdf/${QPDF_VERSION}/arm64
+
+COPY --from=aarch64-builder /usr/src/*.deb ./
+COPY --from=aarch64-builder /usr/src/pkg-list.txt ./


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

This changes how the qpdf .deb installers are built.  

Previously, QEMU emulation through Docker was used to compile for each arch.  This is very slow, because it's emulated.

Now, the installers are cross compiled on x86_64.  This reduces the build time from around 2+ hrs to around 25 minutes.

The how is decently simple, from a Debian based stage, the host architecture for the result is added, the required cross compiler and libraries for that architecture are installed.  Then `dpkg-buildpackage` takes care of basically all the rest.  The resulting files are pulled into a final image.  To keep things separated, in the final image, they are now found at `/usr/src/qpdf/${QPDF_VERSION}/${TARGETARCH}${TARGETVARIANT}` so an image which uses them can locate the correct variant.  The final image is now an Alpine image, because all it does is hold files and Alpine is tiny.

Due to the shared nature of the installer images (for now) this does temporarily break Docker builds until the Dockerfile change is pulled into all branches.

I tested the resulting aarch64 image on my Raspberry Pi and every worked as expected.

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (please explain) - CI improvements

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
