### PR TITLE
Bugfix: Don't run system checks on migrate

### DIFF
--- a/docker/docker-prepare.sh
+++ b/docker/docker-prepare.sh
@@ -20,7 +20,6 @@ wait_for_postgres() {
 			exit 1
 		else
 			echo "Attempt $attempt_num failed! Trying again in 5 seconds..."
-
 		fi
 
 		attempt_num=$(("$attempt_num" + 1))
@@ -67,8 +66,14 @@ migrations() {
 		# of the current container starts.
 		flock 200
 		echo "Apply database migrations..."
-		python3 manage.py migrate
+		python3 manage.py migrate --skip-checks --no-input
 	) 200>"${DATA_DIR}/migration_lock"
+}
+
+django_checks() {
+	# Explicitly run the Django system checks
+	echo "Running Django checks"
+	python3 manage.py check
 }
 
 search_index() {
@@ -99,6 +104,8 @@ do_work() {
 	wait_for_redis
 
 	migrations
+
+	django_checks
 
 	search_index
 


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Minor thing which only happens at startup of a new system.  The system check `changed_password_check` tries to execute a database query.  It correctly catches and handles the error, but the database may still log a message which looks scary, though it doesn't affect anything.

Run the migrations without system checks, which disables this check.  Then run all the system checks explicitly after migrations are completed.

Fixes #2182

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
