### PR TITLE
Chore: Adds "notable" label for release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -4,6 +4,7 @@ autolabeler:
       - '/^fix/'
     title:
       - "/^fix/i"
+      - "/^Bugfix/i"
   - label: "enhancement"
     branch:
       - '/^feature/'
@@ -13,6 +14,9 @@ categories:
   - title: 'Breaking Changes'
     labels:
       - 'breaking-change'
+  - title: 'Notable Changes'
+    labels:
+      - 'notable'
   - title: 'Features'
     labels:
       - 'enhancement'
@@ -20,7 +24,8 @@ categories:
     labels:
       - 'bug'
   - title: 'Documentation'
-    label: 'documentation'
+    labels:
+      - 'documentation'
   - title: 'Maintenance'
     labels:
       - 'chore'
@@ -29,7 +34,8 @@ categories:
       - 'ci-cd'
   - title: 'Dependencies'
     collapse-after: 3
-    label: 'dependencies'
+    labels:
+      - 'dependencies'
   - title: 'All App Changes'
     labels:
       - 'frontend'
@@ -46,6 +52,8 @@ include-labels:
   - 'frontend'
   - 'backend'
   - 'ci-cd'
+  - 'breaking-change'
+  - 'notable'
 category-template: '### $TITLE'
 change-template: '- $TITLE @$AUTHOR ([#$NUMBER]($URL))'
 change-title-escapes: '\<*_&#@'


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

With some PRs, I feel it would be nice to highlight them in the changelog and releases.  I'm calling them "notable".  This would be things like the permissions PR, the all-auth PR and the email consumption.  All these are big and often times much requested changes, but they might be lost in just the features.

Simply applying the label "notable" will be enough and release drafter will highlight them in a new section.  Obviously, it should be use somewhat sparingly or it's not useful, but it's ultimately a judgement call.

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (please explain) - Release/changelog improvements

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
