### PR TITLE
Fix: support `tags__id__none` in advanced search, fix tags filter badge count for excluded

### DIFF
--- a/src-ui/src/app/components/common/filterable-dropdown/filterable-dropdown.component.html
+++ b/src-ui/src/app/components/common/filterable-dropdown/filterable-dropdown.component.html
@@ -4,7 +4,7 @@
       <use attr.xlink:href="assets/bootstrap-icons.svg#{{icon}}" />
     </svg>
     <div class="d-none d-sm-inline">&nbsp;{{title}}</div>
-    <ng-container *ngIf="!editing && selectionModel.selectionSize() > 0">
+    <ng-container *ngIf="!editing && selectionModel.totalCount > 0">
       <app-clearable-badge [number]="multiple ? selectionModel.totalCount : undefined" [selected]="!multiple && selectionModel.selectionSize() > 0" (cleared)="reset()"></app-clearable-badge>
     </ng-container>
   </button>

--- a/src/documents/index.py
+++ b/src/documents/index.py
@@ -143,6 +143,9 @@ class DelayedQuery:
             elif k == "tags__id__all":
                 for tag_id in v.split(","):
                     criterias.append(query.Term("tag_id", tag_id))
+            elif k == "tags__id__none":
+                for tag_id in v.split(","):
+                    criterias.append(query.Not(query.Term("tag_id", tag_id)))
             elif k == "document_type__id":
                 criterias.append(query.Term("type_id", v))
             elif k == "correspondent__isnull":


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Fixes the linked issue where `tags__id__none` isnt currently supported in 'advanced search' (whoosh). Also fixed a frontend bug this made me notice where excluded (x) items in the tags dropdown aren't showing a badge count when they should be.

Fixes #2204 

<img width="744" alt="Screen Shot 2022-12-17 at 7 48 20 PM" src="https://user-images.githubusercontent.com/4887959/208280436-dd47fe7f-0283-43a3-9243-696004165116.png">
<img width="758" alt="Screen Shot 2022-12-17 at 7 48 07 PM" src="https://user-images.githubusercontent.com/4887959/208280442-9385247f-c054-4b18-89f5-aaffa948444f.png">
<img width="750" alt="Screen Shot 2022-12-17 at 7 48 12 PM" src="https://user-images.githubusercontent.com/4887959/208280448-436f6635-e19b-4036-b3b2-b872813ebb14.png">

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] ~~I have made corresponding changes to the documentation as needed.~~
- [x] I have checked my modifications for any breaking changes.
