### PR TITLE
fix typo in test_parser

### DIFF
--- a/src/paperless_tesseract/tests/test_parser.py
+++ b/src/paperless_tesseract/tests/test_parser.py
@@ -625,6 +625,6 @@ class TestParserFileTypes(DirectoriesMixin, TestCase):
         self.assertTrue(os.path.isfile(parser.archive_path))
         # OCR consistent mangles this space, oh well
         self.assertIn(
-            "this is awebp document, created 11/14/2022.",
+            "this is a webp document, created 11/14/2022.",
             parser.get_text().lower(),
         )


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

There is a typo in `src/paperless_tesseract/tests/test_parser.py` 
For some reason though, the CI didn't yield an error. I have only noticed after checking an PR for an update for nixos (https://github.com/NixOS/nixpkgs/pull/206835). The test fails locally for me, too. Last commit was e96d65f9451a1b92aaec0085654c21a50d581adc by @stumpylog 


## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
