### PR TITLE
Add ability to provide the configuration file path using an env variable

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,12 +10,10 @@ run paperless, these settings have to be defined in different places.
 - If you are running paperless on anything else, paperless will search
   for the configuration file in these locations and use the first one
   it finds:
-
-  ```
-  /path/to/paperless/paperless.conf
-  /etc/paperless.conf
-  /usr/local/etc/paperless.conf
-  ```
+  - The environment variable `PAPERLESS_CONFIGURATION_PATH`
+  - `/path/to/paperless/paperless.conf`
+  - `/etc/paperless.conf`
+  - `/usr/local/etc/paperless.conf`
 
 ## Required services
 
@@ -678,7 +676,7 @@ paperless will process in parallel on a single document.
     count, with a slight favor towards threads per worker:
 
     | CPU core count | Workers | Threads |
-    |----------------|---------|---------|
+    | -------------- | ------- | ------- |
     | > 1            | > 1     | > 1     |
     | > 2            | > 2     | > 1     |
     | > 4            | > 2     | > 2     |

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -17,7 +17,10 @@ from django.utils.translation import gettext_lazy as _
 from dotenv import load_dotenv
 
 # Tap paperless.conf if it's available
-if os.path.exists("../paperless.conf"):
+configuration_path = os.getenv("PAPERLESS_CONFIGURATION_PATH")
+if configuration_path and os.path.exists(configuration_path):
+    load_dotenv(configuration_path)
+elif os.path.exists("../paperless.conf"):
     load_dotenv("../paperless.conf")
 elif os.path.exists("/etc/paperless.conf"):
     load_dotenv("/etc/paperless.conf")


### PR DESCRIPTION
## Proposed change

This adds the ability to adjust the configuration file path using the environment variable `PAPERLESS_CONFIGURATION_PATH`. It can be used to run multiple paperless instances on a single server without resorting to a full environment variable based configuration.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [X] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [X] I have made corresponding changes to the documentation as needed.
- [X] I have checked my modifications for any breaking changes.
