### PR TITLE
Bugfix: Reading environment from files didn't work for management commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -165,6 +165,7 @@ COPY [ \
   "docker/docker-prepare.sh", \
   "docker/paperless_cmd.sh", \
   "docker/wait-for-redis.py", \
+  "docker/env-from-file.sh", \
   "docker/management_script.sh", \
   "docker/flower-conditional.sh", \
   "docker/install_management_commands.sh", \
@@ -184,6 +185,8 @@ RUN set -eux \
     && chmod 755 /sbin/docker-prepare.sh \
     && mv wait-for-redis.py /sbin/wait-for-redis.py \
     && chmod 755 /sbin/wait-for-redis.py \
+    && mv env-from-file.sh /sbin/env-from-file.sh \
+    && chmod 755 /sbin/env-from-file.sh \
     && mv paperless_cmd.sh /usr/local/bin/paperless_cmd.sh \
     && chmod 755 /usr/local/bin/paperless_cmd.sh \
     && mv flower-conditional.sh /usr/local/bin/flower-conditional.sh \

--- a/docker/env-from-file.sh
+++ b/docker/env-from-file.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Scans the environment variables for those with the suffix _FILE
+# When located, checks the file exists, and exports the contents
+# of the file as the same name, minus the suffix
+# This allows the use of Docker secrets or mounted files
+# to fill in any of the settings configurable via environment
+# variables
+
+set -eu
+
+for line in $(printenv)
+do
+	# Extract the name of the environment variable
+	env_name=${line%%=*}
+	# Check if it ends in "_FILE"
+	if [[ ${env_name} == *_FILE ]]; then
+		# Extract the value of the environment
+		env_value=${line#*=}
+
+		# Check the file exists
+		if [[ -f ${env_value} ]]; then
+
+			# Trim off the _FILE suffix
+			non_file_env_name=${env_name%"_FILE"}
+			echo "Setting ${non_file_env_name} from file"
+
+			# Reads the value from th file
+			val="$(< "${!env_name}")"
+
+			# Sets the normal name to the read file contents
+			export "${non_file_env_name}"="${val}"
+
+		else
+			echo "File ${env_value} doesn't exist"
+			exit 1
+		fi
+	fi
+done

--- a/docker/management_script.sh
+++ b/docker/management_script.sh
@@ -3,6 +3,9 @@
 set -e
 
 cd /usr/src/paperless/src/
+# This ensures environment is setup
+# shellcheck disable=SC1091
+source /sbin/env-from-file.sh
 
 if [[ $(id -u) == 0 ]] ;
 then


### PR DESCRIPTION
## Proposed change

When reading files to populate environment variables, the exported variables aren't available when running a management command, as that's a different shell.

Refactors the reading of files to populate environment into a seperate script, which is then used in the docker startup and the management command.

Also expands the script to use anything ending in `_FILE`, meaning all environment can be set via a file if one desires.

Fixes #2248

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
