### PR TITLE
Bugfix: Handle email dates maybe being naive

### DIFF
--- a/src/paperless_mail/parsers.py
+++ b/src/paperless_mail/parsers.py
@@ -8,6 +8,8 @@ import requests
 from bleach import clean
 from bleach import linkify
 from django.conf import settings
+from django.utils.timezone import is_naive
+from django.utils.timezone import make_aware
 from documents.parsers import DocumentParser
 from documents.parsers import make_thumbnail_from_pdf
 from documents.parsers import ParseError
@@ -135,7 +137,11 @@ class MailDocumentParser(DocumentParser):
 
         self.text += f"\n\n{strip_text(mail.text)}"
 
-        self.date = mail.date
+        if is_naive(mail.date):
+            self.date = make_aware(mail.date)
+        else:
+            self.date = mail.date
+
         self.archive_path = self.generate_pdf(document_path)
 
     def tika_parse(self, html: str):


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Simple change to check for the email datetime being naive and coerce it into an aware datetime in that case, using the standard Django utils.

Fixes #2264

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
