### PR TITLE
Chore: Log memory usage at checkpoints

### DIFF
--- a/src/documents/consumer.py
+++ b/src/documents/consumer.py
@@ -362,9 +362,6 @@ class Consumer(LoggingMixin):
                 exc_info=True,
                 exception=e,
             )
-        finally:
-            document_parser.memory_checkpoint("final")
-            document_parser.cleanup()
 
         # Prepare the document classifier.
 
@@ -451,6 +448,9 @@ class Consumer(LoggingMixin):
                 exc_info=True,
                 exception=e,
             )
+        finally:
+            document_parser.memory_checkpoint("final")
+            document_parser.cleanup()
 
         self.run_post_consume_script(document)
 

--- a/src/documents/parsers.py
+++ b/src/documents/parsers.py
@@ -3,6 +3,7 @@ import logging
 import mimetypes
 import os
 import re
+import resource
 import shutil
 import subprocess
 import tempfile
@@ -331,3 +332,19 @@ class DocumentParser(LoggingMixin):
     def cleanup(self):
         self.log("debug", f"Deleting directory {self.tempdir}")
         shutil.rmtree(self.tempdir)
+
+    def memory_checkpoint(self, name: str):
+        """
+        Reports a summation of the current process and child
+        process memory usage into the log with a given checkpoint name.
+
+        Memory usage is in kilobytes
+        """
+        usage_self = resource.getrusage(resource.RUSAGE_SELF)
+        usage_children = resource.getrusage(resource.RUSAGE_CHILDREN)
+        self.log(
+            "debug",
+            f"Memory Checkpoint - "
+            f"{name} - "
+            f"{usage_self.ru_maxrss + usage_children.ru_maxrss}",
+        )


### PR DESCRIPTION
## Proposed change

I'd like to take a closer look at where memory usage is coming from and be able to tell if changes I make are having a positive (or negative) affect.  

To help accomplish this, I've added a memory checkpoint method, which is called by the consumer after roughly each major step of the consumption.  Parsers are also able to log more detailed steps if they want, such as what I've added to the tesseract based parser, which is by far the memory hog.

The line is logged at the DEBUG level, so it will only go into the log file and looks something like this:
```log
[2023-01-02 15:49:34,506] [DEBUG] [paperless.parsing.tesseract] Memory Checkpoint - ocr:1 - 1374408
```

Fixes # (issue)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (please explain) - minimal logging for debugging memory usage

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
