### PR TITLE
Feature: include comments in advanced search

### DIFF
--- a/src-ui/src/app/components/document-list/document-card-large/document-card-large.component.html
+++ b/src-ui/src/app/components/document-list/document-card-large/document-card-large.component.html
@@ -25,7 +25,13 @@
           </h5>
         </div>
         <p class="card-text">
-          <span *ngIf="document.__search_hit__" [innerHtml]="document.__search_hit__.highlights"></span>
+          <span *ngIf="document.__search_hit__ && document.__search_hit__.highlights" [innerHtml]="document.__search_hit__.highlights"></span>
+          <span *ngIf="document.__search_hit__ && document.__search_hit__.comment_highlights">
+            <svg width="1em" height="1em" fill="currentColor" class="me-2">
+              <use xlink:href="assets/bootstrap-icons.svg#chat-left-text"/>
+            </svg>
+            <span [innerHtml]="document.__search_hit__.comment_highlights"></span>
+          </span>
           <span *ngIf="!document.__search_hit__" class="result-content">{{contentTrimmed}}</span>
         </p>
 

--- a/src-ui/src/app/data/paperless-document.ts
+++ b/src-ui/src/app/data/paperless-document.ts
@@ -10,6 +10,7 @@ export interface SearchHit {
   rank?: number
 
   highlights?: string
+  comment_highlights?: string
 }
 
 export interface PaperlessDocument extends ObjectWithId {

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -458,10 +458,19 @@ class DocumentViewSet(
 class SearchResultSerializer(DocumentSerializer):
     def to_representation(self, instance):
         doc = Document.objects.get(id=instance["id"])
+        commentTerm = instance.results.q.subqueries[0]
+        comments = ",".join(
+            [
+                str(c.comment)
+                for c in Comment.objects.filter(document=instance["id"])
+                if commentTerm.text in c.comment
+            ],
+        )
         r = super().to_representation(doc)
         r["__search_hit__"] = {
             "score": instance.score,
-            "highlights": instance.highlights("content", text=doc.content)
+            "highlights": instance.highlights("content", text=doc.content),
+            "comment_highlights": instance.highlights("content", text=comments)
             if doc
             else None,
             "rank": instance.rank,


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

This was on the list back when comments were added, hopefully should make them more useful. Adding them to the search was pretty straightforward (first commit), I danced with whoosh a bit for the permissions stuff. But adding the highlighting Im not so totally certain about, open to other solutions, but this seems to work.

<img width="1604" alt="Screen Shot 2023-01-04 at 7 05 16 PM" src="https://user-images.githubusercontent.com/4887959/210714641-04864cd2-b966-4fcb-a8f0-8cf5fe8d221d.png">
<img width="1791" alt="Screen Shot 2023-01-04 at 6 55 23 PM" src="https://user-images.githubusercontent.com/4887959/210714650-be074532-3e21-4b39-9528-32a361862ca1.png">

Fixes #1654
Fixes #687
See #1375 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
