### PR TITLE
Fix: Make missing environment from file files informational only

### DIFF
--- a/docker/env-from-file.sh
+++ b/docker/env-from-file.sh
@@ -13,7 +13,7 @@ for line in $(printenv)
 do
 	# Extract the name of the environment variable
 	env_name=${line%%=*}
-	# Check if it ends in "_FILE"
+	# Check if it starts with "PAPERLESS_" and ends in "_FILE"
 	if [[ ${env_name} == PAPERLESS_*_FILE ]]; then
 		# Extract the value of the environment
 		env_value=${line#*=}
@@ -32,7 +32,7 @@ do
 			export "${non_file_env_name}"="${val}"
 
 		else
-			echo "File ${env_value} referenced ${env_name} by doesn't exist"
+			echo "File ${env_value} referenced by ${env_name} doesn't exist"
 		fi
 	fi
 done

--- a/docker/env-from-file.sh
+++ b/docker/env-from-file.sh
@@ -32,8 +32,7 @@ do
 			export "${non_file_env_name}"="${val}"
 
 		else
-			echo "File ${env_value} doesn't exist"
-			exit 1
+			echo "File ${env_value} referenced ${env_name} by doesn't exist"
 		fi
 	fi
 done

--- a/docker/env-from-file.sh
+++ b/docker/env-from-file.sh
@@ -14,7 +14,7 @@ do
 	# Extract the name of the environment variable
 	env_name=${line%%=*}
 	# Check if it ends in "_FILE"
-	if [[ ${env_name} == *_FILE ]]; then
+	if [[ ${env_name} == PAPERLESS_*_FILE ]]; then
 		# Extract the value of the environment
 		env_value=${line#*=}
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -148,17 +148,9 @@ steps described in [Docker setup](#docker_hub) automatically.
 
     !!! note
 
-        You can utilize Docker secrets for some configuration settings by
-        appending `_FILE` to some configuration values. This is
-        supported currently only by:
-
-        - PAPERLESS_DBUSER
-        - PAPERLESS_DBPASS
-        - PAPERLESS_SECRET_KEY
-        - PAPERLESS_AUTO_LOGIN_USERNAME
-        - PAPERLESS_ADMIN_USER
-        - PAPERLESS_ADMIN_MAIL
-        - PAPERLESS_ADMIN_PASSWORD
+        You can utilize Docker secrets for configuration settings by
+        appending `_FILE` to configuration values. For example `PAPERLESS_DBUSER`
+        can be set using `PAPERLESS_DBUSER_FILE=/var/run/secrets/password.txt`.
 
     !!! warning
 


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Two changes to how setting environment from file contents works.

1. Only look at variables matching `PAPERLESS_*_FILE`
2. Make a missing file non-fatal, in case there's a `*_FILE` variable which isn't 

Fixes #2367

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
