### PR TITLE
Fix build dependency in the bare-metal setup guide.

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -278,7 +278,7 @@ supported.
     - `unpaper`
     - `ghostscript`
     - `icc-profiles-free`
-    - `qpdf`
+    - `libqpdf-dev` >= 11.1.0
     - `liblept5`
     - `libxml2`
     - `pngquant` (suggested for certain PDF image optimizations)
@@ -290,7 +290,7 @@ supported.
     Use this list for your preferred package management:
 
     ```
-    unpaper ghostscript icc-profiles-free qpdf liblept5 libxml2 pngquant zlib1g tesseract-ocr
+    unpaper ghostscript icc-profiles-free libqpdf-dev liblept5 libxml2 pngquant zlib1g tesseract-ocr
     ```
 
     On Raspberry Pi, these libraries are required as well:


### PR DESCRIPTION
## Proposed change

qpdf is the command-line frontend, whereas the library is required to build pikepdf.

This is a documentation fix.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
