### PR TITLE
Feature: Control scheduled tasks via cron expressions

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -713,9 +713,44 @@ for details on how to set it.
 used during automatic classification. If disabled, paperless will
 still preform some basic text pre-processing before matching.
 
-See also `PAPERLESS_NLTK_DIR`.
+: See also `PAPERLESS_NLTK_DIR`.
 
     Defaults to 1.
+
+`PAPERLESS_EMAIL_TASK_CRON=<cron expression>`
+
+: Configures the scheduled email fetching frequency. The value
+should be a valid crontab(5) expression describing when to run.
+
+: If set to the string "disable", no emails will be fetched automatically.
+
+    Defaults to `*/10 * * * *` or every ten minutes.
+
+`PAPERLESS_TRAIN_TASK_CRON=<cron expression>`
+
+: Configures the scheduled automatic classifier training frequency. The value
+should be a valid crontab(5) expression describing when to run.
+
+: If set to the string "disable", the classifier will not be trained automatically.
+
+    Defaults to `5 */1 * * *` or every hour at 5 minutes past the hour.
+
+`PAPERLESS_INDEX_TASK_CRON=<cron expression>`
+
+: Configures the scheduled search index update frequency. The value
+should be a valid crontab(5) expression describing when to run.
+
+: If set to the string "disable", the search index will not be automatically updated.
+
+    Defaults to `0 0 * * *` or daily at midnight.
+
+`PAPERLESS_SANITY_TASK_CRON=<cron expression>`
+
+: Configures the scheduled sanity checker frequency.
+
+: If set to the string "disable", the sanity checker will not run automatically.
+
+    Defaults to `30 0 * * sun` or Sunday at 30 minutes past midnight.
 
 ## Polling {#polling}
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -191,7 +191,7 @@ different means. These are as follows:
     them further.
 
 Paperless is set up to check your mails every 10 minutes. This can be
-configured on the 'Scheduled tasks' page in the admin.
+configured via `PAPERLESS_EMAIL_TASK_CRON` (see [software tweaks](/configuration#software_tweaks))
 
 ### REST API
 

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -141,9 +141,15 @@ def _parse_beat_schedule() -> Dict:
         },
     ]
     for task in tasks:
+        # Either get the environment setting or use the default
         value = os.getenv(task["env_key"], task["env_default"])
+        # Don't add disabled tasks to the schedule
         if value == "disable":
             continue
+        # I find https://crontab.guru/ super helpful
+        # crontab(5) format
+        #   - five time-and-date fields
+        #   - separated by at least one blank
         minute, hour, day_month, month, day_week = value.split(" ")
         schedule[task["name"]] = {
             "task": task["task"],

--- a/src/paperless/tests/test_settings.py
+++ b/src/paperless/tests/test_settings.py
@@ -63,6 +63,8 @@ class TestIgnoreDateParsing(TestCase):
 
         self._parse_checker(test_cases)
 
+
+class TestThreadCalculation(TestCase):
     def test_workers_threads(self):
         """
         GIVEN:
@@ -87,6 +89,8 @@ class TestIgnoreDateParsing(TestCase):
 
                 self.assertLessEqual(default_workers * default_threads, i)
 
+
+class TestRedisSocketConversion(TestCase):
     def test_redis_socket_parsing(self):
         """
         GIVEN:
@@ -143,6 +147,8 @@ class TestIgnoreDateParsing(TestCase):
             result = _parse_redis_url(input)
             self.assertTupleEqual(expected, result)
 
+
+class TestCeleryScheduleParsing(TestCase):
     def test_schedule_configuration_default(self):
         """
         GIVEN:


### PR DESCRIPTION
## Proposed change

It's admittedly not as full control via the admin pages django-q offered, but this PR adds the ability to control each of the scheduled tasks via a cron expression.  A special value "disable" allows disabling of the task.  This is generally not advised for any task besides email fetching.

Fixes # (issue)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
