### PR TITLE
Feature: Retain original filename on upload

### DIFF
--- a/src/documents/signals/handlers.py
+++ b/src/documents/signals/handlers.py
@@ -447,7 +447,7 @@ def update_filename_and_move_files(sender, instance, **kwargs):
             )
 
         except (OSError, DatabaseError, CannotMoveFilesException) as e:
-            logger.warn(f"Exception during file handling: {e}")
+            logger.warning(f"Exception during file handling: {e}")
             # This happens when either:
             #  - moving the files failed due to file system errors
             #  - saving to the database failed due to database errors

--- a/src/documents/tests/test_api.py
+++ b/src/documents/tests/test_api.py
@@ -7,6 +7,7 @@ import tempfile
 import urllib.request
 import uuid
 import zipfile
+from pathlib import Path
 from unittest import mock
 from unittest.mock import MagicMock
 
@@ -808,7 +809,9 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
         m.assert_called_once()
 
         args, kwargs = m.call_args
-        self.assertEqual(kwargs["override_filename"], "simple.pdf")
+        file_path = Path(args[0])
+        self.assertEqual(file_path.name, "simple.pdf")
+        self.assertIn(Path(settings.SCRATCH_DIR), file_path.parents)
         self.assertIsNone(kwargs["override_title"])
         self.assertIsNone(kwargs["override_correspondent_id"])
         self.assertIsNone(kwargs["override_document_type_id"])
@@ -833,7 +836,9 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
         m.assert_called_once()
 
         args, kwargs = m.call_args
-        self.assertEqual(kwargs["override_filename"], "simple.pdf")
+        file_path = Path(args[0])
+        self.assertEqual(file_path.name, "simple.pdf")
+        self.assertIn(Path(settings.SCRATCH_DIR), file_path.parents)
         self.assertIsNone(kwargs["override_title"])
         self.assertIsNone(kwargs["override_correspondent_id"])
         self.assertIsNone(kwargs["override_document_type_id"])

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -635,7 +635,7 @@ class PostDocumentView(GenericAPIView):
 
         task_id = str(uuid.uuid4())
 
-        consume_file.delay(
+        async_task = consume_file.delay(
             # Paths are not JSON friendly
             str(temp_file_path),
             override_title=title,


### PR DESCRIPTION

## Proposed change

When uploading a file, retain the original base name of the file instead of converting it to a temporary file.  It's accomplished by placing the original, but sanitized name into a random directory.

This allows the consume logic to use the normal file's name, no overriding and makes it more clear in the logs what the file was/is.  It may also help pre-consume scripts file don't check mime type, but instead rely on extensions.  And on a failure, having the original named file in a directory is more clear for recovering it.

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
