### PR TITLE
Add AppleMail color tag support

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -151,6 +151,8 @@ different means. These are as follows:
   will not consume mails already tagged. Not all mail servers support
   this feature!
 
+  - **AppleMail support:** AppleMail allows differently colored tags. For this to work use `apple:<color>` (e.g. "apple:green") as a custom tag. Available colors are "red", "orange", "yellow", "blue", "green", "violet" and "grey".
+
 !!! warning
 
     The mail consumer will perform these actions on all mails it has

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -151,7 +151,7 @@ different means. These are as follows:
   will not consume mails already tagged. Not all mail servers support
   this feature!
 
-  - **AppleMail support:** AppleMail allows differently colored tags. For this to work use `apple:<color>` (e.g. "apple:green") as a custom tag. Available colors are "red", "orange", "yellow", "blue", "green", "violet" and "grey".
+  - **Apple Mail support:** Apple Mail clients allow differently colored tags. For this to work use `apple:<color>` (e.g. "apple:green") as a custom tag. Available colors are "red", "orange", "yellow", "blue", "green", "violet" and "grey".
 
 !!! warning
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -151,7 +151,7 @@ different means. These are as follows:
   will not consume mails already tagged. Not all mail servers support
   this feature!
 
-  - **Apple Mail support:** Apple Mail clients allow differently colored tags. For this to work use `apple:<color>` (e.g. "apple:green") as a custom tag. Available colors are "red", "orange", "yellow", "blue", "green", "violet" and "grey".
+  - **Apple Mail support:** Apple Mail clients allow differently colored tags. For this to work use `apple:<color>` (e.g. _apple:green_) as a custom tag. Available colors are _red_, _orange_, _yellow_, _blue_, _green_, _violet_ and _grey_.
 
 !!! warning
 

--- a/src/paperless_mail/mail.py
+++ b/src/paperless_mail/mail.py
@@ -91,7 +91,7 @@ class TagMailAction(BaseMailAction):
     def __init__(self, parameter):
 
         # The custom tag should look like "apple:<color>"
-        if "apple" in parameter.lower():
+        if "apple:" in parameter.lower():
             try:
                 _, self.color = parameter.split(":")
                 self.color = self.color.strip()

--- a/src/paperless_mail/mail.py
+++ b/src/paperless_mail/mail.py
@@ -27,7 +27,6 @@ from paperless_mail.models import MailAccount
 from paperless_mail.models import MailRule
 
 # Apple Mail sets multiple IMAP KEYWORD and the general "\Flagged" FLAG
-
 # imaplib => conn.fetch(b"<message_id>", "FLAGS")
 
 # no flag   - (FLAGS (\\Seen $NotJunk NotJunk))'
@@ -140,7 +139,6 @@ class TagMailAction(BaseMailAction):
             # Set the general \Flagged
             # This defaults to the "red" flag in AppleMail and
             # "stars" in Thunderbird or GMail
-
             M.flag(message_uids, [MailMessageFlags.FLAGGED], True)
 
         elif self.keyword:

--- a/src/paperless_mail/mail.py
+++ b/src/paperless_mail/mail.py
@@ -92,18 +92,13 @@ class TagMailAction(BaseMailAction):
 
         # The custom tag should look like "apple:<color>"
         if "apple:" in parameter.lower():
-            try:
-                _, self.color = parameter.split(":")
-                self.color = self.color.strip()
 
-                if not self.color.lower() in APPLE_MAIL_TAG_COLORS.keys():
-                    raise MailError("Not a valid AppleMail tag color.")
-            except Exception as e:
-                raise MailError(
-                    """Could not parse parameters.
-                    Make sure they look like this: apple:<color> and
-                    only use allowed colors.""",
-                ) from e
+            _, self.color = parameter.split(":")
+            self.color = self.color.strip()
+
+            if not self.color.lower() in APPLE_MAIL_TAG_COLORS.keys():
+                raise MailError("Not a valid AppleMail tag color.")
+
             self.keyword = None
 
         else:

--- a/src/paperless_mail/mail.py
+++ b/src/paperless_mail/mail.py
@@ -33,10 +33,10 @@ from paperless_mail.models import MailRule
 # no flag   - (FLAGS (\\Seen $NotJunk NotJunk))'
 # red       - (FLAGS (\\Flagged \\Seen $NotJunk NotJunk))'
 # orange    - (FLAGS (\\Flagged \\Seen $NotJunk NotJunk $MailFlagBit0))'
-# violet    - (FLAGS (\\Flagged \\Seen $NotJunk NotJunk $MailFlagBit0 $MailFlagBit2))'
-# blue      - (FLAGS (\\Flagged \\Seen $NotJunk NotJunk $MailFlagBit2))'
 # yellow    - (FLAGS (\\Flagged \\Seen $NotJunk NotJunk $MailFlagBit1))'
+# blue      - (FLAGS (\\Flagged \\Seen $NotJunk NotJunk $MailFlagBit2))'
 # green     - (FLAGS (\\Flagged \\Seen $NotJunk NotJunk $MailFlagBit0 $MailFlagBit1))'
+# violet    - (FLAGS (\\Flagged \\Seen $NotJunk NotJunk $MailFlagBit0 $MailFlagBit2))'
 # grey      - (FLAGS (\\Flagged \\Seen $NotJunk NotJunk $MailFlagBit1 $MailFlagBit2))'
 
 APPLE_MAIL_TAG_COLORS = {
@@ -138,7 +138,9 @@ class TagMailAction(BaseMailAction):
             M.flag(message_uids, APPLE_MAIL_TAG_COLORS.get(self.color), True)
 
             # Set the general \Flagged
-            # This defaults to the "red" flag and "stars" in Thunderbird or GMail
+            # This defaults to the "red" flag in AppleMail and
+            # "stars" in Thunderbird or GMail
+
             M.flag(message_uids, [MailMessageFlags.FLAGGED], True)
 
         elif self.keyword:

--- a/src/paperless_mail/mail.py
+++ b/src/paperless_mail/mail.py
@@ -101,13 +101,15 @@ class TagMailAction(BaseMailAction):
                     raise MailError("Not a valid AppleMail tag color.")
             except Exception as e:
                 raise MailError(
-                    """Could not parse the parameters.
-                    Make sure they look like this: apple:<color>""",
+                    """Could not parse parameters.
+                    Make sure they look like this: apple:<color> and
+                    only use allowed colors.""",
                 ) from e
             self.keyword = None
 
         else:
             self.keyword = parameter
+            self.color = None
 
     def get_criteria(self):
 

--- a/src/paperless_mail/mail.py
+++ b/src/paperless_mail/mail.py
@@ -1,3 +1,4 @@
+import itertools
 import os
 import re
 import tempfile
@@ -24,6 +25,29 @@ from imap_tools import NOT
 from imap_tools.mailbox import MailBoxTls
 from paperless_mail.models import MailAccount
 from paperless_mail.models import MailRule
+
+# Apple Mail sets multiple IMAP KEYWORD and the general "\Flagged" FLAG
+
+# imaplib => conn.fetch(b"<message_id>", "FLAGS")
+
+# no flag   - (FLAGS (\\Seen $NotJunk NotJunk))'
+# red       - (FLAGS (\\Flagged \\Seen $NotJunk NotJunk))'
+# orange    - (FLAGS (\\Flagged \\Seen $NotJunk NotJunk $MailFlagBit0))'
+# violet    - (FLAGS (\\Flagged \\Seen $NotJunk NotJunk $MailFlagBit0 $MailFlagBit2))'
+# blue      - (FLAGS (\\Flagged \\Seen $NotJunk NotJunk $MailFlagBit2))'
+# yellow    - (FLAGS (\\Flagged \\Seen $NotJunk NotJunk $MailFlagBit1))'
+# green     - (FLAGS (\\Flagged \\Seen $NotJunk NotJunk $MailFlagBit0 $MailFlagBit1))'
+# grey      - (FLAGS (\\Flagged \\Seen $NotJunk NotJunk $MailFlagBit1 $MailFlagBit2))'
+
+APPLE_MAIL_TAG_COLORS = {
+    "red": [],
+    "orange": ["$MailFlagBit0"],
+    "yellow": ["$MailFlagBit1"],
+    "blue": ["$MailFlagBit2"],
+    "green": ["$MailFlagBit0", "$MailFlagBit1"],
+    "violet": ["$MailFlagBit0", "$MailFlagBit2"],
+    "grey": ["$MailFlagBit1", "$MailFlagBit2"],
+}
 
 
 class MailError(Exception):
@@ -66,17 +90,60 @@ class FlagMailAction(BaseMailAction):
 
 class TagMailAction(BaseMailAction):
     def __init__(self, parameter):
-        self.keyword = parameter
+
+        # The custom tag should look like "apple:<color>"
+        if "apple" in parameter.lower():
+            try:
+                _, self.color = parameter.split(":")
+                self.color = self.color.strip()
+
+                if not self.color.lower() in APPLE_MAIL_TAG_COLORS.keys():
+                    raise MailError("Not a valid AppleMail tag color.")
+            except Exception as e:
+                raise MailError(
+                    """Could not parse the parameters.
+                    Make sure they look like this: apple:<color>""",
+                ) from e
+            self.keyword = None
+
+        else:
+            self.keyword = parameter
 
     def get_criteria(self):
+
+        # AppleMail: We only need to check if mails are \Flagged
+        if self.color:
+            return {"flagged": False}
+
         return {"no_keyword": self.keyword, "gmail_label": self.keyword}
 
     def post_consume(self, M: MailBox, message_uids, parameter):
         if re.search(r"gmail\.com$|googlemail\.com$", M._host):
             for uid in message_uids:
                 M.client.uid("STORE", uid, "X-GM-LABELS", self.keyword)
-        else:
+
+        # AppleMail
+        elif self.color:
+
+            # Remove all existing $MailFlagBits
+            M.flag(
+                message_uids,
+                set(itertools.chain(*APPLE_MAIL_TAG_COLORS.values())),
+                False,
+            )
+
+            # Set new $MailFlagBits
+            M.flag(message_uids, APPLE_MAIL_TAG_COLORS.get(self.color), True)
+
+            # Set the general \Flagged
+            # This defaults to the "red" flag and "stars" in Thunderbird or GMail
+            M.flag(message_uids, [MailMessageFlags.FLAGGED], True)
+
+        elif self.keyword:
             M.flag(message_uids, [self.keyword], True)
+
+        else:
+            raise MailError("No keyword specified.")
 
 
 def get_rule_action(rule) -> BaseMailAction:
@@ -197,14 +264,14 @@ class MailAccountHandler(LoggingMixin):
 
                     try:
                         M.login_utf8(account.username, account.password)
-                    except Exception as err:
+                    except Exception as e:
                         self.log(
                             "error",
                             "Unable to authenticate with mail server using AUTH=PLAIN",
                         )
                         raise MailError(
                             f"Error while authenticating account {account}",
-                        ) from err
+                        ) from e
                 except Exception as e:
                     self.log(
                         "error",

--- a/src/paperless_mail/tests/test_mail.py
+++ b/src/paperless_mail/tests/test_mail.py
@@ -682,11 +682,6 @@ class TestMail(DirectoriesMixin, TestCase):
             TagMailAction,
             "apple:black",
         )
-        self.assertRaises(
-            MailError,
-            TagMailAction,
-            "applegreen",
-        )
 
     def test_handle_mail_account_tag_applemail(self):
         # all mails will be FLAGGED afterwards


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

AppleMail allows for colored tags. Available colors are "red", "orange", "yellow", "blue", "green", "violet" and "grey". On the server these are represented as a variaton of "$MailFlagBit<int>".

```
# no flag   - (FLAGS (\\Seen $NotJunk NotJunk))'
# red       - (FLAGS (\\Flagged \\Seen $NotJunk NotJunk))'
# orange    - (FLAGS (\\Flagged \\Seen $NotJunk NotJunk $MailFlagBit0))'
# violet    - (FLAGS (\\Flagged \\Seen $NotJunk NotJunk $MailFlagBit0 $MailFlagBit2))'
# blue      - (FLAGS (\\Flagged \\Seen $NotJunk NotJunk $MailFlagBit2))'
# yellow    - (FLAGS (\\Flagged \\Seen $NotJunk NotJunk $MailFlagBit1))'
# green     - (FLAGS (\\Flagged \\Seen $NotJunk NotJunk $MailFlagBit0 $MailFlagBit1))'
# grey      - (FLAGS (\\Flagged \\Seen $NotJunk NotJunk $MailFlagBit1 $MailFlagBit2))'
```

This PR implements a quick and easy way to make these colors available using the "custom tag" email rule.
Specify `apple:<color>` in your custom tags and everything will be set for you after the emails are processed.

From a user's perspective tagging your automatically processed emails in a different color makes sense because it won't mess with your flags that are already in place (e.g. "red" for important personal mails, "grey" for everything processed by paperless-ngx).

This (hopefully) will not mess with GMail support because GMail will only allow "starred" mails. The same is true for Thunderbird. A "star" corresponds to a "red" flag in AppleMail which means there is only the "\Flagged" FLAG set and no $MailFlagBits.

EDIT: I'm sure this could be done in a more elegant way via the frontend. This might be something for the future if you find this PR useful.

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
