### PR TITLE
Fix: Better Handle arbitrary ISO 8601 strings after celery serializing

### DIFF
--- a/src/documents/tasks.py
+++ b/src/documents/tasks.py
@@ -3,10 +3,10 @@ import logging
 import os
 import shutil
 import uuid
-from datetime import datetime
 from pathlib import Path
 from typing import Type
 
+import dateutil.parser
 import tqdm
 from asgiref.sync import async_to_sync
 from celery import shared_task
@@ -105,7 +105,7 @@ def consume_file(
     # More types will be retained through JSON encode/decode
     if override_created is not None and isinstance(override_created, str):
         try:
-            override_created = datetime.fromisoformat(override_created)
+            override_created = dateutil.parser.isoparse(override_created)
         except Exception:
             pass
 


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

See linked issue, #2019 did fix this but I think when parsing some iso 8601 strings it will fail e.g. if you pass `2022-01-15` to the API you get `2022-01-15T00:00:00Z` which will fail with `Invalid isoformat string: '2022-01-15T00:00:00Z'`. So dont parse with `datetime.fromisoformat` use `dateutil.parser.isoparse` instead.

Fixes #2435

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] ~~I have made corresponding changes to the documentation as needed.~~
- [x] I have checked my modifications for any breaking changes.
