### PR TITLE
Update docs nginx reverse proxy example

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -881,7 +881,7 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Host $server_name;
-            add_header P3P 'CP=""';
+            add_header P3P 'CP=""'; # may not be required in all setups
         }
     }
 }

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -881,6 +881,7 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Host $server_name;
+            add_header P3P 'CP=""';
         }
     }
 }


### PR DESCRIPTION
According to #817 P3P header is mandatory. Otherwise django CSRF breaks login

<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Update nginx reverse proxy example configuration as a result of issue #817. Makes it easier for people to find the cause why their instance of paperless-ngx won't let them logging in anymore without hour's of poking and googling around to find out this is already known.

Fixes #817

## Type of change

Update docs

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
