### PR TITLE
Fix: tag color ordering

### DIFF
--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -176,7 +176,7 @@ class TagViewSet(ModelViewSet):
     permission_classes = (IsAuthenticated,)
     filter_backends = (DjangoFilterBackend, OrderingFilter)
     filterset_class = TagFilterSet
-    ordering_fields = ("name", "matching_algorithm", "match", "document_count")
+    ordering_fields = ("color", "name", "matching_algorithm", "match", "document_count")
 
 
 class DocumentTypeViewSet(ModelViewSet):


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

This is actually because color wasn't one of the ordering options on the view, easy fix. (I suppose this feature wasn't used much since no one has noticed all this time =)

<img width="179" alt="Screen Shot 2023-01-17 at 6 34 59 AM" src="https://user-images.githubusercontent.com/4887959/212926511-f647b5b5-4d30-41ac-944f-774e7f5daea4.png">
<img width="217" alt="Screen Shot 2023-01-17 at 6 35 04 AM" src="https://user-images.githubusercontent.com/4887959/212926516-c6cf9605-b418-4bc8-b8ba-c01c591f4084.png">

Fixes #2452 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] ~~I have made corresponding changes to the documentation as needed.~~
- [x] I have checked my modifications for any breaking changes.
