### PR TITLE
document existence of document_thumbnails

### DIFF
--- a/docs/administration.md
+++ b/docs/administration.md
@@ -355,7 +355,7 @@ This command takes no arguments.
 
 ### Document thumbnails {#thumbnails}
 
-Sometimes you may wish to re-create document thumbnails. Use
+Use this command to re-create document thumbnails. Optionally include the ` --document {id}` option to generate thumbnails for a specific document only.
 
 ```
 document_thumbnails

--- a/docs/administration.md
+++ b/docs/administration.md
@@ -353,6 +353,14 @@ document_create_classifier
 
 This command takes no arguments.
 
+### Document thumbnails {#thumbnails}
+
+Sometimes you may wish to re-create document thumbnails. Use
+
+```
+document_thumbnails
+```
+
 ### Managing the document search index {#index}
 
 The document search index is responsible for delivering search results


### PR DESCRIPTION
I only found this command by digging through the code, couldn't find mention of it in the docs.