### PR TITLE
Docs: Fix typo - docker-compose.yml file name in setup doc

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -46,7 +46,7 @@ steps described in [Docker setup](#docker_hub) automatically.
     page](https://github.com/paperless-ngx/paperless-ngx/tree/master/docker/compose)
     and download one of the `docker-compose.*.yml` files,
     depending on which database backend you want to use. Rename this
-    file to `docker-compose.*.yml`. If you want to enable
+    file to `docker-compose.yml`. If you want to enable
     optional support for Office documents, download a file with
     `-tika` in the file name. Download the
     `docker-compose.env` file and the `.env` file as well and store them


### PR DESCRIPTION
## Proposed change

Fix typo - file name should be renamed to `docker-compose.yml`, not `docker-compose.*.yml` (which is invalid and not a known Docker file pattern).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
