### PR TITLE
Fix: fix downgrade migration

### DIFF
--- a/src/documents/migrations/1022_paperlesstask.py
+++ b/src/documents/migrations/1022_paperlesstask.py
@@ -24,7 +24,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 ("task_id", models.CharField(max_length=128)),
-                ("name", models.CharField(max_length=256)),
+                ("name", models.CharField(max_length=256, null=True)),
                 (
                     "created",
                     models.DateTimeField(auto_now=True, verbose_name="created"),


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

I think tweaking this field in the old paperlesstask migration is enough to fix the downgrade migration (it fails to reverse the `RemoveField` because the field wasn't nullable) so seems worth fixing as opposed to just not supporting any more. Obviously its not usual practice to change an existing migration but I dont think there will be any negative consequences to this, but if anyone disagrees please shout!

Fixes #2491 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] ~~I have made corresponding changes to the documentation as needed.~~
- [x] I have checked my modifications for any breaking changes.
