### PR TITLE
Bugfix: Request PDF/A format from Gotenberg

### DIFF
--- a/src/paperless_mail/parsers.py
+++ b/src/paperless_mail/parsers.py
@@ -271,6 +271,16 @@ class MailDocumentParser(DocumentParser):
                 "paperHeight": "11.7",
                 "scale": "1.0",
             }
+
+            # Set the output format of the resulting PDF
+            # Valid inputs: https://gotenberg.dev/docs/modules/pdf-engines#uno
+            if settings.OCR_OUTPUT_TYPE in {"pdfa", "pdfa-2"}:
+                data["pdfFormat"] = "PDF/A-2b"
+            elif settings.OCR_OUTPUT_TYPE == "pdfa-1":
+                data["pdfFormat"] = "PDF/A-1a"
+            elif settings.OCR_OUTPUT_TYPE == "pdfa-3":
+                data["pdfFormat"] = "PDF/A-3b"
+
             try:
                 response = requests.post(
                     url,

--- a/src/paperless_mail/tests/test_parsers.py
+++ b/src/paperless_mail/tests/test_parsers.py
@@ -573,8 +573,8 @@ class TestParser(TestCase):
             self.parser.gotenberg_server + "/forms/chromium/convert/html",
             mock_post.call_args.args[0],
         )
-        self.assertEqual({}, mock_post.call_args.kwargs["headers"])
-        self.assertEqual(
+        self.assertDictEqual({}, mock_post.call_args.kwargs["headers"])
+        self.assertDictEqual(
             {
                 "marginTop": "0.1",
                 "marginBottom": "0.1",
@@ -583,6 +583,7 @@ class TestParser(TestCase):
                 "paperWidth": "8.27",
                 "paperHeight": "11.7",
                 "scale": "1.0",
+                "pdfFormat": "PDF/A-2b",
             },
             mock_post.call_args.kwargs["data"],
         )
@@ -663,8 +664,8 @@ class TestParser(TestCase):
             self.parser.gotenberg_server + "/forms/chromium/convert/html",
             mock_post.call_args.args[0],
         )
-        self.assertEqual({}, mock_post.call_args.kwargs["headers"])
-        self.assertEqual(
+        self.assertDictEqual({}, mock_post.call_args.kwargs["headers"])
+        self.assertDictEqual(
             {
                 "marginTop": "0.1",
                 "marginBottom": "0.1",

--- a/src/paperless_tika/parsers.py
+++ b/src/paperless_tika/parsers.py
@@ -95,9 +95,19 @@ class TikaDocumentParser(DocumentParser):
                 ),
             }
             headers = {}
+            data = {}
+
+            # Set the output format of the resulting PDF
+            # Valid inputs: https://gotenberg.dev/docs/modules/pdf-engines#uno
+            if settings.OCR_OUTPUT_TYPE in {"pdfa", "pdfa-2"}:
+                data["pdfFormat"] = "PDF/A-2b"
+            elif settings.OCR_OUTPUT_TYPE == "pdfa-1":
+                data["pdfFormat"] = "PDF/A-1a"
+            elif settings.OCR_OUTPUT_TYPE == "pdfa-3":
+                data["pdfFormat"] = "PDF/A-3b"
 
             try:
-                response = requests.post(url, files=files, headers=headers)
+                response = requests.post(url, files=files, headers=headers, data=data)
                 response.raise_for_status()  # ensure we notice bad responses
             except Exception as err:
                 raise ParseError(


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

This fixes the API call to Gotenberg when converting something to a PDF to request the user requested PDF/A format.  Previously, the output was just a PDF, not the archive version.

Fixes #2522

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
