### PR TITLE
Chore: Fix tag cleaner to work with attestations

### DIFF
--- a/.github/scripts/cleanup-tags.py
+++ b/.github/scripts/cleanup-tags.py
@@ -155,8 +155,10 @@ class RegistryTagsCleaner:
                     proc = subprocess.run(
                         [
                             shutil.which("docker"),
-                            "manifest",
+                            "buildx",
+                            "imagetools",
                             "inspect",
+                            "--raw",
                             full_name,
                         ],
                         capture_output=True,

--- a/.github/workflows/cleanup-tags.yml
+++ b/.github/workflows/cleanup-tags.yml
@@ -72,7 +72,7 @@ jobs:
         name: Cleanup for package "${{ matrix.primary-name }}"
         if: "${{ env.TOKEN != '' }}"
         run: |
-          python ${GITHUB_WORKSPACE}/.github/scripts/cleanup-tags.py --untagged --is-manifest "${{ matrix.primary-name }}"
+          python ${GITHUB_WORKSPACE}/.github/scripts/cleanup-tags.py --untagged --is-manifest --delete "${{ matrix.primary-name }}"
       #
       # Clean up registry cache package
       #
@@ -80,4 +80,4 @@ jobs:
         name: Cleanup for package "${{ matrix.cache-name }}"
         if: "${{ env.TOKEN != '' }}"
         run: |
-          python ${GITHUB_WORKSPACE}/.github/scripts/cleanup-tags.py --untagged "${{ matrix.cache-name }}"
+          python ${GITHUB_WORKSPACE}/.github/scripts/cleanup-tags.py --untagged --delete "${{ matrix.cache-name }}"

--- a/.github/workflows/cleanup-tags.yml
+++ b/.github/workflows/cleanup-tags.yml
@@ -62,9 +62,9 @@ jobs:
         with:
           python-version: "3.10"
       -
-        name: Install httpx
+        name: Install Python libraries
         run: |
-          python -m pip install httpx
+          python -m pip install httpx docker
       #
       # Clean up primary package
       #
@@ -72,7 +72,7 @@ jobs:
         name: Cleanup for package "${{ matrix.primary-name }}"
         if: "${{ env.TOKEN != '' }}"
         run: |
-          python ${GITHUB_WORKSPACE}/.github/scripts/cleanup-tags.py --untagged --is-manifest --delete "${{ matrix.primary-name }}"
+          python ${GITHUB_WORKSPACE}/.github/scripts/cleanup-tags.py --untagged --is-manifest "${{ matrix.primary-name }}"
       #
       # Clean up registry cache package
       #
@@ -80,14 +80,4 @@ jobs:
         name: Cleanup for package "${{ matrix.cache-name }}"
         if: "${{ env.TOKEN != '' }}"
         run: |
-          python ${GITHUB_WORKSPACE}/.github/scripts/cleanup-tags.py --untagged --delete "${{ matrix.cache-name }}"
-      #
-      # Verify tags which are left still pull
-      #
-      -
-        name: Check all tags still pull
-        run: |
-          ghcr_name=$(echo "ghcr.io/${GITHUB_REPOSITORY_OWNER}/${{ matrix.primary-name }}" | awk '{ print tolower($0) }')
-          echo "Pulling all tags of ${ghcr_name}"
-          docker pull --quiet --all-tags ${ghcr_name}
-          docker image list
+          python ${GITHUB_WORKSPACE}/.github/scripts/cleanup-tags.py --untagged "${{ matrix.cache-name }}"


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

With the release of `docker/build-push-action` v3.3, the manifest is now using OCI formatting with attestation, [which docker manifest inspect](https://github.com/paperless-ngx/paperless-ngx/actions/runs/4017209210/jobs/6901406516#step:6:51) doesn't handle.

This PR changes the inspection to use [`docker buildx imagetools inspect`](https://docs.docker.com/engine/reference/commandline/buildx_inspect/) with the raw JSON, which returns the same fields as before, but doesn't balk at the attestation.

Finally, the check that all tags still pull is now moved into the Python, and uses the Docker Python SDK to manage interfacing to the Docker client.  It's also expanded to check the various arches, not just x86_64.

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
