### PR TITLE
Fix comment search highlight + multi-word search

### DIFF
--- a/src-ui/src/app/components/document-list/document-card-large/document-card-large.component.html
+++ b/src-ui/src/app/components/document-list/document-card-large/document-card-large.component.html
@@ -26,11 +26,11 @@
         </div>
         <p class="card-text">
           <span *ngIf="document.__search_hit__ && document.__search_hit__.highlights" [innerHtml]="document.__search_hit__.highlights"></span>
-          <span *ngIf="document.__search_hit__ && document.__search_hit__.comment_highlights" class="d-block">
+          <span *ngFor="let highlight of searchCommentHighlights" class="d-block">
             <svg width="1em" height="1em" fill="currentColor" class="me-2">
               <use xlink:href="assets/bootstrap-icons.svg#chat-left-text"/>
             </svg>
-            <span [innerHtml]="document.__search_hit__.comment_highlights"></span>
+            <span [innerHtml]="highlight"></span>
           </span>
           <span *ngIf="!document.__search_hit__" class="result-content">{{contentTrimmed}}</span>
         </p>

--- a/src-ui/src/app/components/document-list/document-card-large/document-card-large.component.ts
+++ b/src-ui/src/app/components/document-list/document-card-large/document-card-large.component.ts
@@ -70,6 +70,22 @@ export class DocumentCardLargeComponent {
     }
   }
 
+  get searchCommentHighlights() {
+    let highlights = []
+    if (
+      this.document['__search_hit__'] &&
+      this.document['__search_hit__'].comment_highlights
+    ) {
+      // only show comments with a match
+      highlights = (
+        this.document['__search_hit__'].comment_highlights as string
+      )
+        .split(',')
+        .filter((higlight) => higlight.includes('<span'))
+    }
+    return highlights
+  }
+
   getIsThumbInverted() {
     return this.settingsService.get(SETTINGS_KEYS.DARK_MODE_THUMB_INVERTED)
   }

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -477,21 +477,14 @@ class DocumentViewSet(
 class SearchResultSerializer(DocumentSerializer):
     def to_representation(self, instance):
         doc = Document.objects.get(id=instance["id"])
-        comments = ""
-        if hasattr(instance.results.q, "subqueries"):
-            commentTerm = instance.results.q.subqueries[0]
-            comments = ",".join(
-                [
-                    str(c.comment)
-                    for c in Comment.objects.filter(document=instance["id"])
-                    if commentTerm.text in c.comment
-                ],
-            )
+        comments = ",".join(
+            [str(c.comment) for c in Comment.objects.filter(document=instance["id"])],
+        )
         r = super().to_representation(doc)
         r["__search_hit__"] = {
             "score": instance.score,
             "highlights": instance.highlights("content", text=doc.content),
-            "comment_highlights": instance.highlights("content", text=comments)
+            "comment_highlights": instance.highlights("comments", text=comments)
             if doc
             else None,
             "rank": instance.rank,


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Fixes the issue with searching for multi-word comments and fixes some issues that can with comment search highlighting.

Comment searching has proved to be a bit more complicated than I realized, honestly mostly because I find the whoosh docs to be opaque, but thats on me. The fix here is mostly to let whoosh handle the highlighting on its own instead of trying to mess with it. I also took the opportunity to allow for visual highlighting more than one comment. See screenshots of all

<img width="766" alt="Screen Shot 2023-01-27 at 10 28 39 AM" src="https://user-images.githubusercontent.com/4887959/215166462-b695389e-e82b-4eca-b456-a92488f04a98.png">
<img width="970" alt="Screen Shot 2023-01-27 at 10 01 22 AM" src="https://user-images.githubusercontent.com/4887959/215166473-2c595255-0213-49af-9833-e3bf28f0c48a.png">
<img width="958" alt="Screen Shot 2023-01-27 at 10 01 15 AM" src="https://user-images.githubusercontent.com/4887959/215166487-acef2410-6c37-46b2-88cc-1c378a7e5f6e.png">

Fixes #2536

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] ~~I have made corresponding changes to the documentation as needed.~~
- [x] I have checked my modifications for any breaking changes.
