### PR TITLE
Fix importing files with non-ascii names

### DIFF
--- a/src/paperless_tika/parsers.py
+++ b/src/paperless_tika/parsers.py
@@ -90,7 +90,7 @@ class TikaDocumentParser(DocumentParser):
         with open(document_path, "rb") as document_handle:
             files = {
                 "files": (
-                    "convert." + file_name.split(".")[-1] or "convert" + os.path.splitext(document_path)[-1],
+                    os.path.splitext(document_path)[-1],
                     document_handle,
                 ),
             }

--- a/src/paperless_tika/parsers.py
+++ b/src/paperless_tika/parsers.py
@@ -90,7 +90,7 @@ class TikaDocumentParser(DocumentParser):
         with open(document_path, "rb") as document_handle:
             files = {
                 "files": (
-                    file_name or os.path.basename(document_path),
+                    "convert." + file_name.split(".")[-1] or "convert" + os.path.splitext(document_path)[-1],
                     document_handle,
                 ),
             }

--- a/src/paperless_tika/parsers.py
+++ b/src/paperless_tika/parsers.py
@@ -90,7 +90,7 @@ class TikaDocumentParser(DocumentParser):
         with open(document_path, "rb") as document_handle:
             files = {
                 "files": (
-                    os.path.splitext(document_path)[-1],
+                    "convert" + os.path.splitext(document_path)[-1],
                     document_handle,
                 ),
             }


### PR DESCRIPTION
## Proposed change

Replace filename with word "convert" when sending request to Gotenberg. 
Gotenberg can't deal with non-ascii filenames (see https://github.com/gotenberg/gotenberg/issues/427). If any non-ascii characters are present conversion will fail with exit code 6. It looks like filename used in Gotenberg request isn't used anywhere else so we can just replace it with safe string (while keeping file extension, "convert" + file extension)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
