### PR TITLE
Bugfix: Whoosh relative date queries weren't handling timezones

### DIFF
--- a/src/documents/index.py
+++ b/src/documents/index.py
@@ -5,6 +5,7 @@ from contextlib import contextmanager
 
 from dateutil.parser import isoparse
 from django.conf import settings
+from django.utils import timezone
 from documents.models import Comment
 from documents.models import Document
 from whoosh import classify
@@ -262,7 +263,7 @@ class DelayedFullTextQuery(DelayedQuery):
             ["content", "title", "correspondent", "tag", "type", "comments"],
             self.searcher.ixreader.schema,
         )
-        qp.add_plugin(DateParserPlugin())
+        qp.add_plugin(DateParserPlugin(basedate=timezone.now()))
         q = qp.parse(q_str)
 
         corrected = self.searcher.correct_query(q, q_str)

--- a/src/documents/tests/test_api.py
+++ b/src/documents/tests/test_api.py
@@ -518,7 +518,7 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
         WHEN:
             - Query for documents added in the last 7 days
         THEN:
-            - The two recent documents are returned
+            - All three recent documents are returned
         """
         d1 = Document.objects.create(
             title="invoice",


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Still don't know why this has broken, but this fixes Whoosh searching for relative things, such as the query `added:[-1 week to now]`.  The problem comes from the index using UTC time, as Whoosh suggests, but the ending query times were in local time.  By setting `basedate`, the query times are now corrected.

I added testing with UTC time, ahead of UTC and behind UTC for the -1 week, and some basic testing for the month query, which will prevent this in the future.

Fixes #2564

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
