### PR TITLE
Feature: Add filter on correspondent name

### DIFF
--- a/src-ui/src/app/components/document-list/filter-editor/filter-editor.component.ts
+++ b/src-ui/src/app/components/document-list/filter-editor/filter-editor.component.ts
@@ -22,6 +22,7 @@ import {
   FILTER_ADDED_BEFORE,
   FILTER_ASN,
   FILTER_CORRESPONDENT,
+  FILTER_CORRESPONDENT_NAME,
   FILTER_CREATED_AFTER,
   FILTER_CREATED_BEFORE,
   FILTER_DOCUMENT_TYPE,
@@ -93,6 +94,15 @@ export class FilterEditorComponent implements OnInit, OnDestroy {
           if (rule.value) {
             return $localize`Correspondent: ${
               this.correspondents.find((c) => c.id == +rule.value)?.name
+            }`
+          } else {
+            return $localize`Without correspondent`
+          }
+
+        case FILTER_CORRESPONDENT_NAME:
+          if (rule.value) {
+            return $localize`Correspondent: ${
+              this.correspondents.find((c) => c.name == rule.value)?.name
             }`
           } else {
             return $localize`Without correspondent`
@@ -357,6 +367,23 @@ export class FilterEditorComponent implements OnInit, OnDestroy {
             false
           )
           break
+        case FILTER_CORRESPONDENT_NAME:
+          this.correspondentService
+            .listFiltered(
+              1,
+              1,
+              null,
+              null,
+              rule.value
+            )
+            .subscribe((c) => {
+              this.correspondentSelectionModel.set(
+                rule.value ? c.results[0]?.id : null,
+                ToggleableItemState.Selected,
+                false
+              )
+            })
+          break
         case FILTER_DOCUMENT_TYPE:
           this.documentTypeSelectionModel.set(
             rule.value ? +rule.value : null,
@@ -488,6 +515,14 @@ export class FilterEditorComponent implements OnInit, OnDestroy {
         filterRules.push({
           rule_type: FILTER_CORRESPONDENT,
           value: correspondent.id?.toString(),
+        })
+      })
+    this.correspondentSelectionModel
+      .getSelectedItems()
+      .forEach((correspondent) => {
+        filterRules.push({
+          rule_type: FILTER_CORRESPONDENT_NAME,
+          value: correspondent.name?.toString(),
         })
       })
     this.documentTypeSelectionModel

--- a/src-ui/src/app/data/filter-rule-type.ts
+++ b/src-ui/src/app/data/filter-rule-type.ts
@@ -8,6 +8,7 @@ export const FILTER_ASN_GT = 23
 export const FILTER_ASN_LT = 24
 
 export const FILTER_CORRESPONDENT = 3
+export const FILTER_CORRESPONDENT_NAME = 26
 
 export const FILTER_DOCUMENT_TYPE = 4
 
@@ -59,6 +60,13 @@ export const FILTER_RULE_TYPES: FilterRuleType[] = [
   {
     id: FILTER_CORRESPONDENT,
     filtervar: 'correspondent__id',
+    isnull_filtervar: 'correspondent__isnull',
+    datatype: 'correspondent',
+    multi: false,
+  },
+  {
+    id: FILTER_CORRESPONDENT_NAME,
+    filtervar: 'correspondent__name__iexact',
     isnull_filtervar: 'correspondent__isnull',
     datatype: 'correspondent',
     multi: false,


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

This PR adds a way to display all documents of a correspondent using his name.

This could be useful in a company-use, example:
Take a company that has customers identified by a specific customer ID.
In this setup and with this PR, by creating a correspondent per customer and setting that correspondent name to this particular customer ID, we can allow an easy integration into other apps (like a CRM) with an URI like **/documents?correspondent__name__iexact=CUSTOMERSPECIFICID**.

I make this PR a draft because this is just a proposal and it may not be properly achieved.

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
