### PR TITLE
Chore: Fixing minor warnings in testing

### DIFF
--- a/src/documents/consumer.py
+++ b/src/documents/consumer.py
@@ -342,6 +342,7 @@ class Consumer(LoggingMixin):
             mime_type,
         )
         if not parser_class:
+            tempdir.cleanup()
             self._fail(MESSAGE_UNSUPPORTED_TYPE, f"Unsupported mime type {mime_type}")
 
         # Notify all listeners that we're going to do some work.
@@ -400,6 +401,7 @@ class Consumer(LoggingMixin):
 
         except ParseError as e:
             document_parser.cleanup()
+            tempdir.cleanup()
             self._fail(
                 str(e),
                 f"Error while consuming document {self.filename}: {e}",

--- a/src/documents/tests/test_api.py
+++ b/src/documents/tests/test_api.py
@@ -3200,7 +3200,7 @@ class TestApiStoragePaths(DirectoriesMixin, APITestCase):
         self.assertEqual(StoragePath.objects.count(), 1)
 
 
-class TestTasks(APITestCase):
+class TestTasks(DirectoriesMixin, APITestCase):
     ENDPOINT = "/api/tasks/"
     ENDPOINT_ACKNOWLEDGE = "/api/acknowledge_tasks/"
 

--- a/src/documents/tests/test_consumer.py
+++ b/src/documents/tests/test_consumer.py
@@ -847,13 +847,11 @@ class PreConsumeTestCase(TestCase):
                 self.assertEqual(command[0], script.name)
                 self.assertEqual(command[1], "path-to-file")
 
-                self.assertDictContainsSubset(
-                    {
-                        "DOCUMENT_SOURCE_PATH": c.original_path,
-                        "DOCUMENT_WORKING_PATH": c.path,
-                    },
-                    environment,
-                )
+                subset = {
+                    "DOCUMENT_SOURCE_PATH": c.original_path,
+                    "DOCUMENT_WORKING_PATH": c.path,
+                }
+                self.assertDictEqual(environment, {**environment, **subset})
 
     @mock.patch("documents.consumer.Consumer.log")
     def test_script_with_output(self, mocked_log):
@@ -983,16 +981,15 @@ class PostConsumeTestCase(TestCase):
                 self.assertEqual(command[7], "my_bank")
                 self.assertCountEqual(command[8].split(","), ["a", "b"])
 
-                self.assertDictContainsSubset(
-                    {
-                        "DOCUMENT_ID": str(doc.pk),
-                        "DOCUMENT_DOWNLOAD_URL": f"/api/documents/{doc.pk}/download/",
-                        "DOCUMENT_THUMBNAIL_URL": f"/api/documents/{doc.pk}/thumb/",
-                        "DOCUMENT_CORRESPONDENT": "my_bank",
-                        "DOCUMENT_TAGS": "a,b",
-                    },
-                    environment,
-                )
+                subset = {
+                    "DOCUMENT_ID": str(doc.pk),
+                    "DOCUMENT_DOWNLOAD_URL": f"/api/documents/{doc.pk}/download/",
+                    "DOCUMENT_THUMBNAIL_URL": f"/api/documents/{doc.pk}/thumb/",
+                    "DOCUMENT_CORRESPONDENT": "my_bank",
+                    "DOCUMENT_TAGS": "a,b",
+                }
+
+                self.assertDictEqual(environment, {**environment, **subset})
 
     def test_script_exit_non_zero(self):
         """

--- a/src/paperless_mail/tests/test_api.py
+++ b/src/paperless_mail/tests/test_api.py
@@ -2,12 +2,13 @@ from django.contrib.auth.models import User
 from documents.models import Correspondent
 from documents.models import DocumentType
 from documents.models import Tag
+from documents.tests.utils import DirectoriesMixin
 from paperless_mail.models import MailAccount
 from paperless_mail.models import MailRule
 from rest_framework.test import APITestCase
 
 
-class TestAPIMailAccounts(APITestCase):
+class TestAPIMailAccounts(DirectoriesMixin, APITestCase):
     ENDPOINT = "/api/mail_accounts/"
 
     def setUp(self):
@@ -165,7 +166,7 @@ class TestAPIMailAccounts(APITestCase):
         self.assertEqual(returned_account2.password, "123xyz")
 
 
-class TestAPIMailRules(APITestCase):
+class TestAPIMailRules(DirectoriesMixin, APITestCase):
     ENDPOINT = "/api/mail_rules/"
 
     def setUp(self):


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

A few small changes to resolve some warnings generated when the backend tests run.  Eliminating nuisances helps unearth things that actually may require action now or in the future to improve the code.  This caught 1 location where a temporary directory wasn't getting cleaned up.

Mostly, it was just Whitenoise complaining about the static folder not existing.

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (please explain) - general cleanup

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
