### PR TITLE
Fix: Remove files produced by barcode splitting when completed

### DIFF
--- a/src/documents/barcodes.py
+++ b/src/documents/barcodes.py
@@ -325,11 +325,10 @@ def save_to_dir(
     Optionally rename the file.
     """
     if os.path.isfile(filepath) and os.path.isdir(target_dir):
-        dst = shutil.copy(filepath, target_dir)
-        logging.debug(f"saved {str(filepath)} to {str(dst)}")
-        if newname:
-            dst_new = os.path.join(target_dir, newname)
-            logger.debug(f"moving {str(dst)} to {str(dst_new)}")
-            os.rename(dst, dst_new)
+        dest = target_dir
+        if newname is not None:
+            dest = os.path.join(dest, newname)
+        shutil.copy(filepath, dest)
+        logging.debug(f"saved {str(filepath)} to {str(dest)}")
     else:
         logger.warning(f"{str(filepath)} or {str(target_dir)} don't exist.")

--- a/src/documents/tasks.py
+++ b/src/documents/tasks.py
@@ -128,6 +128,18 @@ def consume_file(
                 )
 
                 if document_list:
+
+                    # If the file is an upload, it's in the scratch directory
+                    # Move it to consume directory to be picked up
+                    # Otherwise, use the current parent to keep possible tags
+                    # from subdirectories
+                    try:
+                        # is_relative_to would be nicer, but new in 3.9
+                        _ = path.relative_to(settings.SCRATCH_DIR)
+                        save_to_dir = settings.CONSUMPTION_DIR
+                    except ValueError:
+                        save_to_dir = path.parent
+
                     for n, document in enumerate(document_list):
                         # save to consumption dir
                         # rename it to the original filename  with number prefix
@@ -136,22 +148,17 @@ def consume_file(
                         else:
                             newname = None
 
-                        # If the file is an upload, it's in the scratch directory
-                        # Move it to consume directory to be picked up
-                        # Otherwise, use the current parent to keep possible tags
-                        # from subdirectories
-                        try:
-                            # is_relative_to would be nicer, but new in 3.9
-                            _ = path.relative_to(settings.SCRATCH_DIR)
-                            save_to_dir = settings.CONSUMPTION_DIR
-                        except ValueError:
-                            save_to_dir = path.parent
-
                         barcodes.save_to_dir(
                             document,
                             newname=newname,
                             target_dir=save_to_dir,
                         )
+
+                        # Split file has been copied safely, remove it
+                        os.remove(document)
+
+                    # And clean up the directory as well, now it's empty
+                    shutil.rmtree(os.path.dirname(document_list[0]))
 
                     # Delete the PDF file which was split
                     os.remove(doc_barcode_info.pdf_path)


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

After incoming files have been split via one of the barcode options, the produced files are saved to somewhere in the consumption directory.  But they weren't removed from the temporary directory used to save them.  So clean those up, and the directory as well.

May partly address #2639

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
