### PR TITLE
Add Docker compose files to be able to use the directly in Portainer

### DIFF
--- a/docker/portainer/.env
+++ b/docker/portainer/.env
@@ -1,0 +1,21 @@
+# The docker image tags to use for the various services
+REDIS_TAG=7
+POSTGRES_TAG=13
+MARIADB_TAG=10
+PAPERLESS_TAG=latest
+GOTENBERG_TAG=7.8
+TIKA_TAG=latest
+
+# Postgres default configuration
+POSTGRES_DB=paperless
+POSTGRES_USER=paperless
+POSTGRES_PASSWORD=paperless
+
+# MariaDB default configuration
+MARIADB_DATABASE=paperless
+MARIADB_USER=paperless
+MARIADB_PASSWORD=paperless
+MARIADB_ROOT_PASSWORD=paperless
+
+# Paperless default configuration
+PAPERLESS_REDIS=redis://broker:6379

--- a/docker/portainer/README.md
+++ b/docker/portainer/README.md
@@ -1,0 +1,4 @@
+# Docker compose files for Portainer
+
+Docker compose files that are made to be used directly, especially with
+[Protainer](https://docs.portainer.io), the configuration is done just in the `.env` file.

--- a/docker/portainer/docker-compose.lib.yaml
+++ b/docker/portainer/docker-compose.lib.yaml
@@ -1,0 +1,198 @@
+# Files containing the definition of all services used in the
+# Docker Compose file where we have coherent compositing.
+
+version: "3.4"
+services:
+  redis:
+    image: docker.io/library/redis:${REDIS_TAG}
+    restart: unless-stopped
+    volumes:
+      - redisdata:/data
+
+  postgres:
+    image: docker.io/library/postgres:${POSTGRES_TAG}
+    restart: unless-stopped
+    volumes:
+      - ${PAPERLESS_FOLDER}/pgdata:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_DB
+      - POSTGRES_USER
+      - POSTGRES_PASSWORD
+      # To be able to use psql
+      - PGDATABASE=${POSTGRES_DB}
+      - PGUSER=${POSTGRES_USER}
+      - PGPASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_INITDB_ARGS
+      - POSTGRES_INITDB_WALDIR
+      - POSTGRES_HOST_AUTH_METHOD
+      - PGDATA
+
+  mariadb:
+    image: docker.io/library/mariadb:${MARIADB_TAG}
+    restart: unless-stopped
+    volumes:
+      - ${PAPERLESS_FOLDER}/dbdata:/var/lib/mysql
+    environment:
+      - MARIADB_ROOT_PASSWORD
+      - MYSQL_ROOT_PASSWORD
+      - MARIADB_ROOT_PASSWORD_HASH
+      - MARIADB_ALLOW_EMPTY_ROOT_PASSWORD
+      - MYSQL_ALLOW_EMPTY_PASSWORD
+      - MARIADB_RANDOM_ROOT_PASSWORD
+      - MYSQL_RANDOM_ROOT_PASSWORD
+      - MARIADB_ROOT_HOST
+      - MYSQL_ROOT_HOST
+      - MARIADB_MYSQL_LOCALHOST_USER
+      - MARIADB_MYSQL_LOCALHOST_GRANTS
+      - MARIADB_DATABASE
+      - MYSQL_DATABASE
+      - MARIADB_USER
+      - MYSQL_USER
+      - MARIADB_PASSWORD
+      - MYSQL_PASSWORD
+      - MARIADB_PASSWORD_HASH
+      - MARIADB_INITDB_SKIP_TZINFO
+      - MYSQL_INITDB_SKIP_TZINFO
+      - MARIADB_AUTO_UPGRADE
+      - MARIADB_DISABLE_UPGRADE_BACKUP
+      - MARIADB_HOST
+
+  paperless: &paperless
+    image: ghcr.io/paperless-ngx/paperless-ngx:${PAPERLESS_TAG}
+    restart: unless-stopped
+    ports:
+      - 8000:8000
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+    volumes:
+      - ${PAPERLESS_FOLDER}/data:/usr/src/paperless/data
+      - ${PAPERLESS_FOLDER}/media:/usr/src/paperless/media
+      - ${PAPERLESS_FOLDER}/export:/usr/src/paperless/export
+      - ${PAPERLESS_FOLDER}/consume:/usr/src/paperless/consume
+    environment:
+      - PAPERLESS_REDIS
+      - PAPERLESS_DBENGINE
+      - PAPERLESS_DBHOST
+      - PAPERLESS_DBPORT
+      - PAPERLESS_DBNAME
+      - PAPERLESS_DBUSER
+      - PAPERLESS_DBPASS
+      - PAPERLESS_DBSSLMODE
+      - PAPERLESS_DB_TIMEOUT
+      - PAPERLESS_CONSUMPTION_DIR
+      - PAPERLESS_DATA_DIR
+      - PAPERLESS_TRASH_DIR
+      - PAPERLESS_MEDIA_ROOT
+      - PAPERLESS_STATICDIR
+      - PAPERLESS_FILENAME_FORMAT
+      - PAPERLESS_FILENAME_FORMAT_REMOVE_NONE
+      - PAPERLESS_LOGGING_DIR
+      - PAPERLESS_NLTK_DIR
+      - PAPERLESS_LOGROTATE_MAX_SIZE
+      - PAPERLESS_LOGROTATE_MAX_BACKUPS
+      - PAPERLESS_SECRET_KEY
+      - PAPERLESS_URL
+      - PAPERLESS_CSRF_TRUSTED_ORIGINS
+      - PAPERLESS_ALLOWED_HOSTS
+      - PAPERLESS_CORS_ALLOWED_HOSTS
+      - PAPERLESS_FORCE_SCRIPT_NAME
+      - PAPERLESS_STATIC_URL
+      - PAPERLESS_AUTO_LOGIN_USERNAME
+      - PAPERLESS_ADMIN_USER
+      - PAPERLESS_ADMIN_MAIL
+      - PAPERLESS_ADMIN_PASSWORD
+      - PAPERLESS_COOKIE_PREFIX
+      - PAPERLESS_ENABLE_HTTP_REMOTE_USER
+      - PAPERLESS_HTTP_REMOTE_USER_HEADER_NAME
+      - PAPERLESS_LOGOUT_REDIRECT_URL
+      - PAPERLESS_OCR_LANGUAGE
+      - PAPERLESS_OCR_MODE
+      - PAPERLESS_OCR_CLEAN
+      - PAPERLESS_OCR_DESKEW
+      - PAPERLESS_OCR_ROTATE_PAGES
+      - PAPERLESS_OCR_ROTATE_PAGES_THRESHOLD
+      - PAPERLESS_OCR_OUTPUT_TYPE
+      - PAPERLESS_OCR_PAGES
+      - PAPERLESS_OCR_IMAGE_DPI
+      - PAPERLESS_OCR_MAX_IMAGE_PIXELS
+      - PAPERLESS_OCR_USER_ARGS
+      - PAPERLESS_TIKA_ENABLED
+      - PAPERLESS_TIKA_ENDPOINT
+      - PAPERLESS_TIKA_GOTENBERG_ENDPOINT
+      - PAPERLESS_TASK_WORKERS
+      - PAPERLESS_THREADS_PER_WORKER
+      - PAPERLESS_WORKER_TIMEOUT
+      - PAPERLESS_WORKER_RETRY
+      - PAPERLESS_TIME_ZONE
+      - PAPERLESS_ENABLE_NLTK
+      - PAPERLESS_EMAIL_TASK_CRON
+      - PAPERLESS_TRAIN_TASK_CRON
+      - PAPERLESS_INDEX_TASK_CRON
+      - PAPERLESS_SANITY_TASK_CRON
+      - PAPERLESS_CONSUMER_POLLING
+      - PAPERLESS_CONSUMER_POLLING_RETRY_COUNT
+      - PAPERLESS_CONSUMER_POLLING_DELAY
+      - PAPERLESS_CONSUMER_INOTIFY_DELAY
+      - PAPERLESS_CONSUMER_DELETE_DUPLICATES
+      - PAPERLESS_CONSUMER_RECURSIVE
+      - PAPERLESS_CONSUMER_SUBDIRS_AS_TAGS
+      - PAPERLESS_CONSUMER_ENABLE_BARCODES
+      - PAPERLESS_CONSUMER_BARCODE_TIFF_SUPPORT
+      - PAPERLESS_CONSUMER_ENABLE_ASN_BARCODE
+      - PAPERLESS_CONVERT_MEMORY_LIMIT
+      - PAPERLESS_CONVERT_TMPDIR
+      - PAPERLESS_POST_CONSUME_SCRIPT
+      - PAPERLESS_FILENAME_DATE_ORDER
+      - PAPERLESS_NUMBER_OF_SUGGESTED_DATES
+      - PAPERLESS_THUMBNAIL_FONT_NAME
+      - PAPERLESS_IGNORE_DATES
+      - PAPERLESS_DATE_ORDER
+      - PAPERLESS_CONSUMER_IGNORE_PATTERNS
+      - PAPERLESS_CONVERT_BINARY
+      - PAPERLESS_GS_BINARY
+      - PAPERLESS_WEBSERVER_WORKERS
+      - PAPERLESS_BIND_ADDR
+      - PAPERLESS_PORT
+      - USERMAP_UID
+      - USERMAP_GID
+      - PAPERLESS_OCR_LANGUAGES
+      - PAPERLESS_ENABLE_FLOWER
+      - PAPERLESS_ENABLE_UPDATE_CHECK
+      - OMP_SCHEDULE
+      - OMP_NUM_THREADS
+      - OMP_DYNAMIC
+      - OMP_PROC_BIND
+      - OMP_PLACES
+      - OMP_STACKSIZE
+      - OMP_WAIT_POLICY
+      - OMP_MAX_ACTIVE_LEVELS
+      - OMP_NESTED
+      - OMP_THREAD_LIMIT
+      - OMP_CANCELLATION
+      - OMP_DISPLAY_ENV
+      - OMP_DISPLAY_AFFINITY
+      - OMP_AFFINITY_FORMAT
+      - OMP_DEFAULT_DEVICE
+      - OMP_MAX_TASK_PRIORITY
+      - OMP_TARGET_OFFLOAD
+      - OMP_TOOL
+      - OMP_TOOL_LIBRARIES
+      - OMP_DEBUG
+      - OMP_ALLOCATOR
+
+  gotenberg:
+    image: docker.io/gotenberg/gotenberg:${GOTENBERG_TAG}
+    restart: unless-stopped
+    # The gotenberg chromium route is used to convert .eml files. We do not
+    # want to allow external content like tracking pixels or even javascript.
+    command:
+      - "gotenberg"
+      - "--chromium-disable-javascript=true"
+      - "--chromium-allow-list=file:///tmp/.*"
+
+  tika:
+    image: ghcr.io/paperless-ngx/tika:${TIKA_TAG}
+    restart: unless-stopped

--- a/docker/portainer/docker-compose.mariadb-tika.yaml
+++ b/docker/portainer/docker-compose.mariadb-tika.yaml
@@ -1,0 +1,78 @@
+# docker-compose file for running paperless from the Docker Hub.
+# This file contains everything paperless needs to run.
+# Paperless supports amd64, arm and arm64 hardware.
+#
+# All compose files of paperless configure paperless in the following way:
+#
+# - Paperless is (re)started on system boot, if it was running before shutdown.
+# - Docker volumes for storing data are managed by Docker.
+# - Folders for importing and exporting files are created in the same directory
+#   as this file and mounted to the correct folders inside the container.
+# - Paperless listens on port 8000.
+#
+# In addition to that, this docker-compose file adds the following optional
+# configurations:
+#
+# - Instead of SQLite (default), MariaDB is used as the database server.
+# - Apache Tika and Gotenberg servers are started with paperless and paperless
+#   is configured to use these services. These provide support for consuming
+#   Office documents (Word, Excel, Power Point and their LibreOffice counter-
+#   parts.
+#
+# To install and update paperless with this file, do the following:
+#
+# - Copy this file as 'docker-compose.yml' and the files 'docker-compose.env'
+#   and '.env' into a folder.
+# - Run 'docker-compose pull'.
+# - Run 'docker-compose run --rm webserver createsuperuser' to create a user.
+# - Run 'docker-compose up -d'.
+#
+# For more extensive installation and update instructions, refer to the
+# documentation.
+
+version: "3.4"
+services:
+  broker:
+    extends:
+      file: docker-compose.lib.yaml
+      service: redis
+
+  db:
+    extends:
+      file: docker-compose.lib.yaml
+      service: mariadb
+
+  paperless:
+    extends:
+      file: docker-compose.lib.yaml
+      service: paperless
+    depends_on:
+      - db
+      - broker
+      - gotenberg
+      - tika
+    environment:
+      PAPERLESS_DBENGINE: mariadb
+      PAPERLESS_DBHOST: db
+      PAPERLESS_DBUSER: paperless # only needed if non-default username
+      PAPERLESS_DBPASS: paperless # only needed if non-default password
+      PAPERLESS_DBPORT: 3306
+      PAPERLESS_TIKA_ENABLED: 1
+      PAPERLESS_TIKA_GOTENBERG_ENDPOINT: http://gotenberg:3000
+      PAPERLESS_TIKA_ENDPOINT: http://tika:9998
+
+  gotenberg:
+    extends:
+      file: docker-compose.lib.yaml
+      service: gotenberg
+
+  tika:
+    extends:
+      file: docker-compose.lib.yaml
+      service: tika
+
+volumes:
+  data:
+  media:
+  dbdata:
+  redisdata:

--- a/docker/portainer/docker-compose.mariadb.yaml
+++ b/docker/portainer/docker-compose.mariadb.yaml
@@ -1,0 +1,59 @@
+# docker-compose file for running paperless from the Docker Hub.
+# This file contains everything paperless needs to run.
+# Paperless supports amd64, arm and arm64 hardware.
+#
+# All compose files of paperless configure paperless in the following way:
+#
+# - Paperless is (re)started on system boot, if it was running before shutdown.
+# - Docker volumes for storing data are managed by Docker.
+# - Folders for importing and exporting files are created in the same directory
+#   as this file and mounted to the correct folders inside the container.
+# - Paperless listens on port 8000.
+#
+# In addition to that, this docker-compose file adds the following optional
+# configurations:
+#
+# - Instead of SQLite (default), MariaDB is used as the database server.
+#
+# To install and update paperless with this file, do the following:
+#
+# - Copy this file as 'docker-compose.yml' and the files 'docker-compose.env'
+#   and '.env' into a folder.
+# - Run 'docker-compose pull'.
+# - Run 'docker-compose run --rm webserver createsuperuser' to create a user.
+# - Run 'docker-compose up -d'.
+#
+# For more extensive installation and update instructions, refer to the
+# documentation.
+
+version: "3.4"
+services:
+  broker:
+    extends:
+      file: docker-compose.lib.yaml
+      service: redis
+
+  db:
+    extends:
+      file: docker-compose.lib.yaml
+      service: mariadb
+
+  paperless:
+    extends:
+      file: docker-compose.lib.yaml
+      service: paperless
+    depends_on:
+      - db
+      - broker
+    environment:
+      PAPERLESS_DBENGINE: mariadb
+      PAPERLESS_DBHOST: db
+      PAPERLESS_DBUSER: paperless # only needed if non-default username
+      PAPERLESS_DBPASS: paperless # only needed if non-default password
+      PAPERLESS_DBPORT: 3306
+
+volumes:
+  data:
+  media:
+  dbdata:
+  redisdata:

--- a/docker/portainer/docker-compose.postgres-tika.yaml
+++ b/docker/portainer/docker-compose.postgres-tika.yaml
@@ -1,0 +1,75 @@
+# docker-compose file for running paperless from the docker container registry.
+# This file contains everything paperless needs to run.
+# Paperless supports amd64, arm and arm64 hardware.
+#
+# All compose files of paperless configure paperless in the following way:
+#
+# - Paperless is (re)started on system boot, if it was running before shutdown.
+# - Docker volumes for storing data are managed by Docker.
+# - Folders for importing and exporting files are created in the same directory
+#   as this file and mounted to the correct folders inside the container.
+# - Paperless listens on port 8000.
+#
+# In addition to that, this docker-compose file adds the following optional
+# configurations:
+#
+# - Instead of SQLite (default), PostgreSQL is used as the database server.
+# - Apache Tika and Gotenberg servers are started with paperless and paperless
+#   is configured to use these services. These provide support for consuming
+#   Office documents (Word, Excel, Power Point and their LibreOffice counter-
+#   parts.
+#
+# To install and update paperless with this file, do the following:
+#
+# - Copy this file as 'docker-compose.yml' and the files 'docker-compose.env'
+#   and '.env' into a folder.
+# - Run 'docker-compose pull'.
+# - Run 'docker-compose run --rm webserver createsuperuser' to create a user.
+# - Run 'docker-compose up -d'.
+#
+# For more extensive installation and update instructions, refer to the
+# documentation.
+
+version: "3.4"
+services:
+  broker:
+    extends:
+      file: docker-compose.lib.yaml
+      service: redis
+
+  db:
+    extends:
+      file: docker-compose.lib.yaml
+      service: postgres
+
+  paperless:
+    extends:
+      file: docker-compose.lib.yaml
+      service: paperless
+    depends_on:
+      - db
+      - broker
+      - gotenberg
+      - tika
+    environment:
+      PAPERLESS_REDIS: redis://broker:6379
+      PAPERLESS_DBHOST: db
+      PAPERLESS_TIKA_ENABLED: 1
+      PAPERLESS_TIKA_GOTENBERG_ENDPOINT: http://gotenberg:3000
+      PAPERLESS_TIKA_ENDPOINT: http://tika:9998
+
+  gotenberg:
+    extends:
+      file: docker-compose.lib.yaml
+      service: gotenberg
+
+  tika:
+    extends:
+      file: docker-compose.lib.yaml
+      service: tika
+
+volumes:
+  data:
+  media:
+  pgdata:
+  redisdata:

--- a/docker/portainer/docker-compose.postgres.yaml
+++ b/docker/portainer/docker-compose.postgres.yaml
@@ -1,0 +1,54 @@
+# docker-compose file for running paperless from the Docker Hub.
+# This file contains everything paperless needs to run.
+# Paperless supports amd64, arm and arm64 hardware.
+#
+# All compose files of paperless configure paperless in the following way:
+#
+# - Paperless is (re)started on system boot, if it was running before shutdown.
+# - Docker volumes for storing data are managed by Docker.
+# - Folders for importing and exporting files are created in the same directory
+#   as this file and mounted to the correct folders inside the container.
+# - Paperless listens on port 8000.
+#
+# In addition to that, this docker-compose file adds the following optional
+# configurations:
+#
+# - Instead of SQLite (default), PostgreSQL is used as the database server.
+#
+# To install and update paperless with this file, do the following:
+#
+# - Copy this file as 'docker-compose.yml' and the files 'docker-compose.env'
+#   and '.env' into a folder.
+# - Run 'docker-compose pull'.
+# - Run 'docker-compose run --rm webserver createsuperuser' to create a user.
+# - Run 'docker-compose up -d'.
+#
+# For more extensive installation and update instructions, refer to the
+# documentation.
+
+version: "3.4"
+services:
+  broker:
+    extends:
+      file: docker-compose.lib.yaml
+      service: redis
+
+  db:
+    extends:
+      file: docker-compose.lib.yaml
+      service: postgres
+
+  paperless:
+    extends:
+      file: docker-compose.lib.yaml
+      service: paperless
+    environment:
+      PAPERLESS_REDIS: redis://broker:6379
+      PAPERLESS_DBHOST: db
+
+
+volumes:
+  data:
+  media:
+  pgdata:
+  redisdata:

--- a/docker/portainer/docker-compose.sqlite-tika.yaml
+++ b/docker/portainer/docker-compose.sqlite-tika.yaml
@@ -1,0 +1,67 @@
+# docker-compose file for running paperless from the docker container registry.
+# This file contains everything paperless needs to run.
+# Paperless supports amd64, arm and arm64 hardware.
+# All compose files of paperless configure paperless in the following way:
+#
+# - Paperless is (re)started on system boot, if it was running before shutdown.
+# - Docker volumes for storing data are managed by Docker.
+# - Folders for importing and exporting files are created in the same directory
+#   as this file and mounted to the correct folders inside the container.
+# - Paperless listens on port 8000.
+#
+# SQLite is used as the database. The SQLite file is stored in the data volume.
+#
+# In addition to that, this docker-compose file adds the following optional
+# configurations:
+#
+# - Apache Tika and Gotenberg servers are started with paperless and paperless
+#   is configured to use these services. These provide support for consuming
+#   Office documents (Word, Excel, Power Point and their LibreOffice counter-
+#   parts.
+#
+# To install and update paperless with this file, do the following:
+#
+# - Copy this file as 'docker-compose.yml' and the files 'docker-compose.env'
+#   and '.env' into a folder.
+# - Run 'docker-compose pull'.
+# - Run 'docker-compose run --rm webserver createsuperuser' to create a user.
+# - Run 'docker-compose up -d'.
+#
+# For more extensive installation and update instructions, refer to the
+# documentation.
+
+version: "3.4"
+services:
+  broker:
+    extends:
+      file: docker-compose.lib.yaml
+      service: redis
+
+  paperless:
+    extends:
+      file: docker-compose.lib.yaml
+      service: paperless
+    depends_on:
+      - broker
+      - gotenberg
+      - tika
+    environment:
+      PAPERLESS_REDIS: redis://broker:6379
+      PAPERLESS_TIKA_ENABLED: 1
+      PAPERLESS_TIKA_GOTENBERG_ENDPOINT: http://gotenberg:3000
+      PAPERLESS_TIKA_ENDPOINT: http://tika:9998
+
+  gotenberg:
+    extends:
+      file: docker-compose.lib.yaml
+      service: gotenberg
+
+  tika:
+    extends:
+      file: docker-compose.lib.yaml
+      service: tika
+
+volumes:
+  data:
+  media:
+  redisdata:

--- a/docker/portainer/docker-compose.sqlite.yaml
+++ b/docker/portainer/docker-compose.sqlite.yaml
@@ -1,0 +1,45 @@
+# docker-compose file for running paperless from the Docker Hub.
+# This file contains everything paperless needs to run.
+# Paperless supports amd64, arm and arm64 hardware.
+#
+# All compose files of paperless configure paperless in the following way:
+#
+# - Paperless is (re)started on system boot, if it was running before shutdown.
+# - Docker volumes for storing data are managed by Docker.
+# - Folders for importing and exporting files are created in the same directory
+#   as this file and mounted to the correct folders inside the container.
+# - Paperless listens on port 8000.
+#
+# SQLite is used as the database. The SQLite file is stored in the data volume.
+#
+# To install and update paperless with this file, do the following:
+#
+# - Copy this file as 'docker-compose.yml' and the files 'docker-compose.env'
+#   and '.env' into a folder.
+# - Run 'docker-compose pull'.
+# - Run 'docker-compose run --rm webserver createsuperuser' to create a user.
+# - Run 'docker-compose up -d'.
+#
+# For more extensive installation and update instructions, refer to the
+# documentation.
+
+version: "3.4"
+services:
+  broker:
+    extends:
+      file: docker-compose.lib.yaml
+      service: redis
+
+  paperless:
+    extends:
+      file: docker-compose.lib.yaml
+      service: paperless
+    depends_on:
+      - broker
+    environment:
+      PAPERLESS_REDIS: redis://broker:6379
+
+volumes:
+  data:
+  media:
+  redisdata:

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -6,6 +6,7 @@ You can go multiple routes to setup and run Paperless:
 - [Pull the image from Docker Hub](#docker_hub)
 - [Build the Docker image yourself](#docker_build)
 - [Install Paperless directly on your system manually (bare metal)](#bare_metal)
+- [Install Paperless directly on your system using portainer](#portainer)
 
 The Docker routes are quick & easy. These are the recommended routes.
 This configures all the stuff from the above automatically so that it
@@ -882,3 +883,70 @@ reverse proxy. Please refer to the [hosting and security](/configuration#hosting
 Also read
 [this](https://channels.readthedocs.io/en/stable/deploying.html#nginx-supervisor-ubuntu),
 towards the end of the section.
+
+### Install on Protainer {#portainer}
+
+On the NAS supporting Docker we usually don't have docker-compose to install a Docker application.
+
+To be able to use it you can use [Protainer](https://www.portainer.io/).
+
+1. Install Portainer on your NAS, see the [official documentation](https://docs.portainer.io/start/install-ce/server/docker/linux).
+
+2. Open https://<nas host name>:9443.
+
+3. Click on the environment usualy `locale`.
+
+4. Click on `Stacks`.
+
+5. Click on `+ Add stack`.
+
+6. Click on `Repository`.
+
+7. Set the `Repository URL` to `https://github.com/paperless-ngx/paperless-ngx/`.
+
+8. Set the `Compose path` to `https://github.com/paperless-ngx/paperless-ngx/blob/main/docker/portainer/docker-compose.<env>.yaml`.
+   `<env>` define the sevice you will use, it can be `mariadb-tika.yml`,
+   `mariadb`, `portainer`, `postgres-tika`, `postgres`, `sqlite-tika`, `sqlite`.
+
+9. Fill the environment variables in `Environment variables`.
+
+   You should at leas have the following variables:
+
+   `PAPERLESS_FOLDER`
+   The directory where paperless will store its data.
+   The following directories should exist in your NAS:
+
+   - ${PAPERLESS_FOLDER}/data
+   - ${PAPERLESS_FOLDER}/media
+   - ${PAPERLESS_FOLDER}/export
+   - ${PAPERLESS_FOLDER}/consume
+   - ${PAPERLESS_FOLDER}/pgdata # if you use postgres
+   - ${PAPERLESS_FOLDER}/dbdata # if you use mariadb
+
+   `USERMAP_UID` and `USERMAP_GID`
+   The UID and GID of the user used to run paperless in the container. Set this
+   to your UID and GID on the host so that you have write access to the
+   consumption directory.
+
+   `PAPERLESS_OCR_LANGUAGES`
+   Additional languages to install for text recognition, separated by a
+   whitespace. Note that this is
+   different from PAPERLESS_OCR_LANGUAGE (default=eng), which defines the
+   language used for OCR.
+   The container installs English, German, Italian, Spanish and French by
+   default.
+   See https://packages.debian.org/search?keywords=tesseract-ocr-&searchon=names&suite=buster
+   for available languages.
+
+   `PAPERLESS_SECRET_KEY`
+   Adjust this key if you plan to make paperless available publicly. It should
+   be a very long sequence of random characters. You don't need to remember it.
+
+   `PAPERLESS_TIME_ZONE`
+   Use this variable to set a timezone for the Paperless Docker containers. If not specified, defaults to UTC.
+
+   `PAPERLESS_OCR_LANGUAGE`
+   The default language to use for OCR. Set this to the language most of your
+   documents are written in.
+
+10. Click on `Deploy the stack`.


### PR DESCRIPTION

## Proposed change

Be able to use the docker compose directly in Portainer, currently not working, opened for discussion

The main discussion for me are:
- is it desired 
- should we create separate list of Docker compose files.


## Type of change

Make the docker compose more generic to be able to use them directly in Portainer

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [X] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [X] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [X] I have made corresponding changes to the documentation as needed.
- [X] I have checked my modifications for any breaking changes.
