### PR TITLE
Fix: add missing i18n for mobile preview tab title

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -251,7 +251,7 @@ these parts have to be translated separately.
 - The translated strings need to be placed in the
   `src-ui/src/locale/` folder.
 - In order to extract added or changed strings from the source files,
-  call `ng xi18n --ivy`.
+  call `ng extract-i18n`.
 
 Adding new languages requires adding the translated files in the
 `src-ui/src/locale/` folder and adjusting a couple files.

--- a/src-ui/messages.xlf
+++ b/src-ui/messages.xlf
@@ -2233,6 +2233,13 @@
           <context context-type="linenumber">145</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="1295614462098694869" datatype="html">
+        <source>Preview</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/document-detail/document-detail.component.html</context>
+          <context context-type="linenumber">151</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="8191371354890763172" datatype="html">
         <source>Enter Password</source>
         <context-group purpose="location">

--- a/src-ui/src/app/components/document-detail/document-detail.component.html
+++ b/src-ui/src/app/components/document-detail/document-detail.component.html
@@ -148,7 +148,7 @@
                 </li>
 
                 <li [ngbNavItem]="4" class="d-md-none">
-                    <a ngbNavLink>Preview</a>
+                    <a ngbNavLink i18n>Preview</a>
                     <ng-template ngbNavContent *ngIf="!pdfPreview.offsetParent">
                         <div class="position-relative">
                             <ng-container *ngIf="getContentType() === 'application/pdf'">


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

- [x] Add the translation for the "Preview" pane on mobile view
- [x] (not sure about this one) Fixed documentation for extracting i18n data in the UI. `ng xi18n --ivy` didn't work on my computer (command not found), and I found `ng extract-i18n` on the Angular documentation. But I'm not familiar at all with Angular, so revert this commit if it's not supposed to be like this.

| Before | After |
| :-: | :-: |
|![image](https://user-images.githubusercontent.com/45119518/219663684-50d4a588-ad7d-4c9f-8134-ae83fe0e1282.png)|![image](https://user-images.githubusercontent.com/45119518/219663394-86379b38-17ed-4003-857e-373aa83c72d2.png)|

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
