### PR TITLE
Docs: Remove outdated PAPERLESS_WORKER_RETRY

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -698,13 +698,6 @@ paperless will process in parallel on a single document.
 on large documents within the default 1800 seconds. So extending
 this timeout may prove to be useful on weak hardware setups.
 
-`PAPERLESS_WORKER_RETRY=<num>`
-
-: If PAPERLESS_WORKER_TIMEOUT has been configured, the retry time for
-a task can also be configured. By default, this value will be set to
-10s more than the worker timeout. This value should never be set
-less than the worker timeout.
-
 `PAPERLESS_TIME_ZONE=<timezone>`
 
 : Set the time zone here. See


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

Fixes #2693

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (please explain)

## Checklist:

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
