### PR TITLE
Fix: bulk edit reset apply button state

### DIFF
--- a/src-ui/src/app/components/common/filterable-dropdown/filterable-dropdown.component.ts
+++ b/src-ui/src/app/components/common/filterable-dropdown/filterable-dropdown.component.ts
@@ -358,6 +358,7 @@ export class FilterableDropdownComponent {
       }, 0)
       if (this.editing) {
         this.selectionModel.reset()
+        this.modelIsDirty = false
       }
       this.opened.next(this)
     } else {


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Tiny bug I noticed where the Apply button stays active even after applying a bulk edit, see video for illustration.

New:

https://user-images.githubusercontent.com/4887959/219902263-b4a7bf55-5e73-4fd3-9a9f-a03a2da5c525.mov


Old:

https://user-images.githubusercontent.com/4887959/219902253-8eb96dd1-f996-4367-95f1-cf794011a21e.mov



Fixes # (issue)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] ~~I have made corresponding changes to the documentation as needed.~~
- [x] I have checked my modifications for any breaking changes.
