### PR TITLE
Fix: reset saved view ID on quickFilter

### DIFF
--- a/src-ui/src/app/services/document-list-view.service.ts
+++ b/src-ui/src/app/services/document-list-view.service.ts
@@ -354,6 +354,7 @@ export class DocumentListViewService {
   }
 
   quickFilter(filterRules: FilterRule[]) {
+    this._activeSavedViewId = null
     this.filterRules = filterRules
   }
 


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

See videos below, loading a saved view causes the use of 'quick filters' to break because the saved view ID wasn't being discarded first. Another solid one-liner :b

New:

https://user-images.githubusercontent.com/4887959/219909121-4da98ae9-b63f-4ae7-b3f9-ced01a210929.mov

Old:

https://user-images.githubusercontent.com/4887959/219909128-42d6c732-5458-4766-98d6-cb22f2b6aed9.mov

Fixes #2702 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] ~~I have made corresponding changes to the documentation as needed.~~
- [x] I have checked my modifications for any breaking changes.
