### PR TITLE
Allow setting the ASN on document upload

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -257,11 +257,14 @@ The endpoint supports the following optional form fields:
 - `tags`: Similar to correspondent. Specify this multiple times to
   have multiple tags added to the document.
 - `owner`: An optional user ID to set as the owner.
+- `archive_serial_number`: An optional archive serial number to set.
 
-The endpoint will immediately return "OK" if the document consumption
-process was started successfully. No additional status information about
-the consumption process itself is available, since that happens in a
-different process.
+The endpoint will immediately return HTTP 200 if the document consumption
+process was started successfully, with the UUID of the consumption task
+as the data. No additional status information about
+the consumption process itself is available immediately, since that happens in a
+different process. Querying the tasks endpoint with the returned UUID will
+provide information on the state of the consumption.
 
 ## API Versioning
 

--- a/src/documents/serialisers.py
+++ b/src/documents/serialisers.py
@@ -691,6 +691,14 @@ class PostDocumentSerializer(serializers.Serializer):
         required=False,
     )
 
+    archive_serial_number = serializers.IntegerField(
+        label="ASN",
+        write_only=True,
+        required=False,
+        min_value=Document.ARCHIVE_SERIAL_NUMBER_MIN,
+        max_value=Document.ARCHIVE_SERIAL_NUMBER_MAX,
+    )
+
     def validate_document(self, document):
         document_data = document.file.read()
         mime_type = magic.from_buffer(document_data, mime=True)

--- a/src/documents/tasks.py
+++ b/src/documents/tasks.py
@@ -4,6 +4,7 @@ import os
 import shutil
 import uuid
 from pathlib import Path
+from typing import Optional
 from typing import Type
 
 import dateutil.parser
@@ -97,6 +98,7 @@ def consume_file(
     task_id=None,
     override_created=None,
     override_owner_id=None,
+    override_archive_serial_num: Optional[int] = None,
 ):
 
     path = Path(path).resolve()
@@ -207,7 +209,7 @@ def consume_file(
         override_tag_ids=override_tag_ids,
         task_id=task_id,
         override_created=override_created,
-        override_asn=asn,
+        override_asn=override_archive_serial_num or asn,
         override_owner_id=override_owner_id,
     )
 

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -667,6 +667,7 @@ class PostDocumentView(GenericAPIView):
         title = serializer.validated_data.get("title")
         created = serializer.validated_data.get("created")
         owner_id = serializer.validated_data.get("owner")
+        archive_serial_number = serializer.validated_data.get("archive_serial_number")
 
         t = int(mktime(datetime.now().timetuple()))
 
@@ -692,6 +693,7 @@ class PostDocumentView(GenericAPIView):
             task_id=task_id,
             override_created=created,
             override_owner_id=owner_id,
+            override_archive_serial_num=archive_serial_number,
         )
 
         return Response(async_task.id)


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

Feature requested in #2684, allows setting the ASN through the post document API endpoint.  This value is considered more correct in the rare case where an ASN is also located from a barcode on the document.  Could be switched

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
