### PR TITLE
Chore: Improve clarity of some test asserting

### DIFF
--- a/src/documents/tests/test_api.py
+++ b/src/documents/tests/test_api.py
@@ -1331,7 +1331,7 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
                 {"document": f, "archive_serial_number": 500},
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         m.assert_called_once()
 

--- a/src/documents/tests/test_api.py
+++ b/src/documents/tests/test_api.py
@@ -27,6 +27,7 @@ from django.contrib.auth.models import User
 from django.test import override_settings
 from django.utils import timezone
 from dateutil.relativedelta import relativedelta
+from rest_framework import status
 from documents import bulk_edit
 from documents import index
 from documents.models import Correspondent
@@ -42,8 +43,6 @@ from documents.tests.utils import DirectoriesMixin
 from paperless import version
 from rest_framework.test import APITestCase
 from whoosh.writing import AsyncWriter
-
-from guardian.shortcuts import get_users_with_perms
 
 
 class TestDocumentApi(DirectoriesMixin, APITestCase):
@@ -75,7 +74,7 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
         doc.tags.add(tag)
 
         response = self.client.get("/api/documents/", format="json")
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 1)
 
         returned_doc = response.data["results"][0]
@@ -96,7 +95,7 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
             format="json",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         doc_after_save = Document.objects.get(id=doc.id)
 
@@ -123,27 +122,27 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
         )
 
         response = self.client.get("/api/documents/", format="json")
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         results_full = response.data["results"]
         self.assertIn("content", results_full[0])
         self.assertIn("id", results_full[0])
 
         response = self.client.get("/api/documents/?fields=id", format="json")
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         results = response.data["results"]
         self.assertFalse("content" in results[0])
         self.assertIn("id", results[0])
         self.assertEqual(len(results[0]), 1)
 
         response = self.client.get("/api/documents/?fields=content", format="json")
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         results = response.data["results"]
         self.assertIn("content", results[0])
         self.assertFalse("id" in results[0])
         self.assertEqual(len(results[0]), 1)
 
         response = self.client.get("/api/documents/?fields=id,content", format="json")
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         results = response.data["results"]
         self.assertIn("content", results[0])
         self.assertIn("id", results[0])
@@ -153,19 +152,19 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
             "/api/documents/?fields=id,conteasdnt",
             format="json",
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         results = response.data["results"]
         self.assertFalse("content" in results[0])
         self.assertIn("id", results[0])
         self.assertEqual(len(results[0]), 1)
 
         response = self.client.get("/api/documents/?fields=", format="json")
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         results = response.data["results"]
         self.assertEqual(len(results_full[0]), len(results[0]))
 
         response = self.client.get("/api/documents/?fields=dgfhs", format="json")
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         results = response.data["results"]
         self.assertEqual(len(results[0]), 0)
 
@@ -193,17 +192,17 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
 
         response = self.client.get(f"/api/documents/{doc.pk}/download/")
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.content, content)
 
         response = self.client.get(f"/api/documents/{doc.pk}/preview/")
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.content, content)
 
         response = self.client.get(f"/api/documents/{doc.pk}/thumb/")
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.content, content_thumbnail)
 
     @override_settings(FILENAME_FORMAT="")
@@ -227,26 +226,26 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
 
         response = self.client.get(f"/api/documents/{doc.pk}/download/")
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.content, content_archive)
 
         response = self.client.get(
             f"/api/documents/{doc.pk}/download/?original=true",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.content, content)
 
         response = self.client.get(f"/api/documents/{doc.pk}/preview/")
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.content, content_archive)
 
         response = self.client.get(
             f"/api/documents/{doc.pk}/preview/?original=true",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.content, content)
 
     def test_document_actions_not_existing_file(self):
@@ -258,13 +257,13 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
         )
 
         response = self.client.get(f"/api/documents/{doc.pk}/download/")
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
         response = self.client.get(f"/api/documents/{doc.pk}/preview/")
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
         response = self.client.get(f"/api/documents/{doc.pk}/thumb/")
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_document_filters(self):
 
@@ -294,13 +293,13 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
         doc3.tags.add(tag_3)
 
         response = self.client.get("/api/documents/?is_in_inbox=true")
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         results = response.data["results"]
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0]["id"], doc1.id)
 
         response = self.client.get("/api/documents/?is_in_inbox=false")
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         results = response.data["results"]
         self.assertEqual(len(results), 2)
         self.assertCountEqual([results[0]["id"], results[1]["id"]], [doc2.id, doc3.id])
@@ -308,7 +307,7 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
         response = self.client.get(
             f"/api/documents/?tags__id__in={tag_inbox.id},{tag_3.id}",
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         results = response.data["results"]
         self.assertEqual(len(results), 2)
         self.assertCountEqual([results[0]["id"], results[1]["id"]], [doc1.id, doc3.id])
@@ -316,7 +315,7 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
         response = self.client.get(
             f"/api/documents/?tags__id__in={tag_2.id},{tag_3.id}",
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         results = response.data["results"]
         self.assertEqual(len(results), 2)
         self.assertCountEqual([results[0]["id"], results[1]["id"]], [doc2.id, doc3.id])
@@ -324,7 +323,7 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
         response = self.client.get(
             f"/api/documents/?tags__id__all={tag_2.id},{tag_3.id}",
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         results = response.data["results"]
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0]["id"], doc3.id)
@@ -332,19 +331,19 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
         response = self.client.get(
             f"/api/documents/?tags__id__all={tag_inbox.id},{tag_3.id}",
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         results = response.data["results"]
         self.assertEqual(len(results), 0)
 
         response = self.client.get(
             f"/api/documents/?tags__id__all={tag_inbox.id}a{tag_3.id}",
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         results = response.data["results"]
         self.assertEqual(len(results), 3)
 
         response = self.client.get(f"/api/documents/?tags__id__none={tag_3.id}")
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         results = response.data["results"]
         self.assertEqual(len(results), 2)
         self.assertCountEqual([results[0]["id"], results[1]["id"]], [doc1.id, doc2.id])
@@ -352,7 +351,7 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
         response = self.client.get(
             f"/api/documents/?tags__id__none={tag_3.id},{tag_2.id}",
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         results = response.data["results"]
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0]["id"], doc1.id)
@@ -360,7 +359,7 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
         response = self.client.get(
             f"/api/documents/?tags__id__none={tag_2.id},{tag_inbox.id}",
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         results = response.data["results"]
         self.assertEqual(len(results), 0)
 
@@ -392,7 +391,7 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
         )
 
         response = self.client.get("/api/documents/?title_content=A")
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         results = response.data["results"]
         self.assertEqual(len(results), 3)
         self.assertCountEqual(
@@ -401,7 +400,7 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
         )
 
         response = self.client.get("/api/documents/?title_content=B")
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         results = response.data["results"]
         self.assertEqual(len(results), 3)
         self.assertCountEqual(
@@ -410,7 +409,7 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
         )
 
         response = self.client.get("/api/documents/?title_content=X")
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         results = response.data["results"]
         self.assertEqual(len(results), 0)
 
@@ -507,9 +506,9 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
                 index.update_document(writer, doc)
 
         response = self.client.get("/api/documents/?query=content&page=0&page_size=10")
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
         response = self.client.get("/api/documents/?query=content&page=3&page_size=10")
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @override_settings(
         TIME_ZONE="UTC",
@@ -780,21 +779,21 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
         m.side_effect = lambda ix, term, limit: [term for _ in range(limit)]
 
         response = self.client.get("/api/search/autocomplete/?term=test")
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 10)
 
         response = self.client.get("/api/search/autocomplete/?term=test&limit=20")
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 20)
 
         response = self.client.get("/api/search/autocomplete/?term=test&limit=-1")
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
         response = self.client.get("/api/search/autocomplete/")
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
         response = self.client.get("/api/search/autocomplete/?term=")
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 10)
 
     @pytest.mark.skip(reason="Not implemented yet")
@@ -845,7 +844,7 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
 
         response = self.client.get(f"/api/documents/?more_like_id={d2.id}")
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         results = response.data["results"]
 
@@ -886,7 +885,7 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
 
         def search_query(q):
             r = self.client.get("/api/documents/?query=test" + q)
-            self.assertEqual(r.status_code, 200)
+            self.assertEqual(r.status_code, status.HTTP_200_OK)
             return [hit["id"] for hit in r.data["results"]]
 
         self.assertCountEqual(
@@ -1016,7 +1015,7 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
 
         def search_query(q):
             r = self.client.get("/api/documents/?query=test" + q)
-            self.assertEqual(r.status_code, 200)
+            self.assertEqual(r.status_code, status.HTTP_200_OK)
             return [hit["id"] for hit in r.data["results"]]
 
         self.assertListEqual(
@@ -1049,7 +1048,7 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
         doc1.tags.add(tag_inbox)
 
         response = self.client.get("/api/statistics/")
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["documents_total"], 3)
         self.assertEqual(response.data["documents_inbox"], 1)
 
@@ -1057,7 +1056,7 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
         Document.objects.create(title="none1", checksum="A")
 
         response = self.client.get("/api/statistics/")
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["documents_inbox"], None)
 
     @mock.patch("documents.views.consume_file.delay")
@@ -1074,7 +1073,7 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
                 {"document": f},
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         m.assert_called_once()
 
@@ -1101,7 +1100,7 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
                 {"document": f, "title": "", "correspondent": "", "document_type": ""},
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         m.assert_called_once()
 
@@ -1127,7 +1126,7 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
                 "/api/documents/post_document/",
                 {"documenst": f},
             )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         m.assert_not_called()
 
     @mock.patch("documents.views.consume_file.delay")
@@ -1143,7 +1142,7 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
                 "/api/documents/post_document/",
                 {"document": f},
             )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         m.assert_not_called()
 
     @mock.patch("documents.views.consume_file.delay")
@@ -1159,7 +1158,7 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
                 "/api/documents/post_document/",
                 {"document": f, "title": "my custom title"},
             )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         async_task.assert_called_once()
 
@@ -1181,7 +1180,7 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
                 "/api/documents/post_document/",
                 {"document": f, "correspondent": c.id},
             )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         async_task.assert_called_once()
 
@@ -1202,7 +1201,7 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
                 "/api/documents/post_document/",
                 {"document": f, "correspondent": 3456},
             )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
         async_task.assert_not_called()
 
@@ -1220,7 +1219,7 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
                 "/api/documents/post_document/",
                 {"document": f, "document_type": dt.id},
             )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         async_task.assert_called_once()
 
@@ -1241,7 +1240,7 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
                 "/api/documents/post_document/",
                 {"document": f, "document_type": 34578},
             )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
         async_task.assert_not_called()
 
@@ -1260,7 +1259,7 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
                 "/api/documents/post_document/",
                 {"document": f, "tags": [t2.id, t1.id]},
             )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         async_task.assert_called_once()
 
@@ -1283,7 +1282,7 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
                 "/api/documents/post_document/",
                 {"document": f, "tags": [t2.id, t1.id, 734563]},
             )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
         async_task.assert_not_called()
 
@@ -1310,7 +1309,7 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
                 "/api/documents/post_document/",
                 {"document": f, "created": created},
             )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         async_task.assert_called_once()
 
@@ -1368,7 +1367,7 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
         shutil.copy(archive_file, doc.archive_path)
 
         response = self.client.get(f"/api/documents/{doc.pk}/metadata/")
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         meta = response.data
 
@@ -1383,7 +1382,7 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
 
     def test_get_metadata_invalid_doc(self):
         response = self.client.get("/api/documents/34576/metadata/")
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_get_metadata_no_archive(self):
         doc = Document.objects.create(
@@ -1398,7 +1397,7 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
         )
 
         response = self.client.get(f"/api/documents/{doc.pk}/metadata/")
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         meta = response.data
 
@@ -1419,7 +1418,7 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
         )
 
         response = self.client.get(f"/api/documents/{doc.pk}/metadata/")
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         meta = response.data
 
@@ -1434,7 +1433,7 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
 
         response = self.client.get(f"/api/documents/{doc.pk}/suggestions/")
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(
             response.data,
             {
@@ -1448,7 +1447,7 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
 
     def test_get_suggestions_invalid_doc(self):
         response = self.client.get("/api/documents/34676/suggestions/")
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @mock.patch("documents.views.match_storage_paths")
     @mock.patch("documents.views.match_document_types")
@@ -1512,26 +1511,35 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
         )
 
         response = self.client.get("/api/saved_views/")
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 0)
 
-        self.assertEqual(self.client.get(f"/api/saved_views/{v1.id}/").status_code, 404)
+        self.assertEqual(
+            self.client.get(f"/api/saved_views/{v1.id}/").status_code,
+            status.HTTP_404_NOT_FOUND,
+        )
 
         self.client.force_authenticate(user=u1)
 
         response = self.client.get("/api/saved_views/")
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 1)
 
-        self.assertEqual(self.client.get(f"/api/saved_views/{v1.id}/").status_code, 200)
+        self.assertEqual(
+            self.client.get(f"/api/saved_views/{v1.id}/").status_code,
+            status.HTTP_200_OK,
+        )
 
         self.client.force_authenticate(user=u2)
 
         response = self.client.get("/api/saved_views/")
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 2)
 
-        self.assertEqual(self.client.get(f"/api/saved_views/{v1.id}/").status_code, 404)
+        self.assertEqual(
+            self.client.get(f"/api/saved_views/{v1.id}/").status_code,
+            status.HTTP_404_NOT_FOUND,
+        )
 
     def test_create_update_patch(self):
 
@@ -1546,7 +1554,7 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
         }
 
         response = self.client.post("/api/saved_views/", view, format="json")
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         v1 = SavedView.objects.get(name="test")
         self.assertEqual(v1.sort_field, "created2")
@@ -1560,14 +1568,14 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
         )
 
         v1 = SavedView.objects.get(id=v1.id)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertFalse(v1.show_in_sidebar)
         self.assertEqual(v1.filter_rules.count(), 1)
 
         view["filter_rules"] = [{"rule_type": 12, "value": "secret"}]
 
         response = self.client.put(f"/api/saved_views/{v1.id}/", view, format="json")
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         v1 = SavedView.objects.get(id=v1.id)
         self.assertEqual(v1.filter_rules.count(), 1)
@@ -1576,31 +1584,31 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
         view["filter_rules"] = []
 
         response = self.client.put(f"/api/saved_views/{v1.id}/", view, format="json")
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         v1 = SavedView.objects.get(id=v1.id)
         self.assertEqual(v1.filter_rules.count(), 0)
 
     def test_get_logs(self):
         response = self.client.get("/api/logs/")
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertCountEqual(response.data, ["mail", "paperless"])
 
     def test_get_invalid_log(self):
         response = self.client.get("/api/logs/bogus_log/")
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @override_settings(LOGGING_DIR="bogus_dir")
     def test_get_nonexistent_log(self):
         response = self.client.get("/api/logs/paperless/")
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_get_log(self):
         log_data = "test\ntest2\n"
         with open(os.path.join(settings.LOGGING_DIR, "paperless.log"), "w") as f:
             f.write(log_data)
         response = self.client.get("/api/logs/paperless/")
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertListEqual(response.data, ["test", "test2"])
 
     def test_invalid_regex_other_algorithm(self):
@@ -1614,7 +1622,7 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
                 },
                 format="json",
             )
-            self.assertEqual(response.status_code, 201, endpoint)
+            self.assertEqual(response.status_code, status.HTTP_201_CREATED, endpoint)
 
     def test_invalid_regex(self):
         for endpoint in ["correspondents", "tags", "document_types"]:
@@ -1627,7 +1635,11 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
                 },
                 format="json",
             )
-            self.assertEqual(response.status_code, 400, endpoint)
+            self.assertEqual(
+                response.status_code,
+                status.HTTP_400_BAD_REQUEST,
+                endpoint,
+            )
 
     def test_valid_regex(self):
         for endpoint in ["correspondents", "tags", "document_types"]:
@@ -1640,7 +1652,7 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
                 },
                 format="json",
             )
-            self.assertEqual(response.status_code, 201, endpoint)
+            self.assertEqual(response.status_code, status.HTTP_201_CREATED, endpoint)
 
     def test_regex_no_algorithm(self):
         for endpoint in ["correspondents", "tags", "document_types"]:
@@ -1649,11 +1661,11 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
                 {"name": "test", "match": "[0-9]"},
                 format="json",
             )
-            self.assertEqual(response.status_code, 201, endpoint)
+            self.assertEqual(response.status_code, status.HTTP_201_CREATED, endpoint)
 
     def test_tag_color_default(self):
         response = self.client.post("/api/tags/", {"name": "tag"}, format="json")
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(Tag.objects.get(id=response.data["id"]).color, "#a6cee3")
         self.assertEqual(
             self.client.get(f"/api/tags/{response.data['id']}/", format="json").data[
@@ -1668,7 +1680,7 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
             {"name": "tag", "colour": 3},
             format="json",
         )
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(Tag.objects.get(id=response.data["id"]).color, "#b2df8a")
         self.assertEqual(
             self.client.get(f"/api/tags/{response.data['id']}/", format="json").data[
@@ -1683,7 +1695,7 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
             {"name": "tag", "colour": 34},
             format="json",
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_tag_color_custom(self):
         tag = Tag.objects.create(name="test", color="#abcdef")
@@ -1717,7 +1729,7 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
             format="json",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         resp_data = response.json()
 
@@ -1758,14 +1770,14 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
             f"/api/documents/{doc.pk}/comments/",
             data={"comment": "this is a posted comment"},
         )
-        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
 
         response = self.client.get(
             f"/api/documents/{doc.pk}/comments/",
             format="json",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         resp_data = response.json()
 
@@ -1800,7 +1812,7 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
             format="json",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         self.assertEqual(len(Comment.objects.all()), 0)
 
@@ -1811,13 +1823,13 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
         WHEN:
             - API request for document comments is made
         THEN:
-            - HTTP 404 is returned
+            - HTTP status.HTTP_404_NOT_FOUND is returned
         """
         response = self.client.get(
             "/api/documents/500/comments/",
             format="json",
         )
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
 
 class TestDocumentApiV2(DirectoriesMixin, APITestCase):
@@ -1836,7 +1848,7 @@ class TestDocumentApiV2(DirectoriesMixin, APITestCase):
                 {"name": "test", "color": "#12fFaA"},
                 format="json",
             ).status_code,
-            201,
+            status.HTTP_201_CREATED,
         )
 
         self.assertEqual(
@@ -1845,7 +1857,7 @@ class TestDocumentApiV2(DirectoriesMixin, APITestCase):
                 {"name": "test1", "color": "abcdef"},
                 format="json",
             ).status_code,
-            400,
+            status.HTTP_400_BAD_REQUEST,
         )
         self.assertEqual(
             self.client.post(
@@ -1853,7 +1865,7 @@ class TestDocumentApiV2(DirectoriesMixin, APITestCase):
                 {"name": "test2", "color": "#abcdfg"},
                 format="json",
             ).status_code,
-            400,
+            status.HTTP_400_BAD_REQUEST,
         )
         self.assertEqual(
             self.client.post(
@@ -1861,7 +1873,7 @@ class TestDocumentApiV2(DirectoriesMixin, APITestCase):
                 {"name": "test3", "color": "#asd"},
                 format="json",
             ).status_code,
-            400,
+            status.HTTP_400_BAD_REQUEST,
         )
         self.assertEqual(
             self.client.post(
@@ -1869,7 +1881,7 @@ class TestDocumentApiV2(DirectoriesMixin, APITestCase):
                 {"name": "test4", "color": "#12121212"},
                 format="json",
             ).status_code,
-            400,
+            status.HTTP_400_BAD_REQUEST,
         )
 
     def test_tag_text_color(self):
@@ -1912,7 +1924,7 @@ class TestApiUiSettings(DirectoriesMixin, APITestCase):
 
     def test_api_get_ui_settings(self):
         response = self.client.get(self.ENDPOINT, format="json")
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertDictEqual(
             response.data["settings"],
             {
@@ -1937,7 +1949,7 @@ class TestApiUiSettings(DirectoriesMixin, APITestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         ui_settings = self.test_user.ui_settings
         self.assertDictEqual(
@@ -2134,7 +2146,7 @@ class TestBulkEdit(DirectoriesMixin, APITestCase):
             ),
             content_type="application/json",
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         m.assert_called_once()
         args, kwargs = m.call_args
         self.assertEqual(args[0], [self.doc1.id])
@@ -2154,7 +2166,7 @@ class TestBulkEdit(DirectoriesMixin, APITestCase):
             ),
             content_type="application/json",
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         m.assert_called_once()
         args, kwargs = m.call_args
         self.assertEqual(args[0], [self.doc1.id])
@@ -2174,7 +2186,7 @@ class TestBulkEdit(DirectoriesMixin, APITestCase):
             ),
             content_type="application/json",
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         m.assert_called_once()
         args, kwargs = m.call_args
         self.assertEqual(args[0], [self.doc1.id])
@@ -2194,7 +2206,7 @@ class TestBulkEdit(DirectoriesMixin, APITestCase):
             ),
             content_type="application/json",
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         m.assert_called_once()
         args, kwargs = m.call_args
         self.assertEqual(args[0], [self.doc1.id])
@@ -2214,7 +2226,7 @@ class TestBulkEdit(DirectoriesMixin, APITestCase):
             ),
             content_type="application/json",
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         m.assert_called_once()
         args, kwargs = m.call_args
         self.assertEqual(args[0], [self.doc1.id])
@@ -2234,7 +2246,7 @@ class TestBulkEdit(DirectoriesMixin, APITestCase):
             ),
             content_type="application/json",
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         m.assert_called_once()
         args, kwargs = m.call_args
         self.assertEqual(args[0], [self.doc1.id])
@@ -2257,7 +2269,7 @@ class TestBulkEdit(DirectoriesMixin, APITestCase):
             ),
             content_type="application/json",
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         m.assert_called_once()
         args, kwargs = m.call_args
         self.assertListEqual(args[0], [self.doc1.id, self.doc3.id])
@@ -2289,7 +2301,7 @@ class TestBulkEdit(DirectoriesMixin, APITestCase):
             ),
             content_type="application/json",
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         m.assert_not_called()
 
     @mock.patch("documents.serialisers.bulk_edit.delete")
@@ -2302,7 +2314,7 @@ class TestBulkEdit(DirectoriesMixin, APITestCase):
             ),
             content_type="application/json",
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         m.assert_called_once()
         args, kwargs = m.call_args
         self.assertEqual(args[0], [self.doc1.id])
@@ -2332,7 +2344,7 @@ class TestBulkEdit(DirectoriesMixin, APITestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         m.assert_called_once()
         args, kwargs = m.call_args
 
@@ -2363,7 +2375,7 @@ class TestBulkEdit(DirectoriesMixin, APITestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         m.assert_called_once()
         args, kwargs = m.call_args
 
@@ -2392,7 +2404,7 @@ class TestBulkEdit(DirectoriesMixin, APITestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.async_task.assert_not_called()
 
     def test_api_set_storage_path_not_provided(self):
@@ -2417,7 +2429,7 @@ class TestBulkEdit(DirectoriesMixin, APITestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.async_task.assert_not_called()
 
     def test_api_invalid_doc(self):
@@ -2427,7 +2439,7 @@ class TestBulkEdit(DirectoriesMixin, APITestCase):
             json.dumps({"documents": [-235], "method": "delete", "parameters": {}}),
             content_type="application/json",
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(Document.objects.count(), 5)
 
     def test_api_invalid_method(self):
@@ -2443,7 +2455,7 @@ class TestBulkEdit(DirectoriesMixin, APITestCase):
             ),
             content_type="application/json",
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(Document.objects.count(), 5)
 
     def test_api_invalid_correspondent(self):
@@ -2459,7 +2471,7 @@ class TestBulkEdit(DirectoriesMixin, APITestCase):
             ),
             content_type="application/json",
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
         doc2 = Document.objects.get(id=self.doc2.id)
         self.assertEqual(doc2.correspondent, self.c1)
@@ -2476,7 +2488,7 @@ class TestBulkEdit(DirectoriesMixin, APITestCase):
             ),
             content_type="application/json",
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_api_invalid_document_type(self):
         self.assertEqual(self.doc2.document_type, self.dt1)
@@ -2491,7 +2503,7 @@ class TestBulkEdit(DirectoriesMixin, APITestCase):
             ),
             content_type="application/json",
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
         doc2 = Document.objects.get(id=self.doc2.id)
         self.assertEqual(doc2.document_type, self.dt1)
@@ -2508,7 +2520,7 @@ class TestBulkEdit(DirectoriesMixin, APITestCase):
             ),
             content_type="application/json",
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_api_add_invalid_tag(self):
         self.assertEqual(list(self.doc2.tags.all()), [self.t1])
@@ -2523,7 +2535,7 @@ class TestBulkEdit(DirectoriesMixin, APITestCase):
             ),
             content_type="application/json",
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
         self.assertEqual(list(self.doc2.tags.all()), [self.t1])
 
@@ -2535,7 +2547,7 @@ class TestBulkEdit(DirectoriesMixin, APITestCase):
             ),
             content_type="application/json",
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_api_delete_invalid_tag(self):
         self.assertEqual(list(self.doc2.tags.all()), [self.t1])
@@ -2550,7 +2562,7 @@ class TestBulkEdit(DirectoriesMixin, APITestCase):
             ),
             content_type="application/json",
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
         self.assertEqual(list(self.doc2.tags.all()), [self.t1])
 
@@ -2562,7 +2574,7 @@ class TestBulkEdit(DirectoriesMixin, APITestCase):
             ),
             content_type="application/json",
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_api_modify_invalid_tags(self):
         self.assertEqual(list(self.doc2.tags.all()), [self.t1])
@@ -2580,7 +2592,7 @@ class TestBulkEdit(DirectoriesMixin, APITestCase):
             ),
             content_type="application/json",
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_api_modify_tags_no_tags(self):
         response = self.client.post(
@@ -2594,7 +2606,7 @@ class TestBulkEdit(DirectoriesMixin, APITestCase):
             ),
             content_type="application/json",
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
         response = self.client.post(
             "/api/documents/bulk_edit/",
@@ -2607,7 +2619,7 @@ class TestBulkEdit(DirectoriesMixin, APITestCase):
             ),
             content_type="application/json",
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_api_selection_data_empty(self):
         response = self.client.post(
@@ -2615,7 +2627,7 @@ class TestBulkEdit(DirectoriesMixin, APITestCase):
             json.dumps({"documents": []}),
             content_type="application/json",
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         for field, Entity in [
             ("selected_correspondents", Correspondent),
             ("selected_tags", Tag),
@@ -2637,7 +2649,7 @@ class TestBulkEdit(DirectoriesMixin, APITestCase):
             ),
             content_type="application/json",
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         self.assertCountEqual(
             response.data["selected_correspondents"],
@@ -2689,7 +2701,7 @@ class TestBulkEdit(DirectoriesMixin, APITestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         m.assert_called_once()
         args, kwargs = m.call_args
@@ -2758,7 +2770,7 @@ class TestBulkDownload(DirectoriesMixin, APITestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response["Content-Type"], "application/zip")
 
         with zipfile.ZipFile(io.BytesIO(response.content)) as zipf:
@@ -2779,7 +2791,7 @@ class TestBulkDownload(DirectoriesMixin, APITestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response["Content-Type"], "application/zip")
 
         with zipfile.ZipFile(io.BytesIO(response.content)) as zipf:
@@ -2800,7 +2812,7 @@ class TestBulkDownload(DirectoriesMixin, APITestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response["Content-Type"], "application/zip")
 
         with zipfile.ZipFile(io.BytesIO(response.content)) as zipf:
@@ -2834,7 +2846,7 @@ class TestBulkDownload(DirectoriesMixin, APITestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response["Content-Type"], "application/zip")
 
         with zipfile.ZipFile(io.BytesIO(response.content)) as zipf:
@@ -2893,7 +2905,7 @@ class TestBulkDownload(DirectoriesMixin, APITestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response["Content-Type"], "application/zip")
 
         with zipfile.ZipFile(io.BytesIO(response.content)) as zipf:
@@ -2941,7 +2953,7 @@ class TestBulkDownload(DirectoriesMixin, APITestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response["Content-Type"], "application/zip")
 
         with zipfile.ZipFile(io.BytesIO(response.content)) as zipf:
@@ -2990,7 +3002,7 @@ class TestBulkDownload(DirectoriesMixin, APITestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response["Content-Type"], "application/zip")
 
         with zipfile.ZipFile(io.BytesIO(response.content)) as zipf:
@@ -3023,38 +3035,65 @@ class TestApiAuth(DirectoriesMixin, APITestCase):
 
         d = Document.objects.create(title="Test")
 
-        self.assertEqual(self.client.get("/api/documents/").status_code, 401)
+        self.assertEqual(
+            self.client.get("/api/documents/").status_code,
+            status.HTTP_401_UNAUTHORIZED,
+        )
 
-        self.assertEqual(self.client.get(f"/api/documents/{d.id}/").status_code, 401)
+        self.assertEqual(
+            self.client.get(f"/api/documents/{d.id}/").status_code,
+            status.HTTP_401_UNAUTHORIZED,
+        )
         self.assertEqual(
             self.client.get(f"/api/documents/{d.id}/download/").status_code,
-            401,
+            status.HTTP_401_UNAUTHORIZED,
         )
         self.assertEqual(
             self.client.get(f"/api/documents/{d.id}/preview/").status_code,
-            401,
+            status.HTTP_401_UNAUTHORIZED,
         )
         self.assertEqual(
             self.client.get(f"/api/documents/{d.id}/thumb/").status_code,
-            401,
+            status.HTTP_401_UNAUTHORIZED,
         )
 
-        self.assertEqual(self.client.get("/api/tags/").status_code, 401)
-        self.assertEqual(self.client.get("/api/correspondents/").status_code, 401)
-        self.assertEqual(self.client.get("/api/document_types/").status_code, 401)
+        self.assertEqual(
+            self.client.get("/api/tags/").status_code,
+            status.HTTP_401_UNAUTHORIZED,
+        )
+        self.assertEqual(
+            self.client.get("/api/correspondents/").status_code,
+            status.HTTP_401_UNAUTHORIZED,
+        )
+        self.assertEqual(
+            self.client.get("/api/document_types/").status_code,
+            status.HTTP_401_UNAUTHORIZED,
+        )
 
-        self.assertEqual(self.client.get("/api/logs/").status_code, 401)
-        self.assertEqual(self.client.get("/api/saved_views/").status_code, 401)
+        self.assertEqual(
+            self.client.get("/api/logs/").status_code,
+            status.HTTP_401_UNAUTHORIZED,
+        )
+        self.assertEqual(
+            self.client.get("/api/saved_views/").status_code,
+            status.HTTP_401_UNAUTHORIZED,
+        )
 
-        self.assertEqual(self.client.get("/api/search/autocomplete/").status_code, 401)
-        self.assertEqual(self.client.get("/api/documents/bulk_edit/").status_code, 401)
+        self.assertEqual(
+            self.client.get("/api/search/autocomplete/").status_code,
+            status.HTTP_401_UNAUTHORIZED,
+        )
+        self.assertEqual(
+            self.client.get("/api/documents/bulk_edit/").status_code,
+            status.HTTP_401_UNAUTHORIZED,
+        )
         self.assertEqual(
             self.client.get("/api/documents/bulk_download/").status_code,
-            401,
+            status.HTTP_401_UNAUTHORIZED,
         )
         self.assertEqual(
             self.client.get("/api/documents/selection_data/").status_code,
-            401,
+            status.HTTP_401_UNAUTHORIZED,
         )
 
     def test_api_version_no_auth(self):
@@ -3076,14 +3115,32 @@ class TestApiAuth(DirectoriesMixin, APITestCase):
 
         d = Document.objects.create(title="Test")
 
-        self.assertEqual(self.client.get("/api/documents/").status_code, 403)
+        self.assertEqual(
+            self.client.get("/api/documents/").status_code,
+            status.HTTP_403_FORBIDDEN,
+        )
 
-        self.assertEqual(self.client.get("/api/tags/").status_code, 403)
-        self.assertEqual(self.client.get("/api/correspondents/").status_code, 403)
-        self.assertEqual(self.client.get("/api/document_types/").status_code, 403)
+        self.assertEqual(
+            self.client.get("/api/tags/").status_code,
+            status.HTTP_403_FORBIDDEN,
+        )
+        self.assertEqual(
+            self.client.get("/api/correspondents/").status_code,
+            status.HTTP_403_FORBIDDEN,
+        )
+        self.assertEqual(
+            self.client.get("/api/document_types/").status_code,
+            status.HTTP_403_FORBIDDEN,
+        )
 
-        self.assertEqual(self.client.get("/api/logs/").status_code, 403)
-        self.assertEqual(self.client.get("/api/saved_views/").status_code, 403)
+        self.assertEqual(
+            self.client.get("/api/logs/").status_code,
+            status.HTTP_403_FORBIDDEN,
+        )
+        self.assertEqual(
+            self.client.get("/api/saved_views/").status_code,
+            status.HTTP_403_FORBIDDEN,
+        )
 
     def test_api_sufficient_permissions(self):
         user = User.objects.create_user(username="test")
@@ -3092,14 +3149,26 @@ class TestApiAuth(DirectoriesMixin, APITestCase):
 
         d = Document.objects.create(title="Test")
 
-        self.assertEqual(self.client.get("/api/documents/").status_code, 200)
+        self.assertEqual(
+            self.client.get("/api/documents/").status_code,
+            status.HTTP_200_OK,
+        )
 
-        self.assertEqual(self.client.get("/api/tags/").status_code, 200)
-        self.assertEqual(self.client.get("/api/correspondents/").status_code, 200)
-        self.assertEqual(self.client.get("/api/document_types/").status_code, 200)
+        self.assertEqual(self.client.get("/api/tags/").status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            self.client.get("/api/correspondents/").status_code,
+            status.HTTP_200_OK,
+        )
+        self.assertEqual(
+            self.client.get("/api/document_types/").status_code,
+            status.HTTP_200_OK,
+        )
 
-        self.assertEqual(self.client.get("/api/logs/").status_code, 200)
-        self.assertEqual(self.client.get("/api/saved_views/").status_code, 200)
+        self.assertEqual(self.client.get("/api/logs/").status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            self.client.get("/api/saved_views/").status_code,
+            status.HTTP_200_OK,
+        )
 
     def test_object_permissions(self):
         user1 = User.objects.create_user(username="test1")
@@ -3107,12 +3176,18 @@ class TestApiAuth(DirectoriesMixin, APITestCase):
         user1.user_permissions.add(*Permission.objects.filter(codename="view_document"))
         self.client.force_authenticate(user1)
 
-        self.assertEqual(self.client.get("/api/documents/").status_code, 200)
+        self.assertEqual(
+            self.client.get("/api/documents/").status_code,
+            status.HTTP_200_OK,
+        )
 
         d = Document.objects.create(title="Test", content="the content 1", checksum="1")
 
         # no owner
-        self.assertEqual(self.client.get(f"/api/documents/{d.id}/").status_code, 200)
+        self.assertEqual(
+            self.client.get(f"/api/documents/{d.id}/").status_code,
+            status.HTTP_200_OK,
+        )
 
         d2 = Document.objects.create(
             title="Test 2",
@@ -3121,7 +3196,10 @@ class TestApiAuth(DirectoriesMixin, APITestCase):
             owner=user2,
         )
 
-        self.assertEqual(self.client.get(f"/api/documents/{d2.id}/").status_code, 404)
+        self.assertEqual(
+            self.client.get(f"/api/documents/{d2.id}/").status_code,
+            status.HTTP_404_NOT_FOUND,
+        )
 
 
 class TestApiRemoteVersion(DirectoriesMixin, APITestCase):
@@ -3134,14 +3212,14 @@ class TestApiRemoteVersion(DirectoriesMixin, APITestCase):
     def test_remote_version_enabled_no_update_prefix(self, urlopen_mock):
 
         cm = MagicMock()
-        cm.getcode.return_value = 200
+        cm.getcode.return_value = status.HTTP_200_OK
         cm.read.return_value = json.dumps({"tag_name": "ngx-1.6.0"}).encode()
         cm.__enter__.return_value = cm
         urlopen_mock.return_value = cm
 
         response = self.client.get(self.ENDPOINT)
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertDictEqual(
             response.data,
             {
@@ -3154,7 +3232,7 @@ class TestApiRemoteVersion(DirectoriesMixin, APITestCase):
     def test_remote_version_enabled_no_update_no_prefix(self, urlopen_mock):
 
         cm = MagicMock()
-        cm.getcode.return_value = 200
+        cm.getcode.return_value = status.HTTP_200_OK
         cm.read.return_value = json.dumps(
             {"tag_name": version.__full_version_str__},
         ).encode()
@@ -3163,7 +3241,7 @@ class TestApiRemoteVersion(DirectoriesMixin, APITestCase):
 
         response = self.client.get(self.ENDPOINT)
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertDictEqual(
             response.data,
             {
@@ -3183,7 +3261,7 @@ class TestApiRemoteVersion(DirectoriesMixin, APITestCase):
         new_version_str = ".".join(map(str, new_version))
 
         cm = MagicMock()
-        cm.getcode.return_value = 200
+        cm.getcode.return_value = status.HTTP_200_OK
         cm.read.return_value = json.dumps(
             {"tag_name": new_version_str},
         ).encode()
@@ -3192,7 +3270,7 @@ class TestApiRemoteVersion(DirectoriesMixin, APITestCase):
 
         response = self.client.get(self.ENDPOINT)
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertDictEqual(
             response.data,
             {
@@ -3205,14 +3283,14 @@ class TestApiRemoteVersion(DirectoriesMixin, APITestCase):
     def test_remote_version_bad_json(self, urlopen_mock):
 
         cm = MagicMock()
-        cm.getcode.return_value = 200
+        cm.getcode.return_value = status.HTTP_200_OK
         cm.read.return_value = b'{ "blah":'
         cm.__enter__.return_value = cm
         urlopen_mock.return_value = cm
 
         response = self.client.get(self.ENDPOINT)
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertDictEqual(
             response.data,
             {
@@ -3225,14 +3303,14 @@ class TestApiRemoteVersion(DirectoriesMixin, APITestCase):
     def test_remote_version_exception(self, urlopen_mock):
 
         cm = MagicMock()
-        cm.getcode.return_value = 200
+        cm.getcode.return_value = status.HTTP_200_OK
         cm.read.side_effect = urllib.error.URLError("an error")
         cm.__enter__.return_value = cm
         urlopen_mock.return_value = cm
 
         response = self.client.get(self.ENDPOINT)
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertDictEqual(
             response.data,
             {
@@ -3264,7 +3342,7 @@ class TestApiStoragePaths(DirectoriesMixin, APITestCase):
         """
         response = self.client.get(self.ENDPOINT, format="json")
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 1)
 
         resp_storage_path = response.data["results"][0]
@@ -3291,7 +3369,7 @@ class TestApiStoragePaths(DirectoriesMixin, APITestCase):
             ),
             content_type="application/json",
         )
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(StoragePath.objects.count(), 2)
 
     def test_api_create_invalid_storage_path(self):
@@ -3315,7 +3393,7 @@ class TestApiStoragePaths(DirectoriesMixin, APITestCase):
             ),
             content_type="application/json",
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(StoragePath.objects.count(), 1)
 
     def test_api_storage_path_placeholders(self):
@@ -3344,7 +3422,7 @@ class TestApiStoragePaths(DirectoriesMixin, APITestCase):
             ),
             content_type="application/json",
         )
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(StoragePath.objects.count(), 2)
 
     @mock.patch("documents.bulk_edit.bulk_update_documents.delay")
@@ -3368,7 +3446,7 @@ class TestApiStoragePaths(DirectoriesMixin, APITestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         bulk_update_mock.assert_called_once()
 
@@ -3409,7 +3487,7 @@ class TestTasks(DirectoriesMixin, APITestCase):
 
         response = self.client.get(self.ENDPOINT)
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 2)
         returned_task1 = response.data[1]
         returned_task2 = response.data[0]
@@ -3445,7 +3523,7 @@ class TestTasks(DirectoriesMixin, APITestCase):
 
         response = self.client.get(self.ENDPOINT + f"?task_id={id1}")
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 1)
         returned_task1 = response.data[0]
 
@@ -3472,7 +3550,7 @@ class TestTasks(DirectoriesMixin, APITestCase):
 
         response = self.client.get(self.ENDPOINT + "?task_id=bad-task-id")
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 0)
 
     def test_acknowledge_tasks(self):
@@ -3496,7 +3574,7 @@ class TestTasks(DirectoriesMixin, APITestCase):
             self.ENDPOINT_ACKNOWLEDGE,
             {"tasks": [task.id]},
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         response = self.client.get(self.ENDPOINT)
         self.assertEqual(len(response.data), 0)
@@ -3519,7 +3597,7 @@ class TestTasks(DirectoriesMixin, APITestCase):
 
         response = self.client.get(self.ENDPOINT)
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 1)
 
         returned_data = response.data[0]
@@ -3545,7 +3623,7 @@ class TestTasks(DirectoriesMixin, APITestCase):
 
         response = self.client.get(self.ENDPOINT)
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 1)
 
         returned_data = response.data[0]
@@ -3574,7 +3652,7 @@ class TestTasks(DirectoriesMixin, APITestCase):
 
         response = self.client.get(self.ENDPOINT)
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 1)
 
         returned_data = response.data[0]
@@ -3600,7 +3678,7 @@ class TestTasks(DirectoriesMixin, APITestCase):
 
         response = self.client.get(self.ENDPOINT)
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 1)
 
         returned_data = response.data[0]
@@ -3636,7 +3714,7 @@ class TestApiUser(DirectoriesMixin, APITestCase):
 
         response = self.client.get(self.ENDPOINT)
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 2)
         returned_user2 = response.data["results"][1]
 
@@ -3665,7 +3743,7 @@ class TestApiUser(DirectoriesMixin, APITestCase):
             data=user1,
         )
 
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         returned_user1 = User.objects.get(username="testuser")
 
@@ -3696,7 +3774,7 @@ class TestApiUser(DirectoriesMixin, APITestCase):
             f"{self.ENDPOINT}{user1.pk}/",
         )
 
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
         self.assertEqual(User.objects.count(), nUsers - 1)
 
@@ -3727,7 +3805,7 @@ class TestApiUser(DirectoriesMixin, APITestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         returned_user1 = User.objects.get(pk=user1.pk)
         self.assertEqual(returned_user1.first_name, "Updated Name 1")
@@ -3741,7 +3819,7 @@ class TestApiUser(DirectoriesMixin, APITestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         returned_user2 = User.objects.get(pk=user1.pk)
         self.assertEqual(returned_user2.first_name, "Updated Name 2")
@@ -3773,7 +3851,7 @@ class TestApiGroup(DirectoriesMixin, APITestCase):
 
         response = self.client.get(self.ENDPOINT)
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 1)
         returned_group1 = response.data["results"][0]
 
@@ -3796,7 +3874,7 @@ class TestApiGroup(DirectoriesMixin, APITestCase):
             data=group1,
         )
 
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         returned_group1 = Group.objects.get(name="Test Group")
 
@@ -3820,7 +3898,7 @@ class TestApiGroup(DirectoriesMixin, APITestCase):
             f"{self.ENDPOINT}{group1.pk}/",
         )
 
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
         self.assertEqual(len(Group.objects.all()), 0)
 
@@ -3845,7 +3923,7 @@ class TestApiGroup(DirectoriesMixin, APITestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         returned_group1 = Group.objects.get(pk=group1.pk)
         self.assertEqual(returned_group1.name, "Updated Name 1")

--- a/src/documents/tests/test_barcodes.py
+++ b/src/documents/tests/test_barcodes.py
@@ -9,10 +9,11 @@ from documents import barcodes
 from documents import tasks
 from documents.consumer import ConsumerError
 from documents.tests.utils import DirectoriesMixin
+from documents.tests.utils import FileSystemAssertsMixin
 from PIL import Image
 
 
-class TestBarcode(DirectoriesMixin, TestCase):
+class TestBarcode(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
 
     SAMPLE_DIR = os.path.join(
         os.path.dirname(__file__),
@@ -253,7 +254,7 @@ class TestBarcode(DirectoriesMixin, TestCase):
         shutil.copy(test_file, dst)
         target_file = barcodes.convert_from_tiff_to_pdf(dst)
         file_extension = os.path.splitext(os.path.basename(target_file))[1]
-        self.assertTrue(os.path.isfile(target_file))
+        self.assertIsFile(target_file)
         self.assertEqual(file_extension, ".pdf")
 
     def test_convert_error_from_pdf_to_pdf(self):
@@ -634,7 +635,7 @@ class TestBarcode(DirectoriesMixin, TestCase):
         )
         barcodes.save_to_dir(test_file, target_dir=settings.SCRATCH_DIR)
         target_file = os.path.join(settings.SCRATCH_DIR, "patch-code-t.pdf")
-        self.assertTrue(os.path.isfile(target_file))
+        self.assertIsFile(target_file)
 
     def test_save_to_dir_not_existing(self):
         """
@@ -651,8 +652,7 @@ class TestBarcode(DirectoriesMixin, TestCase):
             "patch-code-t.pdf",
         )
         nonexistingdir = "/nowhere"
-        if os.path.isdir(nonexistingdir):
-            self.fail("non-existing dir exists")
+        self.assertIsNotDir(nonexistingdir)
 
         with self.assertLogs("paperless.barcodes", level="WARNING") as cm:
             barcodes.save_to_dir(test_file, target_dir=nonexistingdir)
@@ -683,7 +683,7 @@ class TestBarcode(DirectoriesMixin, TestCase):
             target_dir=settings.SCRATCH_DIR,
         )
         target_file = os.path.join(settings.SCRATCH_DIR, "newname.pdf")
-        self.assertTrue(os.path.isfile(target_file))
+        self.assertIsFile(target_file)
 
     def test_barcode_splitter(self):
         """
@@ -724,8 +724,8 @@ class TestBarcode(DirectoriesMixin, TestCase):
             "patch-code-t-middle_document_1.pdf",
         )
 
-        self.assertTrue(os.path.isfile(target_file1))
-        self.assertTrue(os.path.isfile(target_file2))
+        self.assertIsFile(target_file1)
+        self.assertIsFile(target_file2)
 
     @override_settings(CONSUMER_ENABLE_BARCODES=True)
     def test_consume_barcode_file(self):

--- a/src/documents/tests/test_management.py
+++ b/src/documents/tests/test_management.py
@@ -13,13 +13,14 @@ from documents.file_handling import generate_filename
 from documents.models import Document
 from documents.tasks import update_document_archive_file
 from documents.tests.utils import DirectoriesMixin
+from documents.tests.utils import FileSystemAssertsMixin
 
 
 sample_file = os.path.join(os.path.dirname(__file__), "samples", "simple.pdf")
 
 
 @override_settings(FILENAME_FORMAT="{correspondent}/{title}")
-class TestArchiver(DirectoriesMixin, TestCase):
+class TestArchiver(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
     def make_models(self):
         return Document.objects.create(
             checksum="A",
@@ -52,8 +53,8 @@ class TestArchiver(DirectoriesMixin, TestCase):
 
         self.assertIsNotNone(doc.checksum)
         self.assertIsNotNone(doc.archive_checksum)
-        self.assertTrue(os.path.isfile(doc.archive_path))
-        self.assertTrue(os.path.isfile(doc.source_path))
+        self.assertIsFile(doc.archive_path)
+        self.assertIsFile(doc.source_path)
         self.assertTrue(filecmp.cmp(sample_file, doc.source_path))
         self.assertEqual(doc.archive_filename, "none/A.pdf")
 
@@ -70,7 +71,7 @@ class TestArchiver(DirectoriesMixin, TestCase):
         self.assertIsNotNone(doc.checksum)
         self.assertIsNone(doc.archive_checksum)
         self.assertIsNone(doc.archive_filename)
-        self.assertTrue(os.path.isfile(doc.source_path))
+        self.assertIsFile(doc.source_path)
 
     @override_settings(FILENAME_FORMAT="{title}")
     def test_naming_priorities(self):
@@ -104,7 +105,7 @@ class TestArchiver(DirectoriesMixin, TestCase):
         self.assertEqual(doc2.archive_filename, "document_01.pdf")
 
 
-class TestDecryptDocuments(TestCase):
+class TestDecryptDocuments(FileSystemAssertsMixin, TestCase):
     @override_settings(
         ORIGINALS_DIR=os.path.join(os.path.dirname(__file__), "samples", "originals"),
         THUMBNAIL_DIR=os.path.join(os.path.dirname(__file__), "samples", "thumb"),
@@ -161,10 +162,10 @@ class TestDecryptDocuments(TestCase):
 
         self.assertEqual(doc.storage_type, Document.STORAGE_TYPE_UNENCRYPTED)
         self.assertEqual(doc.filename, "0000004.pdf")
-        self.assertTrue(os.path.isfile(os.path.join(originals_dir, "0000004.pdf")))
-        self.assertTrue(os.path.isfile(doc.source_path))
-        self.assertTrue(os.path.isfile(os.path.join(thumb_dir, f"{doc.id:07}.webp")))
-        self.assertTrue(os.path.isfile(doc.thumbnail_path))
+        self.assertIsFile(os.path.join(originals_dir, "0000004.pdf"))
+        self.assertIsFile(doc.source_path)
+        self.assertIsFile(os.path.join(thumb_dir, f"{doc.id:07}.webp"))
+        self.assertIsFile(doc.thumbnail_path)
 
         with doc.source_file as f:
             checksum = hashlib.md5(f.read()).hexdigest()
@@ -183,7 +184,7 @@ class TestMakeIndex(TestCase):
         m.assert_called_once()
 
 
-class TestRenamer(DirectoriesMixin, TestCase):
+class TestRenamer(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
     @override_settings(FILENAME_FORMAT="")
     def test_rename(self):
         doc = Document.objects.create(title="test", mime_type="image/jpeg")
@@ -201,10 +202,10 @@ class TestRenamer(DirectoriesMixin, TestCase):
 
         self.assertEqual(doc2.filename, "none/test.jpg")
         self.assertEqual(doc2.archive_filename, "none/test.pdf")
-        self.assertFalse(os.path.isfile(doc.source_path))
-        self.assertFalse(os.path.isfile(doc.archive_path))
-        self.assertTrue(os.path.isfile(doc2.source_path))
-        self.assertTrue(os.path.isfile(doc2.archive_path))
+        self.assertIsNotFile(doc.source_path)
+        self.assertIsNotFile(doc.archive_path)
+        self.assertIsFile(doc2.source_path)
+        self.assertIsFile(doc2.archive_path)
 
 
 class TestCreateClassifier(TestCase):

--- a/src/documents/tests/test_management_exporter.py
+++ b/src/documents/tests/test_management_exporter.py
@@ -23,10 +23,11 @@ from documents.models import User
 from documents.sanity_checker import check_sanity
 from documents.settings import EXPORTER_FILE_NAME
 from documents.tests.utils import DirectoriesMixin
+from documents.tests.utils import FileSystemAssertsMixin
 from documents.tests.utils import paperless_environment
 
 
-class TestExportImport(DirectoriesMixin, TestCase):
+class TestExportImport(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
     def setUp(self) -> None:
         self.target = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, self.target)
@@ -145,7 +146,7 @@ class TestExportImport(DirectoriesMixin, TestCase):
             4,
         )
 
-        self.assertTrue(os.path.exists(os.path.join(self.target, "manifest.json")))
+        self.assertIsFile(os.path.join(self.target, "manifest.json"))
 
         self.assertEqual(
             self._get_document_from_manifest(manifest, self.d1.id)["fields"]["title"],
@@ -170,13 +171,11 @@ class TestExportImport(DirectoriesMixin, TestCase):
                     self.target,
                     element[document_exporter.EXPORTER_FILE_NAME],
                 )
-                self.assertTrue(os.path.exists(fname))
-                self.assertTrue(
-                    os.path.exists(
-                        os.path.join(
-                            self.target,
-                            element[document_exporter.EXPORTER_THUMBNAIL_NAME],
-                        ),
+                self.assertIsFile(fname)
+                self.assertIsFile(
+                    os.path.join(
+                        self.target,
+                        element[document_exporter.EXPORTER_THUMBNAIL_NAME],
                     ),
                 )
 
@@ -194,7 +193,7 @@ class TestExportImport(DirectoriesMixin, TestCase):
                         self.target,
                         element[document_exporter.EXPORTER_ARCHIVE_NAME],
                     )
-                    self.assertTrue(os.path.exists(fname))
+                    self.assertIsFile(fname)
 
                     with open(fname, "rb") as f:
                         checksum = hashlib.md5(f.read()).hexdigest()
@@ -247,7 +246,7 @@ class TestExportImport(DirectoriesMixin, TestCase):
         )
 
         self._do_export()
-        self.assertTrue(os.path.exists(os.path.join(self.target, "manifest.json")))
+        self.assertIsFile(os.path.join(self.target, "manifest.json"))
 
         st_mtime_1 = os.stat(os.path.join(self.target, "manifest.json")).st_mtime
 
@@ -257,7 +256,7 @@ class TestExportImport(DirectoriesMixin, TestCase):
             self._do_export()
             m.assert_not_called()
 
-        self.assertTrue(os.path.exists(os.path.join(self.target, "manifest.json")))
+        self.assertIsFile(os.path.join(self.target, "manifest.json"))
         st_mtime_2 = os.stat(os.path.join(self.target, "manifest.json")).st_mtime
 
         Path(self.d1.source_path).touch()
@@ -269,7 +268,7 @@ class TestExportImport(DirectoriesMixin, TestCase):
             self.assertEqual(m.call_count, 1)
 
         st_mtime_3 = os.stat(os.path.join(self.target, "manifest.json")).st_mtime
-        self.assertTrue(os.path.exists(os.path.join(self.target, "manifest.json")))
+        self.assertIsFile(os.path.join(self.target, "manifest.json"))
 
         self.assertNotEqual(st_mtime_1, st_mtime_2)
         self.assertNotEqual(st_mtime_2, st_mtime_3)
@@ -283,7 +282,7 @@ class TestExportImport(DirectoriesMixin, TestCase):
 
         self._do_export()
 
-        self.assertTrue(os.path.exists(os.path.join(self.target, "manifest.json")))
+        self.assertIsFile(os.path.join(self.target, "manifest.json"))
 
         with mock.patch(
             "documents.management.commands.document_exporter.shutil.copy2",
@@ -291,7 +290,7 @@ class TestExportImport(DirectoriesMixin, TestCase):
             self._do_export()
             m.assert_not_called()
 
-        self.assertTrue(os.path.exists(os.path.join(self.target, "manifest.json")))
+        self.assertIsFile(os.path.join(self.target, "manifest.json"))
 
         self.d2.checksum = "asdfasdgf3"
         self.d2.save()
@@ -302,7 +301,7 @@ class TestExportImport(DirectoriesMixin, TestCase):
             self._do_export(compare_checksums=True)
             self.assertEqual(m.call_count, 1)
 
-        self.assertTrue(os.path.exists(os.path.join(self.target, "manifest.json")))
+        self.assertIsFile(os.path.join(self.target, "manifest.json"))
 
     def test_update_export_deleted_document(self):
         shutil.rmtree(os.path.join(self.dirs.media_dir, "documents"))
@@ -315,10 +314,8 @@ class TestExportImport(DirectoriesMixin, TestCase):
 
         self.assertTrue(len(manifest), 7)
         doc_from_manifest = self._get_document_from_manifest(manifest, self.d3.id)
-        self.assertTrue(
-            os.path.isfile(
-                os.path.join(self.target, doc_from_manifest[EXPORTER_FILE_NAME]),
-            ),
+        self.assertIsFile(
+            os.path.join(self.target, doc_from_manifest[EXPORTER_FILE_NAME]),
         )
         self.d3.delete()
 
@@ -329,17 +326,13 @@ class TestExportImport(DirectoriesMixin, TestCase):
             manifest,
             self.d3.id,
         )
-        self.assertTrue(
-            os.path.isfile(
-                os.path.join(self.target, doc_from_manifest[EXPORTER_FILE_NAME]),
-            ),
+        self.assertIsFile(
+            os.path.join(self.target, doc_from_manifest[EXPORTER_FILE_NAME]),
         )
 
         manifest = self._do_export(delete=True)
-        self.assertFalse(
-            os.path.isfile(
-                os.path.join(self.target, doc_from_manifest[EXPORTER_FILE_NAME]),
-            ),
+        self.assertIsNotFile(
+            os.path.join(self.target, doc_from_manifest[EXPORTER_FILE_NAME]),
         )
 
         self.assertTrue(len(manifest), 6)
@@ -353,20 +346,20 @@ class TestExportImport(DirectoriesMixin, TestCase):
         )
 
         m = self._do_export(use_filename_format=True)
-        self.assertTrue(os.path.isfile(os.path.join(self.target, "wow1", "c.pdf")))
+        self.assertIsFile(os.path.join(self.target, "wow1", "c.pdf"))
 
-        self.assertTrue(os.path.exists(os.path.join(self.target, "manifest.json")))
+        self.assertIsFile(os.path.join(self.target, "manifest.json"))
 
         self.d1.title = "new_title"
         self.d1.save()
         self._do_export(use_filename_format=True, delete=True)
-        self.assertFalse(os.path.isfile(os.path.join(self.target, "wow1", "c.pdf")))
-        self.assertFalse(os.path.isdir(os.path.join(self.target, "wow1")))
-        self.assertTrue(os.path.isfile(os.path.join(self.target, "new_title", "c.pdf")))
-        self.assertTrue(os.path.exists(os.path.join(self.target, "manifest.json")))
-        self.assertTrue(os.path.isfile(os.path.join(self.target, "wow2", "none.pdf")))
-        self.assertTrue(
-            os.path.isfile(os.path.join(self.target, "wow2", "none_01.pdf")),
+        self.assertIsNotFile(os.path.join(self.target, "wow1", "c.pdf"))
+        self.assertIsNotDir(os.path.join(self.target, "wow1"))
+        self.assertIsFile(os.path.join(self.target, "new_title", "c.pdf"))
+        self.assertIsFile(os.path.join(self.target, "manifest.json"))
+        self.assertIsFile(os.path.join(self.target, "wow2", "none.pdf"))
+        self.assertIsFile(
+            (os.path.join(self.target, "wow2", "none_01.pdf")),
         )
 
     def test_export_missing_files(self):
@@ -407,7 +400,7 @@ class TestExportImport(DirectoriesMixin, TestCase):
             f"export-{timezone.localdate().isoformat()}.zip",
         )
 
-        self.assertTrue(os.path.isfile(expected_file))
+        self.assertIsFile(expected_file)
 
         with ZipFile(expected_file) as zip:
             self.assertEqual(len(zip.namelist()), 11)
@@ -444,7 +437,7 @@ class TestExportImport(DirectoriesMixin, TestCase):
             f"export-{timezone.localdate().isoformat()}.zip",
         )
 
-        self.assertTrue(os.path.isfile(expected_file))
+        self.assertIsFile(expected_file)
 
         with ZipFile(expected_file) as zip:
             # Extras are from the directories, which also appear in the listing

--- a/src/documents/tests/test_management_thumbnails.py
+++ b/src/documents/tests/test_management_thumbnails.py
@@ -7,9 +7,10 @@ from django.test import TestCase
 from documents.management.commands.document_thumbnails import _process_document
 from documents.models import Document
 from documents.tests.utils import DirectoriesMixin
+from documents.tests.utils import FileSystemAssertsMixin
 
 
-class TestMakeThumbnails(DirectoriesMixin, TestCase):
+class TestMakeThumbnails(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
     def make_models(self):
         self.d1 = Document.objects.create(
             checksum="A",
@@ -40,9 +41,9 @@ class TestMakeThumbnails(DirectoriesMixin, TestCase):
         self.make_models()
 
     def test_process_document(self):
-        self.assertFalse(os.path.isfile(self.d1.thumbnail_path))
+        self.assertIsNotFile(self.d1.thumbnail_path)
         _process_document(self.d1.id)
-        self.assertTrue(os.path.isfile(self.d1.thumbnail_path))
+        self.assertIsFile(self.d1.thumbnail_path)
 
     @mock.patch("documents.management.commands.document_thumbnails.shutil.move")
     def test_process_document_invalid_mime_type(self, m):
@@ -54,15 +55,15 @@ class TestMakeThumbnails(DirectoriesMixin, TestCase):
         m.assert_not_called()
 
     def test_command(self):
-        self.assertFalse(os.path.isfile(self.d1.thumbnail_path))
-        self.assertFalse(os.path.isfile(self.d2.thumbnail_path))
+        self.assertIsNotFile(self.d1.thumbnail_path)
+        self.assertIsNotFile(self.d2.thumbnail_path)
         call_command("document_thumbnails")
-        self.assertTrue(os.path.isfile(self.d1.thumbnail_path))
-        self.assertTrue(os.path.isfile(self.d2.thumbnail_path))
+        self.assertTrue(self.d1.thumbnail_path)
+        self.assertTrue(self.d2.thumbnail_path)
 
     def test_command_documentid(self):
-        self.assertFalse(os.path.isfile(self.d1.thumbnail_path))
-        self.assertFalse(os.path.isfile(self.d2.thumbnail_path))
+        self.assertIsNotFile(self.d1.thumbnail_path)
+        self.assertIsNotFile(self.d2.thumbnail_path)
         call_command("document_thumbnails", "-d", f"{self.d1.id}")
-        self.assertTrue(os.path.isfile(self.d1.thumbnail_path))
-        self.assertFalse(os.path.isfile(self.d2.thumbnail_path))
+        self.assertIsFile(self.d1.thumbnail_path)
+        self.assertIsNotFile(self.d2.thumbnail_path)

--- a/src/documents/tests/test_views.py
+++ b/src/documents/tests/test_views.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from django.contrib.auth.models import User
 from django.test import override_settings
 from django.test import TestCase
+from rest_framework import status
 
 
 class TestViews(TestCase):
@@ -28,7 +29,7 @@ class TestViews(TestCase):
 
     def test_login_redirect(self):
         response = self.client.get("/")
-        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
         self.assertEqual(response.url, "/accounts/login/?next=/")
 
     def test_index(self):
@@ -52,7 +53,7 @@ class TestViews(TestCase):
             response = self.client.get(
                 "/",
             )
-            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
             self.assertEqual(
                 response.context_data["webmanifest"],
                 f"frontend/{language_actual}/manifest.webmanifest",

--- a/src/documents/tests/utils.py
+++ b/src/documents/tests/utils.py
@@ -3,6 +3,9 @@ import shutil
 import tempfile
 from collections import namedtuple
 from contextlib import contextmanager
+from os import PathLike
+from pathlib import Path
+from typing import Union
 from unittest import mock
 
 from django.apps import apps
@@ -85,6 +88,24 @@ class DirectoriesMixin:
     def tearDown(self) -> None:
         super().tearDown()
         remove_dirs(self.dirs)
+
+
+class FileSystemAssertsMixin:
+    def assertIsFile(self, path: Union[PathLike, str]):
+        if not Path(path).resolve().is_file():
+            raise AssertionError(f"File does not exist: {path}")
+
+    def assertIsNotFile(self, path: Union[PathLike, str]):
+        if Path(path).resolve().is_file():
+            raise AssertionError(f"File does exist: {path}")
+
+    def assertIsDir(self, path: Union[PathLike, str]):
+        if not Path(path).resolve().is_dir():
+            raise AssertionError(f"Dir does not exist: {path}")
+
+    def assertIsNotDir(self, path: Union[PathLike, str]):
+        if Path(path).resolve().is_dir():
+            raise AssertionError(f"Dir does exist: {path}")
 
 
 class ConsumerProgressMixin:

--- a/src/documents/tests/utils.py
+++ b/src/documents/tests/utils.py
@@ -92,20 +92,16 @@ class DirectoriesMixin:
 
 class FileSystemAssertsMixin:
     def assertIsFile(self, path: Union[PathLike, str]):
-        if not Path(path).resolve().is_file():
-            raise AssertionError(f"File does not exist: {path}")
+        self.assertTrue(Path(path).resolve().is_file(), f"File does not exist: {path}")
 
     def assertIsNotFile(self, path: Union[PathLike, str]):
-        if Path(path).resolve().is_file():
-            raise AssertionError(f"File does exist: {path}")
+        self.assertFalse(Path(path).resolve().is_file(), f"File does exist: {path}")
 
     def assertIsDir(self, path: Union[PathLike, str]):
-        if not Path(path).resolve().is_dir():
-            raise AssertionError(f"Dir does not exist: {path}")
+        self.assertTrue(Path(path).resolve().is_dir(), f"Dir does not exist: {path}")
 
     def assertIsNotDir(self, path: Union[PathLike, str]):
-        if Path(path).resolve().is_dir():
-            raise AssertionError(f"Dir does exist: {path}")
+        self.assertFalse(Path(path).resolve().is_dir(), f"Dir does exist: {path}")
 
 
 class ConsumerProgressMixin:

--- a/src/paperless_mail/tests/test_api.py
+++ b/src/paperless_mail/tests/test_api.py
@@ -5,6 +5,7 @@ from documents.models import Tag
 from documents.tests.utils import DirectoriesMixin
 from paperless_mail.models import MailAccount
 from paperless_mail.models import MailRule
+from rest_framework import status
 from rest_framework.test import APITestCase
 
 
@@ -39,7 +40,7 @@ class TestAPIMailAccounts(DirectoriesMixin, APITestCase):
 
         response = self.client.get(self.ENDPOINT)
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 1)
         returned_account1 = response.data["results"][0]
 
@@ -77,7 +78,7 @@ class TestAPIMailAccounts(DirectoriesMixin, APITestCase):
             data=account1,
         )
 
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         returned_account1 = MailAccount.objects.get(name="Email1")
 
@@ -113,7 +114,7 @@ class TestAPIMailAccounts(DirectoriesMixin, APITestCase):
             f"{self.ENDPOINT}{account1.pk}/",
         )
 
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
         self.assertEqual(len(MailAccount.objects.all()), 0)
 
@@ -145,7 +146,7 @@ class TestAPIMailAccounts(DirectoriesMixin, APITestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         returned_account1 = MailAccount.objects.get(pk=account1.pk)
         self.assertEqual(returned_account1.name, "Updated Name 1")
@@ -159,7 +160,7 @@ class TestAPIMailAccounts(DirectoriesMixin, APITestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         returned_account2 = MailAccount.objects.get(pk=account1.pk)
         self.assertEqual(returned_account2.name, "Updated Name 2")
@@ -213,7 +214,7 @@ class TestAPIMailRules(DirectoriesMixin, APITestCase):
 
         response = self.client.get(self.ENDPOINT)
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 1)
         returned_rule1 = response.data["results"][0]
 
@@ -294,11 +295,11 @@ class TestAPIMailRules(DirectoriesMixin, APITestCase):
             data=rule1,
         )
 
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         response = self.client.get(self.ENDPOINT)
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 1)
         returned_rule1 = response.data["results"][0]
 
@@ -375,7 +376,7 @@ class TestAPIMailRules(DirectoriesMixin, APITestCase):
             f"{self.ENDPOINT}{rule1.pk}/",
         )
 
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
         self.assertEqual(len(MailRule.objects.all()), 0)
 
@@ -423,7 +424,7 @@ class TestAPIMailRules(DirectoriesMixin, APITestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         returned_rule1 = MailRule.objects.get(pk=rule1.pk)
         self.assertEqual(returned_rule1.name, "Updated Name 1")

--- a/src/paperless_mail/tests/test_mail.py
+++ b/src/paperless_mail/tests/test_mail.py
@@ -14,6 +14,7 @@ from django.db import DatabaseError
 from django.test import TestCase
 from documents.models import Correspondent
 from documents.tests.utils import DirectoriesMixin
+from documents.tests.utils import FileSystemAssertsMixin
 from imap_tools import EmailAddress
 from imap_tools import FolderInfo
 from imap_tools import MailboxFolderSelectError
@@ -241,7 +242,7 @@ def fake_magic_from_buffer(buffer, mime=False):
 
 
 @mock.patch("paperless_mail.mail.magic.from_buffer", fake_magic_from_buffer)
-class TestMail(DirectoriesMixin, TestCase):
+class TestMail(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
     def setUp(self):
         patcher = mock.patch("paperless_mail.mail.MailBox")
         m = patcher.start()
@@ -389,12 +390,12 @@ class TestMail(DirectoriesMixin, TestCase):
         args1, kwargs1 = self.async_task.call_args_list[0]
         args2, kwargs2 = self.async_task.call_args_list[1]
 
-        self.assertTrue(os.path.isfile(kwargs1["path"]), kwargs1["path"])
+        self.assertIsFile(kwargs1["path"])
 
         self.assertEqual(kwargs1["override_title"], "file_0")
         self.assertEqual(kwargs1["override_filename"], "file_0.pdf")
 
-        self.assertTrue(os.path.isfile(kwargs2["path"]), kwargs1["path"])
+        self.assertIsFile(kwargs2["path"])
 
         self.assertEqual(kwargs2["override_title"], "file_1")
         self.assertEqual(kwargs2["override_filename"], "file_1.pdf")
@@ -435,7 +436,7 @@ class TestMail(DirectoriesMixin, TestCase):
         self.assertEqual(self.async_task.call_count, 1)
 
         args, kwargs = self.async_task.call_args
-        self.assertTrue(os.path.isfile(kwargs["path"]), kwargs["path"])
+        self.assertIsFile(kwargs["path"])
         self.assertEqual(kwargs["override_filename"], "f1.pdf")
 
     def test_handle_disposition(self):

--- a/src/paperless_mail/tests/test_parsers.py
+++ b/src/paperless_mail/tests/test_parsers.py
@@ -4,10 +4,11 @@ from unittest import mock
 
 from django.test import TestCase
 from documents.parsers import ParseError
+from documents.tests.utils import FileSystemAssertsMixin
 from paperless_mail.parsers import MailDocumentParser
 
 
-class TestParser(TestCase):
+class TestParser(FileSystemAssertsMixin, TestCase):
     SAMPLE_FILES = os.path.join(os.path.dirname(__file__), "samples")
 
     def setUp(self) -> None:
@@ -331,7 +332,7 @@ class TestParser(TestCase):
         )
 
     @mock.patch("paperless_mail.parsers.MailDocumentParser.generate_pdf")
-    def test_parse_simple_eml(self, n):
+    def test_parse_simple_eml(self, m: mock.MagicMock):
         """
         GIVEN:
             - Fresh start
@@ -361,8 +362,8 @@ class TestParser(TestCase):
             self.parser.date,
         )
 
-        # Just check if file exists, the unittest for generate_pdf() goes deeper.
-        self.assertTrue(os.path.isfile(self.parser.archive_path))
+        # Just check if tried to generate archive, the unittest for generate_pdf() goes deeper.
+        m.assert_called()
 
     @mock.patch("paperless_mail.parsers.parser.from_buffer")
     def test_tika_parse_unsuccessful(self, mock_from_buffer: mock.MagicMock):
@@ -494,7 +495,7 @@ class TestParser(TestCase):
         mock_response.content = b"Content"
         mock_post.return_value = mock_response
         pdf_path = self.parser.generate_pdf(os.path.join(self.SAMPLE_FILES, "html.eml"))
-        self.assertTrue(os.path.isfile(pdf_path))
+        self.assertIsFile(pdf_path)
 
         mock_generate_pdf_from_mail.assert_called_once_with(
             self.parser.get_parsed(None),

--- a/src/paperless_mail/tests/test_parsers_live.py
+++ b/src/paperless_mail/tests/test_parsers_live.py
@@ -7,13 +7,14 @@ from urllib.request import urlopen
 import pytest
 from django.test import TestCase
 from documents.parsers import run_convert
+from documents.tests.utils import FileSystemAssertsMixin
 from imagehash import average_hash
 from paperless_mail.parsers import MailDocumentParser
 from pdfminer.high_level import extract_text
 from PIL import Image
 
 
-class TestParserLive(TestCase):
+class TestParserLive(FileSystemAssertsMixin, TestCase):
     SAMPLE_FILES = os.path.join(os.path.dirname(__file__), "samples")
 
     def setUp(self) -> None:
@@ -85,7 +86,7 @@ class TestParserLive(TestCase):
             os.path.join(self.SAMPLE_FILES, "simple_text.eml"),
             "message/rfc822",
         )
-        self.assertTrue(os.path.isfile(thumb))
+        self.assertIsFile(thumb)
 
         expected = os.path.join(self.SAMPLE_FILES, "simple_text.eml.pdf.webp")
 
@@ -161,7 +162,7 @@ class TestParserLive(TestCase):
             self.parser.generate_pdf,
             [os.path.join(self.SAMPLE_FILES, "html.eml")],
         )
-        self.assertTrue(os.path.isfile(pdf_path))
+        self.assertIsFile(pdf_path)
 
         extracted = extract_text(pdf_path)
         expected = (
@@ -232,7 +233,7 @@ class TestParserLive(TestCase):
             output_file=converted,
             logging_group=None,
         )
-        self.assertTrue(os.path.isfile(converted))
+        self.assertIsFile(converted)
         thumb_hash = self.imagehash(converted)
 
         # The created pdf is not reproducible. But the converted image should always look the same.
@@ -337,7 +338,7 @@ class TestParserLive(TestCase):
             output_file=converted,
             logging_group=None,
         )
-        self.assertTrue(os.path.isfile(converted))
+        self.assertIsFile(converted)
         thumb_hash = self.imagehash(converted)
 
         # The created pdf is not reproducible. But the converted image should always look the same.

--- a/src/paperless_tesseract/tests/test_parser.py
+++ b/src/paperless_tesseract/tests/test_parser.py
@@ -10,6 +10,7 @@ from django.test import TestCase
 from documents.parsers import ParseError
 from documents.parsers import run_convert
 from documents.tests.utils import DirectoriesMixin
+from documents.tests.utils import FileSystemAssertsMixin
 from paperless_tesseract.parsers import post_process_text
 from paperless_tesseract.parsers import RasterisedDocumentParser
 
@@ -36,7 +37,7 @@ class FakeImageFile(ContextManager):
         return os.path.basename(self.fname)
 
 
-class TestParser(DirectoriesMixin, TestCase):
+class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
 
     SAMPLE_FILES = os.path.join(os.path.dirname(__file__), "samples")
 
@@ -88,7 +89,7 @@ class TestParser(DirectoriesMixin, TestCase):
             os.path.join(self.SAMPLE_FILES, "simple-digital.pdf"),
             "application/pdf",
         )
-        self.assertTrue(os.path.isfile(thumb))
+        self.assertIsFile(thumb)
 
     @mock.patch("documents.parsers.run_convert")
     def test_thumbnail_fallback(self, m):
@@ -105,7 +106,7 @@ class TestParser(DirectoriesMixin, TestCase):
             os.path.join(self.SAMPLE_FILES, "simple-digital.pdf"),
             "application/pdf",
         )
-        self.assertTrue(os.path.isfile(thumb))
+        self.assertIsFile(thumb)
 
     def test_thumbnail_encrypted(self):
         parser = RasterisedDocumentParser(uuid.uuid4())
@@ -113,7 +114,7 @@ class TestParser(DirectoriesMixin, TestCase):
             os.path.join(self.SAMPLE_FILES, "encrypted.pdf"),
             "application/pdf",
         )
-        self.assertTrue(os.path.isfile(thumb))
+        self.assertIsFile(thumb)
 
     def test_get_dpi(self):
         parser = RasterisedDocumentParser(None)
@@ -132,7 +133,7 @@ class TestParser(DirectoriesMixin, TestCase):
             "application/pdf",
         )
 
-        self.assertTrue(os.path.isfile(parser.archive_path))
+        self.assertIsFile(parser.archive_path)
 
         self.assertContainsStrings(parser.get_text(), ["This is a test document."])
 
@@ -144,7 +145,7 @@ class TestParser(DirectoriesMixin, TestCase):
             "application/pdf",
         )
 
-        self.assertTrue(os.path.isfile(parser.archive_path))
+        self.assertIsFile(parser.archive_path)
 
         self.assertContainsStrings(
             parser.get_text(),
@@ -225,7 +226,7 @@ class TestParser(DirectoriesMixin, TestCase):
 
         parser.parse(os.path.join(self.SAMPLE_FILES, "simple.png"), "image/png")
 
-        self.assertTrue(os.path.isfile(parser.archive_path))
+        self.assertIsFile(parser.archive_path)
 
         self.assertContainsStrings(parser.get_text(), ["This is a test document."])
 
@@ -241,7 +242,7 @@ class TestParser(DirectoriesMixin, TestCase):
 
             parser.parse(dest_file, "image/png")
 
-            self.assertTrue(os.path.isfile(parser.archive_path))
+            self.assertIsFile(parser.archive_path)
 
             self.assertContainsStrings(parser.get_text(), ["This is a test document."])
 
@@ -273,7 +274,7 @@ class TestParser(DirectoriesMixin, TestCase):
 
         parser.parse(os.path.join(self.SAMPLE_FILES, "simple-no-dpi.png"), "image/png")
 
-        self.assertTrue(os.path.isfile(parser.archive_path))
+        self.assertIsFile(parser.archive_path)
 
         self.assertContainsStrings(
             parser.get_text().lower(),
@@ -286,7 +287,7 @@ class TestParser(DirectoriesMixin, TestCase):
             os.path.join(self.SAMPLE_FILES, "multi-page-digital.pdf"),
             "application/pdf",
         )
-        self.assertTrue(os.path.isfile(parser.archive_path))
+        self.assertIsFile(parser.archive_path)
         self.assertContainsStrings(
             parser.get_text().lower(),
             ["page 1", "page 2", "page 3"],
@@ -299,7 +300,7 @@ class TestParser(DirectoriesMixin, TestCase):
             os.path.join(self.SAMPLE_FILES, "multi-page-digital.pdf"),
             "application/pdf",
         )
-        self.assertTrue(os.path.isfile(parser.archive_path))
+        self.assertIsFile(parser.archive_path)
         self.assertContainsStrings(
             parser.get_text().lower(),
             ["page 1", "page 2", "page 3"],
@@ -312,7 +313,7 @@ class TestParser(DirectoriesMixin, TestCase):
             os.path.join(self.SAMPLE_FILES, "multi-page-digital.pdf"),
             "application/pdf",
         )
-        self.assertTrue(os.path.isfile(parser.archive_path))
+        self.assertIsFile(parser.archive_path)
         self.assertContainsStrings(
             parser.get_text().lower(),
             ["page 1", "page 2", "page 3"],
@@ -325,7 +326,7 @@ class TestParser(DirectoriesMixin, TestCase):
             os.path.join(self.SAMPLE_FILES, "multi-page-digital.pdf"),
             "application/pdf",
         )
-        self.assertTrue(os.path.isfile(parser.archive_path))
+        self.assertIsFile(parser.archive_path)
         self.assertContainsStrings(
             parser.get_text().lower(),
             ["page 1", "page 2", "page 3"],
@@ -338,7 +339,7 @@ class TestParser(DirectoriesMixin, TestCase):
             os.path.join(self.SAMPLE_FILES, "multi-page-images.pdf"),
             "application/pdf",
         )
-        self.assertTrue(os.path.isfile(parser.archive_path))
+        self.assertIsFile(parser.archive_path)
         self.assertContainsStrings(
             parser.get_text().lower(),
             ["page 1", "page 2", "page 3"],
@@ -362,7 +363,7 @@ class TestParser(DirectoriesMixin, TestCase):
             os.path.join(self.SAMPLE_FILES, "multi-page-images.pdf"),
             "application/pdf",
         )
-        self.assertTrue(os.path.isfile(parser.archive_path))
+        self.assertIsFile(parser.archive_path)
         self.assertContainsStrings(parser.get_text().lower(), ["page 1", "page 2"])
         self.assertNotIn("page 3", parser.get_text().lower())
 
@@ -384,7 +385,7 @@ class TestParser(DirectoriesMixin, TestCase):
             os.path.join(self.SAMPLE_FILES, "multi-page-images.pdf"),
             "application/pdf",
         )
-        self.assertTrue(os.path.isfile(parser.archive_path))
+        self.assertIsFile(parser.archive_path)
         self.assertContainsStrings(parser.get_text().lower(), ["page 1"])
         self.assertNotIn("page 2", parser.get_text().lower())
         self.assertNotIn("page 3", parser.get_text().lower())
@@ -455,7 +456,7 @@ class TestParser(DirectoriesMixin, TestCase):
             "application/pdf",
         )
         self.assertIsNotNone(parser.archive_path)
-        self.assertTrue(os.path.isfile(parser.archive_path))
+        self.assertIsFile(parser.archive_path)
         self.assertContainsStrings(
             parser.get_text().lower(),
             ["page 1", "page 2", "page 3", "page 4", "page 5", "page 6"],
@@ -486,7 +487,7 @@ class TestParser(DirectoriesMixin, TestCase):
             "application/pdf",
         )
         self.assertIsNotNone(parser.archive_path)
-        self.assertTrue(os.path.isfile(parser.archive_path))
+        self.assertIsFile(parser.archive_path)
         self.assertContainsStrings(
             parser.get_text().lower(),
             [
@@ -556,7 +557,7 @@ class TestParser(DirectoriesMixin, TestCase):
             os.path.join(self.SAMPLE_FILES, "multi-page-images.tiff"),
             "image/tiff",
         )
-        self.assertTrue(os.path.isfile(parser.archive_path))
+        self.assertIsFile(parser.archive_path)
         self.assertContainsStrings(
             parser.get_text().lower(),
             ["page 1", "page 2", "page 3"],
@@ -580,7 +581,7 @@ class TestParser(DirectoriesMixin, TestCase):
                 tmp_file.name,
                 "image/tiff",
             )
-            self.assertTrue(os.path.isfile(parser.archive_path))
+            self.assertIsFile(parser.archive_path)
             self.assertContainsStrings(
                 parser.get_text().lower(),
                 ["page 1", "page 2", "page 3"],
@@ -608,7 +609,7 @@ class TestParser(DirectoriesMixin, TestCase):
                 tmp_file.name,
                 "image/tiff",
             )
-            self.assertTrue(os.path.isfile(parser.archive_path))
+            self.assertIsFile(parser.archive_path)
             self.assertContainsStrings(
                 parser.get_text().lower(),
                 ["page 1", "page 2", "page 3"],
@@ -689,40 +690,40 @@ class TestParser(DirectoriesMixin, TestCase):
         self.assertIn("ةﯾﻠﺧﺎدﻻ ةرازو", parser.get_text())
 
 
-class TestParserFileTypes(DirectoriesMixin, TestCase):
+class TestParserFileTypes(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
 
     SAMPLE_FILES = os.path.join(os.path.dirname(__file__), "samples")
 
     def test_bmp(self):
         parser = RasterisedDocumentParser(None)
         parser.parse(os.path.join(self.SAMPLE_FILES, "simple.bmp"), "image/bmp")
-        self.assertTrue(os.path.isfile(parser.archive_path))
+        self.assertIsFile(parser.archive_path)
         self.assertIn("this is a test document", parser.get_text().lower())
 
     def test_jpg(self):
         parser = RasterisedDocumentParser(None)
         parser.parse(os.path.join(self.SAMPLE_FILES, "simple.jpg"), "image/jpeg")
-        self.assertTrue(os.path.isfile(parser.archive_path))
+        self.assertIsFile(parser.archive_path)
         self.assertIn("this is a test document", parser.get_text().lower())
 
     @override_settings(OCR_IMAGE_DPI=200)
     def test_gif(self):
         parser = RasterisedDocumentParser(None)
         parser.parse(os.path.join(self.SAMPLE_FILES, "simple.gif"), "image/gif")
-        self.assertTrue(os.path.isfile(parser.archive_path))
+        self.assertIsFile(parser.archive_path)
         self.assertIn("this is a test document", parser.get_text().lower())
 
     def test_tiff(self):
         parser = RasterisedDocumentParser(None)
         parser.parse(os.path.join(self.SAMPLE_FILES, "simple.tif"), "image/tiff")
-        self.assertTrue(os.path.isfile(parser.archive_path))
+        self.assertIsFile(parser.archive_path)
         self.assertIn("this is a test document", parser.get_text().lower())
 
     @override_settings(OCR_IMAGE_DPI=72)
     def test_webp(self):
         parser = RasterisedDocumentParser(None)
         parser.parse(os.path.join(self.SAMPLE_FILES, "document.webp"), "image/webp")
-        self.assertTrue(os.path.isfile(parser.archive_path))
+        self.assertIsFile(parser.archive_path)
         # OCR consistent mangles this space, oh well
         self.assertIn(
             "this is awebp document, created 11/14/2022.",

--- a/src/paperless_text/tests/test_parser.py
+++ b/src/paperless_text/tests/test_parser.py
@@ -2,10 +2,11 @@ import os
 
 from django.test import TestCase
 from documents.tests.utils import DirectoriesMixin
+from documents.tests.utils import FileSystemAssertsMixin
 from paperless_text.parsers import TextDocumentParser
 
 
-class TestTextParser(DirectoriesMixin, TestCase):
+class TestTextParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
     def test_thumbnail(self):
 
         parser = TextDocumentParser(None)
@@ -15,7 +16,7 @@ class TestTextParser(DirectoriesMixin, TestCase):
             os.path.join(os.path.dirname(__file__), "samples", "test.txt"),
             "text/plain",
         )
-        self.assertTrue(os.path.isfile(f))
+        self.assertIsFile(f)
 
     def test_parse(self):
 

--- a/src/paperless_tika/tests/test_tika_parser.py
+++ b/src/paperless_tika/tests/test_tika_parser.py
@@ -8,6 +8,7 @@ from django.test import TestCase
 from documents.parsers import ParseError
 from paperless_tika.parsers import TikaDocumentParser
 from requests import Response
+from rest_framework import status
 
 
 class TestTikaParser(TestCase):
@@ -26,7 +27,7 @@ class TestTikaParser(TestCase):
         }
         response = Response()
         response._content = b"PDF document"
-        response.status_code = 200
+        response.status_code = status.HTTP_200_OK
         post.return_value = response
 
         file = os.path.join(self.parser.tempdir, "input.odt")
@@ -74,7 +75,7 @@ class TestTikaParser(TestCase):
         }
         response = Response()
         response._content = b"PDF document"
-        response.status_code = 500
+        response.status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
         post.return_value = response
 
         file = os.path.join(self.parser.tempdir, "input.odt")
@@ -98,7 +99,7 @@ class TestTikaParser(TestCase):
 
         response = Response()
         response._content = b"PDF document"
-        response.status_code = 200
+        response.status_code = status.HTTP_200_OK
         post.return_value = response
 
         for setting, expected_key in [


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

No structural changes or increased coverage, just a more declarative asserting and prep for some further ideas/work I have.

- New mix-in class for asserting some things about the file system state
- Usages of `+` to create paths replaced with `os.path.join`
- Bare HTTP status codes replaced with DRFs nicer names 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (please explain) - useful testing clarity

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
