### PR TITLE
Fix: permissions editing and initial view issues

### DIFF
--- a/src-ui/cypress/e2e/settings/settings.cy.ts
+++ b/src-ui/cypress/e2e/settings/settings.cy.ts
@@ -115,7 +115,7 @@ describe('settings', () => {
     cy.contains('a', 'Dashboard').click()
     cy.contains('You have unsaved changes')
     cy.contains('button', 'Cancel').click()
-    cy.contains('button', 'Save').click().wait('@savedViews').wait(2000)
+    cy.contains('button', 'Save').click().wait(2000)
     cy.contains('a', 'Dashboard').click()
     cy.contains('You have unsaved changes').should('not.exist')
   })

--- a/src-ui/src/app/components/common/permissions-select/permissions-select.component.html
+++ b/src-ui/src/app/components/common/permissions-select/permissions-select.component.html
@@ -18,7 +18,7 @@
       </div>
 
       <div *ngFor="let action of PermissionAction | keyvalue" class="col form-check form-check-inline" [ngbPopover]="inheritedWarning" [disablePopover]="!isInherited(type.key, action.key)" placement="left" triggers="mouseenter:mouseleave">
-        <input type="checkbox" class="form-check-input" id="{{type.key}}_{{action.key}}" formControlName="{{action.key}}" [attr.disabled]="isDisabled(type.key, action.key)">
+        <input type="checkbox" class="form-check-input" id="{{type.key}}_{{action.key}}" formControlName="{{action.key}}">
         <label class="form-check-label visually-hidden" for="{{type.key}}_{{action.key}}" i18n>{{action.key}}</label>
       </div>
     </li>

--- a/src-ui/src/app/components/common/permissions-select/permissions-select.component.ts
+++ b/src-ui/src/app/components/common/permissions-select/permissions-select.component.ts
@@ -1,5 +1,6 @@
 import { Component, forwardRef, Input, OnInit } from '@angular/core'
 import {
+  AbstractControl,
   ControlValueAccessor,
   FormControl,
   FormGroup,
@@ -54,6 +55,8 @@ export class PermissionsSelectComponent
       this._inheritedPermissions = newInheritedPermissions
       this.writeValue(this.permissions) // updates visual checks etc.
     }
+
+    this.updateDisabledStates()
   }
 
   inheritedWarning: string = $localize`Inerhited from group`
@@ -98,6 +101,8 @@ export class PermissionsSelectComponent
         this.typesWithAllActions.delete(type)
       }
     })
+
+    this.updateDisabledStates()
   }
 
   onChange = (newValue: string[]) => {}
@@ -185,12 +190,16 @@ export class PermissionsSelectComponent
     }
   }
 
-  // if checkbox is disabled either because "All", inhereted or entire component disabled
-  isDisabled(typeKey: string, actionKey: string) {
-    return this.typesWithAllActions.has(typeKey) ||
-      this.isInherited(typeKey, actionKey) ||
-      this.disabled
-      ? true
-      : null
+  updateDisabledStates() {
+    for (const type in PermissionType) {
+      const control = this.form.get(type)
+      let actionControl: AbstractControl
+      for (const action in PermissionAction) {
+        actionControl = control.get(action)
+        this.isInherited(type, action) || this.disabled
+          ? actionControl.disable()
+          : actionControl.enable()
+      }
+    }
   }
 }

--- a/src-ui/src/app/components/common/permissions-select/permissions-select.component.ts
+++ b/src-ui/src/app/components/common/permissions-select/permissions-select.component.ts
@@ -69,6 +69,10 @@ export class PermissionsSelectComponent
   }
 
   writeValue(permissions: string[]): void {
+    if (this.permissions === permissions) {
+      return
+    }
+
     this.permissions = permissions ?? []
     const allPerms = this._inheritedPermissions.concat(this.permissions)
 
@@ -138,7 +142,10 @@ export class PermissionsSelectComponent
           this.typesWithAllActions.delete(typeKey)
         }
       })
-      this.onChange(permissions)
+
+      this.onChange(
+        permissions.filter((p) => !this._inheritedPermissions.includes(p))
+      )
     })
   }
 

--- a/src-ui/src/app/components/dashboard/dashboard.component.ts
+++ b/src-ui/src/app/components/dashboard/dashboard.component.ts
@@ -1,4 +1,9 @@
 import { Component } from '@angular/core'
+import {
+  PermissionAction,
+  PermissionsService,
+  PermissionType,
+} from 'src/app/services/permissions.service'
 import { SavedViewService } from 'src/app/services/rest/saved-view.service'
 import { SettingsService } from 'src/app/services/settings.service'
 import { ComponentWithPermissions } from '../with-permissions/with-permissions.component'
@@ -10,10 +15,20 @@ import { ComponentWithPermissions } from '../with-permissions/with-permissions.c
 })
 export class DashboardComponent extends ComponentWithPermissions {
   constructor(
-    public savedViewService: SavedViewService,
-    public settingsService: SettingsService
+    public settingsService: SettingsService,
+    private permissionsService: PermissionsService,
+    public savedViewService: SavedViewService
   ) {
     super()
+
+    if (
+      permissionsService.currentUserCan(
+        PermissionAction.View,
+        PermissionType.SavedView
+      )
+    ) {
+      savedViewService.initialize()
+    }
   }
 
   get subtitle() {

--- a/src-ui/src/app/services/rest/saved-view.service.ts
+++ b/src-ui/src/app/services/rest/saved-view.service.ts
@@ -3,6 +3,7 @@ import { Injectable } from '@angular/core'
 import { combineLatest, Observable } from 'rxjs'
 import { tap } from 'rxjs/operators'
 import { PaperlessSavedView } from 'src/app/data/paperless-saved-view'
+import { PermissionsService } from '../permissions.service'
 import { AbstractPaperlessService } from './abstract-paperless-service'
 
 @Injectable({
@@ -11,8 +12,11 @@ import { AbstractPaperlessService } from './abstract-paperless-service'
 export class SavedViewService extends AbstractPaperlessService<PaperlessSavedView> {
   loading: boolean
 
-  constructor(http: HttpClient) {
+  constructor(http: HttpClient, permissionService: PermissionsService) {
     super(http, 'saved_views')
+  }
+
+  public initialize() {
     this.reload()
   }
 


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Permissions still a WIP of course. This PR fixes four things with permissions:

1. The first was noted by Jonas where you couldn't un-select an existing permission. 
2. The second was the fact that currently saving the user permissions assigns all of the permissions that were inherited from a group at the user level as well. This doesn't immediately cause a problem but its not necessary and more importantly when you remove a group from a user they wouldn't actually lose those permissions until you saved the permissions matrix.
3. Also noted some small UI things in toggling the "All" button and disabling checkboxes.
4. Fixes an issue where logging in without saved view permissions caused infinite loading (also noted by Jonas).

Videos below for the first and third items.


https://user-images.githubusercontent.com/4887959/220079500-25719d72-acc8-406f-83be-4c19b597e246.mov


https://user-images.githubusercontent.com/4887959/220079521-b16c5063-2601-47c1-848f-9b6d8bccb7da.mov



Fixes # (issue)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] ~~I have made corresponding changes to the documentation as needed.~~
- [x] I have checked my modifications for any breaking changes.
