### PR TITLE
[REVERTED] Feature: Add a setting to disable creating archive files

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -419,7 +419,10 @@ modes are available:
         an archived version of your documents when it finds any text in
         them. This is useful if you don't want to have two
         almost-identical versions of your digital documents in the media
-        folder. This is the fastest option.
+        folder.
+
+    -   `skip_neverarchive`: In addition to skip, paperless will never
+        create an archive version of your documents. This is the fastest option.
 
     -   `redo`: Paperless will OCR all pages of your documents and
         attempt to replace any existing text layers with new text. This

--- a/src/paperless/checks.py
+++ b/src/paperless/checks.py
@@ -127,7 +127,13 @@ def settings_values_check(app_configs, **kwargs):
                 Error(f'OCR output type "{settings.OCR_OUTPUT_TYPE}" is not valid'),
             )
 
-        if settings.OCR_MODE not in {"force", "skip", "redo", "skip_noarchive"}:
+        if settings.OCR_MODE not in {
+            "force",
+            "skip",
+            "redo",
+            "skip_noarchive",
+            "skip_neverarchive",
+        }:
             msgs.append(Error(f'OCR output mode "{settings.OCR_MODE}" is not valid'))
 
         if settings.OCR_CLEAN not in {"clean", "clean-final", "none"}:

--- a/src/paperless_tesseract/parsers.py
+++ b/src/paperless_tesseract/parsers.py
@@ -192,7 +192,7 @@ class RasterisedDocumentParser(DocumentParser):
 
         if settings.OCR_MODE == "force" or safe_fallback:
             ocrmypdf_args["force_ocr"] = True
-        elif settings.OCR_MODE in ["skip", "skip_noarchive"]:
+        elif settings.OCR_MODE in ["skip", "skip_noarchive", "skip_neverarchive"]:
             ocrmypdf_args["skip_text"] = True
         elif settings.OCR_MODE == "redo":
             ocrmypdf_args["redo_ocr"] = True
@@ -294,7 +294,10 @@ class RasterisedDocumentParser(DocumentParser):
 
         # If the original has text, and the user doesn't want an archive,
         # we're done here
-        if settings.OCR_MODE == "skip_noarchive" and original_has_text:
+        if (
+            settings.OCR_MODE in ["skip_noarchive", "skip_neverarchive"]
+            and original_has_text
+        ):
             self.log("debug", "Document has text, skipping OCRmyPDF entirely.")
             self.text = text_original
             return
@@ -320,7 +323,9 @@ class RasterisedDocumentParser(DocumentParser):
             self.log("debug", f"Calling OCRmyPDF with args: {args}")
             ocrmypdf.ocr(**args)
 
-            self.archive_path = archive_path
+            # Only create archive file if archiving isn't being skipped
+            if settings.OCR_MODE != "skip_neverarchive":
+                self.archive_path = archive_path
 
             self.text = self.extract_text(sidecar_file, archive_path)
 

--- a/src/paperless_tesseract/tests/test_parser.py
+++ b/src/paperless_tesseract/tests/test_parser.py
@@ -438,6 +438,52 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
 
         self.assertIsNotNone(parser.archive_path)
 
+    @override_settings(OCR_MODE="skip_neverarchive")
+    def test_skip_neverarchive_withtext(self):
+        """
+        GIVEN:
+            - File with existing text layer
+            - OCR mode set to skip_neverarchive
+        WHEN:
+            - Document is parsed
+        THEN:
+            - Text from images is extracted
+            - No archive file is created
+        """
+        parser = RasterisedDocumentParser(None)
+        parser.parse(
+            os.path.join(self.SAMPLE_FILES, "multi-page-digital.pdf"),
+            "application/pdf",
+        )
+        self.assertIsNone(parser.archive_path)
+        self.assertContainsStrings(
+            parser.get_text().lower(),
+            ["page 1", "page 2", "page 3"],
+        )
+
+    @override_settings(OCR_MODE="skip_neverarchive")
+    def test_skip_neverarchive_notext(self):
+        """
+        GIVEN:
+            - File with text contained in images but no text layer
+            - OCR mode set to skip_neverarchive
+        WHEN:
+            - Document is parsed
+        THEN:
+            - Text from images is extracted
+            - No archive file is created
+        """
+        parser = RasterisedDocumentParser(None)
+        parser.parse(
+            os.path.join(self.SAMPLE_FILES, "multi-page-images.pdf"),
+            "application/pdf",
+        )
+        self.assertIsNone(parser.archive_path)
+        self.assertContainsStrings(
+            parser.get_text().lower(),
+            ["page 1", "page 2", "page 3"],
+        )
+
     @override_settings(OCR_MODE="skip")
     def test_multi_page_mixed(self):
         """


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change
This PR adds a new `PAPERLESS_OCR_MODE` to completely disable the creation of archive files, while still performing OCR and storing the recognized text in the database. I personally have no desire for archive files with the OCR text embedded, I only want to be able to search the text in Paperless. I named the new option `skip_neverarchive` but I realize the names are a bit confusing and am open to suggestions for a better name.

This functionality was accidentally implemented in https://github.com/paperless-ngx/paperless-ngx/pull/1442 but was later reverted. In this PR I have re-implemented it under a separate option, using https://github.com/paperless-ngx/paperless-ngx/pull/1442 as a reference. https://github.com/paperless-ngx/paperless-ngx/pull/1829 says that the feature can be reintroduced if there is demand for it. At least one user has said they would appreciate this feature (https://github.com/paperless-ngx/paperless-ngx/issues/1678#issuecomment-1261775698), and I myself would find it extremely useful.

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
