### PR TITLE
Fix: only offer log files that exist

### DIFF
--- a/src-ui/src/app/components/manage/logs/logs.component.ts
+++ b/src-ui/src/app/components/manage/logs/logs.component.ts
@@ -38,14 +38,14 @@ export class LogsComponent implements OnInit, AfterViewChecked {
   }
 
   reloadLogs() {
-    this.logService.get(this.activeLog).subscribe(
-      (result) => {
+    this.logService.get(this.activeLog).subscribe({
+      next: (result) => {
         this.logs = result
       },
-      (error) => {
+      error: () => {
         this.logs = []
-      }
-    )
+      },
+    })
   }
 
   getLogLevel(log: string) {

--- a/src/documents/tests/test_api.py
+++ b/src/documents/tests/test_api.py
@@ -1590,9 +1590,22 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
         self.assertEqual(v1.filter_rules.count(), 0)
 
     def test_get_logs(self):
+        log_data = "test\ntest2\n"
+        with open(os.path.join(settings.LOGGING_DIR, "mail.log"), "w") as f:
+            f.write(log_data)
+        with open(os.path.join(settings.LOGGING_DIR, "paperless.log"), "w") as f:
+            f.write(log_data)
         response = self.client.get("/api/logs/")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertCountEqual(response.data, ["mail", "paperless"])
+
+    def test_get_logs_only_when_exist(self):
+        log_data = "test\ntest2\n"
+        with open(os.path.join(settings.LOGGING_DIR, "paperless.log"), "w") as f:
+            f.write(log_data)
+        response = self.client.get("/api/logs/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertCountEqual(response.data, ["paperless"])
 
     def test_get_invalid_log(self):
         response = self.client.get("/api/logs/bogus_log/")

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -593,11 +593,14 @@ class LogViewSet(ViewSet):
 
     log_files = ["paperless", "mail"]
 
+    def get_log_filename(self, log):
+        return os.path.join(settings.LOGGING_DIR, f"{log}.log")
+
     def retrieve(self, request, pk=None, *args, **kwargs):
         if pk not in self.log_files:
             raise Http404()
 
-        filename = os.path.join(settings.LOGGING_DIR, f"{pk}.log")
+        filename = self.get_log_filename(pk)
 
         if not os.path.isfile(filename):
             raise Http404()
@@ -608,7 +611,10 @@ class LogViewSet(ViewSet):
         return Response(lines)
 
     def list(self, request, *args, **kwargs):
-        return Response(self.log_files)
+        exist = [
+            log for log in self.log_files if os.path.isfile(self.get_log_filename(log))
+        ]
+        return Response(exist)
 
 
 class SavedViewViewSet(ModelViewSet, PassUserMixin):


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Extremely minor thing but I couldn't resist after issue was raised. The frontend already handles this fine, the change to the frontend file is just updated rxjs syntax as the old method signature is deprecated.

Fixes #2738

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] ~~I have made corresponding changes to the documentation as needed.~~
- [x] I have checked my modifications for any breaking changes.
