### PR TITLE
Feature: Stronger typing for file consumption

### DIFF
--- a/src/documents/barcodes.py
+++ b/src/documents/barcodes.py
@@ -11,7 +11,6 @@ from typing import List
 from typing import Optional
 
 import img2pdf
-import magic
 from django.conf import settings
 from pdf2image import convert_from_path
 from pdf2image.exceptions import PDFPageCountError
@@ -63,7 +62,7 @@ class DocumentBarcodeInfo:
 
 
 @lru_cache(maxsize=8)
-def supported_file_type(mime_type) -> bool:
+def supported_file_type(mime_type: str) -> bool:
     """
     Determines if the file is valid for barcode
     processing, based on MIME type and settings
@@ -115,33 +114,16 @@ def barcode_reader(image: Image) -> List[str]:
     return barcodes
 
 
-def get_file_mime_type(path: Path) -> str:
-    """
-    Determines the file type, based on MIME type.
-
-    Returns the MIME type.
-    """
-    mime_type = magic.from_file(path, mime=True)
-    logger.debug(f"Detected mime type: {mime_type}")
-    return mime_type
-
-
 def convert_from_tiff_to_pdf(filepath: Path) -> Path:
     """
     converts a given TIFF image file to pdf into a temporary directory.
 
     Returns the new pdf file.
     """
-    mime_type = get_file_mime_type(filepath)
     tempdir = tempfile.mkdtemp(prefix="paperless-", dir=settings.SCRATCH_DIR)
     # use old file name with pdf extension
-    if mime_type == "image/tiff":
-        newpath = Path(tempdir) / Path(filepath.name).with_suffix(".pdf")
-    else:
-        logger.warning(
-            f"Cannot convert mime type {mime_type} from {filepath} to pdf.",
-        )
-        return None
+    newpath = Path(tempdir) / Path(filepath.name).with_suffix(".pdf")
+
     with Image.open(filepath) as im:
         has_alpha_layer = im.mode in ("RGBA", "LA")
     if has_alpha_layer:
@@ -162,6 +144,7 @@ def convert_from_tiff_to_pdf(filepath: Path) -> Path:
 
 def scan_file_for_barcodes(
     filepath: Path,
+    mime_type: str,
 ) -> DocumentBarcodeInfo:
     """
     Scan the provided pdf file for any barcodes
@@ -186,7 +169,6 @@ def scan_file_for_barcodes(
         return detected_barcodes
 
     pdf_filepath = None
-    mime_type = get_file_mime_type(filepath)
     barcodes = []
 
     if supported_file_type(mime_type):

--- a/src/documents/consumer.py
+++ b/src/documents/consumer.py
@@ -284,7 +284,7 @@ class Consumer(LoggingMixin):
 
     def try_consume_file(
         self,
-        path,
+        path: Path,
         override_filename=None,
         override_title=None,
         override_correspondent_id=None,

--- a/src/documents/data_models.py
+++ b/src/documents/data_models.py
@@ -1,0 +1,62 @@
+import dataclasses
+import datetime
+import enum
+from pathlib import Path
+from typing import List
+from typing import Optional
+
+import magic
+
+
+@dataclasses.dataclass
+class DocumentMetadataOverrides:
+    """
+    Manages overrides for document fields which normally would
+    be set from content or matching.  All fields default to None,
+    meaning no override is happening
+    """
+
+    filename: Optional[str] = None
+    title: Optional[str] = None
+    correspondent_id: Optional[int] = None
+    document_type_id: Optional[int] = None
+    tag_ids: Optional[List[int]] = None
+    created: Optional[datetime.datetime] = None
+    asn: Optional[int] = None
+    owner_id: Optional[int] = None
+
+
+class DocumentSource(enum.IntEnum):
+    """
+    The source of an incoming document.  May have other uses in the future
+    """
+
+    ConsumeFolder = enum.auto()
+    ApiUpload = enum.auto()
+    MailFetch = enum.auto()
+
+
+@dataclasses.dataclass
+class ConsumableDocument:
+    """
+    Encapsulates an incoming document, either from consume folder, API upload
+    or mail fetching and certain useful operations on it.
+    """
+
+    source: DocumentSource
+    original_file: Path
+    mime_type: str = dataclasses.field(init=False, default=None)
+
+    def __post_init__(self):
+        """
+        After a dataclass is initialized, this is called to finalize some data
+        1. Make sure the original path is an absolute, fully qualified path
+        2. Get the mime type of the file
+        """
+        # Always fully qualify the path first thing
+        # Just in case, convert to a path if it's a str
+        self.original_file = Path(self.original_file).resolve()
+
+        # Get the file type once at init
+        # Note this function isn't called when the object is unpickled
+        self.mime_type = magic.from_file(self.original_file, mime=True)

--- a/src/documents/management/commands/document_consumer.py
+++ b/src/documents/management/commands/document_consumer.py
@@ -13,6 +13,9 @@ from typing import Set
 from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.core.management.base import CommandError
+from documents.data_models import ConsumableDocument
+from documents.data_models import DocumentMetadataOverrides
+from documents.data_models import DocumentSource
 from documents.models import Tag
 from documents.parsers import is_file_ext_supported
 from documents.tasks import consume_file
@@ -122,8 +125,11 @@ def _consume(filepath: str) -> None:
     try:
         logger.info(f"Adding {filepath} to the task queue.")
         consume_file.delay(
-            filepath,
-            override_tag_ids=list(tag_ids) if tag_ids else None,
+            ConsumableDocument(
+                source=DocumentSource.ConsumeFolder,
+                original_file=filepath,
+            ),
+            DocumentMetadataOverrides(tag_ids=tag_ids),
         )
     except Exception:
         # Catch all so that the consumer won't crash.

--- a/src/documents/signals/handlers.py
+++ b/src/documents/signals/handlers.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import shutil
-from pathlib import Path
 
 from celery import states
 from celery.signals import before_task_publish
@@ -533,17 +532,9 @@ def before_task_publish_handler(sender=None, headers=None, body=None, **kwargs):
 
     try:
         task_args = body[0]
-        task_kwargs = body[1]
+        input_doc, _ = task_args
 
-        task_file_name = ""
-        if "override_filename" in task_kwargs:
-            task_file_name = task_kwargs["override_filename"]
-
-        # Nothing was found, report the task first argument
-        if not len(task_file_name):
-            # There are always some arguments to the consume, first is always filename
-            filepath = Path(task_args[0])
-            task_file_name = filepath.name
+        task_file_name = input_doc.original_file.name
 
         PaperlessTask.objects.create(
             task_id=headers["id"],

--- a/src/documents/tests/test_management_consumer.py
+++ b/src/documents/tests/test_management_consumer.py
@@ -1,6 +1,7 @@
 import filecmp
 import os
 import shutil
+from pathlib import Path
 from threading import Thread
 from time import sleep
 from unittest import mock
@@ -11,9 +12,12 @@ from django.core.management import CommandError
 from django.test import override_settings
 from django.test import TransactionTestCase
 from documents.consumer import ConsumerError
+from documents.data_models import ConsumableDocument
+from documents.data_models import DocumentMetadataOverrides
 from documents.management.commands import document_consumer
 from documents.models import Tag
 from documents.tests.utils import DirectoriesMixin
+from documents.tests.utils import DocumentConsumeDelayMixin
 
 
 class ConsumerThread(Thread):
@@ -35,18 +39,19 @@ def chunked(size, source):
         yield source[i : i + size]
 
 
-class ConsumerMixin:
+class ConsumerThreadMixin(DocumentConsumeDelayMixin):
+    """
+    Provides a thread which runs the consumer management command at setUp
+    and stops it at tearDown
+    """
 
-    sample_file = os.path.join(os.path.dirname(__file__), "samples", "simple.pdf")
+    sample_file: Path = (
+        Path(__file__).parent / Path("samples") / Path("simple.pdf")
+    ).resolve()
 
     def setUp(self) -> None:
         super().setUp()
         self.t = None
-        patcher = mock.patch(
-            "documents.tasks.consume_file.delay",
-        )
-        self.task_mock = patcher.start()
-        self.addCleanup(patcher.stop)
 
     def t_start(self):
         self.t = ConsumerThread()
@@ -67,7 +72,7 @@ class ConsumerMixin:
     def wait_for_task_mock_call(self, expected_call_count=1):
         n = 0
         while n < 50:
-            if self.task_mock.call_count >= expected_call_count:
+            if self.consume_file_mock.call_count >= expected_call_count:
                 # give task_mock some time to finish and raise errors
                 sleep(1)
                 return
@@ -76,8 +81,12 @@ class ConsumerMixin:
 
     # A bogus async_task that will simply check the file for
     # completeness and raise an exception otherwise.
-    def bogus_task(self, filename, **kwargs):
-        eq = filecmp.cmp(filename, self.sample_file, shallow=False)
+    def bogus_task(
+        self,
+        input_doc: ConsumableDocument,
+        overrides=None,
+    ):
+        eq = filecmp.cmp(input_doc.original_file, self.sample_file, shallow=False)
         if not eq:
             print("Consumed an INVALID file.")
             raise ConsumerError("Incomplete File READ FAILED")
@@ -103,19 +112,20 @@ class ConsumerMixin:
 @override_settings(
     CONSUMER_INOTIFY_DELAY=0.01,
 )
-class TestConsumer(DirectoriesMixin, ConsumerMixin, TransactionTestCase):
+class TestConsumer(DirectoriesMixin, ConsumerThreadMixin, TransactionTestCase):
     def test_consume_file(self):
         self.t_start()
 
-        f = os.path.join(self.dirs.consumption_dir, "my_file.pdf")
+        f = Path(os.path.join(self.dirs.consumption_dir, "my_file.pdf"))
         shutil.copy(self.sample_file, f)
 
         self.wait_for_task_mock_call()
 
-        self.task_mock.assert_called_once()
+        self.consume_file_mock.assert_called_once()
 
-        args, kwargs = self.task_mock.call_args
-        self.assertEqual(args[0], f)
+        input_doc, _ = self.get_last_consume_delay_call_args()
+
+        self.assertEqual(input_doc.original_file, f)
 
     def test_consume_file_invalid_ext(self):
         self.t_start()
@@ -125,26 +135,27 @@ class TestConsumer(DirectoriesMixin, ConsumerMixin, TransactionTestCase):
 
         self.wait_for_task_mock_call()
 
-        self.task_mock.assert_not_called()
+        self.consume_file_mock.assert_not_called()
 
     def test_consume_existing_file(self):
-        f = os.path.join(self.dirs.consumption_dir, "my_file.pdf")
+        f = Path(os.path.join(self.dirs.consumption_dir, "my_file.pdf"))
         shutil.copy(self.sample_file, f)
 
         self.t_start()
-        self.task_mock.assert_called_once()
+        self.consume_file_mock.assert_called_once()
 
-        args, kwargs = self.task_mock.call_args
-        self.assertEqual(args[0], f)
+        input_doc, _ = self.get_last_consume_delay_call_args()
+
+        self.assertEqual(input_doc.original_file, f)
 
     @mock.patch("documents.management.commands.document_consumer.logger.error")
     def test_slow_write_pdf(self, error_logger):
 
-        self.task_mock.side_effect = self.bogus_task
+        self.consume_file_mock.side_effect = self.bogus_task
 
         self.t_start()
 
-        fname = os.path.join(self.dirs.consumption_dir, "my_file.pdf")
+        fname = Path(os.path.join(self.dirs.consumption_dir, "my_file.pdf"))
 
         self.slow_write_file(fname)
 
@@ -152,48 +163,52 @@ class TestConsumer(DirectoriesMixin, ConsumerMixin, TransactionTestCase):
 
         error_logger.assert_not_called()
 
-        self.task_mock.assert_called_once()
+        self.consume_file_mock.assert_called_once()
 
-        args, kwargs = self.task_mock.call_args
-        self.assertEqual(args[0], fname)
+        input_doc, _ = self.get_last_consume_delay_call_args()
+
+        self.assertEqual(input_doc.original_file, fname)
 
     @mock.patch("documents.management.commands.document_consumer.logger.error")
     def test_slow_write_and_move(self, error_logger):
 
-        self.task_mock.side_effect = self.bogus_task
+        self.consume_file_mock.side_effect = self.bogus_task
 
         self.t_start()
 
-        fname = os.path.join(self.dirs.consumption_dir, "my_file.~df")
-        fname2 = os.path.join(self.dirs.consumption_dir, "my_file.pdf")
+        fname = Path(os.path.join(self.dirs.consumption_dir, "my_file.~df"))
+        fname2 = Path(os.path.join(self.dirs.consumption_dir, "my_file.pdf"))
 
         self.slow_write_file(fname)
         shutil.move(fname, fname2)
 
         self.wait_for_task_mock_call()
 
-        self.task_mock.assert_called_once()
+        self.consume_file_mock.assert_called_once()
 
-        args, kwargs = self.task_mock.call_args
-        self.assertEqual(args[0], fname2)
+        input_doc, _ = self.get_last_consume_delay_call_args()
+
+        self.assertEqual(input_doc.original_file, fname2)
 
         error_logger.assert_not_called()
 
     @mock.patch("documents.management.commands.document_consumer.logger.error")
     def test_slow_write_incomplete(self, error_logger):
 
-        self.task_mock.side_effect = self.bogus_task
+        self.consume_file_mock.side_effect = self.bogus_task
 
         self.t_start()
 
-        fname = os.path.join(self.dirs.consumption_dir, "my_file.pdf")
+        fname = Path(os.path.join(self.dirs.consumption_dir, "my_file.pdf"))
         self.slow_write_file(fname, incomplete=True)
 
         self.wait_for_task_mock_call()
 
-        self.task_mock.assert_called_once()
-        args, kwargs = self.task_mock.call_args
-        self.assertEqual(args[0], fname)
+        self.consume_file_mock.assert_called_once()
+
+        input_doc, _ = self.get_last_consume_delay_call_args()
+
+        self.assertEqual(input_doc.original_file, fname)
 
         # assert that we have an error logged with this invalid file.
         error_logger.assert_called_once()
@@ -209,7 +224,7 @@ class TestConsumer(DirectoriesMixin, ConsumerMixin, TransactionTestCase):
         self.assertRaises(CommandError, call_command, "document_consumer", "--oneshot")
 
     def test_mac_write(self):
-        self.task_mock.side_effect = self.bogus_task
+        self.consume_file_mock.side_effect = self.bogus_task
 
         self.t_start()
 
@@ -238,12 +253,13 @@ class TestConsumer(DirectoriesMixin, ConsumerMixin, TransactionTestCase):
 
         self.wait_for_task_mock_call(expected_call_count=2)
 
-        self.assertEqual(2, self.task_mock.call_count)
+        self.assertEqual(2, self.consume_file_mock.call_count)
 
-        fnames = [
-            os.path.basename(args[0]) for args, _ in self.task_mock.call_args_list
-        ]
-        self.assertCountEqual(fnames, ["my_file.pdf", "my_second_file.pdf"])
+        consumed_files = []
+        for input_doc, _ in self.get_all_consume_delay_call_args():
+            consumed_files.append(input_doc.original_file.name)
+
+        self.assertCountEqual(consumed_files, ["my_file.pdf", "my_second_file.pdf"])
 
     def test_is_ignored(self):
         test_paths = [
@@ -341,7 +357,7 @@ class TestConsumer(DirectoriesMixin, ConsumerMixin, TransactionTestCase):
 
         self.wait_for_task_mock_call()
 
-        self.task_mock.assert_not_called()
+        self.consume_file_mock.assert_not_called()
 
 
 @override_settings(
@@ -373,7 +389,7 @@ class TestConsumerRecursivePolling(TestConsumer):
     pass
 
 
-class TestConsumerTags(DirectoriesMixin, ConsumerMixin, TransactionTestCase):
+class TestConsumerTags(DirectoriesMixin, ConsumerThreadMixin, TransactionTestCase):
     @override_settings(CONSUMER_RECURSIVE=True, CONSUMER_SUBDIRS_AS_TAGS=True)
     def test_consume_file_with_path_tags(self):
 
@@ -387,7 +403,7 @@ class TestConsumerTags(DirectoriesMixin, ConsumerMixin, TransactionTestCase):
 
         path = os.path.join(self.dirs.consumption_dir, *tag_names)
         os.makedirs(path, exist_ok=True)
-        f = os.path.join(path, "my_file.pdf")
+        f = Path(os.path.join(path, "my_file.pdf"))
         # Wait at least inotify read_delay for recursive watchers
         # to be created for the new directories
         sleep(1)
@@ -395,18 +411,19 @@ class TestConsumerTags(DirectoriesMixin, ConsumerMixin, TransactionTestCase):
 
         self.wait_for_task_mock_call()
 
-        self.task_mock.assert_called_once()
+        self.consume_file_mock.assert_called_once()
 
         # Add the pk of the Tag created by _consume()
         tag_ids.append(Tag.objects.get(name=tag_names[1]).pk)
 
-        args, kwargs = self.task_mock.call_args
-        self.assertEqual(args[0], f)
+        input_doc, overrides = self.get_last_consume_delay_call_args()
+
+        self.assertEqual(input_doc.original_file, f)
 
         # assertCountEqual has a bad name, but test that the first
         # sequence contains the same elements as second, regardless of
         # their order.
-        self.assertCountEqual(kwargs["override_tag_ids"], tag_ids)
+        self.assertCountEqual(overrides.tag_ids, tag_ids)
 
     @override_settings(
         CONSUMER_POLLING=1,

--- a/src/documents/tests/test_task_signals.py
+++ b/src/documents/tests/test_task_signals.py
@@ -1,76 +1,21 @@
+import uuid
+from unittest import mock
+
 import celery
 from django.test import TestCase
+from documents.data_models import ConsumableDocument
+from documents.data_models import DocumentMetadataOverrides
+from documents.data_models import DocumentSource
 from documents.models import PaperlessTask
 from documents.signals.handlers import before_task_publish_handler
 from documents.signals.handlers import task_postrun_handler
 from documents.signals.handlers import task_prerun_handler
+from documents.tests.test_consumer import fake_magic_from_file
 from documents.tests.utils import DirectoriesMixin
 
 
+@mock.patch("documents.consumer.magic.from_file", fake_magic_from_file)
 class TestTaskSignalHandler(DirectoriesMixin, TestCase):
-
-    HEADERS_CONSUME = {
-        "lang": "py",
-        "task": "documents.tasks.consume_file",
-        "id": "52d31e24-9dcc-4c32-9e16-76007e9add5e",
-        "shadow": None,
-        "eta": None,
-        "expires": None,
-        "group": None,
-        "group_index": None,
-        "retries": 0,
-        "timelimit": [None, None],
-        "root_id": "52d31e24-9dcc-4c32-9e16-76007e9add5e",
-        "parent_id": None,
-        "argsrepr": "('/consume/hello-999.pdf',)",
-        "kwargsrepr": "{'override_tag_ids': None}",
-        "origin": "gen260@paperless-ngx-dev-webserver",
-        "ignore_result": False,
-    }
-
-    BODY_CONSUME = (
-        # args
-        ("/consume/hello-999.pdf",),
-        # kwargs
-        {"override_tag_ids": None},
-        {"callbacks": None, "errbacks": None, "chain": None, "chord": None},
-    )
-
-    HEADERS_WEB_UI = {
-        "lang": "py",
-        "task": "documents.tasks.consume_file",
-        "id": "6e88a41c-e5f8-4631-9972-68c314512498",
-        "shadow": None,
-        "eta": None,
-        "expires": None,
-        "group": None,
-        "group_index": None,
-        "retries": 0,
-        "timelimit": [None, None],
-        "root_id": "6e88a41c-e5f8-4631-9972-68c314512498",
-        "parent_id": None,
-        "argsrepr": "('/tmp/paperless/paperless-upload-st9lmbvx',)",
-        "kwargsrepr": "{'override_filename': 'statement.pdf', 'override_title': None, 'override_correspondent_id': None, 'override_document_type_id': None, 'override_tag_ids': None, 'task_id': 'f5622ca9-3707-4ed0-b418-9680b912572f', 'override_created': None}",
-        "origin": "gen342@paperless-ngx-dev-webserver",
-        "ignore_result": False,
-    }
-
-    BODY_WEB_UI = (
-        # args
-        ("/tmp/paperless/paperless-upload-st9lmbvx",),
-        # kwargs
-        {
-            "override_filename": "statement.pdf",
-            "override_title": None,
-            "override_correspondent_id": None,
-            "override_document_type_id": None,
-            "override_tag_ids": None,
-            "task_id": "f5622ca9-3707-4ed0-b418-9680b912572f",
-            "override_created": None,
-        },
-        {"callbacks": None, "errbacks": None, "chain": None, "chord": None},
-    )
-
     def util_call_before_task_publish_handler(self, headers_to_use, body_to_use):
         """
         Simple utility to call the pre-run handle and ensure it created a single task
@@ -91,38 +36,33 @@ class TestTaskSignalHandler(DirectoriesMixin, TestCase):
         THEN:
             - The task is created and marked as pending
         """
+        headers = {
+            "id": str(uuid.uuid4()),
+            "task": "documents.tasks.consume_file",
+        }
+        body = (
+            # args
+            (
+                ConsumableDocument(
+                    source=DocumentSource.ConsumeFolder,
+                    original_file="/consume/hello-999.pdf",
+                ),
+                None,
+            ),
+            # kwargs
+            {},
+            # celery stuff
+            {"callbacks": None, "errbacks": None, "chain": None, "chord": None},
+        )
         self.util_call_before_task_publish_handler(
-            headers_to_use=self.HEADERS_CONSUME,
-            body_to_use=self.BODY_CONSUME,
+            headers_to_use=headers,
+            body_to_use=body,
         )
 
         task = PaperlessTask.objects.get()
         self.assertIsNotNone(task)
-        self.assertEqual(self.HEADERS_CONSUME["id"], task.task_id)
+        self.assertEqual(headers["id"], task.task_id)
         self.assertEqual("hello-999.pdf", task.task_file_name)
-        self.assertEqual("documents.tasks.consume_file", task.task_name)
-        self.assertEqual(celery.states.PENDING, task.status)
-
-    def test_before_task_publish_handler_webui(self):
-        """
-        GIVEN:
-            - A celery task is started via the web ui
-        WHEN:
-            - Task before publish handler is called
-        THEN:
-            - The task is created and marked as pending
-        """
-        self.util_call_before_task_publish_handler(
-            headers_to_use=self.HEADERS_WEB_UI,
-            body_to_use=self.BODY_WEB_UI,
-        )
-
-        task = PaperlessTask.objects.get()
-
-        self.assertIsNotNone(task)
-
-        self.assertEqual(self.HEADERS_WEB_UI["id"], task.task_id)
-        self.assertEqual("statement.pdf", task.task_file_name)
         self.assertEqual("documents.tasks.consume_file", task.task_name)
         self.assertEqual(celery.states.PENDING, task.status)
 
@@ -135,12 +75,32 @@ class TestTaskSignalHandler(DirectoriesMixin, TestCase):
         THEN:
             - The task is marked as started
         """
-        self.util_call_before_task_publish_handler(
-            headers_to_use=self.HEADERS_CONSUME,
-            body_to_use=self.BODY_CONSUME,
+
+        headers = {
+            "id": str(uuid.uuid4()),
+            "task": "documents.tasks.consume_file",
+        }
+        body = (
+            # args
+            (
+                ConsumableDocument(
+                    source=DocumentSource.ConsumeFolder,
+                    original_file="/consume/hello-99.pdf",
+                ),
+                None,
+            ),
+            # kwargs
+            {},
+            # celery stuff
+            {"callbacks": None, "errbacks": None, "chain": None, "chord": None},
         )
 
-        task_prerun_handler(task_id=self.HEADERS_CONSUME["id"])
+        self.util_call_before_task_publish_handler(
+            headers_to_use=headers,
+            body_to_use=body,
+        )
+
+        task_prerun_handler(task_id=headers["id"])
 
         task = PaperlessTask.objects.get()
 
@@ -155,13 +115,31 @@ class TestTaskSignalHandler(DirectoriesMixin, TestCase):
         THEN:
             - The task is marked as started
         """
+        headers = {
+            "id": str(uuid.uuid4()),
+            "task": "documents.tasks.consume_file",
+        }
+        body = (
+            # args
+            (
+                ConsumableDocument(
+                    source=DocumentSource.ConsumeFolder,
+                    original_file="/consume/hello-9.pdf",
+                ),
+                None,
+            ),
+            # kwargs
+            {},
+            # celery stuff
+            {"callbacks": None, "errbacks": None, "chain": None, "chord": None},
+        )
         self.util_call_before_task_publish_handler(
-            headers_to_use=self.HEADERS_CONSUME,
-            body_to_use=self.BODY_CONSUME,
+            headers_to_use=headers,
+            body_to_use=body,
         )
 
         task_postrun_handler(
-            task_id=self.HEADERS_CONSUME["id"],
+            task_id=headers["id"],
             retval="Success. New document id 1 created",
             state=celery.states.SUCCESS,
         )

--- a/src/documents/tests/utils.py
+++ b/src/documents/tests/utils.py
@@ -4,6 +4,8 @@ from collections import namedtuple
 from contextlib import contextmanager
 from os import PathLike
 from pathlib import Path
+from typing import Iterator
+from typing import Tuple
 from typing import Union
 from unittest import mock
 
@@ -12,6 +14,8 @@ from django.db import connection
 from django.db.migrations.executor import MigrationExecutor
 from django.test import override_settings
 from django.test import TransactionTestCase
+from documents.data_models import ConsumableDocument
+from documents.data_models import DocumentMetadataOverrides
 
 
 def setup_directories():
@@ -116,6 +120,11 @@ class ConsumerProgressMixin:
 
 
 class DocumentConsumeDelayMixin:
+    """
+    Provides mocking of the consume_file asynchronous task and useful utilities
+    for decoding its arguments
+    """
+
     def setUp(self) -> None:
         self.consume_file_patcher = mock.patch("documents.tasks.consume_file.delay")
         self.consume_file_mock = self.consume_file_patcher.start()
@@ -124,6 +133,47 @@ class DocumentConsumeDelayMixin:
     def tearDown(self) -> None:
         super().tearDown()
         self.consume_file_patcher.stop()
+
+    def get_last_consume_delay_call_args(
+        self,
+    ) -> Tuple[ConsumableDocument, DocumentMetadataOverrides]:
+        """
+        Returns the most recent arguments to the async task
+        """
+        # Must be at least 1 call
+        self.consume_file_mock.assert_called()
+
+        args, _ = self.consume_file_mock.call_args
+        input_doc, overrides = args
+
+        return (input_doc, overrides)
+
+    def get_all_consume_delay_call_args(
+        self,
+    ) -> Iterator[Tuple[ConsumableDocument, DocumentMetadataOverrides]]:
+        """
+        Iterates over all calls to the async task and returns the arguments
+        """
+
+        for args, _ in self.consume_file_mock.call_args_list:
+            input_doc, overrides = args
+
+            yield (input_doc, overrides)
+
+    def get_specific_consume_delay_call_args(
+        self,
+        index: int,
+    ) -> Iterator[Tuple[ConsumableDocument, DocumentMetadataOverrides]]:
+        """
+        Returns the arguments of a specific call to the async task
+        """
+        # Must be at least 1 call
+        self.consume_file_mock.assert_called()
+
+        args, _ = self.consume_file_mock.call_args_list[index]
+        input_doc, overrides = args
+
+        return (input_doc, overrides)
 
 
 class TestMigrations(TransactionTestCase):
@@ -140,7 +190,7 @@ class TestMigrations(TransactionTestCase):
 
         assert (
             self.migrate_from and self.migrate_to
-        ), "TestCase '{}' must define migrate_from and migrate_to     properties".format(
+        ), "TestCase '{}' must define migrate_from and migrate_to properties".format(
             type(self).__name__,
         )
         self.migrate_from = [(self.app, self.migrate_from)]

--- a/src/paperless_mail/mail.py
+++ b/src/paperless_mail/mail.py
@@ -21,6 +21,9 @@ from django.conf import settings
 from django.db import DatabaseError
 from django.utils.timezone import is_naive
 from django.utils.timezone import make_aware
+from documents.data_models import ConsumableDocument
+from documents.data_models import DocumentMetadataOverrides
+from documents.data_models import DocumentSource
 from documents.loggers import LoggingMixin
 from documents.models import Correspondent
 from documents.parsers import is_mime_type_supported
@@ -694,18 +697,22 @@ class MailAccountHandler(LoggingMixin):
                     f"{message.subject} from {message.from_}",
                 )
 
+                input_doc = ConsumableDocument(
+                    source=DocumentSource.MailFetch,
+                    original_file=temp_filename,
+                )
+                doc_overrides = DocumentMetadataOverrides(
+                    title=title,
+                    filename=pathvalidate.sanitize_filename(att.filename),
+                    correspondent_id=correspondent.id if correspondent else None,
+                    document_type_id=doc_type.id if doc_type else None,
+                    tag_ids=tag_ids,
+                    owner_id=rule.owner.id if rule.owner else None,
+                )
+
                 consume_task = consume_file.s(
-                    path=temp_filename,
-                    override_filename=pathvalidate.sanitize_filename(
-                        att.filename,
-                    ),
-                    override_title=title,
-                    override_correspondent_id=correspondent.id
-                    if correspondent
-                    else None,
-                    override_document_type_id=doc_type.id if doc_type else None,
-                    override_tag_ids=tag_ids,
-                    override_owner_id=rule.owner.id if rule.owner else None,
+                    input_doc,
+                    doc_overrides,
                 )
 
                 consume_tasks.append(consume_task)
@@ -770,16 +777,22 @@ class MailAccountHandler(LoggingMixin):
             f"{message.subject} from {message.from_}",
         )
 
+        input_doc = ConsumableDocument(
+            source=DocumentSource.MailFetch,
+            original_file=temp_filename,
+        )
+        doc_overrides = DocumentMetadataOverrides(
+            title=message.subject,
+            filename=pathvalidate.sanitize_filename(f"{message.subject}.eml"),
+            correspondent_id=correspondent.id if correspondent else None,
+            document_type_id=doc_type.id if doc_type else None,
+            tag_ids=tag_ids,
+            owner_id=rule.owner.id if rule.owner else None,
+        )
+
         consume_task = consume_file.s(
-            path=temp_filename,
-            override_filename=pathvalidate.sanitize_filename(
-                message.subject + ".eml",
-            ),
-            override_title=message.subject,
-            override_correspondent_id=correspondent.id if correspondent else None,
-            override_document_type_id=doc_type.id if doc_type else None,
-            override_tag_ids=tag_ids,
-            override_owner_id=rule.owner.id if rule.owner else None,
+            input_doc,
+            doc_overrides,
         )
 
         queue_consumption_tasks(


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

This is a larger change, but I think worthwhile to make.  It creates 2 data classes for handling typing and serialization of types when calling the main shared task `consume_file`.  Some of the benefits I can think of:

- Arguments are consistently serialized and serialized into the correct types, instead of maybe becoming unexpected strings
- File mime type is gotten once, early on, instead of multiple times during consume and stored for all needs downstream
- New ability to define where the document is coming from, allowing some simplifications now (and maybe useful in the future)
- Easier to add new overrides
- Testing is less dependent on kwarg names, but can use strongly typed and named fields instead
- Testing utility for getting last call or call by index, nicely decoded included


Fixes # (issue)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
