### PR TITLE
Don't submit owner via API on document upload

### DIFF
--- a/src-ui/src/app/services/upload-documents.service.ts
+++ b/src-ui/src/app/services/upload-documents.service.ts
@@ -28,7 +28,6 @@ export class UploadDocumentsService {
         fileEntry.file((file: File) => {
           let formData = new FormData()
           formData.append('document', file, file.name)
-          formData.set('owner', this.settings.currentUser.id.toString())
           let status = this.consumerStatusService.newFileUpload(file.name)
 
           status.message = $localize`Connecting...`

--- a/src/documents/serialisers.py
+++ b/src/documents/serialisers.py
@@ -683,14 +683,6 @@ class PostDocumentSerializer(serializers.Serializer):
         required=False,
     )
 
-    owner = serializers.PrimaryKeyRelatedField(
-        queryset=User.objects.all(),
-        label="Owner",
-        allow_null=True,
-        write_only=True,
-        required=False,
-    )
-
     archive_serial_number = serializers.IntegerField(
         label="ASN",
         write_only=True,
@@ -725,12 +717,6 @@ class PostDocumentSerializer(serializers.Serializer):
     def validate_tags(self, tags):
         if tags:
             return [tag.id for tag in tags]
-        else:
-            return None
-
-    def validate_owner(self, owner):
-        if owner:
-            return owner.id
         else:
             return None
 

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -672,7 +672,6 @@ class PostDocumentView(GenericAPIView):
         tag_ids = serializer.validated_data.get("tags")
         title = serializer.validated_data.get("title")
         created = serializer.validated_data.get("created")
-        owner_id = serializer.validated_data.get("owner")
         archive_serial_number = serializer.validated_data.get("archive_serial_number")
 
         t = int(mktime(datetime.now().timetuple()))
@@ -698,7 +697,7 @@ class PostDocumentView(GenericAPIView):
             override_tag_ids=tag_ids,
             task_id=task_id,
             override_created=created,
-            override_owner_id=owner_id,
+            override_owner_id=request.user.id,
             override_archive_serial_num=archive_serial_number,
         )
 


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

Don't allow owner to be submitted via API, instead use currently logged in user for the new document.

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
