### PR TITLE
fix database locked error

### DIFF
--- a/src/documents/bulk_edit.py
+++ b/src/documents/bulk_edit.py
@@ -8,7 +8,6 @@ from documents.models import StoragePath
 from documents.permissions import set_permissions_for_object
 from documents.tasks import bulk_update_documents
 from documents.tasks import update_document_archive_file
-from documents.tasks import update_owner_for_object
 
 
 def set_correspondent(doc_ids, correspondent):
@@ -136,7 +135,7 @@ def set_permissions(doc_ids, set_permissions, owner=None):
 
     qs = Document.objects.filter(id__in=doc_ids)
 
-    update_owner_for_object.delay(document_ids=doc_ids, owner=owner)
+    qs.update(owner=owner)
 
     for doc in qs:
         set_permissions_for_object(set_permissions, doc)

--- a/src/documents/tasks.py
+++ b/src/documents/tasks.py
@@ -13,7 +13,6 @@ from asgiref.sync import async_to_sync
 from celery import shared_task
 from channels.layers import get_channel_layer
 from django.conf import settings
-from django.contrib.auth.models import User
 from django.db import transaction
 from django.db.models.signals import post_save
 from documents import barcodes
@@ -312,12 +311,3 @@ def update_document_archive_file(document_id):
         )
     finally:
         parser.cleanup()
-
-
-@shared_task
-def update_owner_for_object(document_ids, owner):
-    documents = Document.objects.filter(id__in=document_ids)
-    ownerUser = User.objects.get(pk=owner) if owner is not None else None
-    for document in documents:
-        document.owner = ownerUser if owner is not None else None
-        document.save()


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

Changing the owner on many documents (lets say 2000+) takes a while. With SQLite, "Database locked" errors can be observed, since both the main thread changing permissions as well as the running celery task changing owners run at the same time. Updating owners is actually very fast and doesn't require a separate task.

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
