### PR TITLE
Fix: Disable suggestions for read-only docs

### DIFF
--- a/src-ui/src/app/components/document-detail/document-detail.component.ts
+++ b/src-ui/src/app/components/document-detail/document-detail.component.ts
@@ -306,20 +306,27 @@ export class DocumentDetailComponent
           )
         },
       })
-    this.documentsService
-      .getSuggestions(doc.id)
-      .pipe(first())
-      .subscribe({
-        next: (result) => {
-          this.suggestions = result
-        },
-        error: (error) => {
-          this.suggestions = null
-          this.toastService.showError(
-            $localize`Error retrieving suggestions` + ': ' + error.toString()
-          )
-        },
-      })
+    if (
+      this.permissionsService.currentUserHasObjectPermissions(
+        PermissionAction.Change,
+        doc
+      )
+    ) {
+      this.documentsService
+        .getSuggestions(doc.id)
+        .pipe(first())
+        .subscribe({
+          next: (result) => {
+            this.suggestions = result
+          },
+          error: (error) => {
+            this.suggestions = null
+            this.toastService.showError(
+              $localize`Error retrieving suggestions` + ': ' + error.toString()
+            )
+          },
+        })
+    }
     this.title = this.documentTitlePipe.transform(doc.title)
     const docFormValues = Object.assign({}, doc)
     docFormValues['permissions_form'] = {


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Fixes #2811 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
