### PR TITLE
Chore: Create list parsing utility for settings

### DIFF
--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -7,6 +7,7 @@ import re
 import tempfile
 from typing import Dict
 from typing import Final
+from typing import List
 from typing import Optional
 from typing import Set
 from typing import Tuple
@@ -68,6 +69,23 @@ def __get_path(key: str, default: str) -> str:
     Return a normalized, absolute path based on the environment variable or a default
     """
     return os.path.abspath(os.path.normpath(os.environ.get(key, default)))
+
+
+def __get_list(
+    key: str,
+    default: Optional[List[str]] = None,
+    sep: str = ",",
+) -> List[str]:
+    """
+    Return a list of elements from the environment, as separated by the given
+    string, or the default if the key does not exist
+    """
+    if key in os.environ:
+        return os.environ[key].split(sep)
+    elif default is not None:
+        return default
+    else:
+        return []
 
 
 def _parse_redis_url(env_redis: Optional[str]) -> Tuple[str]:
@@ -239,7 +257,7 @@ SCRATCH_DIR = __get_path(
 # Application Definition                                                      #
 ###############################################################################
 
-env_apps = os.getenv("PAPERLESS_APPS").split(",") if os.getenv("PAPERLESS_APPS") else []
+env_apps = __get_list("PAPERLESS_APPS")
 
 INSTALLED_APPS = [
     "whitenoise.runserver_nostatic",
@@ -384,44 +402,33 @@ else:
 
 
 # The next 3 settings can also be set using just PAPERLESS_URL
-_csrf_origins = os.getenv("PAPERLESS_CSRF_TRUSTED_ORIGINS")
-if _csrf_origins:
-    CSRF_TRUSTED_ORIGINS = _csrf_origins.split(",")
-else:
-    CSRF_TRUSTED_ORIGINS = []
+CSRF_TRUSTED_ORIGINS = __get_list("PAPERLESS_CSRF_TRUSTED_ORIGINS")
 
 # We allow CORS from localhost:8000
-CORS_ALLOWED_ORIGINS = tuple(
-    os.getenv("PAPERLESS_CORS_ALLOWED_HOSTS", "http://localhost:8000").split(","),
+CORS_ALLOWED_ORIGINS = __get_list(
+    "PAPERLESS_CORS_ALLOWED_HOSTS",
+    ["http://localhost:8000"],
 )
 
 if DEBUG:
     # Allow access from the angular development server during debugging
-    CORS_ALLOWED_ORIGINS += ("http://localhost:4200",)
+    CORS_ALLOWED_ORIGINS.append("http://localhost:4200")
 
-_allowed_hosts = os.getenv("PAPERLESS_ALLOWED_HOSTS")
-if _allowed_hosts:
-    ALLOWED_HOSTS = _allowed_hosts.split(",")
-else:
-    ALLOWED_HOSTS = ["*"]
+ALLOWED_HOSTS = __get_list("PAPERLESS_ALLOWED_HOSTS", ["*"])
 
 _paperless_url = os.getenv("PAPERLESS_URL")
 if _paperless_url:
     _paperless_uri = urlparse(_paperless_url)
     CSRF_TRUSTED_ORIGINS.append(_paperless_url)
-    CORS_ALLOWED_ORIGINS += (_paperless_url,)
-    if _allowed_hosts:
+    CORS_ALLOWED_ORIGINS.append(_paperless_url)
+    if ALLOWED_HOSTS != ["*"]:
         ALLOWED_HOSTS.append(_paperless_uri.hostname)
     else:
         # always allow localhost. Necessary e.g. for healthcheck in docker.
         ALLOWED_HOSTS = [_paperless_uri.hostname] + ["localhost"]
 
 # For use with trusted proxies
-_trusted_proxies = os.getenv("PAPERLESS_TRUSTED_PROXIES")
-if _trusted_proxies:
-    TRUSTED_PROXIES = _trusted_proxies.split(",")
-else:
-    TRUSTED_PROXIES = []
+TRUSTED_PROXIES = __get_list("PAPERLESS_TRUSTED_PROXIES")
 
 # The secret key has a default that should be fine so long as you're hosting
 # Paperless on a closed network.  However, if you're putting this anywhere

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -81,7 +81,7 @@ def __get_list(
     string, or the default if the key does not exist
     """
     if key in os.environ:
-        return os.environ[key].split(sep)
+        return list(filter(None, os.environ[key].split(sep)))
     elif default is not None:
         return default
     else:


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Quick little getter in the same idea as the others for getting a list from an environment key, and setting a default if the key isn't present.  Handles different separation chars for future use, defaulting to comma seperated.

A few settings keys changed type from tuple to list to support using the util.

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
