### PR TITLE
Fix: permissions display should not show users with inherited permissions & unable to change owner

### DIFF
--- a/src-ui/cypress/fixtures/documents/documents.json
+++ b/src-ui/cypress/fixtures/documents/documents.json
@@ -21,7 +21,16 @@
             "original_file_name": "2022-03-22 no latin title.pdf",
             "archived_file_name": "2022-03-22 no latin title.pdf",
             "owner": null,
-            "permissions": [],
+            "permissions": {
+                "view": {
+                    "users": [],
+                    "groups": []
+                },
+                "change": {
+                    "users": [],
+                    "groups": []
+                }
+            },
             "notes": [
                 {
                     "id": 9,
@@ -59,7 +68,16 @@
             "original_file_name": "2022-03-23 lorem ipsum dolor sit amet.pdf",
             "archived_file_name": "2022-03-23 llorem ipsum dolor sit amet.pdf",
             "owner": null,
-            "permissions": [],
+            "permissions": {
+                "view": {
+                    "users": [],
+                    "groups": []
+                },
+                "change": {
+                    "users": [],
+                    "groups": []
+                }
+            },
             "notes": []
         },
         {
@@ -80,7 +98,16 @@
             "original_file_name": "2022-03-24 dolor.pdf",
             "archived_file_name": "2022-03-24 dolor.pdf",
             "owner": null,
-            "permissions": [],
+            "permissions": {
+                "view": {
+                    "users": [],
+                    "groups": []
+                },
+                "change": {
+                    "users": [],
+                    "groups": []
+                }
+            },
             "notes": []
         },
         {
@@ -101,7 +128,16 @@
             "original_file_name": "2022-06-01 sit amet.pdf",
             "archived_file_name": "2022-06-01 sit amet.pdf",
             "owner": null,
-            "permissions": [],
+            "permissions": {
+                "view": {
+                    "users": [],
+                    "groups": []
+                },
+                "change": {
+                    "users": [],
+                    "groups": []
+                }
+            },
             "notes": []
         }
     ]

--- a/src-ui/cypress/fixtures/ui_settings/settings.json
+++ b/src-ui/cypress/fixtures/ui_settings/settings.json
@@ -2,7 +2,8 @@
     "user": {
         "id": 1,
         "username": "admin",
-        "is_superuser": true
+        "is_superuser": true,
+        "groups": []
     },
     "settings": {
         "language": "",

--- a/src-ui/cypress/fixtures/ui_settings/settings_restricted.json
+++ b/src-ui/cypress/fixtures/ui_settings/settings_restricted.json
@@ -2,7 +2,8 @@
     "user": {
         "id": 1,
         "username": "admin",
-        "is_superuser": false
+        "is_superuser": false,
+        "groups": []
     },
     "settings": {
         "language": "",

--- a/src-ui/src/app/components/common/input/permissions/permissions-user/permissions-user.component.ts
+++ b/src-ui/src/app/components/common/input/permissions/permissions-user/permissions-user.component.ts
@@ -28,11 +28,6 @@ export class PermissionsUserComponent extends AbstractInputComponent<
     userService
       .listAll()
       .pipe(first())
-      .subscribe(
-        (result) =>
-          (this.users = result.results.filter(
-            (u) => u.id !== settings.currentUser.id
-          ))
-      )
+      .subscribe((result) => (this.users = result.results))
   }
 }

--- a/src-ui/src/app/components/common/input/select/select.component.ts
+++ b/src-ui/src/app/components/common/input/select/select.component.ts
@@ -77,7 +77,7 @@ export class SelectComponent extends AbstractInputComponent<number> {
   }
 
   get isPrivate(): boolean {
-    return this.items.find((i) => i.id === this.value)?.private
+    return this.items?.find((i) => i.id === this.value)?.private
   }
 
   getSuggestions() {

--- a/src-ui/src/app/components/document-detail/document-detail.component.ts
+++ b/src-ui/src/app/components/document-detail/document-detail.component.ts
@@ -446,6 +446,10 @@ export class DocumentDetailComponent
       .subscribe({
         next: (doc) => {
           Object.assign(this.document, doc)
+          doc['permissions_form'] = {
+            owner: doc.owner,
+            set_permissions: doc.permissions,
+          }
           this.title = doc.title
           this.documentForm.patchValue(doc)
           this.openDocumentService.setDirty(doc, false)

--- a/src-ui/src/app/components/document-detail/document-detail.component.ts
+++ b/src-ui/src/app/components/document-detail/document-detail.component.ts
@@ -474,12 +474,17 @@ export class DocumentDetailComponent
         },
         error: (error) => {
           this.networkActive = false
-          this.error = error.error
-          this.toastService.showError(
-            $localize`Error saving document` +
-              ': ' +
-              (error.message ?? error.toString())
-          )
+          if (!this.userCanEdit) {
+            this.toastService.showInfo($localize`Document saved successfully.`)
+            this.close()
+          } else {
+            this.error = error.error
+            this.toastService.showError(
+              $localize`Error saving document` +
+                ': ' +
+                (error.message ?? error.toString())
+            )
+          }
         },
       })
   }

--- a/src-ui/src/app/components/document-detail/document-detail.component.ts
+++ b/src-ui/src/app/components/document-detail/document-detail.component.ts
@@ -676,8 +676,8 @@ export class DocumentDetailComponent
   get userIsOwner(): boolean {
     let doc: PaperlessDocument = Object.assign({}, this.document)
     // dont disable while editing
-    if (this.document && this.store?.value.owner) {
-      doc.owner = this.store?.value.owner
+    if (this.document && this.store?.value.permissions_form?.owner) {
+      doc.owner = this.store?.value.permissions_form?.owner
     }
     return !this.document || this.permissionsService.currentUserOwnsObject(doc)
   }
@@ -685,8 +685,8 @@ export class DocumentDetailComponent
   get userCanEdit(): boolean {
     let doc: PaperlessDocument = Object.assign({}, this.document)
     // dont disable while editing
-    if (this.document && this.store?.value.owner) {
-      doc.owner = this.store?.value.owner
+    if (this.document && this.store?.value.permissions_form?.owner) {
+      doc.owner = this.store?.value.permissions_form?.owner
     }
     return (
       !this.document ||

--- a/src-ui/src/app/data/paperless-user.ts
+++ b/src-ui/src/app/data/paperless-user.ts
@@ -9,7 +9,7 @@ export interface PaperlessUser extends ObjectWithId {
   is_staff?: boolean
   is_active?: boolean
   is_superuser?: boolean
-  groups?: PaperlessGroup[]
+  groups?: number[] // PaperlessGroup[]
   user_permissions?: string[]
   inherited_permissions?: string[]
 }

--- a/src-ui/src/app/services/permissions.service.ts
+++ b/src-ui/src/app/services/permissions.service.ts
@@ -58,11 +58,16 @@ export class PermissionsService {
     action: string,
     object: ObjectWithPermissions
   ): boolean {
+    let actionObject = null
+    if (action === PermissionAction.View) actionObject = object.permissions.view
+    else if (action === PermissionAction.Change)
+      actionObject = object.permissions.change
+    if (!actionObject) return false
     return (
       this.currentUserOwnsObject(object) ||
-      (object.permissions[action]['users'] as Array<number>)?.includes(
-        this.currentUser.id
-      )
+      actionObject.users.includes(this.currentUser.id) ||
+      actionObject.groups.filter((g) => this.currentUser.groups.includes(g))
+        .length > 0
     )
   }
 

--- a/src/documents/permissions.py
+++ b/src/documents/permissions.py
@@ -63,6 +63,7 @@ def set_permissions_for_object(permissions, object):
         users_to_remove = get_users_with_perms(
             object,
             only_with_perms_in=[permission],
+            with_group_users=False,
         )
         if len(users_to_add) > 0 and len(users_to_remove) > 0:
             users_to_remove = users_to_remove.difference(users_to_add)

--- a/src/documents/serialisers.py
+++ b/src/documents/serialisers.py
@@ -161,6 +161,7 @@ class OwnedObjectSerializer(serializers.ModelSerializer, SetPermissionsMixin):
                 "users": get_users_with_perms(
                     obj,
                     only_with_perms_in=[view_codename],
+                    with_group_users=False,
                 ).values_list("id", flat=True),
                 "groups": get_groups_with_only_permission(
                     obj,
@@ -171,6 +172,7 @@ class OwnedObjectSerializer(serializers.ModelSerializer, SetPermissionsMixin):
                 "users": get_users_with_perms(
                     obj,
                     only_with_perms_in=[change_codename],
+                    with_group_users=False,
                 ).values_list("id", flat=True),
                 "groups": get_groups_with_only_permission(
                     obj,

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -964,6 +964,7 @@ class UiSettingsView(GenericAPIView):
                     "id": user.id,
                     "username": user.username,
                     "is_superuser": user.is_superuser,
+                    "groups": user.groups.values_list("id", flat=True),
                 },
                 "settings": ui_settings,
                 "permissions": roles,


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

This PR now corrects a couple things (see linked issues). Most importantly it updates the api / permissions forms to (correctly, and what was expected) only show groups and not the users inheriting object permissions from that group. I think that was causing confusion / problems.

In other words if a user has access only via a group, they no longer show up under "users".

Not being able to change the owner was just because document owner was being used from the current value in the form i.e. the user 'lost' permissions, the location of owner changed in the form.

Fixes #2809 
Fixes #2810

<img width="543" alt="Screenshot 2023-03-17 at 8 55 19 PM" src="https://user-images.githubusercontent.com/4887959/226083732-3cec545f-9471-4615-80fb-9393351ea25a.png">

https://user-images.githubusercontent.com/4887959/222873409-b2d47271-8e1f-4b3b-b2b3-c9016ea1bc00.mov

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
