### PR TITLE
Fix: disable bulk edit dialog buttons during operation

### DIFF
--- a/src-ui/src/app/components/common/permissions-dialog/permissions-dialog.component.html
+++ b/src-ui/src/app/components/common/permissions-dialog/permissions-dialog.component.html
@@ -13,6 +13,6 @@
 
   </div>
   <div class="modal-footer">
-    <button type="button" class="btn btn-outline-primary" (click)="cancelClicked()" i18n>Cancel</button>
-    <button type="button" class="btn btn-primary" (click)="confirmClicked.emit(permissions)" i18n>Confirm</button>
+    <button type="button" class="btn btn-outline-primary" (click)="cancelClicked()" [disabled]="!buttonsEnabled" i18n>Cancel</button>
+    <button type="button" class="btn btn-primary" (click)="confirmClicked.emit(permissions)" [disabled]="!buttonsEnabled" i18n>Confirm</button>
   </div>

--- a/src-ui/src/app/components/common/permissions-dialog/permissions-dialog.component.ts
+++ b/src-ui/src/app/components/common/permissions-dialog/permissions-dialog.component.ts
@@ -29,6 +29,8 @@ export class PermissionsDialogComponent {
     permissions_form: new FormControl(),
   })
 
+  buttonsEnabled: boolean = true
+
   get permissions() {
     return {
       owner: this.form.get('permissions_form').value?.owner ?? null,


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

(same applies in successful bulk operation and error which is shown)

https://user-images.githubusercontent.com/4887959/222873827-1b21ba1f-87f5-4c05-a5bd-5a2462402418.mov

Fixes #2815

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
