### PR TITLE
docs: better language code help

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1096,11 +1096,13 @@ actual group ID on the host system, which you can get by executing
 : Additional OCR languages to install. By default, paperless comes
 with English, German, Italian, Spanish and French. If your language
 is not in this list, install additional languages with this
-configuration option:
+configuration option ([find the right LangCodes](https://tesseract-ocr.github.io/tessdoc/Data-Files-in-different-versions.html)):
 
     ``` bash
     PAPERLESS_OCR_LANGUAGES=tur ces
     ```
+
+    Make sure it's a space separated list when using several values.
 
     To actually use these languages, also set the default OCR language
     of paperless:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -383,21 +383,20 @@ needs.
 : Customize the language that paperless will attempt to use when
 parsing documents.
 
-    It should be a 3-letter language code consistent with ISO 639:
-    https://www.loc.gov/standards/iso639-2/php/code_list.php
+    It should be a 3-letter code, see the list of [languages Tesseract supports](https://tesseract-ocr.github.io/tessdoc/Data-Files-in-different-versions.html).
 
     Set this to the language most of your documents are written in.
 
     This can be a combination of multiple languages such as `deu+eng`,
-    in which case tesseract will use whatever language matches best.
-    Keep in mind that tesseract uses much more cpu time with multiple
+    in which case Tesseract will use whatever language matches best.
+    Keep in mind that Tesseract uses much more CPU time with multiple
     languages enabled.
 
     Defaults to "eng".
 
     !!! note
 
-        If your language contains a '-' such as chi-sim, you must use chi_sim
+        If your language contains a '-' such as chi-sim, you must use `chi_sim`.
 
 `PAPERLESS_OCR_MODE=<mode>`
 


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

The [docs](https://docs.paperless-ngx.com/configuration/#ocr) currently link https://www.loc.gov/standards/iso639-2/php/code_list.php and ask to use ISO639-2 codes.
Turns out those are not always correct, and Tesseract sometimes has its own variant.
The issue appeared in https://github.com/paperless-ngx/paperless-ngx/issues/1106#issuecomment-1427057018 and https://github.com/paperless-ngx/paperless-ngx/issues/2824#issuecomment-1454892159 recently.

The Tesseract docs seems to not be very actively maintained and currently do not list languages for v5 in the table for example. But linking to the official docs still seems most reasonable and should provide a good help resource to users:
https://tesseract-ocr.github.io/tessdoc/Data-Files-in-different-versions.html

Alternative links if you think they are a better fit:
- https://packages.debian.org/source/bullseye/tesseract-lang (needs to be kept up to date with the debian base image)
- https://tesseract-ocr.github.io/tessdoc/Data-Files#data-files-for-version-400-november-29-2016
- https://github.com/tesseract-ocr/tessdata

The commit also includes a few tiny layout fixes in this section.
Also, the link is now clickable.

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (docs)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
