### PR TITLE
Fix: Ensure email date is made aware during action processing

### DIFF
--- a/src/paperless_mail/mail.py
+++ b/src/paperless_mail/mail.py
@@ -19,6 +19,8 @@ from celery import shared_task
 from celery.canvas import Signature
 from django.conf import settings
 from django.db import DatabaseError
+from django.utils.timezone import is_naive
+from django.utils.timezone import make_aware
 from documents.loggers import LoggingMixin
 from documents.models import Correspondent
 from documents.parsers import is_mime_type_supported
@@ -235,6 +237,10 @@ def apply_mail_action(
 
     rule = MailRule.objects.get(pk=rule_id)
     account = MailAccount.objects.get(pk=rule.account.pk)
+
+    # Ensure the date is properly timezone aware
+    if is_naive(message_date):
+        message_date = make_aware(message_date)
 
     try:
 

--- a/src/paperless_mail/tests/test_mail.py
+++ b/src/paperless_mail/tests/test_mail.py
@@ -1,6 +1,5 @@
 import dataclasses
 import email.contentmanager
-import os
 import random
 import uuid
 from collections import namedtuple


### PR DESCRIPTION


## Proposed change

Small change to resolve a warning from Django:
```
RuntimeWarning: DateTimeField ProcessedMail.received received a naive datetime (1900-01-01 00:00:00) while time zone support is active.
```

`MailMessage` dates may or may not be timezone aware dates, as following RFC2822.  If it is not aware, the assumption the date is in the currently configured timezone.

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
