### PR TITLE
Fix: frontend handle "private" tags, doctypes, correspondents

### DIFF
--- a/src-ui/messages.xlf
+++ b/src-ui/messages.xlf
@@ -1824,7 +1824,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/common/input/select/select.component.html</context>
-          <context context-type="linenumber">31</context>
+          <context context-type="linenumber">32</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/common/input/tags/tags.component.html</context>
@@ -1963,9 +1963,24 @@
         <source>Add item</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/common/input/select/select.component.html</context>
-          <context context-type="linenumber">11</context>
+          <context context-type="linenumber">12</context>
         </context-group>
         <note priority="1" from="description">Used for both types, correspondents, storage paths</note>
+      </trans-unit>
+      <trans-unit id="3686284950598311784" datatype="html">
+        <source>Private</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/common/input/select/select.component.ts</context>
+          <context context-type="linenumber">36</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/common/tag/tag.component.html</context>
+          <context context-type="linenumber">7</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/common/tag/tag.component.html</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
       </trans-unit>
       <trans-unit id="6560126119609945418" datatype="html">
         <source>Add tag</source>

--- a/src-ui/src/app/components/common/input/select/select.component.html
+++ b/src-ui/src/app/components/common/input/select/select.component.html
@@ -5,6 +5,7 @@
         [disabled]="disabled"
         [style.color]="textColor"
         [style.background]="backgroundColor"
+        [class.private]="isPrivate"
         [clearable]="allowNull"
         [items]="items"
         [addTag]="allowCreateNew && addItemRef"

--- a/src-ui/src/app/components/common/input/select/select.component.scss
+++ b/src-ui/src/app/components/common/input/select/select.component.scss
@@ -12,3 +12,8 @@
         }
     }
 }
+
+::ng-deep .private .ng-value-container {
+    font-style: italic;
+    opacity: .75;
+}

--- a/src-ui/src/app/components/common/input/select/select.component.ts
+++ b/src-ui/src/app/components/common/input/select/select.component.ts
@@ -26,8 +26,23 @@ export class SelectComponent extends AbstractInputComponent<number> {
     this.addItemRef = this.addItem.bind(this)
   }
 
+  _items: any[]
+
   @Input()
-  items: any[]
+  set items(items) {
+    if (this.value && items.find((i) => i.id === this.value) === undefined) {
+      items.push({
+        id: this.value,
+        name: $localize`Private`,
+        private: true,
+      })
+    }
+    this._items = items
+  }
+
+  get items(): any[] {
+    return this._items
+  }
 
   @Input()
   textColor: any
@@ -59,6 +74,10 @@ export class SelectComponent extends AbstractInputComponent<number> {
 
   get allowCreateNew(): boolean {
     return this.createNew.observers.length > 0
+  }
+
+  get isPrivate(): boolean {
+    return this.items.find((i) => i.id === this.value)?.private
   }
 
   getSuggestions() {

--- a/src-ui/src/app/components/common/tag/tag.component.html
+++ b/src-ui/src/app/components/common/tag/tag.component.html
@@ -1,2 +1,9 @@
-<span *ngIf="!clickable" class="badge" [style.background]="tag.color" [style.color]="tag.text_color">{{tag.name}}</span>
-<a [title]="linkTitle" *ngIf="clickable" class="badge" [style.background]="tag.color" [style.color]="tag.text_color">{{tag.name}}</a>
+<ng-container *ngIf="tag !== undefined; else privateTag" >
+    <span *ngIf="!clickable" class="badge" [style.background]="tag.color" [style.color]="tag.text_color">{{tag.name}}</span>
+    <a [title]="linkTitle" *ngIf="clickable" class="badge" [style.background]="tag.color" [style.color]="tag.text_color">{{tag.name}}</a>
+</ng-container>
+
+<ng-template #privateTag>
+    <span *ngIf="!clickable" class="badge private" i18n>Private</span>
+    <a [title]="linkTitle" *ngIf="clickable" class="badge private" i18n>Private</a>
+</ng-template>

--- a/src-ui/src/app/components/common/tag/tag.component.scss
+++ b/src-ui/src/app/components/common/tag/tag.component.scss
@@ -4,3 +4,10 @@ a {
     word-break: break-word;
     text-align: end;
 }
+
+.private {
+    background-color: #000000;
+    color: #ffffff;
+    opacity: .5;
+    font-style: italic;
+}


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

_Draft for now:_ This didn't come up in the original PR so this is a possible way to handle viewing a document where the current user doesn't have access to all the attached objects e.g. tags etc. This implementation is handled by the frontend, retaining the object by ID but displaying "Private" ("Hidden", "Not Shared"?) for the name. Screenshot below. I could also imagine this being handled in the backend such that the private objects are returned but with their name replaced or something like that.

Of course alternatives include changing how this works overall but this makes sense to me. Im not sure how frequent this will come up in real-world use especially on a newly-setup install where objects are owned from the start.

<img width="512" alt="Screenshot 2023-03-06 at 4 29 13 PM" src="https://user-images.githubusercontent.com/4887959/223288898-be5bb6e6-cd94-4c62-8eff-f287bf70c20d.png">

Fixes # (issue)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
