### PR TITLE
[Documentation] Update docker-compose steps to support podman

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -160,8 +160,7 @@ steps described in [Docker setup](#docker_hub) automatically.
         `PAPERLESS_CONSUMER_POLLING`, which will disable inotify. See
         [here](/configuration#polling).
 
-6.  Run `docker-compose pull`, followed by `docker-compose up -d`. This
-    will pull the image, create and start the necessary containers.
+6.  Run `docker-compose pull`. This will pull the image.
 
 7.  To be able to login, you will need a super user. To create it,
     execute the following command:
@@ -173,7 +172,9 @@ steps described in [Docker setup](#docker_hub) automatically.
     This will prompt you to set a username, an optional e-mail address
     and finally a password (at least 8 characters).
 
-8.  The default `docker-compose.yml` exports the webserver on your local
+8.  Run `docker-compose up -d`. This will create and start the necessary containers.
+
+9.  The default `docker-compose.yml` exports the webserver on your local
     port
 
     8000\. If you did not change this, you should now be able to visit


### PR DESCRIPTION
Update the documentation.

As also written in the docker-compose file it is necessary to do the steps in the order:

1. Run 'docker-compose pull'.
2. Run 'docker-compose run --rm webserver createsuperuser' to create a user.
3. Run 'docker-compose up -d'.

This is also the order of steps in the setup script:

https://github.com/paperless-ngx/paperless-ngx/blob/9564a9c28d3910fbca66f6a34bca221fd2e9129f/install-paperless-ngx.sh#L385-L389

<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

Fixes # (issue)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
