### PR TITLE
Fix: Append Gmail labels instead of replacing

### DIFF
--- a/src/paperless_mail/mail.py
+++ b/src/paperless_mail/mail.py
@@ -165,7 +165,7 @@ class TagMailAction(BaseMailAction):
 
     def post_consume(self, M: MailBox, message_uid: str, parameter: str):
         if re.search(r"gmail\.com$|googlemail\.com$", M._host):
-            M.client.uid("STORE", message_uid, "X-GM-LABELS", self.keyword)
+            M.client.uid("STORE", message_uid, "+X-GM-LABELS", self.keyword)
 
         # AppleMail
         elif self.color:


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Based on the IMAPv4 RFC, [section 6.46](https://www.rfc-editor.org/rfc/rfc3501#section-6.4.6), adding the `+` will append the label instead of replacing all labels with the given one.  This is also [how imap_tools](https://github.com/ikvk/imap_tools/blob/ea9f752fe3d325b7ba6234b341664ad490340403/imap_tools/mailbox.py#L222) behaves when we call it, so we should align these.

Fixes #2856

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
