### PR TITLE
Feature: Change celery serializer to pickle

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -365,6 +365,10 @@ supported.
       documents are written in.
     - Set `PAPERLESS_TIME_ZONE` to your local time zone.
 
+    !!! warning
+
+        Ensure your Redis instance [is secured](https://redis.io/docs/getting-started/#securing-redis).
+
 7.  Create the following directories if they are missing:
 
     - `/opt/paperless/media`

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -628,6 +628,11 @@ CELERY_RESULT_EXTENDED = True
 CELERY_RESULT_BACKEND = "django-db"
 CELERY_CACHE_BACKEND = "default"
 
+# https://docs.celeryq.dev/en/stable/userguide/configuration.html#task-serializer
+CELERY_TASK_SERIALIZER = "pickle"
+# https://docs.celeryq.dev/en/stable/userguide/configuration.html#std-setting-accept_content
+CELERY_ACCEPT_CONTENT = ["application/json", "application/x-python-serialize"]
+
 # https://docs.celeryq.dev/en/stable/userguide/configuration.html#beat-schedule
 CELERY_BEAT_SCHEDULE = _parse_beat_schedule()
 


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

There's no need to support anything other than Python, so using pickle is acceptable.  Pickle may have security implications, but a Redis broker shouldn't be accessible to bad actors and the official Redis documentation on [security](https://redis.io/docs/management/security/) provides a lot of options for further securing the broker.

For the moment, JSON is still accepted by a worker, just in case there are pending tasks when a user upgrades.  It could be removed eventually, but it doesn't cost anything to keep it.

See also the celery [documentation on serialization](https://docs.celeryq.dev/projects/kombu/en/stable/userguide/serialization.html).  Pickle should have smaller message sizes and be slightly faster.  It also will allow almost all types to be preserved through the task, instead of converting to unexpected strings.

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
