### PR TITLE
Chore: Update to qpdf 11.3.0 in Docker image

### DIFF
--- a/.build-config.json
+++ b/.build-config.json
@@ -1,6 +1,6 @@
 {
   "qpdf": {
-      "version": "11.2.0"
+      "version": "11.3.0"
     },
   "jbig2enc": {
       "version": "0.29",

--- a/Dockerfile
+++ b/Dockerfile
@@ -180,7 +180,7 @@ RUN set -eux \
 RUN set -eux \
   && echo "Getting binaries" \
     && mkdir paperless-ngx \
-    && curl --fail --silent --show-error --output paperless-ngx.tar.gz --location https://github.com/paperless-ngx/paperless-ngx/archive/2a18975fe33e7b1c06254a72a2433c914cd49ed1.tar.gz \
+    && curl --fail --silent --show-error --output paperless-ngx.tar.gz --location https://github.com/paperless-ngx/paperless-ngx/archive/40895f1cdb7702d8cd4b9c3b1d1d7a886018ccd2.tar.gz \
     && tar -xf paperless-ngx.tar.gz --directory paperless-ngx --strip-components=1 \
     && cd paperless-ngx \
     # Setting a specific revision ensures we know what this installed


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

While awaiting the release of a Python bookworm image to really simplify things, updates the image to qpdf 11.3.0 and some more recently built wheels for the other imstallers.

https://qpdf.readthedocs.io/en/stable/release-notes.html

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
