### PR TITLE
Feature: Allow naming to include owner and original name

### DIFF
--- a/docs/advanced_usage.md
+++ b/docs/advanced_usage.md
@@ -309,6 +309,8 @@ Paperless provides the following placeholders within filenames:
 - `{added_month_name_short}`: Month added abbreviated name, as per
   locale
 - `{added_day}`: Day added only (number 01-31).
+- `{owner_username}`: Username of document owner, if any, or "none"
+- `{original_name}`: Document original filename, minus the extension, if any, or "none"
 
 Paperless will try to conserve the information from your database as
 much as possible. However, some characters that you can use in document

--- a/src/documents/serialisers.py
+++ b/src/documents/serialisers.py
@@ -818,6 +818,8 @@ class StoragePathSerializer(MatchingModelSerializer, OwnedObjectSerializer):
                 asn="asn",
                 tags="tags",
                 tag_list="tag_list",
+                owner_username="someone",
+                original_name="testfile",
             )
 
         except (KeyError):

--- a/src/documents/tests/test_api.py
+++ b/src/documents/tests/test_api.py
@@ -20,8 +20,6 @@ except ImportError:
     import backports.zoneinfo as zoneinfo
 
 import pytest
-from django.db import transaction
-from django.db.utils import IntegrityError
 from django.conf import settings
 from django.contrib.auth.models import Group
 from django.contrib.auth.models import Permission


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Adds two new possible options for the file name format.

- `owner_username` fills in with the document's owner's username
  - Does anyone see security implications here?  The files are just open on the file system anyway, so.. not for me 
- `original_name` is the original document name, minus the extension 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
