### PR TITLE
Fix: Update outdated docs referencing master

### DIFF
--- a/docs/administration.md
+++ b/docs/administration.md
@@ -98,7 +98,7 @@ the background.
     won't automatically update to newer versions. In order to enable
     updates as described above, either get the new `docker-compose.yml`
     file from
-    [here](https://github.com/paperless-ngx/paperless-ngx/tree/master/docker/compose)
+    [here](https://github.com/paperless-ngx/paperless-ngx/tree/main/docker/compose)
     or edit the `docker-compose.yml` file, find the line that says
 
     ```

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -43,7 +43,7 @@ steps described in [Docker setup](#docker_hub) automatically.
     ```
 
 2.  Go to the [/docker/compose directory on the project
-    page](https://github.com/paperless-ngx/paperless-ngx/tree/master/docker/compose)
+    page](https://github.com/paperless-ngx/paperless-ngx/tree/main/docker/compose)
     and download one of the `docker-compose.*.yml` files,
     depending on which database backend you want to use. Rename this
     file to `docker-compose.yml`. If you want to enable
@@ -190,7 +190,7 @@ steps described in [Docker setup](#docker_hub) automatically.
     git clone https://github.com/paperless-ngx/paperless-ngx
     ```
 
-    The master branch always reflects the latest stable version.
+    The main branch always reflects the latest stable version.
 
 2.  Copy one of the `docker/compose/docker-compose.*.yml` to
     `docker-compose.yml` in the root folder, depending on which database
@@ -590,7 +590,7 @@ Migration to paperless-ngx is then performed in a few simple steps:
 
 3.  Download the latest release of paperless-ngx. You can either go with
     the docker-compose files from
-    [here](https://github.com/paperless-ngx/paperless-ngx/tree/master/docker/compose)
+    [here](https://github.com/paperless-ngx/paperless-ngx/tree/main/docker/compose)
     or clone the repository to build the image yourself (see
     [above](#docker_build)). You can
     either replace your current paperless folder or put paperless-ngx in


### PR DESCRIPTION
## Proposed change

The primary release branch has been renamed to `main`. Some parts of the documentation still refer to `master` though.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
