### PR TITLE
Allow psql client certificate authentication

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -86,6 +86,36 @@ changed here.
 
     Default is `prefer`.
 
+`PAPERLESS_DBSSLROOTCERT=<ca-path>`
+
+: SSL root certificate path
+
+    See [the official documentation about
+    sslmode](https://www.postgresql.org/docs/current/libpq-ssl.html).
+    Changes path of `root.crt`.
+
+    Defaults to unset, using the documented path in the home directory.
+
+`PAPERLESS_DBSSLCERT=<client-cert-path>`
+
+: SSL client certificate path
+
+    See [the official documentation about
+    sslmode](https://www.postgresql.org/docs/current/libpq-ssl.html).
+    Changes path of `postgresql.crt`.
+
+    Defaults to unset, using the documented path in the home directory.
+
+`PAPERLESS_DBSSLKEY=<client-cert-key>`
+
+: SSL client key path
+
+    See [the official documentation about
+    sslmode](https://www.postgresql.org/docs/current/libpq-ssl.html).
+    Changes path of `postgresql.key`.
+
+    Defaults to unset, using the documented path in the home directory.
+
 `PAPERLESS_DB_TIMEOUT=<float>`
 
 : Amount of time for a database connection to wait for the database to

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -509,7 +509,12 @@ if os.getenv("PAPERLESS_DBHOST"):
 
     else:  # Default to PostgresDB
         engine = "django.db.backends.postgresql_psycopg2"
-        options = {"sslmode": os.getenv("PAPERLESS_DBSSLMODE", "prefer")}
+        options = {
+            "sslmode": os.getenv("PAPERLESS_DBSSLMODE", "prefer"),
+            "sslrootcert": os.getenv("PAPERLESS_DBSSLROOTCERT", None),
+            "sslcert": os.getenv("PAPERLESS_DBSSLCERT", None),
+            "sslkey": os.getenv("PAPERLESS_DBSSLKEY", None),
+        }
 
     DATABASES["default"]["ENGINE"] = engine
     DATABASES["default"]["OPTIONS"].update(options)


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Add support for more postgres connection options to enable client certificate authentication.
To test thix you need a a PKI and postgres server setup for certificate based auth. 

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

Fixes # (issue)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
