### PR TITLE
Feature: add percetage bar for file types in statistics section

### DIFF
--- a/src-ui/src/app/components/dashboard/widgets/statistics-widget/statistics-widget.component.html
+++ b/src-ui/src/app/components/dashboard/widgets/statistics-widget/statistics-widget.component.html
@@ -13,14 +13,33 @@
         <ng-container i18n>Total characters</ng-container>:
         <span class="badge bg-secondary text-light rounded-pill">{{statistics?.character_count | number}}</span>
       </div>
-      <div class="list-group-item d-flex justify-content-between align-items-center">
-        <div class="flex-grow-1"><ng-container i18n>File types</ng-container>:</div>
-        <div class="d-flex flex-column flex-grow-1 filetypes-list">
-          <div *ngFor="let filetype of statistics?.document_file_type_counts; let i = index" class="d-flex justify-content-between align-items-center">
-            <span class="fst-italic text-muted text-truncate pe-3">{{filetype.mime_type}}</span>
-            <span class="badge bg-secondary text-light rounded-pill">{{getFileTypePercent(filetype) | number: '1.0-1'}}%</span>
-          </div>
+
+      <div class="list-group-item widget-container">
+        <div class="file-type-bar">
+          <ng-container
+            *ngFor="
+              let fileType of fileTypeDataArray;
+              let isFirst = first;
+              let isLast = last
+            "
+          >
+            <div
+              class="file-type"
+              [style.width.%]="fileType.percentage"
+              [style.backgroundColor]="fileType.color"
+              [ngClass]="{ 'rounded-left': isFirst, 'rounded-right': isLast }"
+            ></div>
+          </ng-container>
         </div>
+        <ng-container *ngFor="let fileType of fileTypeDataArray">
+          <div class="file-type-label">
+            <div
+              class="file-type-color"
+              [style.backgroundColor]="fileType.color"
+            ></div>
+            <span>{{ fileType.name }} ({{ fileType.percentage }}%)</span>
+          </div>
+        </ng-container>
       </div>
     </div>
   </ng-container>

--- a/src-ui/src/app/components/dashboard/widgets/statistics-widget/statistics-widget.component.scss
+++ b/src-ui/src/app/components/dashboard/widgets/statistics-widget/statistics-widget.component.scss
@@ -1,7 +1,26 @@
-.flex-column {
-    row-gap: 0.2rem;
+.file-type-bar {
+  display: flex;
+  height: 10px;
+  margin-bottom: 10px;
 }
-
-.filetypes-list {
-    max-width: 75%;
+.file-type {
+  height: 100%;
+}
+.file-type-label {
+  align-items: center;
+  float: left;
+  padding-right: 10px;
+}
+.file-type-color {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  display: inline-block;
+  margin-right: 5px;
+}
+.rounded-left {
+  border-radius: 5px 0 0 5px;
+}
+.rounded-right {
+  border-radius: 0 5px 5px 0;
 }


### PR DESCRIPTION
## Proposed change

This PR adds a GitHub like distribution bar for document types.

![image](https://user-images.githubusercontent.com/1324555/226176404-ebadabf5-7f0e-4c6f-910e-b52d42e09be2.png)

![image](https://user-images.githubusercontent.com/1324555/226176703-2c0b891f-1a55-4baf-a52a-77c5ea332155.png)


Build upon #2910

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] ~~I have made corresponding changes to the documentation as needed.~~
- [x] I have checked my modifications for any breaking changes.
