### PR TITLE
Fix: Consumer polling could overwhelm database

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -332,3 +332,16 @@ change the port gunicorn listens on.
 
 To fix this, set `PAPERLESS_PORT` again to your desired port, or the
 default of 8000.
+
+## Database Warns about unique constraint "documents_tag_name_uniq
+
+You may see database log lines like:
+
+```
+ERROR:  duplicate key value violates unique constraint "documents_tag_name_uniq"
+DETAIL:  Key (name)=(NameF) already exists.
+STATEMENT:  INSERT INTO "documents_tag" ("owner_id", "name", "match", "matching_algorithm", "is_insensitive", "color", "is_inbox_tag") VALUES (NULL, 'NameF', '', 1, true, '#a6cee3', false) RETURNING "documents_tag"."id"
+```
+
+This can happen during heavy consumption when using polling. Paperless will handle it correctly and the file
+will still be consumed


### PR DESCRIPTION

## Proposed change

When a user has configured polling, the handler for events created a new thread for each event, an event roughly being a file.  In cases where a large number of files have been copied to the consume directory, this will result in a thread per event.  In my testing, I copied in around 700 files, across multiple subdirectories, which spawns about that many threads.

If the consumer is recursive and creating tags from directories, that means each thread is trying to open a database connection.  This results in `psycopg2.OperationalError: FATAL: sorry, too many clients already`, as each thread is a new client.  If the consumer is not creating tags from directories, this problem won't be visible.

To resolve this, the number of threads waiting for a file to be "ready" is restricted.  For the moment, I chose a pool size of 4, not configurable.  The resulting client count will be pool workers + task workers + 3 (from other sources).

inotify based consumption does not suffer this issue, as the events are processed serially, not delegated to a new thread.

Discovered while looking at #2919, but I'm not sure they are using polling or not.

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
