### PR TITLE
Feature: Capture celery and kombu logs to a file

### DIFF
--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -28,7 +28,7 @@ stderr_logfile_maxbytes=0
 
 [program:celery]
 
-command = celery --app paperless worker --loglevel INFO
+command = celery --app paperless worker --loglevel INFO --without-mingle --without-gossip
 user=paperless
 stopasgroup = true
 stopwaitsecs = 60

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -611,11 +611,20 @@ LOGGING = {
             "maxBytes": LOGROTATE_MAX_SIZE,
             "backupCount": LOGROTATE_MAX_BACKUPS,
         },
+        "file_celery": {
+            "class": "concurrent_log_handler.ConcurrentRotatingFileHandler",
+            "formatter": "verbose",
+            "filename": os.path.join(LOGGING_DIR, "celery.log"),
+            "maxBytes": LOGROTATE_MAX_SIZE,
+            "backupCount": LOGROTATE_MAX_BACKUPS,
+        },
     },
     "root": {"handlers": ["console"]},
     "loggers": {
         "paperless": {"handlers": ["file_paperless"], "level": "DEBUG"},
         "paperless_mail": {"handlers": ["file_mail"], "level": "DEBUG"},
+        "celery": {"handlers": ["file_celery"], "level": "DEBUG"},
+        "kombu": {"handlers": ["file_celery"], "level": "DEBUG"},
     },
 }
 


### PR DESCRIPTION

## Proposed change

Not really a fix for #2787, but perhaps having the logs captured will allow further debugging or a better bug report to celery.

I also disabled gossip and mingle, which are only relevant if you're running multiple workers in a cluster to allow synchronization between workers.

Fixes # (issue)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
