### PR TITLE
Cover all cases of plaintext doc colors

### DIFF
--- a/src-ui/src/app/components/document-detail/document-detail.component.html
+++ b/src-ui/src/app/components/document-detail/document-detail.component.html
@@ -208,7 +208,7 @@
             </ng-template>
         </ng-container>
         <ng-container *ngIf="getContentType() === 'text/plain'">
-            <object [data]="previewUrl | safeUrl" type="text/plain" class="preview-sticky bg-white" width="100%"></object>
+            <object [data]="previewUrl | safeUrl" type="text/plain" class="preview-sticky bg-light" width="100%"></object>
         </ng-container>
         <div *ngIf="requiresPassword" class="password-prompt">
             <form>

--- a/src-ui/src/theme.scss
+++ b/src-ui/src/theme.scss
@@ -246,10 +246,6 @@ $form-check-radio-checked-bg-image-dark: url("data:image/svg+xml,<svg xmlns='htt
       background-color: rgb(var(--bs-dark-rgb)) !important;
     }
   }
-
-  .preview-sticky.bg-white {
-    background-color: var(--pngx-bg-darker) !important;
-  }
 }
 
 body.color-scheme-dark {
@@ -279,5 +275,27 @@ body.color-scheme-dark {
     }
 
     @include dark-mode;
+  }
+}
+
+// For bkgd of plain text docs OS color scheme sets text color see #3012
+@media (prefers-color-scheme: dark) {
+  .preview-sticky.bg-light {
+    background-color: var(--bs-gray-800) !important; // dark --bs-light
+  }
+
+  body.color-scheme-system,
+  body.color-scheme-dark {
+    .preview-sticky.bg-light {
+      background-color: var(--pngx-bg-darker) !important;
+    }
+  }
+}
+
+@media not (prefers-color-scheme: dark) {
+  body.color-scheme-dark {
+    .preview-sticky.bg-light {
+      background-color: var(--bs-gray-400) !important;
+    }
   }
 }


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Turns out the logic behind colors for plaintext docs is a bit more complicated than I had considered. To explain (this explanation is frankly just checking my logic out loud, its not that exciting):

- The color of the text of these docs is determined by color scheme preference from browser or OS, we can detect this but not change the text color (alternatives to actually e.g. inject CSS here seem don't seem viable, unless someone knows otherwise...).
- Thus we need to handle a few permutations, e.g. if user "prefers" dark = text will be light vs "not prefers dark" = text will be dark. From there we need to know if user is using system settings / dark mode or not. Screenshots below which I think cover them all (browser chrome shows you what the system setting is). For example, user in the linked issue will have "not prefers dark" but paperless "enable dark mode" which corresponds to one of the weird-ish cases where the app is dark but these docs will need a lighter background since text will be black.

<img width="1840" alt="Screenshot 2023-04-03 at 9 02 25 AM" src="https://user-images.githubusercontent.com/4887959/229571479-255acd30-e272-40ab-a6e9-ae4db75a4695.png">
<img width="1840" alt="Screenshot 2023-04-03 at 9 02 36 AM" src="https://user-images.githubusercontent.com/4887959/229571489-a0ba2360-a27f-479b-a7da-3cd50b178eb8.png">
<img width="1840" alt="Screenshot 2023-04-03 at 9 02 20 AM" src="https://user-images.githubusercontent.com/4887959/229571467-bbdec087-37e0-4326-81da-8beeb1d96f3b.png">
<img width="1840" alt="Screenshot 2023-04-03 at 9 02 40 AM" src="https://user-images.githubusercontent.com/4887959/229571493-ac26a335-bbda-47d7-baf6-4d378a369325.png">

Fixes #3004 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
