### PR TITLE
v1.14.0 delete document fixes

### DIFF
--- a/src-ui/src/app/components/document-detail/document-detail.component.html
+++ b/src-ui/src/app/components/document-detail/document-detail.component.html
@@ -5,7 +5,7 @@
       <div class="input-group-text" i18n>of {{previewNumPages}}</div>
     </div>
 
-    <button type="button" class="btn btn-sm btn-outline-danger me-2 ms-auto" (click)="delete()" [disabled]="!userIsOwner">
+    <button type="button" class="btn btn-sm btn-outline-danger me-2 ms-auto" (click)="delete()" [disabled]="!userIsOwner" *appIfPermissions="{ action: PermissionAction.Delete, type: PermissionType.Document }">
         <svg class="buttonicon" fill="currentColor">
             <use xlink:href="assets/bootstrap-icons.svg#trash" />
         </svg><span class="d-none d-lg-inline ps-1" i18n>Delete</span>

--- a/src-ui/src/app/components/document-detail/document-detail.component.ts
+++ b/src-ui/src/app/components/document-detail/document-detail.component.ts
@@ -496,7 +496,7 @@ export class DocumentDetailComponent
             this.toastService.showError(
               $localize`Error saving document` +
                 ': ' +
-                (error.message ?? error.toString())
+                (error.error?.detail ?? error.message ?? JSON.stringify(error))
             )
           }
         },
@@ -541,7 +541,7 @@ export class DocumentDetailComponent
           this.toastService.showError(
             $localize`Error saving document` +
               ': ' +
-              (error.message ?? error.toString())
+              (error.error?.detail ?? error.message ?? JSON.stringify(error))
           )
         },
       })
@@ -573,6 +573,10 @@ export class DocumentDetailComponent
     modal.componentInstance.message = $localize`The files for this document will be deleted permanently. This operation cannot be undone.`
     modal.componentInstance.btnClass = 'btn-danger'
     modal.componentInstance.btnCaption = $localize`Delete document`
+    this.subscribeModalDelete(modal) // so can be re-subscribed if error
+  }
+
+  subscribeModalDelete(modal) {
     modal.componentInstance.confirmClicked
       .pipe(
         switchMap(() => {
@@ -581,18 +585,21 @@ export class DocumentDetailComponent
         })
       )
       .pipe(takeUntil(this.unsubscribeNotifier))
-      .subscribe(
-        () => {
+      .subscribe({
+        next: () => {
           modal.close()
           this.close()
         },
-        (error) => {
+        error: (error) => {
           this.toastService.showError(
-            $localize`Error deleting document: ${JSON.stringify(error)}`
+            $localize`Error deleting document: ${
+              error.error?.detail ?? error.message ?? JSON.stringify(error)
+            }`
           )
           modal.componentInstance.buttonsEnabled = true
-        }
-      )
+          this.subscribeModalDelete(modal)
+        },
+      })
   }
 
   moreLike() {


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

This fixes a couple small things in the beta, the first couple noted in the linked issue:

- Delete button shouldn't be visible at all if user doesn't have global delete permissions
- Error display when user didn't have permissions wasn't great
- After error the Delete button didn't work a second time

Fixes #3016

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
