### PR TITLE
Fix consumer ignore pattern for macOS .DS_Store

### DIFF
--- a/src/documents/tests/test_management_consumer.py
+++ b/src/documents/tests/test_management_consumer.py
@@ -271,25 +271,11 @@ class TestConsumer(DirectoriesMixin, ConsumerThreadMixin, TransactionTestCase):
                 "ignore": False,
             },
             {
-                "path": os.path.join(self.dirs.consumption_dir, ".DS_STORE", "foo.pdf"),
+                "path": os.path.join(self.dirs.consumption_dir, ".DS_STORE"),
                 "ignore": True,
             },
             {
-                "path": os.path.join(
-                    self.dirs.consumption_dir,
-                    "foo",
-                    ".DS_STORE",
-                    "bar.pdf",
-                ),
-                "ignore": True,
-            },
-            {
-                "path": os.path.join(
-                    self.dirs.consumption_dir,
-                    ".DS_STORE",
-                    "foo",
-                    "bar.pdf",
-                ),
+                "path": os.path.join(self.dirs.consumption_dir, ".DS_Store"),
                 "ignore": True,
             },
             {

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -710,7 +710,7 @@ CONSUMER_IGNORE_PATTERNS = list(
     json.loads(
         os.getenv(
             "PAPERLESS_CONSUMER_IGNORE_PATTERNS",
-            '[".DS_STORE/*", "._*", ".stfolder/*", ".stversions/*", ".localized/*", "desktop.ini", "@eaDir/*"]',  # noqa: E501
+            '[".DS_Store", ".DS_STORE", "._*", ".stfolder/*", ".stversions/*", ".localized/*", "desktop.ini", "@eaDir/*"]',  # noqa: E501
         ),
     ),
 )


### PR DESCRIPTION

<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

The current ignore patterns includes ".DS_STORE" which does not reflect the current MacOS filename ".DS_Store". While MacOS and Windows are generally "cicp" the glob patterns are case *sensitive* when run via Docker (=Linux=case sensitive). Whilst it is easy to add this pattern via an environment variable, as it represents an entire operating system, it seems reasonable to make the change.

I left ".DS_STORE" as it may be relevant for MacOS files transferred via other filesystems where case may not always be preserved.

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

Fixes # (issue)

Webserver logs an error when encountering ".DS_Store" files on MacOS via Docker.
```
[2023-04-16 21:04:32,191] [WARNING] [paperless.management.consumer] Not consuming file /usr/src/paperless/consume/.DS_Store: Unknown file extension.
```

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (please explain)

Non-breaking change to modify current behaviour. Not really a bug.

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
