### PR TITLE
Fix: Allow setting additional Django settings for proxies

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -453,6 +453,33 @@ redirect the user back to the SSO application's logout page.
 
     Defaults to None, which disables this feature.
 
+`PAPERLESS_USE_X_FORWARD_HOST=<bool>`
+
+: Configures the Django setting [USE_X_FORWARDED_HOST](https://docs.djangoproject.com/en/4.2/ref/settings/#use-x-forwarded-host)
+which may be needed for hosting behind a proxy.
+
+    Defaults to False
+
+`PAPERLESS_USE_X_FORWARD_PORT=<bool>`
+
+: Configures the Django setting [USE_X_FORWARDED_PORT](https://docs.djangoproject.com/en/4.2/ref/settings/#use-x-forwarded-port)
+which may be needed for hosting behind a proxy.
+
+    Defaults to False
+
+`PAPERLESS_PROXY_SSL_HEADER=<json-list>`
+
+: Configures the Django setting [SECURE_PROXY_SSL_HEADER](https://docs.djangoproject.com/en/4.2/ref/settings/#secure-proxy-ssl-header)
+which may be needed for hosting behind a proxy. The two values in the list will form the tuple of
+HTTP header/value expected by Django, eg `'["HTTP_X_FORWARDED_PROTO", "https"]'`.
+
+    Defaults to None
+
+!!! warning
+
+    Settings this value has security implications.  Read the Django documentation
+    and be sure you understand its usage before setting it.
+
 ## OCR settings {#ocr}
 
 Paperless uses [OCRmyPDF](https://ocrmypdf.readthedocs.io/en/latest/)

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -431,6 +431,14 @@ if _paperless_url:
 # For use with trusted proxies
 TRUSTED_PROXIES = __get_list("PAPERLESS_TRUSTED_PROXIES")
 
+USE_X_FORWARDED_HOST = __get_boolean("PAPERLESS_USE_X_FORWARD_HOST", "false")
+USE_X_FORWARDED_PORT = __get_boolean("PAPERLESS_USE_X_FORWARD_PORT", "false")
+SECURE_PROXY_SSL_HEADER = (
+    tuple(json.loads(os.environ["PAPERLESS_PROXY_SSL_HEADER"]))
+    if "PAPERLESS_PROXY_SSL_HEADER" in os.environ
+    else None
+)
+
 # The secret key has a default that should be fine so long as you're hosting
 # Paperless on a closed network.  However, if you're putting this anywhere
 # public, you should change the key to something unique and verbose.


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Adds additional hosting configuration options, which may be needed for some proxy setups and configurations for Django to treat the request as secure or not.  They're all passthrough for setting a Django setting and keep the Django defaults if not set.

Fixes #3130

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
