### PR TITLE
Fix: Handle delete mail action with no filters

### DIFF
--- a/src/paperless_mail/mail.py
+++ b/src/paperless_mail/mail.py
@@ -381,7 +381,7 @@ def make_criterias(rule):
 
     rule_query = get_rule_action(rule).get_criteria()
     if isinstance(rule_query, dict):
-        if len(rule_query) != 0 or len(criterias) != 0:
+        if len(rule_query) or len(criterias):
             return AND(**rule_query, **criterias)
     else:
         return AND(rule_query, **criterias)

--- a/src/paperless_mail/mail.py
+++ b/src/paperless_mail/mail.py
@@ -381,7 +381,8 @@ def make_criterias(rule):
 
     rule_query = get_rule_action(rule).get_criteria()
     if isinstance(rule_query, dict):
-        return AND(**rule_query, **criterias)
+        if len(rule_query) != 0 or len(criterias) != 0:
+            return AND(**rule_query, **criterias)
     else:
         return AND(rule_query, **criterias)
 

--- a/src/paperless_mail/tests/test_mail.py
+++ b/src/paperless_mail/tests/test_mail.py
@@ -612,6 +612,29 @@ class TestMail(
 
         self.assertEqual(len(self.bogus_mailbox.messages), 1)
 
+    def test_handle_mail_account_delete_no_filters(self):
+
+        account = MailAccount.objects.create(
+            name="test",
+            imap_server="",
+            username="admin",
+            password="secret",
+        )
+
+        _ = MailRule.objects.create(
+            name="testrule",
+            account=account,
+            action=MailRule.MailAction.DELETE,
+            maximum_age=0,
+        )
+
+        self.assertEqual(len(self.bogus_mailbox.messages), 3)
+
+        self.mail_account_handler.handle_mail_account(account)
+        self.apply_mail_actions()
+
+        self.assertEqual(len(self.bogus_mailbox.messages), 0)
+
     def test_handle_mail_account_flag(self):
         account = MailAccount.objects.create(
             name="test",


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Fixes the linked issue. The reason the current tests didnt catch this is because `maximum_age` defaults to 30 so the tests were actually passing in that criteria (if you use 0 its left off entirely), you can see in the screenshot the test I added fails before applying this fix.

<img width="946" alt="Screenshot 2023-04-24 at 8 53 21 PM" src="https://user-images.githubusercontent.com/4887959/234171082-210abe9f-7c48-4302-9098-b69ede2bf9d8.png">

Fixes #3160

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- ~~[ ] I have made corresponding changes to the documentation as needed.~~
- [x] I have checked my modifications for any breaking changes.
