### PR TITLE
Fix typos and wrong version number in doc

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -204,7 +204,7 @@ for details.
 
 ## Permissions
 
-As of version 1.13.0 Paperless-ngx added core support for user / group permissions. Permissions is
+As of version 1.14.0 Paperless-ngx added core support for user / group permissions. Permissions is
 based around an object 'owner' and 'view' and 'edit' permissions can be granted to other users
 or groups.
 
@@ -212,13 +212,13 @@ Permissions uses the built-in user model of the backend framework, Django.
 
 !!! note
 
-    After migration to version 1.13.0 all existing documents, tags etc. will have no explicit owner
+    After migration to version 1.14.0 all existing documents, tags etc. will have no explicit owner
     set which means they will be visible / editable by all users. Once an object has an owner set,
     only the owner can explicitly grant / revoke permissions.
 
 !!! note
 
-    When first migrating to permissions it is recommended to user a 'superuser' account (which
+    When first migrating to permissions it is recommended to use a 'superuser' account (which
     would usually have been setup during installation) to ensure you have full permissions.
 
     Note that superusers have access to all objects.
@@ -230,7 +230,7 @@ do not have an owner set.
 
 ### Users and Groups
 
-Paperless-ngx versions after 1.13.0 allow creating and editing users and groups via the 'frontend' UI.
+Paperless-ngx versions after 1.14.0 allow creating and editing users and groups via the 'frontend' UI.
 These can be found under Settings > Users & Groups, assuming the user has access. If a user is designated
 as a member of a group those permissions will be inherited and this is reflected in the UI. Explicit
 permissions can be granted to limit access to certain parts of the UI (and corresponding API endpoints).


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Fixed some typos in the documentation, under basic usage, in the section for the new users & groups feature. Mainly there it was stating version 1.13 instead of 1.14 for the new feature.

Fixes # (issue)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [ x ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ x ] I have made corresponding changes to the documentation as needed.
- [ x ] I have checked my modifications for any breaking changes.
