### PR TITLE
Fix: dropdown Private items with empty set

### DIFF
--- a/src-ui/src/app/components/common/input/select/select.component.ts
+++ b/src-ui/src/app/components/common/input/select/select.component.ts
@@ -43,8 +43,8 @@ export class SelectComponent extends AbstractInputComponent<number> {
   }
 
   checkForPrivateItems(value: any) {
-    if (Array.isArray(value) && value.length > 0) {
-      value.forEach((id) => this.checkForPrivateItem(id))
+    if (Array.isArray(value)) {
+      if (value.length > 0) value.forEach((id) => this.checkForPrivateItem(id))
     } else {
       this.checkForPrivateItem(value)
     }


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Basically a code error. The linked issue actually throws an error in the JS console, as demonstrated in this fix it doesn't any longer (and more importantly doesn't create a phantom group)

Fixes #3178

https://user-images.githubusercontent.com/4887959/234475157-2ea4178b-3ced-4087-93a0-06980ddfbf47.mov

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] ~~I have made corresponding changes to the documentation as needed.~~
- [x] I have checked my modifications for any breaking changes.
