### PR TITLE
Fix: reduce frequency of permissions queries to speed up v1.14.0

### DIFF
--- a/src-ui/cypress/e2e/documents/document-detail.cy.ts
+++ b/src-ui/cypress/e2e/documents/document-detail.cy.ts
@@ -5,11 +5,15 @@ describe('document-detail', () => {
     this.modifiedDocuments = []
 
     cy.fixture('documents/documents.json').then((documentsJson) => {
-      cy.intercept('GET', 'http://localhost:8000/api/documents/1/', (req) => {
-        let response = { ...documentsJson }
-        response = response.results.find((d) => d.id == 1)
-        req.reply(response)
-      })
+      cy.intercept(
+        'GET',
+        'http://localhost:8000/api/documents/1/?full_perms=true',
+        (req) => {
+          let response = { ...documentsJson }
+          response = response.results.find((d) => d.id == 1)
+          req.reply(response)
+        }
+      )
     })
 
     cy.intercept('PUT', 'http://localhost:8000/api/documents/1/', (req) => {

--- a/src-ui/cypress/fixtures/documents/documents.json
+++ b/src-ui/cypress/fixtures/documents/documents.json
@@ -21,6 +21,7 @@
             "original_file_name": "2022-03-22 no latin title.pdf",
             "archived_file_name": "2022-03-22 no latin title.pdf",
             "owner": null,
+            "user_can_change": true,
             "permissions": {
                 "view": {
                     "users": [],
@@ -68,6 +69,7 @@
             "original_file_name": "2022-03-23 lorem ipsum dolor sit amet.pdf",
             "archived_file_name": "2022-03-23 llorem ipsum dolor sit amet.pdf",
             "owner": null,
+            "user_can_change": true,
             "permissions": {
                 "view": {
                     "users": [],
@@ -98,6 +100,7 @@
             "original_file_name": "2022-03-24 dolor.pdf",
             "archived_file_name": "2022-03-24 dolor.pdf",
             "owner": null,
+            "user_can_change": true,
             "permissions": {
                 "view": {
                     "users": [],
@@ -128,6 +131,7 @@
             "original_file_name": "2022-06-01 sit amet.pdf",
             "archived_file_name": "2022-06-01 sit amet.pdf",
             "owner": null,
+            "user_can_change": true,
             "permissions": {
                 "view": {
                     "users": [],

--- a/src-ui/src/app/components/manage/management-list/management-list.component.ts
+++ b/src-ui/src/app/components/manage/management-list/management-list.component.ts
@@ -122,7 +122,8 @@ export abstract class ManagementListComponent<T extends ObjectWithId>
         null,
         this.sortField,
         this.sortReverse,
-        this._nameFilter
+        this._nameFilter,
+        true
       )
       .subscribe((c) => {
         this.data = c.results

--- a/src-ui/src/app/data/object-with-permissions.ts
+++ b/src-ui/src/app/data/object-with-permissions.ts
@@ -16,4 +16,6 @@ export interface ObjectWithPermissions extends ObjectWithId {
   owner?: number
 
   permissions?: PermissionsObject
+
+  user_can_change?: boolean
 }

--- a/src-ui/src/app/services/permissions.service.ts
+++ b/src-ui/src/app/services/permissions.service.ts
@@ -58,17 +58,24 @@ export class PermissionsService {
     action: string,
     object: ObjectWithPermissions
   ): boolean {
-    let actionObject = null
-    if (action === PermissionAction.View) actionObject = object.permissions.view
-    else if (action === PermissionAction.Change)
-      actionObject = object.permissions.change
-    if (!actionObject) return false
-    return (
-      this.currentUserOwnsObject(object) ||
-      actionObject.users.includes(this.currentUser.id) ||
-      actionObject.groups.filter((g) => this.currentUser.groups.includes(g))
-        .length > 0
-    )
+    if (action === PermissionAction.View) {
+      return (
+        this.currentUserOwnsObject(object) ||
+        object.permissions?.view.users.includes(this.currentUser.id) ||
+        object.permissions?.view.groups.filter((g) =>
+          this.currentUser.groups.includes(g)
+        ).length > 0
+      )
+    } else if (action === PermissionAction.Change) {
+      return (
+        this.currentUserOwnsObject(object) ||
+        object.user_can_change ||
+        object.permissions?.change.users.includes(this.currentUser.id) ||
+        object.permissions?.change.groups.filter((g) =>
+          this.currentUser.groups.includes(g)
+        ).length > 0
+      )
+    }
   }
 
   public getPermissionCode(

--- a/src-ui/src/app/services/rest/abstract-name-filter-service.ts
+++ b/src-ui/src/app/services/rest/abstract-name-filter-service.ts
@@ -9,11 +9,15 @@ export abstract class AbstractNameFilterService<
     pageSize?: number,
     sortField?: string,
     sortReverse?: boolean,
-    nameFilter?: string
+    nameFilter?: string,
+    fullPerms?: boolean
   ) {
     let params = {}
     if (nameFilter) {
-      params = { name__icontains: nameFilter }
+      params['name__icontains'] = nameFilter
+    }
+    if (fullPerms) {
+      params['full_perms'] = true
     }
     return this.list(page, pageSize, sortField, sortReverse, params)
   }

--- a/src-ui/src/app/services/rest/document.service.ts
+++ b/src-ui/src/app/services/rest/document.service.ts
@@ -113,6 +113,14 @@ export class DocumentService extends AbstractPaperlessService<PaperlessDocument>
     }).pipe(map((response) => response.results.map((doc) => doc.id)))
   }
 
+  get(id: number): Observable<PaperlessDocument> {
+    return this.http.get<PaperlessDocument>(this.getResourceUrl(id), {
+      params: {
+        full_perms: true,
+      },
+    })
+  }
+
   getPreviewUrl(id: number, original: boolean = false): string {
     let url = this.getResourceUrl(id, 'preview')
     if (this._searchQuery) url += `#search="${this._searchQuery}"`

--- a/src/documents/tests/test_api.py
+++ b/src/documents/tests/test_api.py
@@ -3396,6 +3396,36 @@ class TestApiAuth(DirectoriesMixin, APITestCase):
             status.HTTP_404_NOT_FOUND,
         )
 
+    def test_dynamic_permissions_fields(self):
+        Document.objects.create(title="Test", content="content 1", checksum="1")
+
+        user1 = User.objects.create_superuser(username="test1")
+        self.client.force_authenticate(user1)
+
+        response = self.client.get(
+            "/api/documents/",
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        resp_data = response.json()
+
+        self.assertNotIn("permissions", resp_data["results"][0])
+        self.assertIn("user_can_change", resp_data["results"][0])
+
+        response = self.client.get(
+            "/api/documents/?full_perms=true",
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        resp_data = response.json()
+
+        self.assertIn("permissions", resp_data["results"][0])
+        self.assertNotIn("user_can_change", resp_data["results"][0])
+
 
 class TestApiRemoteVersion(DirectoriesMixin, APITestCase):
     ENDPOINT = "/api/remote_version/"

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -156,6 +156,10 @@ class PassUserMixin(CreateModelMixin):
 
     def get_serializer(self, *args, **kwargs):
         kwargs.setdefault("user", self.request.user)
+        kwargs.setdefault(
+            "full_perms",
+            self.request.query_params.get("full_perms", False),
+        )
         return super().get_serializer(*args, **kwargs)
 
 
@@ -274,6 +278,10 @@ class DocumentViewSet(
         kwargs.setdefault("context", self.get_serializer_context())
         kwargs.setdefault("fields", fields)
         kwargs.setdefault("truncate_content", truncate_content.lower() in ["true", "1"])
+        kwargs.setdefault(
+            "full_perms",
+            self.request.query_params.get("full_perms", False),
+        )
         return serializer_class(*args, **kwargs)
 
     def update(self, request, *args, **kwargs):


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

This PR addresses slower loading in 1.14 due to permissions. The basic issue is that I did not appreciate how expensive those operations are (presumably as they are much more noticeable on lower-powered machines), so they were being run for e.g. each document in a list, this changes them to run only if requested `?full_perms=true` (dont love that query var?). Otherwise we just return a less expensive `user_can_change` since the doc won't even be included in the list if the user doesn't have view perms.

In my testing (and [OP of linked issue](https://github.com/paperless-ngx/paperless-ngx/discussions/3169#discussioncomment-5734310)) this significantly improves the number of queries.

I would appreciate eyes / testing on this, the image `feature-reduce-permissions-queries` can be used (once built). Its not a total overhaul but significant-enough I want to double-check there are no accidental regressions.

Fixes #3169
Fixes #3164 (should have left as issue)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
