### PR TITLE
Fix: advanced search or date searching + doc type/correspondent/storage path broken

### DIFF
--- a/src/documents/index.py
+++ b/src/documents/index.py
@@ -172,6 +172,14 @@ class DelayedQuery:
         for k, v in self.query_params.items():
             if k == "correspondent__id":
                 criterias.append(query.Term("correspondent_id", v))
+            elif k == "correspondent__id__in":
+                for correspondent_id in v.split(","):
+                    criterias.append(query.Term("correspondent_id", correspondent_id))
+            elif k == "correspondent__id__none":
+                for correspondent_id in v.split(","):
+                    criterias.append(
+                        query.Not(query.Term("correspondent_id", correspondent_id)),
+                    )
             elif k == "tags__id__all":
                 for tag_id in v.split(","):
                     criterias.append(query.Term("tag_id", tag_id))
@@ -180,6 +188,12 @@ class DelayedQuery:
                     criterias.append(query.Not(query.Term("tag_id", tag_id)))
             elif k == "document_type__id":
                 criterias.append(query.Term("type_id", v))
+            elif k == "document_type__id__in":
+                for document_type_id in v.split(","):
+                    criterias.append(query.Term("type_id", document_type_id))
+            elif k == "document_type__id__none":
+                for document_type_id in v.split(","):
+                    criterias.append(query.Not(query.Term("type_id", document_type_id)))
             elif k == "correspondent__isnull":
                 criterias.append(query.Term("has_correspondent", v == "false"))
             elif k == "is_tagged":
@@ -200,6 +214,12 @@ class DelayedQuery:
                 criterias.append(query.DateRange("added", start=None, end=isoparse(v)))
             elif k == "storage_path__id":
                 criterias.append(query.Term("path_id", v))
+            elif k == "storage_path__id__in":
+                for storage_path_id in v.split(","):
+                    criterias.append(query.Term("path_id", storage_path_id))
+            elif k == "storage_path__id__none":
+                for storage_path_id in v.split(","):
+                    criterias.append(query.Not(query.Term("path_id", storage_path_id)))
             elif k == "storage_path__isnull":
                 criterias.append(query.Term("has_path", v == "false"))
 

--- a/src/documents/tests/test_api.py
+++ b/src/documents/tests/test_api.py
@@ -955,8 +955,32 @@ class TestDocumentApi(DirectoriesMixin, DocumentConsumeDelayMixin, APITestCase):
             [d1.id, d2.id, d5.id, d7.id],
         )
         self.assertCountEqual(search_query("&correspondent__id=" + str(c.id)), [d1.id])
+        self.assertCountEqual(
+            search_query("&correspondent__id__in=" + str(c.id)),
+            [d1.id],
+        )
+        self.assertCountEqual(
+            search_query("&correspondent__id__none=" + str(c.id)),
+            [d2.id, d3.id, d4.id, d5.id, d7.id],
+        )
         self.assertCountEqual(search_query("&document_type__id=" + str(dt.id)), [d2.id])
+        self.assertCountEqual(
+            search_query("&document_type__id__in=" + str(dt.id)),
+            [d2.id],
+        )
+        self.assertCountEqual(
+            search_query("&document_type__id__none=" + str(dt.id)),
+            [d1.id, d3.id, d4.id, d5.id, d7.id],
+        )
         self.assertCountEqual(search_query("&storage_path__id=" + str(sp.id)), [d7.id])
+        self.assertCountEqual(
+            search_query("&storage_path__id__in=" + str(sp.id)),
+            [d7.id],
+        )
+        self.assertCountEqual(
+            search_query("&storage_path__id__none=" + str(sp.id)),
+            [d1.id, d2.id, d3.id, d4.id, d5.id],
+        )
 
         self.assertCountEqual(
             search_query("&storage_path__isnull"),


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

This is because of #2893 because the new query vars are `object__id__in` and `object__id__none` which weren't included in the list when using whoosh searches (e.g. date or advanced search)

Fixes #3206

<img width="1840" alt="Screenshot 2023-04-27 at 7 59 49 AM" src="https://user-images.githubusercontent.com/4887959/234906541-0a398c91-b136-4b3e-8967-01493a3cdb48.png">
<img width="1840" alt="Screenshot 2023-04-27 at 7 59 45 AM" src="https://user-images.githubusercontent.com/4887959/234906569-c2a4bc5b-7536-4f66-b6a8-5e9f41bb3434.png">


## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
