### PR TITLE
Fix MixedContentTypeError in add_inbox_tags handler

### DIFF
--- a/src/documents/signals/handlers.py
+++ b/src/documents/signals/handlers.py
@@ -37,7 +37,7 @@ def add_inbox_tags(sender, document=None, logging_group=None, **kwargs):
     if document.owner is not None:
         tags = get_objects_for_user_owner_aware(
             document.owner,
-            "documents.view_documenttype",
+            "documents.view_tag",
             Tag,
         )
     else:


### PR DESCRIPTION
## Proposed change

The fact that Tags were fetched while the `view_documenttype` permission was validated caused a MixedContentTypeError, thus the document consumptio to fail because the list of available tags could not be fetched.

I noticed this when I packaged 1.14.1 for NixOS/nixpkgs and had [the integration tests](https://github.com/NixOS/nixpkgs/blob/76a85de7a731a037f44f1fcc81165c934c66b0a2/nixos/tests/paperless.nix#L18-L43) fail on me. 

Relevant error log:

```log
vm-test-run-paperless> machine # [   87.672169] celery[1560]: [2023-04-27 16:05:18,452] [DEBUG] [paperless.parsing.tesseract] Using text from sidecar file
vm-test-run-paperless> machine # [   87.674322] celery[1560]: [2023-04-27 16:05:18,454] [DEBUG] [paperless.consumer] Generating thumbnail for webdoc.png...
vm-test-run-paperless> machine # [   87.678704] celery[1560]: [2023-04-27 16:05:18,458] [DEBUG] [paperless.parsing] Execute: convert -density 300 -scale 500x5000> -alpha remove -strip -auto-orient /tmp/paperless/paperless-fyyqcghy/archive.pdf[0] /tmp/paperless/paperless-fyyqcghy/convert.webp
vm-test-run-paperless> machine # [   88.815407] celery[1560]: [2023-04-27 16:05:19,595] [DEBUG] [paperless.classifier] Document classification model does not exist (yet), not performing automatic matching.
vm-test-run-paperless> machine # [   88.826019] celery[1560]: [2023-04-27 16:05:19,605] [DEBUG] [paperless.consumer] Saving record to database
vm-test-run-paperless> machine # [   88.827754] celery[1560]: [2023-04-27 16:05:19,607] [DEBUG] [paperless.consumer] Creation date from parse_date: 2005-10-16 00:00:00+00:00
vm-test-run-paperless> machine # [   88.853377] celery[1560]: [2023-04-27 16:05:19,627] [ERROR] [paperless.consumer] The following error occurred while consuming webdoc.png: Content type for given perms and klass differs
vm-test-run-paperless> machine # [   88.855761] celery[1560]: Traceback (most recent call last):
vm-test-run-paperless> machine # [   88.858292] celery[1560]:   File "/nix/store/gzx1sskclpph1cq8p436j80vx7mnqgc1-paperless-ngx-1.14.1/lib/paperless-ngx/src/documents/consumer.py", line 434, in try_consume_file
vm-test-run-paperless> machine # [   88.867826] celery[1560]:     document_consumption_finished.send(
vm-test-run-paperless> machine # [   88.869693] celery[1560]:   File "/nix/store/cgrfqj4wmhsczsjfbls213q2phwjlya0-python3.10-Django-4.2/lib/python3.10/site-packages/django/dispatch/dispatcher.py", line 176, in send
vm-test-run-paperless> machine # [   88.874768] celery[1560]:     return [
vm-test-run-paperless> machine # [   88.875556] celery[1560]:   File "/nix/store/cgrfqj4wmhsczsjfbls213q2phwjlya0-python3.10-Django-4.2/lib/python3.10/site-packages/django/dispatch/dispatcher.py", line 177, in <listcomp>
vm-test-run-paperless> machine # [   88.881647] celery[1560]:     (receiver, receiver(signal=self, sender=sender, **named))
vm-test-run-paperless> machine # [   88.882702] celery[1560]:   File "/nix/store/gzx1sskclpph1cq8p436j80vx7mnqgc1-paperless-ngx-1.14.1/lib/paperless-ngx/src/documents/signals/handlers.py", line 38, in add_inbox_tags
vm-test-run-paperless> machine # [   88.885613] celery[1560]:     tags = get_objects_for_user_owner_aware(
vm-test-run-paperless> machine # [   88.891565] celery[1560]:   File "/nix/store/gzx1sskclpph1cq8p436j80vx7mnqgc1-paperless-ngx-1.14.1/lib/paperless-ngx/src/documents/permissions.py", line 111, in get_objects_for_user_owner_aware
vm-test-run-paperless> machine # [   88.894208] celery[1560]:     objects_with_perms = get_objects_for_user(
vm-test-run-paperless> machine # [   88.895165] celery[1560]:   File "/nix/store/w27ppsxv6ygn20snj0k0dg3bwf9h8b7z-python3.10-django-guardian-2.4.0/lib/python3.10/site-packages/guardian/shortcuts.py", line 534, in get_objects_for_user
vm-test-run-paperless> machine # [   88.900491] celery[1560]:     raise MixedContentTypeError("Content type for given perms and "
vm-test-run-paperless> machine # [   88.901727] celery[1560]: guardian.exceptions.MixedContentTypeError: Content type for given perms and klass differs
vm-test-run-paperless> machine # [   88.907508] celery[1560]: [2023-04-27 16:05:19,632] [DEBUG] [paperless.parsing.tesseract] Deleting directory /tmp/paperless/paperless-fyyqcghy
vm-test-run-paperless> machine # [   88.938551] celery[1560]: [2023-04-27 16:05:19,718] [ERROR] [celery.app.trace] Task documents.tasks.consume_file[0596f796-fd95-405d-bf11-b7e5e3e4202f] raised unexpected: ExceptionWithTraceback()
vm-test-run-paperless> machine # [   88.942568] celery[1560]: Traceback (most recent call last):
vm-test-run-paperless> machine # [   88.943294] celery[1560]:   File "/nix/store/xqdd0grnacgskvr6qad7fbacy9dy67vn-python3.10-celery-5.2.7/lib/python3.10/site-packages/celery/app/trace.py", line 451, in trace_task
vm-test-run-paperless> machine # [   88.948531] celery[1560]:     R = retval = fun(*args, **kwargs)
vm-test-run-paperless> machine # [   88.950429] celery[1560]:   File "/nix/store/xqdd0grnacgskvr6qad7fbacy9dy67vn-python3.10-celery-5.2.7/lib/python3.10/site-packages/celery/app/trace.py", line 734, in __protected_call__
vm-test-run-paperless> machine # [   88.954311] celery[1560]:     return self.run(*args, **kwargs)
vm-test-run-paperless> machine # [   88.958498] celery[1560]:   File "/nix/store/gzx1sskclpph1cq8p436j80vx7mnqgc1-paperless-ngx-1.14.1/lib/paperless-ngx/src/documents/tasks.py", line 190, in consume_file
vm-test-run-paperless> machine # [   88.960607] celery[1560]:     document = Consumer().try_consume_file(
vm-test-run-paperless> machine # [   88.962208] celery[1560]:   File "/nix/store/gzx1sskclpph1cq8p436j80vx7mnqgc1-paperless-ngx-1.14.1/lib/paperless-ngx/src/documents/consumer.py", line 493, in try_consume_file
vm-test-run-paperless> machine # [   88.968564] celery[1560]:     self._fail(
vm-test-run-paperless> machine # [   88.969168] celery[1560]:   File "/nix/store/gzx1sskclpph1cq8p436j80vx7mnqgc1-paperless-ngx-1.14.1/lib/paperless-ngx/src/documents/consumer.py", line 96, in _fail
vm-test-run-paperless> machine # [   88.971678] celery[1560]:     raise ConsumerError(f"{self.filename}: {log_message or message}") from exception
vm-test-run-paperless> machine # [   88.976743] celery[1560]: billiard.einfo.ExceptionWithTraceback:
vm-test-run-paperless> machine # [   88.978437] celery[1560]: """
vm-test-run-paperless> machine # [   88.979022] celery[1560]: Traceback (most recent call last):
vm-test-run-paperless> machine # [   88.986620] celery[1560]:   File "/nix/store/a6l0smx9i52idmykwggdqkjxc64wz2xz-python3.10-asgiref-3.6.0/lib/python3.10/site-packages/asgiref/sync.py", line 302, in main_wrap
vm-test-run-paperless> machine # [   88.993673] celery[1560]:     raise exc_info[1]
vm-test-run-paperless> machine # [   88.994734] celery[1560]:   File "/nix/store/gzx1sskclpph1cq8p436j80vx7mnqgc1-paperless-ngx-1.14.1/lib/paperless-ngx/src/documents/consumer.py", line 434, in try_consume_file
vm-test-run-paperless> machine # [   89.005116] celery[1560]:     document_consumption_finished.send(
vm-test-run-paperless> machine # [   89.006035] celery[1560]:   File "/nix/store/cgrfqj4wmhsczsjfbls213q2phwjlya0-python3.10-Django-4.2/lib/python3.10/site-packages/django/dispatch/dispatcher.py", line 176, in send
vm-test-run-paperless> machine # [   89.011216] celery[1560]:     return [
vm-test-run-paperless> machine # [   89.012653] celery[1560]:   File "/nix/store/cgrfqj4wmhsczsjfbls213q2phwjlya0-python3.10-Django-4.2/lib/python3.10/site-packages/django/dispatch/dispatcher.py", line 177, in <listcomp>
vm-test-run-paperless> machine # [   89.017577] celery[1560]:     (receiver, receiver(signal=self, sender=sender, **named))
vm-test-run-paperless> machine # [   89.019597] celery[1560]:   File "/nix/store/gzx1sskclpph1cq8p436j80vx7mnqgc1-paperless-ngx-1.14.1/lib/paperless-ngx/src/documents/signals/handlers.py", line 38, in add_inbox_tags
vm-test-run-paperless> machine # [   89.024488] celery[1560]:     tags = get_objects_for_user_owner_aware(
vm-test-run-paperless> machine # [   89.025331] celery[1560]:   File "/nix/store/gzx1sskclpph1cq8p436j80vx7mnqgc1-paperless-ngx-1.14.1/lib/paperless-ngx/src/documents/permissions.py", line 111, in get_objects_for_user_owner_aware
vm-test-run-paperless> machine # [   89.031540] celery[1560]:     objects_with_perms = get_objects_for_user(
vm-test-run-paperless> machine # [   89.032459] celery[1560]:   File "/nix/store/w27ppsxv6ygn20snj0k0dg3bwf9h8b7z-python3.10-django-guardian-2.4.0/lib/python3.10/site-packages/guardian/shortcuts.py", line 534, in get_objects_for_user
vm-test-run-paperless> machine # [   89.035639] celery[1560]:     raise MixedContentTypeError("Content type for given perms and "
vm-test-run-paperless> machine # [   89.041568] celery[1560]: guardian.exceptions.MixedContentTypeError: Content type for given perms and klass differs
vm-test-run-paperless> machine # [   89.043171] celery[1560]: The above exception was the direct cause of the following exception:
vm-test-run-paperless> machine # [   89.044556] celery[1560]: Traceback (most recent call last):
vm-test-run-paperless> machine # [   89.046440] celery[1560]:   File "/nix/store/xqdd0grnacgskvr6qad7fbacy9dy67vn-python3.10-celery-5.2.7/lib/python3.10/site-packages/celery/app/trace.py", line 451, in trace_task
vm-test-run-paperless> machine # [   89.050529] celery[1560]:     R = retval = fun(*args, **kwargs)
vm-test-run-paperless> machine # [   89.052374] celery[1560]:   File "/nix/store/xqdd0grnacgskvr6qad7fbacy9dy67vn-python3.10-celery-5.2.7/lib/python3.10/site-packages/celery/app/trace.py", line 734, in __protected_call__
vm-test-run-paperless> machine # [   89.059407] celery[1560]:     return self.run(*args, **kwargs)
vm-test-run-paperless> machine # [   89.060507] celery[1560]:   File "/nix/store/gzx1sskclpph1cq8p436j80vx7mnqgc1-paperless-ngx-1.14.1/lib/paperless-ngx/src/documents/tasks.py", line 190, in consume_file
vm-test-run-paperless> machine # [   89.062887] celery[1560]:     document = Consumer().try_consume_file(
vm-test-run-paperless> machine # [   89.066087] celery[1560]:   File "/nix/store/gzx1sskclpph1cq8p436j80vx7mnqgc1-paperless-ngx-1.14.1/lib/paperless-ngx/src/documents/consumer.py", line 493, in try_consume_file
vm-test-run-paperless> machine # [   89.072541] celery[1560]:     self._fail(
vm-test-run-paperless> machine # [   89.073142] celery[1560]:   File "/nix/store/gzx1sskclpph1cq8p436j80vx7mnqgc1-paperless-ngx-1.14.1/lib/paperless-ngx/src/documents/consumer.py", line 96, in _fail
vm-test-run-paperless> machine # [   89.074950] celery[1560]:     raise ConsumerError(f"{self.filename}: {log_message or message}") from exception
vm-test-run-paperless> machine # [   89.079589] celery[1560]: documents.consumer.ConsumerError: webdoc.png: The following error occurred while consuming webdoc.png: Content type for given perms and klass differs
vm-test-run-paperless> machine # [   89.082508] celery[1560]: """
```

The full test output is available at https://bin.moritz-fromm.de/?fc9b38c0e7d6a9bc#E7w5JzUwsFrZ787JSA2z5U9nqdzNhYKDFhgF13WGk785 (too long for GitHub)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
