### PR TITLE
Fix: ALLOWED_HOSTS logic being overwritten when * is set

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -322,8 +322,7 @@ You can read more about this in [the Django project's documentation](https://doc
 
     Can also be set using PAPERLESS_URL (see above).
 
-    If manually set, please remember to include "localhost". Otherwise
-    docker healthcheck will fail.
+    "localhost" is always allowed for docker healthcheck
 
     Defaults to "\*", which is all hosts.
 

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -425,7 +425,7 @@ if _paperless_url:
 
 if ["*"] != ALLOWED_HOSTS:
     # always allow localhost. Necessary e.g. for healthcheck in docker.
-    ALLOWED_HOSTS.append(["localhost"])
+    ALLOWED_HOSTS.append("localhost")
     if _paperless_url:
         ALLOWED_HOSTS.append(_paperless_uri.hostname)
 

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -422,11 +422,12 @@ if _paperless_url:
     _paperless_uri = urlparse(_paperless_url)
     CSRF_TRUSTED_ORIGINS.append(_paperless_url)
     CORS_ALLOWED_ORIGINS.append(_paperless_url)
-    if ["*"] != ALLOWED_HOSTS:
+
+if ["*"] != ALLOWED_HOSTS:
+    # always allow localhost. Necessary e.g. for healthcheck in docker.
+    ALLOWED_HOSTS.append(["localhost"])
+    if _paperless_url:
         ALLOWED_HOSTS.append(_paperless_uri.hostname)
-    else:
-        # always allow localhost. Necessary e.g. for healthcheck in docker.
-        ALLOWED_HOSTS = [_paperless_uri.hostname] + ["localhost"]
 
 # For use with trusted proxies
 TRUSTED_PROXIES = __get_list("PAPERLESS_TRUSTED_PROXIES")


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

1. If ALLOWED_HOSTS = ["*"], do nothing
2. If ALLOWED_HOSTS != ["*"] append `localhost`
3. If ALLOWED_HOSTS != ["*"] and `PAPERLESS_URL` is defined, append `localhost` and `_paperless_uri.hostname`

Fixes #3214 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
