### PR TITLE
Fix: Respect superuser for advanced queries, test coverage for object perms

### DIFF
--- a/src/documents/index.py
+++ b/src/documents/index.py
@@ -225,15 +225,19 @@ class DelayedQuery:
 
         user_criterias = [query.Term("has_owner", False)]
         if "user" in self.query_params:
-            user_criterias.append(query.Term("owner_id", self.query_params["user"]))
-            user_criterias.append(
-                query.Term("viewer_id", str(self.query_params["user"])),
-            )
+            if self.query_params["is_superuser"]:  # superusers see all docs
+                user_criterias = []
+            else:
+                user_criterias.append(query.Term("owner_id", self.query_params["user"]))
+                user_criterias.append(
+                    query.Term("viewer_id", str(self.query_params["user"])),
+                )
         if len(criterias) > 0:
-            criterias.append(query.Or(user_criterias))
+            if len(user_criterias) > 0:
+                criterias.append(query.Or(user_criterias))
             return query.And(criterias)
         else:
-            return query.Or(user_criterias)
+            return query.Or(user_criterias) if len(user_criterias) > 0 else None
 
     def _get_query_sortedby(self):
         if "ordering" not in self.query_params:

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -604,6 +604,9 @@ class UnifiedSearchViewSet(DocumentViewSet):
                 # pass user to query for perms
                 self.request.query_params._mutable = True
                 self.request.query_params["user"] = self.request.user.id
+                self.request.query_params[
+                    "is_superuser"
+                ] = self.request.user.is_superuser
                 self.request.query_params._mutable = False
 
             if "query" in self.request.query_params:


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Lotta PRs today! Im not 100% positive if this fixes #3221 but I think so (hard to nail down the exact conditions described by OP) but this is a bug. Superusers are not currently shown all docs for whoosh (advanced) queries. When we changed the behavior for superusers (they can see all docs) this wasn't incorporated into advanced queries. This is all because we basically have to re-create all of the filtering logic for whoosh queries.

This fixes that issue and adds test coverage for that (running that test on `dev` demonstrates this), I also added coverage for object perms with whoosh queries (which I believe is already working as shown by the test).

Fixes #3221 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
