### PR TITLE
Retain doc changes on tab switch after refresh doc

### DIFF
--- a/src-ui/src/app/components/document-detail/document-detail.component.ts
+++ b/src-ui/src/app/components/document-detail/document-detail.component.ts
@@ -236,10 +236,21 @@ export class DocumentDetailComponent
             true
           )
           this.suggestions = null
-          if (this.openDocumentService.getOpenDocument(this.documentId)) {
-            this.updateComponent(
-              this.openDocumentService.getOpenDocument(this.documentId)
-            )
+          const openDocument = this.openDocumentService.getOpenDocument(
+            this.documentId
+          )
+          if (openDocument) {
+            if (this.documentForm.dirty) {
+              Object.assign(openDocument, this.documentForm.value)
+              openDocument['owner'] =
+                this.documentForm.get('permissions_form').value['owner']
+              openDocument['permissions'] =
+                this.documentForm.get('permissions_form').value[
+                  'set_permissions'
+                ]
+              delete openDocument['permissions_form']
+            }
+            this.updateComponent(openDocument)
           } else {
             this.openDocumentService.openDocument(doc)
             this.updateComponent(doc)


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Trickier than it seemed but in the end a simple fix to retain any changes on tab switch. See video.


https://user-images.githubusercontent.com/4887959/235289654-ee2cf9c9-2780-4dee-ba53-0f5027f7a2ef.mov


Fixes #3229

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
