### PR TITLE
Fix: Handle cases where media files aren't all in the same filesystem

### DIFF
--- a/src/documents/management/commands/document_thumbnails.py
+++ b/src/documents/management/commands/document_thumbnails.py
@@ -10,8 +10,8 @@ from documents.models import Document
 from documents.parsers import get_parser_class_for_mime_type
 
 
-def _process_document(doc_in):
-    document: Document = Document.objects.get(id=doc_in)
+def _process_document(doc_id):
+    document: Document = Document.objects.get(id=doc_id)
     parser_class = get_parser_class_for_mime_type(document.mime_type)
 
     if parser_class:

--- a/src/documents/signals/handlers.py
+++ b/src/documents/signals/handlers.py
@@ -429,12 +429,12 @@ def update_filename_and_move_files(sender, instance: Document, **kwargs):
             if move_original:
                 validate_move(instance, old_source_path, instance.source_path)
                 create_source_path_directory(instance.source_path)
-                os.rename(old_source_path, instance.source_path)
+                shutil.move(old_source_path, instance.source_path)
 
             if move_archive:
                 validate_move(instance, old_archive_path, instance.archive_path)
                 create_source_path_directory(instance.archive_path)
-                os.rename(old_archive_path, instance.archive_path)
+                shutil.move(old_archive_path, instance.archive_path)
 
             # Don't save() here to prevent infinite recursion.
             Document.objects.filter(pk=instance.pk).update(
@@ -453,11 +453,11 @@ def update_filename_and_move_files(sender, instance: Document, **kwargs):
             try:
                 if move_original and os.path.isfile(instance.source_path):
                     logger.info("Restoring previous original path")
-                    os.rename(instance.source_path, old_source_path)
+                    shutil.move(instance.source_path, old_source_path)
 
                 if move_archive and os.path.isfile(instance.archive_path):
                     logger.info("Restoring previous archive path")
-                    os.rename(instance.archive_path, old_archive_path)
+                    shutil.move(instance.archive_path, old_archive_path)
 
             except Exception:
                 # This is fine, since:

--- a/src/documents/tests/test_file_handling.py
+++ b/src/documents/tests/test_file_handling.py
@@ -697,7 +697,7 @@ class TestFileHandlingWithArchive(DirectoriesMixin, FileSystemAssertsMixin, Test
         self.assertIsFile(doc.archive_path)
 
     @override_settings(FILENAME_FORMAT="{correspondent}/{title}")
-    @mock.patch("documents.signals.handlers.os.rename")
+    @mock.patch("documents.signals.handlers.shutil.move")
     def test_move_archive_error(self, m):
         def fake_rename(src, dst):
             if "archive" in str(src):
@@ -748,7 +748,7 @@ class TestFileHandlingWithArchive(DirectoriesMixin, FileSystemAssertsMixin, Test
         self.assertIsFile(doc.archive_path)
 
     @override_settings(FILENAME_FORMAT="{correspondent}/{title}")
-    @mock.patch("documents.signals.handlers.os.rename")
+    @mock.patch("documents.signals.handlers.shutil.move")
     def test_move_file_error(self, m):
         def fake_rename(src, dst):
             if "original" in str(src):

--- a/src/documents/tests/test_management_thumbnails.py
+++ b/src/documents/tests/test_management_thumbnails.py
@@ -47,12 +47,16 @@ class TestMakeThumbnails(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
         self.assertIsFile(self.d1.thumbnail_path)
 
     @mock.patch("documents.management.commands.document_thumbnails.shutil.move")
-    def test_process_document_invalid_mime_type(self, m):
+    def test_process_document_invalid_mime_type(self, m: mock.Mock):
         self.d1.mime_type = "asdasdasd"
         self.d1.save()
 
+        # .save() triggers filename handling
+        m.reset_mock()
+
         _process_document(self.d1.id)
 
+        # Not called during processing of document
         m.assert_not_called()
 
     def test_command(self):


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Small fix for the odd case where a user has mounted specific folders within media, causing renames to be across filesystem.  shutil handles it with a copy/delete cycle.

Fixes #3257 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
