### PR TITLE
Fix: Prevent erroneous warning when starting container

### DIFF
--- a/docker/env-from-file.sh
+++ b/docker/env-from-file.sh
@@ -15,6 +15,10 @@ do
 	env_name=${line%%=*}
 	# Check if it starts with "PAPERLESS_" and ends in "_FILE"
 	if [[ ${env_name} == PAPERLESS_*_FILE ]]; then
+		# This should have been named different..
+		if [[ ${env_name} == "PAPERLESS_OCR_SKIP_ARCHIVE_FILE" ]]; then
+			continue
+		fi
 		# Extract the value of the environment
 		env_value=${line#*=}
 


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Noticed in #3244, there is a warning output when using this setting, because it looks like a user trying to set something via a secret, but the file won't exist, because they aren't.

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
