### PR TITLE
Fix: permission-aware bulk editing in 1.14.1+

### DIFF
--- a/src/documents/tests/test_api.py
+++ b/src/documents/tests/test_api.py
@@ -3533,9 +3533,28 @@ class TestApiAuth(DirectoriesMixin, APITestCase):
         )
 
     def test_dynamic_permissions_fields(self):
-        Document.objects.create(title="Test", content="content 1", checksum="1")
+        user1 = User.objects.create_user(username="user1")
+        user1.user_permissions.add(*Permission.objects.filter(codename="view_document"))
+        user2 = User.objects.create_user(username="user2")
 
-        user1 = User.objects.create_superuser(username="test1")
+        Document.objects.create(title="Test", content="content 1", checksum="1")
+        doc2 = Document.objects.create(
+            title="Test2",
+            content="content 2",
+            checksum="2",
+            owner=user2,
+        )
+        doc3 = Document.objects.create(
+            title="Test3",
+            content="content 3",
+            checksum="3",
+            owner=user2,
+        )
+
+        assign_perm("view_document", user1, doc2)
+        assign_perm("view_document", user1, doc3)
+        assign_perm("change_document", user1, doc3)
+
         self.client.force_authenticate(user1)
 
         response = self.client.get(
@@ -3549,6 +3568,9 @@ class TestApiAuth(DirectoriesMixin, APITestCase):
 
         self.assertNotIn("permissions", resp_data["results"][0])
         self.assertIn("user_can_change", resp_data["results"][0])
+        self.assertEqual(resp_data["results"][0]["user_can_change"], True)  # doc1
+        self.assertEqual(resp_data["results"][1]["user_can_change"], False)  # doc2
+        self.assertEqual(resp_data["results"][2]["user_can_change"], True)  # doc3
 
         response = self.client.get(
             "/api/documents/?full_perms=true",

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -270,11 +270,9 @@ class DocumentViewSet(
         return Document.objects.distinct().annotate(num_notes=Count("notes"))
 
     def get_serializer(self, *args, **kwargs):
-        super().get_serializer(*args, **kwargs)
         fields_param = self.request.query_params.get("fields", None)
         fields = fields_param.split(",") if fields_param else None
         truncate_content = self.request.query_params.get("truncate_content", "False")
-        serializer_class = self.get_serializer_class()
         kwargs.setdefault("context", self.get_serializer_context())
         kwargs.setdefault("fields", fields)
         kwargs.setdefault("truncate_content", truncate_content.lower() in ["true", "1"])
@@ -282,7 +280,7 @@ class DocumentViewSet(
             "full_perms",
             self.request.query_params.get("full_perms", False),
         )
-        return serializer_class(*args, **kwargs)
+        return super().get_serializer(*args, **kwargs)
 
     def update(self, request, *args, **kwargs):
         response = super().update(request, *args, **kwargs)


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

This was related to #3201, its a simple fix as you can see, the `super()` call (calls `PassUserMixin`) as-is doesn't actually pass the user as it should...

Fixes #3341

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
