### PR TITLE
Add links to third-party REST API clients in documentation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -323,3 +323,18 @@ Initial API version.
   color to use for a specific tag, which is either black or white
   depending on the brightness of `Tag.color`.
 - Removed field `Tag.colour`.
+
+### Third-party clients
+
+!!! note
+
+    The Paperless project provides no support for the third-party client
+    implementations.
+
+*   Dart:
+    [astubenbord/paperless-mobile](https://github.com/astubenbord/paperless-mobile/)
+    uses its own API client.
+*   Go: [hansmi/paperhooks](https://github.com/hansmi/paperhooks/) is a toolkit
+    for writing consumption hooks and includes a REST API client.
+*   Python: [tb1337/paperless-api](https://github.com/tb1337/paperless-api) is
+    an asynchronous wrapper for the REST API.


### PR DESCRIPTION
## Proposed change

Add a section to the [REST API documentation](https://docs.paperless-ngx.com/api/) listing third-party clients.

## Type of change

Documentation only.

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
