### PR TITLE
Add  SSL Support for MariaDB

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -87,12 +87,12 @@ changed here.
 
     See [the official documentation about
     sslmode for PostgreSQL](https://www.postgresql.org/docs/current/libpq-ssl.html).
-    
+
     See [the official documentation about
-    sslmode for MySQL and MariaDB](https://dev.mysql.com/doc/refman/8.0/en/connection-options.html#option_general_ssl-mode)
-    
+    sslmode for MySQL and MariaDB](https://dev.mysql.com/doc/refman/8.0/en/connection-options.html#option_general_ssl-mode).
+
     *Note*: SSL mode values differ between PostgreSQL and MariaDB.
-    
+
     Default is `prefer` for PostgreSQL and `PREFERRED` for MariaDB.
 
 `PAPERLESS_DBSSLROOTCERT=<ca-path>`
@@ -102,9 +102,9 @@ changed here.
     See [the official documentation about
     sslmode for PostgreSQL](https://www.postgresql.org/docs/current/libpq-ssl.html).
     Changes path of `root.crt`.
-    
+
     See [the official documentation about
-    sslmode for MySQL and MariaDB](https://dev.mysql.com/doc/refman/8.0/en/connection-options.html#option_general_ssl-ca)
+    sslmode for MySQL and MariaDB](https://dev.mysql.com/doc/refman/8.0/en/connection-options.html#option_general_ssl-ca).
 
     Defaults to unset, using the documented path in the home directory.
 
@@ -116,7 +116,7 @@ changed here.
     sslmode for PostgreSQL](https://www.postgresql.org/docs/current/libpq-ssl.html).
 
     See [the official documentation about
-    sslmode for MySQL and MariaDB](https://dev.mysql.com/doc/refman/8.0/en/connection-options.html#option_general_ssl-cert)
+    sslmode for MySQL and MariaDB](https://dev.mysql.com/doc/refman/8.0/en/connection-options.html#option_general_ssl-cert).
 
     Changes path of `postgresql.crt`.
 
@@ -128,10 +128,10 @@ changed here.
 
     See [the official documentation about
     sslmode for PostgreSQL](https://www.postgresql.org/docs/current/libpq-ssl.html).
-    
+
     See [the official documentation about
-    sslmode for MySQL and MariaDB](https://dev.mysql.com/doc/refman/8.0/en/connection-options.html#option_general_ssl-key)
-    
+    sslmode for MySQL and MariaDB](https://dev.mysql.com/doc/refman/8.0/en/connection-options.html#option_general_ssl-key).
+
     Changes path of `postgresql.key`.
 
     Defaults to unset, using the documented path in the home directory.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -83,20 +83,28 @@ changed here.
 
 `PAPERLESS_DBSSLMODE=<mode>`
 
-: SSL mode to use when connecting to PostgreSQL.
+: SSL mode to use when connecting to PostgreSQL or MariaDB.
 
     See [the official documentation about
-    sslmode](https://www.postgresql.org/docs/current/libpq-ssl.html).
-
-    Default is `prefer`.
+    sslmode for PostgreSQL](https://www.postgresql.org/docs/current/libpq-ssl.html).
+    
+    See [the official documentation about
+    sslmode for MySQL and MariaDB](https://dev.mysql.com/doc/refman/8.0/en/connection-options.html#option_general_ssl-mode)
+    
+    *Note*: SSL mode values differ between PostgreSQL and MariaDB.
+    
+    Default is `prefer` for PostgreSQL and `PREFERRED` for MariaDB.
 
 `PAPERLESS_DBSSLROOTCERT=<ca-path>`
 
 : SSL root certificate path
 
     See [the official documentation about
-    sslmode](https://www.postgresql.org/docs/current/libpq-ssl.html).
+    sslmode for PostgreSQL](https://www.postgresql.org/docs/current/libpq-ssl.html).
     Changes path of `root.crt`.
+    
+    See [the official documentation about
+    sslmode for MySQL and MariaDB](https://dev.mysql.com/doc/refman/8.0/en/connection-options.html#option_general_ssl-ca)
 
     Defaults to unset, using the documented path in the home directory.
 
@@ -105,7 +113,11 @@ changed here.
 : SSL client certificate path
 
     See [the official documentation about
-    sslmode](https://www.postgresql.org/docs/current/libpq-ssl.html).
+    sslmode for PostgreSQL](https://www.postgresql.org/docs/current/libpq-ssl.html).
+
+    See [the official documentation about
+    sslmode for MySQL and MariaDB](https://dev.mysql.com/doc/refman/8.0/en/connection-options.html#option_general_ssl-cert)
+
     Changes path of `postgresql.crt`.
 
     Defaults to unset, using the documented path in the home directory.
@@ -115,7 +127,11 @@ changed here.
 : SSL client key path
 
     See [the official documentation about
-    sslmode](https://www.postgresql.org/docs/current/libpq-ssl.html).
+    sslmode for PostgreSQL](https://www.postgresql.org/docs/current/libpq-ssl.html).
+    
+    See [the official documentation about
+    sslmode for MySQL and MariaDB](https://dev.mysql.com/doc/refman/8.0/en/connection-options.html#option_general_ssl-key)
+    
     Changes path of `postgresql.key`.
 
     Defaults to unset, using the documented path in the home directory.

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -506,7 +506,15 @@ if os.getenv("PAPERLESS_DBHOST"):
     # Leave room for future extensibility
     if os.getenv("PAPERLESS_DBENGINE") == "mariadb":
         engine = "django.db.backends.mysql"
-        options = {"read_default_file": "/etc/mysql/my.cnf", "charset": "utf8mb4"}
+        options = {
+            "read_default_file": "/etc/mysql/my.cnf", 
+            "charset": "utf8mb4",
+            "ssl": {
+                "ca": os.getenv("PAPERLESS_DBSSLROOTCERT", None),
+                "cert": os.getenv("PAPERLESS_DBSSLCERT", None),
+                "key": os.getenv("PAPERLESS_DBSSLKEY", None),
+            }
+        }
 
         # Silence Django error on old MariaDB versions.
         # VARCHAR can support > 255 in modern versions

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -507,14 +507,14 @@ if os.getenv("PAPERLESS_DBHOST"):
     if os.getenv("PAPERLESS_DBENGINE") == "mariadb":
         engine = "django.db.backends.mysql"
         options = {
-            "read_default_file": "/etc/mysql/my.cnf", 
+            "read_default_file": "/etc/mysql/my.cnf",
             "charset": "utf8mb4",
             "ssl": {
                 "ssl_mode": os.getenv("PAPERLESS_DBSSLMODE", "PREFERRED"),
                 "ca": os.getenv("PAPERLESS_DBSSLROOTCERT", None),
                 "cert": os.getenv("PAPERLESS_DBSSLCERT", None),
                 "key": os.getenv("PAPERLESS_DBSSLKEY", None),
-            }
+            },
         }
 
         # Silence Django error on old MariaDB versions.

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -510,6 +510,7 @@ if os.getenv("PAPERLESS_DBHOST"):
             "read_default_file": "/etc/mysql/my.cnf", 
             "charset": "utf8mb4",
             "ssl": {
+                "ssl_mode": os.getenv("PAPERLESS_DBSSLMODE", "PREFERRED"),
                 "ca": os.getenv("PAPERLESS_DBSSLROOTCERT", None),
                 "cert": os.getenv("PAPERLESS_DBSSLCERT", None),
                 "key": os.getenv("PAPERLESS_DBSSLKEY", None),


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

This PR adds SSL options for MariaDB/MySQL.
Note: `ssl_mode` values are a bit different than with postgresql.

From the docs: https://mysqlclient.readthedocs.io/user_guide.html#functions-and-attributes

> **ssl_mode**
> If present, specify the security settings for the connection to the server. For more information on ssl_mode, see the MySQL > > documentation. Only one of ‘DISABLED’, ‘PREFERRED’, ‘REQUIRED’, ‘VERIFY_CA’, ‘VERIFY_IDENTITY’ can be specified.
> 
> If not present, the session ssl_mode will be unchanged, but in version 5.7 and later, the default is PREFERRED.
> 
> This must be a keyword parameter.

Fixes #3434

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
