### PR TITLE
Chore: Improves the logging mixin and allows it to be typed better

### DIFF
--- a/src/documents/loggers.py
+++ b/src/documents/loggers.py
@@ -3,18 +3,16 @@ import uuid
 
 
 class LoggingMixin:
-    logging_group = None
-
-    logging_name = None
+    def __init__(self) -> None:
+        self.renew_logging_group()
 
     def renew_logging_group(self):
+        """
+        Creates a new UUID to group subsequent log calls together with
+        the extra data named group
+        """
         self.logging_group = uuid.uuid4()
-
-    def log(self, level, message, **kwargs):
-        if self.logging_name:
-            logger = logging.getLogger(self.logging_name)
-        else:
-            name = ".".join([self.__class__.__module__, self.__class__.__name__])
-            logger = logging.getLogger(name)
-
-        getattr(logger, level)(message, extra={"group": self.logging_group}, **kwargs)
+        self.log = logging.LoggerAdapter(
+            logging.getLogger(self.logging_name),
+            extra={"group": self.logging_group},
+        )

--- a/src/documents/parsers.py
+++ b/src/documents/parsers.py
@@ -328,7 +328,7 @@ class DocumentParser(LoggingMixin):
         try:
             text = filepath.read_text(encoding="utf-8")
         except UnicodeDecodeError as e:
-            self.log("warning", f"Unicode error during text reading, continuing: {e}")
+            self.log.warning(f"Unicode error during text reading, continuing: {e}")
             text = filepath.read_bytes().decode("utf-8", errors="replace")
         return text
 
@@ -354,5 +354,5 @@ class DocumentParser(LoggingMixin):
         return self.date
 
     def cleanup(self):
-        self.log("debug", f"Deleting directory {self.tempdir}")
+        self.log.debug(f"Deleting directory {self.tempdir}")
         shutil.rmtree(self.tempdir)

--- a/src/paperless_mail/parsers.py
+++ b/src/paperless_mail/parsers.py
@@ -64,8 +64,7 @@ class MailDocumentParser(DocumentParser):
         try:
             mail = self.get_parsed(document_path)
         except ParseError as e:
-            self.log(
-                "warning",
+            self.log.warning(
                 f"Error while fetching document metadata for {document_path}: {e}",
             )
             return result
@@ -146,7 +145,7 @@ class MailDocumentParser(DocumentParser):
         self.archive_path = self.generate_pdf(document_path)
 
     def tika_parse(self, html: str):
-        self.log("info", "Sending content to Tika server")
+        self.log.info("Sending content to Tika server")
 
         try:
             parsed = parser.from_buffer(html, self.tika_server)
@@ -251,7 +250,7 @@ class MailDocumentParser(DocumentParser):
 
     def generate_pdf_from_mail(self, mail):
         url = self.gotenberg_server + "/forms/chromium/convert/html"
-        self.log("info", "Converting mail to PDF")
+        self.log.info("Converting mail to PDF")
 
         css_file = os.path.join(os.path.dirname(__file__), "templates/output.css")
 
@@ -320,7 +319,7 @@ class MailDocumentParser(DocumentParser):
 
     def generate_pdf_from_html(self, orig_html, attachments):
         url = self.gotenberg_server + "/forms/chromium/convert/html"
-        self.log("info", "Converting html to PDF")
+        self.log.info("Converting html to PDF")
 
         files = {}
         for name, file in self.transform_inline_html(orig_html, attachments):

--- a/src/paperless_mail/tests/test_parsers.py
+++ b/src/paperless_mail/tests/test_parsers.py
@@ -129,8 +129,7 @@ class TestParser(FileSystemAssertsMixin, TestCase):
         )
         self.assertEqual(mocked_return, thumb)
 
-    @mock.patch("documents.loggers.LoggingMixin.log")
-    def test_extract_metadata_fail(self, m: mock.MagicMock):
+    def test_extract_metadata_fail(self):
         """
         GIVEN:
             - Fresh start
@@ -140,8 +139,12 @@ class TestParser(FileSystemAssertsMixin, TestCase):
             - A log warning should be generated
         """
         # Validate if warning is logged when parsing fails
-        self.assertEqual([], self.parser.extract_metadata("na", "message/rfc822"))
-        self.assertEqual("warning", m.call_args[0][0])
+        with self.assertLogs("paperless.parsing.mail", level="WARNING") as cm:
+            self.assertEqual([], self.parser.extract_metadata("na", "message/rfc822"))
+            self.assertIn(
+                "WARNING:paperless.parsing.mail:Error while fetching document metadata for na",
+                cm.output[0],
+            )
 
     def test_extract_metadata(self):
         """

--- a/src/paperless_tika/parsers.py
+++ b/src/paperless_tika/parsers.py
@@ -38,8 +38,7 @@ class TikaDocumentParser(DocumentParser):
         try:
             parsed = parser.from_file(document_path, tika_server)
         except Exception as e:
-            self.log(
-                "warning",
+            self.log.warning(
                 f"Error while fetching document metadata for {document_path}: {e}",
             )
             return []
@@ -55,7 +54,7 @@ class TikaDocumentParser(DocumentParser):
         ]
 
     def parse(self, document_path: Path, mime_type, file_name=None):
-        self.log("info", f"Sending {document_path} to Tika server")
+        self.log.info(f"Sending {document_path} to Tika server")
         tika_server = settings.TIKA_ENDPOINT
 
         # tika does not support a PathLike, only strings
@@ -75,8 +74,7 @@ class TikaDocumentParser(DocumentParser):
         try:
             self.date = dateutil.parser.isoparse(parsed["metadata"]["Creation-Date"])
         except Exception as e:
-            self.log(
-                "warning",
+            self.log.warning(
                 f"Unable to extract date for document {document_path}: {e}",
             )
 
@@ -87,7 +85,7 @@ class TikaDocumentParser(DocumentParser):
         gotenberg_server = settings.TIKA_GOTENBERG_ENDPOINT
         url = gotenberg_server + "/forms/libreoffice/convert"
 
-        self.log("info", f"Converting {document_path} to PDF as {pdf_path}")
+        self.log.info(f"Converting {document_path} to PDF as {pdf_path}")
         with open(document_path, "rb") as document_handle:
             files = {
                 "files": (


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Small change to the backend logging mixin so it doesn't require passing a string argument, then using getattr to actually do the log.  Creates an actual logger and directly uses that instead.

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (please explain) - Clean up

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
