### PR TITLE
consumer.py: read `create_date` from original file (instead of temp copy)

### DIFF
--- a/src/documents/consumer.py
+++ b/src/documents/consumer.py
@@ -530,7 +530,7 @@ class Consumer(LoggingMixin):
             create_date = date
             self.log.debug(f"Creation date from parse_date: {create_date}")
         else:
-            stats = os.stat(self.path)
+            stats = os.stat(self.original_path)
             create_date = timezone.make_aware(
                 datetime.datetime.fromtimestamp(stats.st_mtime),
             )


### PR DESCRIPTION
In line 328, `self.path` is set to a fresh written copy of the source file. This copy has a different timestamp (=now).

## Proposed change

When using the source file's timestamp as `create_date`, it makes much more sense to ask for the timestamp from `self.original_path`

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [X] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [X] I have checked my modifications for any breaking changes.
