### PR TITLE
Fix: prevent date suggestion search if disabled

### DIFF
--- a/src/documents/tests/test_api.py
+++ b/src/documents/tests/test_api.py
@@ -1948,6 +1948,29 @@ class TestDocumentApi(DirectoriesMixin, DocumentConsumeDelayMixin, APITestCase):
             },
         )
 
+    @mock.patch("documents.parsers.parse_date_generator")
+    @override_settings(NUMBER_OF_SUGGESTED_DATES=0)
+    def test_get_suggestions_dates_disabled(
+        self,
+        parse_date_generator,
+    ):
+        """
+        GIVEN:
+            - NUMBER_OF_SUGGESTED_DATES = 0 (disables feature)
+        WHEN:
+            - API reuqest for document suggestions
+        THEN:
+            - Dont check for suggested dates at all
+        """
+        doc = Document.objects.create(
+            title="test",
+            mime_type="application/pdf",
+            content="this is an invoice from 12.04.2022!",
+        )
+
+        self.client.get(f"/api/documents/{doc.pk}/suggestions/")
+        self.assertFalse(parse_date_generator.called)
+
     def test_saved_views(self):
         u1 = User.objects.create_superuser("user1")
         u2 = User.objects.create_superuser("user2")

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -422,10 +422,12 @@ class DocumentViewSet(
 
         classifier = load_classifier()
 
-        gen = parse_date_generator(doc.filename, doc.content)
-        dates = sorted(
-            {i for i in itertools.islice(gen, settings.NUMBER_OF_SUGGESTED_DATES)},
-        )
+        dates = []
+        if settings.NUMBER_OF_SUGGESTED_DATES > 0:
+            gen = parse_date_generator(doc.filename, doc.content)
+            dates = sorted(
+                {i for i in itertools.islice(gen, settings.NUMBER_OF_SUGGESTED_DATES)},
+            )
 
         return Response(
             {


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Tiny fix, just prevent date suggestion if the feature is disabled (`NUMBER_OF_SUGGESTED_DATES=0`).

Discovered in #2735

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
