### PR TITLE
Fix: DocumentSerializer should return correct original filename

### DIFF
--- a/src/documents/serialisers.py
+++ b/src/documents/serialisers.py
@@ -414,7 +414,7 @@ class DocumentSerializer(OwnedObjectSerializer, DynamicFieldsModelSerializer):
     )
 
     def get_original_file_name(self, obj):
-        return obj.get_public_filename()
+        return obj.original_filename
 
     def get_archived_file_name(self, obj):
         if obj.has_archive_version:

--- a/src/documents/tests/test_api.py
+++ b/src/documents/tests/test_api.py
@@ -579,6 +579,7 @@ class TestDocumentApi(DirectoriesMixin, DocumentConsumeDelayMixin, APITestCase):
             content="things i paid for in september",
             pk=3,
             checksum="C",
+            original_filename="someepdf.pdf",
         )
         with AsyncWriter(index.open_index()) as writer:
             # Note to future self: there is a reason we dont use a model signal handler to update the index: some operations edit many documents at once
@@ -598,6 +599,7 @@ class TestDocumentApi(DirectoriesMixin, DocumentConsumeDelayMixin, APITestCase):
         self.assertEqual(response.data["count"], 1)
         self.assertEqual(len(results), 1)
         self.assertCountEqual(response.data["all"], [d3.id])
+        self.assertEqual(results[0]["original_file_name"], "someepdf.pdf")
 
         response = self.client.get("/api/documents/?query=statement")
         results = response.data["results"]


### PR DESCRIPTION
## Proposed change
The DocumentSerializer does currently return the public filename instead of the original one in get_original_file_name(). This change fixes that.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
