### PR TITLE
Fix: exclude consumer & AnonymousUser users from export manifest

### DIFF
--- a/src/documents/management/commands/document_exporter.py
+++ b/src/documents/management/commands/document_exporter.py
@@ -250,7 +250,12 @@ class Command(BaseCommand):
 
             manifest += json.loads(serializers.serialize("json", Group.objects.all()))
 
-            manifest += json.loads(serializers.serialize("json", User.objects.all()))
+            manifest += json.loads(
+                serializers.serialize(
+                    "json",
+                    User.objects.exclude(username__in=["consumer", "AnonymousUser"]),
+                ),
+            )
 
             manifest += json.loads(
                 serializers.serialize("json", UiSettings.objects.all()),

--- a/src/documents/tests/test_management_exporter.py
+++ b/src/documents/tests/test_management_exporter.py
@@ -141,7 +141,14 @@ class TestExportImport(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
 
         manifest = self._do_export(use_filename_format=use_filename_format)
 
-        self.assertEqual(len(manifest), 12)
+        self.assertEqual(len(manifest), 10)
+
+        # dont include consumer or AnonymousUser users
+        self.assertEqual(
+            len(list(filter(lambda e: e["model"] == "auth.user", manifest))),
+            1,
+        )
+
         self.assertEqual(
             len(list(filter(lambda e: e["model"] == "documents.document", manifest))),
             4,


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

See linked issue, I dont think theres any reason to include `consumer` and `AnonymousUser` in exports since they get created with migrations. Am I missing anything here?

It comes from Django Guardian https://django-guardian.readthedocs.io/en/stable/configuration.html and will always (I think) get created by migrations anyway

Fixes #3484 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
