### PR TITLE
Fix: KeyError error on unauthenticated API calls & persist authentication when `HTTP_REMOTE_USER` enabled

### DIFF
--- a/src/paperless/auth.py
+++ b/src/paperless/auth.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.contrib import auth
-from django.contrib.auth.middleware import RemoteUserMiddleware
+from django.contrib.auth.middleware import PersistentRemoteUserMiddleware
 from django.contrib.auth.models import User
 from django.utils.deprecation import MiddlewareMixin
 from rest_framework import authentication
@@ -37,7 +37,7 @@ class AngularApiAuthenticationOverride(authentication.BaseAuthentication):
             return None
 
 
-class HttpRemoteUserMiddleware(RemoteUserMiddleware):
+class HttpRemoteUserMiddleware(PersistentRemoteUserMiddleware):
     """This class allows authentication via HTTP_REMOTE_USER which is set for
     example by certain SSO applications.
     """

--- a/src/paperless/signals.py
+++ b/src/paperless/signals.py
@@ -12,21 +12,21 @@ def handle_failed_login(sender, credentials, request, **kwargs):
     client_ip, _ = ipware.get_client_ip(
         meta=request.META,
     )
-    username = credentials.get("username") or "anonymous"
+    username = credentials.get("username")
+    log_output = (
+        "No authentication provided"
+        if username is None
+        else f"Login failed for user `{username}`"
+    )
 
     if client_ip is None:
-        logger.info(
-            f"Login failed for user `{username}`. Unable to determine IP address.",
-        )
+        log_output += ". Unable to determine IP address."
     else:
         if client_ip.is_global:
             # We got the client's IP address
-            logger.info(
-                f"Login failed for user `{username}` from IP `{client_ip}.`",
-            )
+            log_output += f" from IP `{client_ip}.`"
         else:
             # The client's IP address is private
-            logger.info(
-                f"Login failed for user `{username}`"
-                f" from private IP `{client_ip}.`",
-            )
+            log_output += f" from private IP `{client_ip}.`"
+
+    logger.info(log_output)

--- a/src/paperless/signals.py
+++ b/src/paperless/signals.py
@@ -12,22 +12,21 @@ def handle_failed_login(sender, credentials, request, **kwargs):
     client_ip, _ = ipware.get_client_ip(
         meta=request.META,
     )
+    username = credentials.get("username") or "anonymous"
 
     if client_ip is None:
         logger.info(
-            f"Login failed for user `{credentials['username']}`."
-            " Unable to determine IP address.",
+            f"Login failed for user `{username}`. Unable to determine IP address.",
         )
     else:
         if client_ip.is_global:
             # We got the client's IP address
             logger.info(
-                f"Login failed for user `{credentials['username']}`"
-                f" from IP `{client_ip}.`",
+                f"Login failed for user `{username}` from IP `{client_ip}.`",
             )
         else:
             # The client's IP address is private
             logger.info(
-                f"Login failed for user `{credentials['username']}`"
+                f"Login failed for user `{username}`"
                 f" from private IP `{client_ip}.`",
             )

--- a/src/paperless/tests/test_signals.py
+++ b/src/paperless/tests/test_signals.py
@@ -12,6 +12,26 @@ class TestFailedLoginLogging(TestCase):
             "username": "john lennon",
         }
 
+    def test_unauthenticated(self):
+        """
+        GIVEN:
+            - Request with no authentication provided
+        WHEN:
+            - Request provided to signal handler
+        THEN:
+            - Unable to determine logged for unauthenticated user
+        """
+        request = HttpRequest()
+        request.META = {}
+        with self.assertLogs("paperless.auth") as logs:
+            handle_failed_login(None, {}, request)
+            self.assertEqual(
+                logs.output,
+                [
+                    "INFO:paperless.auth:No authentication provided. Unable to determine IP address.",
+                ],
+            )
+
     def test_none(self):
         """
         GIVEN:


### PR DESCRIPTION
## Proposed change

### The problem

Enabling `ENABLE_HTTP_REMOTE_USER` makes all `/api/` endpoints completely useless, until the `HTTP_REMOTE_USER` header is sent. This is problematic for mobile applications, behined forward-auth guardians (like authelia), because even exposing `/api/` to them, doesn't help.

### Expected behavior

- User wants to have web app hidden behind reverse proxy with forwarding auth, and be auto-logged in via `HTTP_REMOTE_USER` header
- User also wants to use mobile application. To do so, he whitelists `/api/*` endpoints, so application can authenticate and work properly.

### Actual behavior

- Enabling `ENABLE_HTTP_REMOTE_USER`, makes all `/api/` endpoints return `500` if no remote-user header is sent, rendering all mobile apps unusable.

### Proposed solution

Unfortunatelly, I'm not a python dev, and I understand even less all magic in Django, but effectively the necessary patch (which this PR is attempting to do), should do two things:

- `/api` (root only) and `/api/token` endpoints needs to have authentication disabled completely. It doesn't make much sense anyway, as `/api/token` is used solely to authenticate, and `/api` only returns list of endpoints, which is also fine. I suggest whitelisting `/api`, because some clients (paperless-mobile for example) use it to check if server is alive. I managed to do this in dirty and hacky way in `urls.py` - it works, but I'm sure it can be done better :)
- `HttpRemoteUserMiddleware` should inherit from `PersistentRemoteUserMiddleware` instead of `RemoteUserMiddleware`. This is because, when user disabled forwarding-proxy on `/api` endpoints (to make mobile apps work), means these endpoints never receive `Remote-User` header. Since web-app uses `/api` as well, these requests will remain unauthenticated from web-app point of view. Switching to `PersistentRemoteUserMiddleware` solves this issue, as only one request with `Remote-User` header needs to be sent, for django to remember the session until logout. And conviniently - this is done, via root url of webapp, fetching main view.

Btw, probably some tests wouldn't also hurt, but as I mention - I have no idea how to do them, since I python is not my cup of tea - I'm also marking this PR as WIP, so somebody can pick it up and turn it into proper python code, as I'm unable to do it better :(

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
