### PR TITLE
Chore: Adds test for barcode ASN when it already exists

### DIFF
--- a/src/documents/consumer.py
+++ b/src/documents/consumer.py
@@ -69,7 +69,7 @@ class Consumer(LoggingMixin):
         status,
         message=None,
         document_id=None,
-    ):
+    ):  # pragma: no cover
         payload = {
             "filename": os.path.basename(self.filename) if self.filename else None,
             "task_id": self.task_id,
@@ -352,7 +352,7 @@ class Consumer(LoggingMixin):
 
         self.run_pre_consume_script()
 
-        def progress_callback(current_progress, max_progress):
+        def progress_callback(current_progress, max_progress):  # pragma: no cover
             # recalculate progress to be within 20 and 80
             p = int((current_progress / max_progress) * 50 + 20)
             self._send_progress(p, 100, "WORKING")


### PR DESCRIPTION
## Proposed change

Minor test update to include a new test for handling the case where an ASN read from a barcode is already assigned to a document.

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (please explain) - Small coverage update

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
