### PR TITLE
Chore: Copy file stats from original file

### DIFF
--- a/src/documents/barcodes.py
+++ b/src/documents/barcodes.py
@@ -180,6 +180,9 @@ class BarcodeReader:
         with scratch_image.open("rb") as img_file, self.pdf_file.open("wb") as pdf_file:
             pdf_file.write(img2pdf.convert(img_file))
 
+        # Copy what file stat is possible
+        shutil.copystat(self.file, self.pdf_file)
+
     def detect(self) -> None:
         """
         Scan all pages of the PDF as images, updating barcodes and the pages
@@ -292,6 +295,9 @@ class BarcodeReader:
                 savepath = Path(self.temp_dir.name) / output_filename
                 with open(savepath, "wb") as out:
                     dst.save(out)
+
+                shutil.copystat(self.file, savepath)
+
                 document_paths.append(savepath)
 
             return document_paths

--- a/src/documents/consumer.py
+++ b/src/documents/consumer.py
@@ -326,7 +326,7 @@ class Consumer(LoggingMixin):
             dir=settings.SCRATCH_DIR,
         )
         self.path = Path(tempdir.name) / Path(self.filename)
-        shutil.copy(self.original_path, self.path)
+        shutil.copy2(self.original_path, self.path)
 
         # Determine the parser class.
 
@@ -582,6 +582,7 @@ class Consumer(LoggingMixin):
     def _write(self, storage_type, source, target):
         with open(source, "rb") as read_file, open(target, "wb") as write_file:
             write_file.write(read_file.read())
+        shutil.copystat(source, target)
 
     def _log_script_outputs(self, completed_process: CompletedProcess):
         """


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

During certain cases a new file is either created, written to or a copy of the original.  In these cases, either copy the file with its stats or use copystat to copy them to a newly created file.

- When TIFF support for barcodes is enabled, copy the TIFF file stats to the created PDF
- When splitting a PDF to a new PDF, copy the original stats to each new file
- When creating a temporary copy of the original for working on, use copy2 instead of plain copy
- When writing the files to storage, copy the source file stats to destination file

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (please explain) - More metadata preservation

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
