### PR TITLE
Fix: handle mail rules with no filters on some imap servers

### DIFF
--- a/src/paperless_mail/mail.py
+++ b/src/paperless_mail/mail.py
@@ -384,6 +384,8 @@ def make_criterias(rule: MailRule, supports_gmail_labels: bool):
     if isinstance(rule_query, dict):
         if len(rule_query) or len(criterias):
             return AND(**rule_query, **criterias)
+        else:
+            return "ALL"
     else:
         return AND(rule_query, **criterias)
 

--- a/src/paperless_mail/tests/test_mail.py
+++ b/src/paperless_mail/tests/test_mail.py
@@ -721,6 +721,31 @@ class TestMail(
         self.assertEqual(len(self.bogus_mailbox.messages), 2)
         self.assertEqual(len(self.bogus_mailbox.messages_spam), 1)
 
+    def test_handle_mail_account_move_no_filters(self):
+        account = MailAccount.objects.create(
+            name="test",
+            imap_server="",
+            username="admin",
+            password="secret",
+        )
+
+        _ = MailRule.objects.create(
+            name="testrule",
+            account=account,
+            action=MailRule.MailAction.MOVE,
+            action_parameter="spam",
+            maximum_age=0,
+        )
+
+        self.assertEqual(len(self.bogus_mailbox.messages), 3)
+        self.assertEqual(len(self.bogus_mailbox.messages_spam), 0)
+
+        self.mail_account_handler.handle_mail_account(account)
+        self.apply_mail_actions()
+
+        self.assertEqual(len(self.bogus_mailbox.messages), 0)
+        self.assertEqual(len(self.bogus_mailbox.messages_spam), 3)
+
     def test_handle_mail_account_tag(self):
         account = MailAccount.objects.create(
             name="test",


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

@stumpylog is correct as usual, gmail servers (possibly others) cant handle the `None` so we fall back to 'ALL' (the default). Coverage is included but then again this test works fine with a dummy mailbox, only with testing against gmail will you see the issue. Let me know if I've missed anything here, of course.

But:
`[DEBUG] [paperless_mail] Rule test move: Searching folder with criteria ALL`

Fixes #3553 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
