### PR TITLE
Fix use of `PAPERLESS_DB_TIMEOUT` for all db types

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -136,7 +136,7 @@ changed here.
 
     Defaults to unset, using the documented path in the home directory.
 
-`PAPERLESS_DB_TIMEOUT=<float>`
+`PAPERLESS_DB_TIMEOUT=<int>`
 
 : Amount of time for a database connection to wait for the database to
 unlock. Mostly applicable for sqlite based installation. Consider changing

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -139,8 +139,8 @@ changed here.
 `PAPERLESS_DB_TIMEOUT=<float>`
 
 : Amount of time for a database connection to wait for the database to
-unlock. Mostly applicable for an sqlite based installation, consider
-changing to postgresql if you need to increase this.
+unlock. Mostly applicable for sqlite based installation. Consider changing
+to postgresql if you are having concurrency problems with sqlite.
 
     Defaults to unset, keeping the Django defaults.
 

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -532,14 +532,14 @@ def _parse_db_settings() -> Dict:
     if os.getenv("PAPERLESS_DB_TIMEOUT") is not None:
         if databases["default"]["ENGINE"] == "django.db.backends.sqlite3":
             databases["default"]["OPTIONS"].update(
-                {"timeout": float(os.getenv("PAPERLESS_DB_TIMEOUT"))},
+                {"timeout": int(os.getenv("PAPERLESS_DB_TIMEOUT"))},
             )
         else:
             databases["default"]["OPTIONS"].update(
-                {"connect_timeout": float(os.getenv("PAPERLESS_DB_TIMEOUT"))},
+                {"connect_timeout": int(os.getenv("PAPERLESS_DB_TIMEOUT"))},
             )
             databases["sqlite"]["OPTIONS"].update(
-                {"timeout": float(os.getenv("PAPERLESS_DB_TIMEOUT"))},
+                {"timeout": int(os.getenv("PAPERLESS_DB_TIMEOUT"))},
             )
     return databases
 


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

Fixes #3569

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
