### PR TITLE
Chore: Set CI artifact retention days

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,7 @@ jobs:
         with:
           name: documentation
           path: site/
+          retention-days: 7
 
   documentation-deploy:
     name: "Deploy Documentation"
@@ -208,6 +209,7 @@ jobs:
         with:
           name: jest-coverage-report
           path: src-ui/coverage
+          retention-days: 7
       -
         name: Upload frontend coverage to Codecov
         if: always()
@@ -227,6 +229,7 @@ jobs:
         with:
           name: playwright-report
           path: src-ui/playwright-report
+          retention-days: 7
 
   build-docker-image:
     name: Build Docker image for ${{ github.ref_name }}
@@ -347,6 +350,7 @@ jobs:
         with:
           name: frontend-compiled
           path: src/documents/static/frontend/
+          retention-days: 7
 
   build-release:
     needs:
@@ -455,6 +459,7 @@ jobs:
         with:
           name: release
           path: dist/paperless-ngx.tar.xz
+          retention-days: 7
 
   publish-release:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Small change for being slightly better guests on GitHub, retain uploaded artifacts from each CI run for only 7 days, down from 90 days by default.  I don't think anyone is looking at history or artifacts from 7+ days ago (but if you are, it could be adjusted)

This shouldn't affect the release .tar.xz, as that's added to a release right away and it shouldn't be affected.

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (please explain) - Small CI change

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
