### PR TITLE
Fix: Increase httpx operation timeouts to 30s

### DIFF
--- a/src/paperless_mail/parsers.py
+++ b/src/paperless_mail/parsers.py
@@ -218,7 +218,7 @@ class MailDocumentParser(DocumentParser):
                         file_multi_part[2],
                     )
 
-                response = httpx.post(url_merge, files=pdf_collection)
+                response = httpx.post(url_merge, files=pdf_collection, timeout=30.0)
                 response.raise_for_status()  # ensure we notice bad responses
 
                 archive_path.write_bytes(response.content)
@@ -336,6 +336,7 @@ class MailDocumentParser(DocumentParser):
                     files=files,
                     headers=headers,
                     data=data,
+                    timeout=30.0,
                 )
                 response.raise_for_status()  # ensure we notice bad responses
             except Exception as err:
@@ -414,11 +415,7 @@ class MailDocumentParser(DocumentParser):
                     file_multi_part[2],
                 )
 
-            response = httpx.post(
-                url,
-                files=files,
-                data=data,
-            )
+            response = httpx.post(url, files=files, data=data, timeout=30.0)
             response.raise_for_status()  # ensure we notice bad responses
         except Exception as err:
             raise ParseError(f"Error while converting document to PDF: {err}") from err

--- a/src/paperless_tika/parsers.py
+++ b/src/paperless_tika/parsers.py
@@ -96,7 +96,13 @@ class TikaDocumentParser(DocumentParser):
                 data["pdfFormat"] = "PDF/A-3b"
 
             try:
-                response = httpx.post(url, files=files, headers=headers, data=data)
+                response = httpx.post(
+                    url,
+                    files=files,
+                    headers=headers,
+                    data=data,
+                    timeout=30.0,
+                )
                 response.raise_for_status()  # ensure we notice bad responses
             except Exception as err:
                 raise ParseError(


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Seems like the default is 5s, which is pretty small.  Increase to 30s.  `tika-client` already sets 30s by default

Fixes #3626 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
