### PR TITLE
Fix: Copy default thumbnail if thumbnail generation fails

### DIFF
--- a/src/documents/parsers.py
+++ b/src/documents/parsers.py
@@ -202,7 +202,12 @@ def make_thumbnail_from_pdf_gs_fallback(in_path, temp_dir, logging_group=None) -
         return out_path
 
     except ParseError:
-        return get_default_thumbnail()
+        # The caller might expect a generated thumbnail that can be moved,
+        # so we need to copy it before it gets moved.
+        # https://github.com/paperless-ngx/paperless-ngx/issues/3631
+        default_thumbnail_path = os.path.join(temp_dir, "document.png")
+        shutil.copy2(get_default_thumbnail(), default_thumbnail_path)
+        return default_thumbnail_path
 
 
 def make_thumbnail_from_pdf(in_path, temp_dir, logging_group=None) -> str:


### PR DESCRIPTION
Fix #3631

## Proposed change

When the thumbnail generation fails, the path to the default thumbnail is returned. The calling code assumes a generated thumbnail, and moves that to the user's thumbnails folder. To avoid moving the default thumbnail from `src/documents/resources/document.png` this change copies it, and returns the path to the copy.

Fixes #3631 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
