### PR TITLE
Fix: Fix quick install with external database not being fully ready

### DIFF
--- a/install-paperless-ngx.sh
+++ b/install-paperless-ngx.sh
@@ -384,6 +384,14 @@ fi
 
 ${DOCKER_COMPOSE_CMD} pull
 
+if [ "$DATABASE_BACKEND" == "postgres" ] || [ "$DATABASE_BACKEND" == "mariadb" ] ; then
+	echo "Starting DB first for initilzation"
+	${DOCKER_COMPOSE_CMD} up --detach db
+	# hopefully enough time for even the slower systems
+	sleep 15
+	${DOCKER_COMPOSE_CMD} stop
+fi
+
 ${DOCKER_COMPOSE_CMD} run --rm -e DJANGO_SUPERUSER_PASSWORD="$PASSWORD" webserver createsuperuser --noinput --username "$USERNAME" --email "$EMAIL"
 
 ${DOCKER_COMPOSE_CMD} up --detach


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Mostly applicable to Postgres, but I made the fix for both, just in case.  When Postgres starts in Docker for the first time, it actually starts twice.  Once sets up the basic database, the second is the actual long lived process.  Though our container waits for the DB to report ready, that may be the first startup that's ready, not the actual DB.  This leads to potential issues with starting with the install script, as the creation of the super user may fail, as the DB reports ready, then goes away on us.

So, start the DB container first, give it 15s to initialize, then do the superuser creation.  15s is 100% a magic number, but hopefully it can't take more time than that, even on slow system.

Fixes #3568 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
