### PR TITLE
Fix: Ignore errors when trying to copy the original file's stats

### DIFF
--- a/src/documents/consumer.py
+++ b/src/documents/consumer.py
@@ -582,7 +582,12 @@ class Consumer(LoggingMixin):
     def _write(self, storage_type, source, target):
         with open(source, "rb") as read_file, open(target, "wb") as write_file:
             write_file.write(read_file.read())
-        shutil.copystat(source, target)
+
+        # Attempt to copy file's original stats, but it's ok if we can't
+        try:
+            shutil.copystat(source, target)
+        except Exception:  # pragma: no cover
+            pass
 
     def _log_script_outputs(self, completed_process: CompletedProcess):
         """


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Some filesystems seem to not support copying a file's stats over.  At least in this case a network mount.  So just ignore errors when doing it, it is just an attempt to preserve some things that weren't before anyway.

Other copies are probably fine, since they're from/to temporary locations.

Fixes #3649 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain)

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
