### PR TITLE
Fix: Use row gap for filter editor

### DIFF
--- a/src-ui/src/app/components/document-list/filter-editor/filter-editor.component.html
+++ b/src-ui/src/app/components/document-list/filter-editor/filter-editor.component.html
@@ -1,90 +1,89 @@
-<div class="row flex-wrap" tourAnchor="tour.documents-filter-editor">
-   <div class="col mb-3 mb-xxl-0">
-     <div class="form-inline d-flex align-items-center">
-         <div class="input-group input-group-sm flex-fill w-auto flex-nowrap">
-           <div ngbDropdown>
-            <button class="btn btn-sm btn-outline-primary" ngbDropdownToggle>{{textFilterTargetName}}</button>
-            <div class="dropdown-menu shadow" ngbDropdownMenu>
-              <button *ngFor="let t of textFilterTargets" ngbDropdownItem [class.active]="textFilterTarget === t.id" (click)="changeTextFilterTarget(t.id)">{{t.name}}</button>
-            </div>
+<div class="row flex-wrap row-gap-3" tourAnchor="tour.documents-filter-editor">
+  <div class="col">
+    <div class="form-inline d-flex align-items-center">
+      <div class="input-group input-group-sm flex-fill w-auto flex-nowrap">
+        <div ngbDropdown>
+          <button class="btn btn-sm btn-outline-primary" ngbDropdownToggle>{{textFilterTargetName}}</button>
+          <div class="dropdown-menu shadow" ngbDropdownMenu>
+            <button *ngFor="let t of textFilterTargets" ngbDropdownItem [class.active]="textFilterTarget === t.id" (click)="changeTextFilterTarget(t.id)">{{t.name}}</button>
           </div>
-          <select *ngIf="textFilterTarget === 'asn'" class="form-select flex-grow-0 w-auto" [(ngModel)]="textFilterModifier" (change)="textFilterModifierChange()">
-            <option *ngFor="let m of textFilterModifiers" ngbDropdownItem [value]="m.id">{{m.label}}</option>
-          </select>
-          <button *ngIf="_textFilter" class="btn btn-link btn-sm px-0 position-absolute top-0 end-0 z-10" (click)="resetTextField()">
-            <svg fill="currentColor" class="buttonicon-sm me-1">
-              <use xlink:href="assets/bootstrap-icons.svg#x"/>
-            </svg>
-          </button>
-          <input #textFilterInput class="form-control form-control-sm" type="text" [disabled]="textFilterModifierIsNull" [(ngModel)]="textFilter" (keyup)="textFilterKeyup($event)" [readonly]="textFilterTarget === 'fulltext-morelike'">
-         </div>
-     </div>
+        </div>
+        <select *ngIf="textFilterTarget === 'asn'" class="form-select flex-grow-0 w-auto" [(ngModel)]="textFilterModifier" (change)="textFilterModifierChange()">
+          <option *ngFor="let m of textFilterModifiers" ngbDropdownItem [value]="m.id">{{m.label}}</option>
+        </select>
+        <button *ngIf="_textFilter" class="btn btn-link btn-sm px-0 position-absolute top-0 end-0 z-10" (click)="resetTextField()">
+          <svg fill="currentColor" class="buttonicon-sm me-1">
+            <use xlink:href="assets/bootstrap-icons.svg#x"/>
+          </svg>
+        </button>
+        <input #textFilterInput class="form-control form-control-sm" type="text" [disabled]="textFilterModifierIsNull" [(ngModel)]="textFilter" (keyup)="textFilterKeyup($event)" [readonly]="textFilterTarget === 'fulltext-morelike'">
+      </div>
+    </div>
   </div>
-  <div class="w-100 d-xxl-none"></div>
-    <div class="col col-xl-auto">
-      <div class="d-flex flex-wrap gap-3">
-        <div class="d-flex flex-wrap gap-2">
-          <app-filterable-dropdown class="flex-fill" title="Tags" icon="tag-fill" i18n-title
-            filterPlaceholder="Filter tags" i18n-filterPlaceholder
-            [items]="tags"
-            [manyToOne]="true"
-            [(selectionModel)]="tagSelectionModel"
-            (selectionModelChange)="updateRules()"
-            (opened)="onTagsDropdownOpen()"
-            [documentCounts]="tagDocumentCounts"
-            [allowSelectNone]="true"></app-filterable-dropdown>
-          <app-filterable-dropdown class="flex-fill" title="Correspondent" icon="person-fill" i18n-title
-            filterPlaceholder="Filter correspondents" i18n-filterPlaceholder
-            [items]="correspondents"
-            [(selectionModel)]="correspondentSelectionModel"
-            (selectionModelChange)="updateRules()"
-            (opened)="onCorrespondentDropdownOpen()"
-            [documentCounts]="correspondentDocumentCounts"
-            [allowSelectNone]="true"></app-filterable-dropdown>
-          <app-filterable-dropdown class="flex-fill" title="Document type" icon="file-earmark-fill" i18n-title
-            filterPlaceholder="Filter document types" i18n-filterPlaceholder
-            [items]="documentTypes"
-            [(selectionModel)]="documentTypeSelectionModel"
-            (selectionModelChange)="updateRules()"
-            (opened)="onDocumentTypeDropdownOpen()"
-            [documentCounts]="documentTypeDocumentCounts"
-            [allowSelectNone]="true"></app-filterable-dropdown>
-          <app-filterable-dropdown class="flex-fill" title="Storage path" icon="folder-fill" i18n-title
-            filterPlaceholder="Filter storage paths" i18n-filterPlaceholder
-            [items]="storagePaths"
-            [(selectionModel)]="storagePathSelectionModel"
-            (selectionModelChange)="updateRules()"
-            (opened)="onStoragePathDropdownOpen()"
-            [documentCounts]="storagePathDocumentCounts"
-            [allowSelectNone]="true"></app-filterable-dropdown>
-        </div>
-        <div class="d-flex flex-wrap gap-2">
-          <app-date-dropdown
-            title="Created" i18n-title
-            (datesSet)="updateRules()"
-            [(dateBefore)]="dateCreatedBefore"
-            [(dateAfter)]="dateCreatedAfter"
-            [(relativeDate)]="dateCreatedRelativeDate"></app-date-dropdown>
-          <app-date-dropdown
-            title="Added" i18n-title
-            (datesSet)="updateRules()"
-            [(dateBefore)]="dateAddedBefore"
-            [(dateAfter)]="dateAddedAfter"
-            [(relativeDate)]="dateAddedRelativeDate"></app-date-dropdown>
-        </div>
-        <div class="d-flex flex-wrap">
-          <app-permissions-filter-dropdown
-            title="Permissions" i18n-title
-            (ownerFilterSet)="updateRules()"
-            [(selectionModel)]="permissionsSelectionModel"></app-permissions-filter-dropdown>
-        </div>
-        <div class="d-flex flex-wrap d-none d-sm-inline-block">
-          <button class="btn btn-outline-secondary btn-sm" [disabled]="!rulesModified" (click)="resetSelected()">
-            <svg class="toolbaricon ms-n1" fill="currentColor">
-              <use xlink:href="assets/bootstrap-icons.svg#x"></use>
-            </svg><ng-container i18n>Reset filters</ng-container>
-          </button>
-        </div>
-     </div>
-   </div>
+  <div class="col-auto">
+    <div class="d-flex flex-wrap gap-3">
+      <div class="d-flex flex-wrap gap-2">
+        <app-filterable-dropdown class="flex-fill" title="Tags" icon="tag-fill" i18n-title
+          filterPlaceholder="Filter tags" i18n-filterPlaceholder
+          [items]="tags"
+          [manyToOne]="true"
+          [(selectionModel)]="tagSelectionModel"
+          (selectionModelChange)="updateRules()"
+          (opened)="onTagsDropdownOpen()"
+          [documentCounts]="tagDocumentCounts"
+          [allowSelectNone]="true"></app-filterable-dropdown>
+        <app-filterable-dropdown class="flex-fill" title="Correspondent" icon="person-fill" i18n-title
+          filterPlaceholder="Filter correspondents" i18n-filterPlaceholder
+          [items]="correspondents"
+          [(selectionModel)]="correspondentSelectionModel"
+          (selectionModelChange)="updateRules()"
+          (opened)="onCorrespondentDropdownOpen()"
+          [documentCounts]="correspondentDocumentCounts"
+          [allowSelectNone]="true"></app-filterable-dropdown>
+        <app-filterable-dropdown class="flex-fill" title="Document type" icon="file-earmark-fill" i18n-title
+          filterPlaceholder="Filter document types" i18n-filterPlaceholder
+          [items]="documentTypes"
+          [(selectionModel)]="documentTypeSelectionModel"
+          (selectionModelChange)="updateRules()"
+          (opened)="onDocumentTypeDropdownOpen()"
+          [documentCounts]="documentTypeDocumentCounts"
+          [allowSelectNone]="true"></app-filterable-dropdown>
+        <app-filterable-dropdown class="flex-fill" title="Storage path" icon="folder-fill" i18n-title
+          filterPlaceholder="Filter storage paths" i18n-filterPlaceholder
+          [items]="storagePaths"
+          [(selectionModel)]="storagePathSelectionModel"
+          (selectionModelChange)="updateRules()"
+          (opened)="onStoragePathDropdownOpen()"
+          [documentCounts]="storagePathDocumentCounts"
+          [allowSelectNone]="true"></app-filterable-dropdown>
+      </div>
+      <div class="d-flex flex-wrap gap-2">
+        <app-date-dropdown
+          title="Created" i18n-title
+          (datesSet)="updateRules()"
+          [(dateBefore)]="dateCreatedBefore"
+          [(dateAfter)]="dateCreatedAfter"
+          [(relativeDate)]="dateCreatedRelativeDate"></app-date-dropdown>
+        <app-date-dropdown
+          title="Added" i18n-title
+          (datesSet)="updateRules()"
+          [(dateBefore)]="dateAddedBefore"
+          [(dateAfter)]="dateAddedAfter"
+          [(relativeDate)]="dateAddedRelativeDate"></app-date-dropdown>
+      </div>
+      <div class="d-flex flex-wrap">
+        <app-permissions-filter-dropdown
+          title="Permissions" i18n-title
+          (ownerFilterSet)="updateRules()"
+          [(selectionModel)]="permissionsSelectionModel"></app-permissions-filter-dropdown>
+      </div>
+      <div class="d-flex flex-wrap d-none d-sm-inline-block">
+        <button class="btn btn-outline-secondary btn-sm" [disabled]="!rulesModified" (click)="resetSelected()">
+          <svg class="toolbaricon ms-n1" fill="currentColor">
+            <use xlink:href="assets/bootstrap-icons.svg#x"></use>
+          </svg><ng-container i18n>Reset filters</ng-container>
+        </button>
+      </div>
+    </div>
+  </div>
 </div>


### PR DESCRIPTION
## Proposed change

The filter editor uses the (x)xl breakpoint to add space below the search bar if the buttons are placed into a new row. However the breakpoint is not related to when the browser decides to move the buttons into a new row. We now use the row gap feature which tells to browser to automatically add the space when it decides to break the row.

As a side effect I've removed the empty row. It was used to avoid putting multi-row buttons right to the search bar and force them below it first. The same effect can be achieved by unconditionally using col-auto.

Note: The diff is best viewed with ignoring whitespace, as I fixed the indentation.

## Before/After

For my, Chrome decides to break the buttons into a new row at a page width of 1562 but `mb-xxl-0` will disable any space until I reach 1400. For all other windows sizes down to 575px I have not seen any differences.

Before at 1400px:

![1400](https://github.com/paperless-ngx/paperless-ngx/assets/102600/a355ab09-0d7e-4b39-ab67-bdc05623cb3b)

After at 1400px:

![1400](https://github.com/paperless-ngx/paperless-ngx/assets/102600/ee3e70d7-ae67-444a-9145-1e4b93693305)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain):

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. -> Tested on Safari & Chrome on macOS and Safari on iOS
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
