### PR TITLE
Fix: prevent button wrapping when sidebar narrows in MS Edge

### DIFF
--- a/src-ui/src/app/components/app-frame/app-frame.component.scss
+++ b/src-ui/src/app/components/app-frame/app-frame.component.scss
@@ -137,6 +137,7 @@ main {
 
 .sidebar .nav-link {
   font-weight: 500;
+  white-space: nowrap;
 
   &:hover, &.active, &:focus {
     color: var(--bs-primary);


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

I can only reproduce this (in MS Edge on Browserstack) with absurd screen sizes (eg 1040px x 240px) but the fix won't affect anything else, so is very safe, its 1 line of css...

After:
<img width="273" alt="Screenshot 2023-06-25 at 7 23 54 AM" src="https://github.com/paperless-ngx/paperless-ngx/assets/4887959/2350dcab-8778-4609-a4da-a382c4a494fe">

Before:
<img width="227" alt="Screenshot 2023-06-25 at 7 24 00 AM" src="https://github.com/paperless-ngx/paperless-ngx/assets/4887959/d94a0e0a-2b5c-4e23-a135-7f22cf18d94c">

Fixes #3679

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain):

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] ~~If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.~~
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] ~~I have made corresponding changes to the documentation as needed.~~
- [x] I have checked my modifications for any breaking changes.
