### PR TITLE
Fix: Generation of thumbnails for existing stored emails

### DIFF
--- a/src/paperless_mail/parsers.py
+++ b/src/paperless_mail/parsers.py
@@ -33,7 +33,9 @@ class MailDocumentParser(DocumentParser):
 
     def get_thumbnail(self, document_path: Path, mime_type: str, file_name=None):
         if not self.archive_path:
-            self.archive_path = self.generate_pdf(document_path)
+            self.archive_path = self.generate_pdf(
+                self.parse_file_to_message(document_path),
+            )
 
         return make_thumbnail_from_pdf(
             self.archive_path,
@@ -299,9 +301,6 @@ class MailDocumentParser(DocumentParser):
 
         css_file = Path(__file__).parent / "templates" / "output.css"
         email_html_file = self.mail_to_html(mail)
-
-        print(css_file)
-        print(email_html_file)
 
         with css_file.open("rb") as css_handle, email_html_file.open(
             "rb",

--- a/src/paperless_mail/tests/test_parsers.py
+++ b/src/paperless_mail/tests/test_parsers.py
@@ -293,9 +293,7 @@ class TestEmailThumbnailGenerate(BaseMailParserTestCase):
             "message/rfc822",
         )
 
-        mock_generate_pdf.assert_called_once_with(
-            test_file,
-        )
+        mock_generate_pdf.assert_called_once()
         mock_make_thumbnail_from_pdf.assert_called_once_with(
             "Mocked return value..",
             self.parser.tempdir,


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

If the archive didn't exist already, the code was passing a Path where a MailMessage was expected.

Fixes #3692 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain):

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
