### PR TITLE
Fix: owner removed when set_permissions passed on object create

### DIFF
--- a/src/documents/serialisers.py
+++ b/src/documents/serialisers.py
@@ -213,15 +213,12 @@ class OwnedObjectSerializer(serializers.ModelSerializer, SetPermissionsMixin):
     # other methods in mixin
 
     def create(self, validated_data):
-        if self.user and (
-            "owner" not in validated_data or validated_data["owner"] is None
-        ):
+        # default to current user if not set
+        if "owner" not in validated_data and self.user:
             validated_data["owner"] = self.user
         permissions = None
         if "set_permissions" in validated_data:
             permissions = validated_data.pop("set_permissions")
-            if "user" not in permissions or permissions["user"] is None:
-                validated_data["owner"] = None
         instance = super().create(validated_data)
         if permissions is not None:
             self._set_permissions(permissions, instance)


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

This got messed up in #3347, seems like glorified typos (owner should not be inside set_permissions in the tests, set_permissions["user"] should not overwrite owner in serializer). I separated / fleshed out the tests to illustrate, `test_api_set_owner_w_permissions` fails in v1.16.4. Frontend is hitting API correctly.

Fixes #3700

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain):

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] ~~I have made corresponding changes to the documentation as needed.~~
- [x] I have checked my modifications for any breaking changes.
