### PR TITLE
Fix: Bumps playwright to 1.36.0

### DIFF
--- a/src-ui/package-lock.json
+++ b/src-ui/package-lock.json
@@ -4279,13 +4279,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.35.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.35.1.tgz",
-      "integrity": "sha512-b5YoFe6J9exsMYg0pQAobNDR85T1nLumUYgUTtKm4d21iX2L7WqKq9dW8NGJ+2vX0etZd+Y7UeuqsxDXm9+5ZA==",
+      "version": "1.36.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.36.0.tgz",
+      "integrity": "sha512-yN+fvMYtiyLFDCQos+lWzoX4XW3DNuaxjBu68G0lkgLgC6BP+m/iTxJQoSicz/x2G5EsrqlZTqTIP9sTgLQerg==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
-        "playwright-core": "1.35.1"
+        "playwright-core": "1.36.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -14349,9 +14349,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.35.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.35.1.tgz",
-      "integrity": "sha512-pNXb6CQ7OqmGDRspEjlxE49w+4YtR6a3X6mT1hZXeJHWmsEz7SunmvZeiG/+y1yyMZdHnnn73WKYdtV1er0Xyg==",
+      "version": "1.36.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.36.0.tgz",
+      "integrity": "sha512-7RTr8P6YJPAqB+8j5ATGHqD6LvLLM39sYVNsslh78g8QeLcBs5750c6+msjrHUwwGt+kEbczBj1XB22WMwn+WA==",
       "dev": true,
       "bin": {
         "playwright-core": "cli.js"

--- a/src-ui/package.json
+++ b/src-ui/package.json
@@ -45,7 +45,7 @@
     "@angular-eslint/template-parser": "16.0.3",
     "@angular/cli": "~16.1.3",
     "@angular/compiler-cli": "~16.1.3",
-    "@playwright/test": "^1.35.1",
+    "@playwright/test": "^1.36.0",
     "@types/jest": "^29.5.0",
     "@types/node": "^20.2.5",
     "@typescript-eslint/eslint-plugin": "^5.59.2",


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Because it started failing again for no reason and no one can tell me why but bumping it fixes it so fine.

Fixes # (issue)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain):
