### PR TITLE
Fix interaction between API and barcode archive serial number

### DIFF
--- a/src/documents/tasks.py
+++ b/src/documents/tasks.py
@@ -124,10 +124,11 @@ def consume_file(
                 return "File successfully split"
 
             # try reading the ASN from barcode
-            if settings.CONSUMER_ENABLE_ASN_BARCODE:
+            if settings.CONSUMER_ENABLE_ASN_BARCODE and reader.asn is not None:
+                # Note this will take precedence over an API provided ASN
+                # But it's from a physical barcode, so that's good
                 overrides.asn = reader.asn
-                if overrides.asn:
-                    logger.info(f"Found ASN in barcode: {overrides.asn}")
+                logger.info(f"Found ASN in barcode: {overrides.asn}")
 
     # continue with consumption if no barcode was found
     document = Consumer().try_consume_file(


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Don't always override the archive serial number, only do it one is actually found.  This will preserve an already set ASN, such as from an upload, instead of always clearing it.

Fixes #3771 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain):

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
