### PR TITLE
Add 'doc_pk' to PAPERLESS_FILENAME_FORMAT handling

### DIFF
--- a/docs/advanced_usage.md
+++ b/docs/advanced_usage.md
@@ -311,6 +311,7 @@ Paperless provides the following placeholders within filenames:
 - `{added_day}`: Day added only (number 01-31).
 - `{owner_username}`: Username of document owner, if any, or "none"
 - `{original_name}`: Document original filename, minus the extension, if any, or "none"
+- `{doc_pk}`: The paperless identifier (primary key) for the document.
 
 Paperless will try to conserve the information from your database as
 much as possible. However, some characters that you can use in document

--- a/src/documents/file_handling.py
+++ b/src/documents/file_handling.py
@@ -218,6 +218,7 @@ def generate_filename(
                 tag_list=tag_list,
                 owner_username=owner_username_str,
                 original_name=original_name,
+                doc_pk=f"{doc.pk:07}",
             ).strip()
 
             if settings.FILENAME_FORMAT_REMOVE_NONE:

--- a/src/documents/tests/test_file_handling.py
+++ b/src/documents/tests/test_file_handling.py
@@ -446,6 +446,19 @@ class TestFileHandling(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
         self.assertIsNotDir(os.path.join(settings.ORIGINALS_DIR, "none"))
         self.assertIsDir(settings.ORIGINALS_DIR)
 
+    @override_settings(FILENAME_FORMAT="{doc_pk}")
+    def test_format_doc_pk(self):
+        document = Document()
+        document.pk = 1
+        document.mime_type = "application/pdf"
+        document.storage_type = Document.STORAGE_TYPE_UNENCRYPTED
+
+        self.assertEqual(generate_filename(document), "0000001.pdf")
+
+        document.pk = 13579
+
+        self.assertEqual(generate_filename(document), "0013579.pdf")
+
     @override_settings(FILENAME_FORMAT=None)
     def test_format_none(self):
         document = Document()


### PR DESCRIPTION
## Proposed change

The default behaviour of Paperless is to output files named e.g. `0000123.pdf` in the media directory. I would like to customise the folder path using `PAPERLESS_FILENAME_FORMAT` but retain the document PK inside the folder structure. This was previously not possible; this PR adds support for my desire through using the new `{doc_pk}` placeholder.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain):

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
