### PR TITLE
Fix: Provide SSL context to IMAP client

### DIFF
--- a/src/paperless_mail/mail.py
+++ b/src/paperless_mail/mail.py
@@ -2,6 +2,7 @@ import datetime
 import itertools
 import logging
 import os
+import ssl
 import tempfile
 import traceback
 from datetime import date
@@ -394,13 +395,12 @@ def get_mailbox(server, port, security) -> MailBox:
     """
     Returns the correct MailBox instance for the given configuration.
     """
-
     if security == MailAccount.ImapSecurity.NONE:
         mailbox = MailBoxUnencrypted(server, port)
     elif security == MailAccount.ImapSecurity.STARTTLS:
-        mailbox = MailBoxTls(server, port)
+        mailbox = MailBoxTls(server, port, ssl_context=ssl.create_default_context())
     elif security == MailAccount.ImapSecurity.SSL:
-        mailbox = MailBox(server, port)
+        mailbox = MailBox(server, port, ssl_context=ssl.create_default_context())
     else:
         raise NotImplementedError("Unknown IMAP security")  # pragma: nocover
     return mailbox


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Provides the default SSL context to the client, which uses it either in the IMAP4 or starttls later.  Small chance this is breaking if people were using self signed certificates, but with things like Let's Encrypt, getting a free and valid certificate isn't really hard anymore.

I checked again my test IMAP account and it connected without errors

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain):

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
