### PR TITLE
Add support for additional UK date formats

### DIFF
--- a/src/documents/parsers.py
+++ b/src/documents/parsers.py
@@ -290,7 +290,6 @@ def parse_date_generator(filename, text) -> Iterator[datetime.datetime]:
     def __process_content(content: str, date_order: str) -> Iterator[datetime.datetime]:
         for m in re.finditer(DATE_REGEX, content):
             date = __process_match(m, date_order)
-            print(date)
             if date is not None:
                 yield date
 

--- a/src/documents/parsers.py
+++ b/src/documents/parsers.py
@@ -32,16 +32,18 @@ from documents.utils import copy_file_with_basic_stats
 # - MONTH ZZZZ, with ZZZZ being 4 digits
 # - MONTH XX, ZZZZ with XX being 1 or 2 and ZZZZ being 4 digits
 # - XX MON ZZZZ with XX being 1 or 2 and ZZZZ being 4 digits. MONTH is 3 letters
+# - XXPP MONTH ZZZZ with XX being 1 or 2 and PP being 2 letters and ZZZZ being 4 digits
 
 # TODO: isnt there a date parsing library for this?
 
 DATE_REGEX = re.compile(
     r"(\b|(?!=([_-])))([0-9]{1,2})[\.\/-]([0-9]{1,2})[\.\/-]([0-9]{4}|[0-9]{2})(\b|(?=([_-])))|"  # noqa: E501
     r"(\b|(?!=([_-])))([0-9]{4}|[0-9]{2})[\.\/-]([0-9]{1,2})[\.\/-]([0-9]{1,2})(\b|(?=([_-])))|"  # noqa: E501
-    r"(\b|(?!=([_-])))([0-9]{1,2}[\. ]+[^ ]{3,9} ([0-9]{4}|[0-9]{2}))(\b|(?=([_-])))|"  # noqa: E501
+    r"(\b|(?!=([_-])))([0-9]{1,2}[\. ]+[a-zA-Z]{3,9} ([0-9]{4}|[0-9]{2}))(\b|(?=([_-])))|"  # noqa: E501
     r"(\b|(?!=([_-])))([^\W\d_]{3,9} [0-9]{1,2}, ([0-9]{4}))(\b|(?=([_-])))|"
     r"(\b|(?!=([_-])))([^\W\d_]{3,9} [0-9]{4})(\b|(?=([_-])))|"
-    r"(\b|(?!=([_-])))(\b[0-9]{1,2}[ \.\/-][A-Z]{3}[ \.\/-][0-9]{4})(\b|(?=([_-])))",  # noqa: E501
+    r"(\b|(?!=([_-])))([0-9]{1,2}[^ ]{2}[\. ]+[^ ]{3,9}[ \.\/-][0-9]{4})(\b|(?=([_-])))|"  # noqa: E501
+    r"(\b|(?!=([_-])))(\b[0-9]{1,2}[ \.\/-][a-zA-Z]{3}[ \.\/-][0-9]{4})(\b|(?=([_-])))",  # noqa: E501
 )
 
 
@@ -288,6 +290,7 @@ def parse_date_generator(filename, text) -> Iterator[datetime.datetime]:
     def __process_content(content: str, date_order: str) -> Iterator[datetime.datetime]:
         for m in re.finditer(DATE_REGEX, content):
             date = __process_match(m, date_order)
+            print(date)
             if date is not None:
                 yield date
 

--- a/src/documents/tests/test_date_parsing.py
+++ b/src/documents/tests/test_date_parsing.py
@@ -160,7 +160,7 @@ class TestDate(TestCase):
         )
 
     def test_date_format_20(self):
-        text = "Customer Number Currency 22nd MAR 2022 Credit Card 1934829304"
+        text = "Customer Number Currency 22nd March 2022 Credit Card 1934829304"
         self.assertEqual(
             parse_date("", text),
             datetime.datetime(2022, 3, 22, 0, 0, tzinfo=tz.gettz(settings.TIME_ZONE)),

--- a/src/documents/tests/test_date_parsing.py
+++ b/src/documents/tests/test_date_parsing.py
@@ -152,6 +152,55 @@ class TestDate(TestCase):
         text = "Customer Number Currency 22 MAR,2022 Credit Card 1934829304"
         self.assertIsNone(parse_date("", text), None)
 
+    def test_date_format_19(self):
+        text = "Customer Number Currency 21st MAR 2022 Credit Card 1934829304"
+        self.assertEqual(
+            parse_date("", text),
+            datetime.datetime(2022, 3, 21, 0, 0, tzinfo=tz.gettz(settings.TIME_ZONE)),
+        )
+
+    def test_date_format_20(self):
+        text = "Customer Number Currency 22nd MAR 2022 Credit Card 1934829304"
+        self.assertEqual(
+            parse_date("", text),
+            datetime.datetime(2022, 3, 22, 0, 0, tzinfo=tz.gettz(settings.TIME_ZONE)),
+        )
+
+    def test_date_format_21(self):
+        text = "Customer Number Currency 2nd MAR 2022 Credit Card 1934829304"
+        self.assertEqual(
+            parse_date("", text),
+            datetime.datetime(2022, 3, 2, 0, 0, tzinfo=tz.gettz(settings.TIME_ZONE)),
+        )
+
+    def test_date_format_22(self):
+        text = "Customer Number Currency 23rd MAR 2022 Credit Card 1934829304"
+        self.assertEqual(
+            parse_date("", text),
+            datetime.datetime(2022, 3, 23, 0, 0, tzinfo=tz.gettz(settings.TIME_ZONE)),
+        )
+
+    def test_date_format_23(self):
+        text = "Customer Number Currency 24th MAR 2022 Credit Card 1934829304"
+        self.assertEqual(
+            parse_date("", text),
+            datetime.datetime(2022, 3, 24, 0, 0, tzinfo=tz.gettz(settings.TIME_ZONE)),
+        )
+
+    def test_date_format_24(self):
+        text = "Customer Number Currency 21-MAR-2022 Credit Card 1934829304"
+        self.assertEqual(
+            parse_date("", text),
+            datetime.datetime(2022, 3, 21, 0, 0, tzinfo=tz.gettz(settings.TIME_ZONE)),
+        )
+
+    def test_date_format_25(self):
+        text = "Customer Number Currency 25TH MAR 2022 Credit Card 1934829304"
+        self.assertEqual(
+            parse_date("", text),
+            datetime.datetime(2022, 3, 25, 0, 0, tzinfo=tz.gettz(settings.TIME_ZONE)),
+        )
+
     def test_crazy_date_past(self, *args):
         self.assertIsNone(parse_date("", "01-07-0590 00:00:00"))
 


### PR DESCRIPTION
## Proposed change

Added support for some additional date formats commonly found in the UK.
e.g. 
- 21st MAR 2022
- 22nd March 2022
- 23rd MAR 2022
- 24th MAR 2022
- 21-MAR-2022

Fixes # (issue)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain):

## Checklist:
- [x ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x ] I have made corresponding changes to the documentation as needed.
- [ x] I have checked my modifications for any breaking changes.
