### PR TITLE
Fix: notes show persistent scrollbars

### DIFF
--- a/src-ui/src/app/components/document-notes/document-notes.component.scss
+++ b/src-ui/src/app/components/document-notes/document-notes.component.scss
@@ -1,6 +1,5 @@
 .card-body {
     max-height: 12rem;
-    overflow: scroll;
     white-space: pre-wrap;
 }
 


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Cant recall why this was here but has ugly effects on some browsers (see below).

<img width="498" alt="Screenshot 2023-08-01 at 9 11 16 AM" src="https://github.com/paperless-ngx/paperless-ngx/assets/4887959/61598ec6-7f87-4fab-8d57-3940116f61c9">

<img width="476" alt="Screenshot 2023-08-01 at 9 10 54 AM" src="https://github.com/paperless-ngx/paperless-ngx/assets/4887959/342a1b4e-39e0-47cc-ae22-94ca7ad5f0a8">

Fixes # (issue)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain):

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
