### PR TITLE
Fix: cancel possibly slow queries on doc details

### DIFF
--- a/src-ui/src/app/components/document-detail/document-detail.component.ts
+++ b/src-ui/src/app/components/document-detail/document-detail.component.ts
@@ -213,22 +213,22 @@ export class DocumentDetailComponent
 
     this.correspondentService
       .listAll()
-      .pipe(first())
+      .pipe(first(), takeUntil(this.unsubscribeNotifier))
       .subscribe((result) => (this.correspondents = result.results))
 
     this.documentTypeService
       .listAll()
-      .pipe(first())
+      .pipe(first(), takeUntil(this.unsubscribeNotifier))
       .subscribe((result) => (this.documentTypes = result.results))
 
     this.storagePathService
       .listAll()
-      .pipe(first())
+      .pipe(first(), takeUntil(this.unsubscribeNotifier))
       .subscribe((result) => (this.storagePaths = result.results))
 
     this.userService
       .listAll()
-      .pipe(first())
+      .pipe(first(), takeUntil(this.unsubscribeNotifier))
       .subscribe((result) => (this.users = result.results))
 
     this.route.paramMap
@@ -406,7 +406,7 @@ export class DocumentDetailComponent
     ) {
       this.documentsService
         .getSuggestions(doc.id)
-        .pipe(first())
+        .pipe(first(), takeUntil(this.unsubscribeNotifier))
         .subscribe({
           next: (result) => {
             this.suggestions = result


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

This issue seems most noticeable on suggestions which can be very slow on some machines. The fix is simple (and probably should have been written this way from the start), just cancel queries when e.g. navigating away. Video demonstrates this (for testing I added `time.sleep(60)` into the suggestions view), without these changes the requests remain pending.

Fixes #3715


https://github.com/paperless-ngx/paperless-ngx/assets/4887959/de4e0ee2-eeff-4992-8911-3a289987fa21



## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain):

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] ~~If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.~~
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
