### PR TITLE
Chore: Reduces the 2 mail tests flakiness

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -81,11 +81,13 @@ pytest-httpx = "*"
 pytest-env = "*"
 pytest-sugar = "*"
 pytest-xdist = "*"
+pytest-rerunfailures = "*"
 "pdfminer.six" = "*"
 imagehash = "*"
 daphne = "*"
 # Documentation
 mkdocs-material = "*"
+
 
 [typing-dev]
 mypy = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "3913b5fd4b48095586e377129b3ba37f2d4610f44ae0edab736f81e103a8a837"
+            "sha256": "6ec43d0989237b0ed7da3e3306be49a1c637d2ad44222cf097b25c64c3e8d76d"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -2921,6 +2921,7 @@
                 "sha256:b4bf8c45bd59934ed84001ad51e11b4ee40d40a1229d2c79f9c592b0a3f6bd8a"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.7'",
             "version": "==7.4.0"
         },
         "pytest-cov": {
@@ -2954,6 +2955,15 @@
             ],
             "index": "pypi",
             "version": "==0.22.0"
+        },
+        "pytest-rerunfailures": {
+            "hashes": [
+                "sha256:784f462fa87fe9bdf781d0027d856b47a4bfe6c12af108f6bd887057a917b48e",
+                "sha256:9a1afd04e21b8177faf08a9bbbf44de7a0fe3fc29f8ddbe83b9684bd5f8f92a9"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.7'",
+            "version": "==12.0"
         },
         "pytest-sugar": {
             "hashes": [

--- a/src/paperless_mail/tests/test_mail.py
+++ b/src/paperless_mail/tests/test_mail.py
@@ -9,6 +9,7 @@ from typing import Optional
 from typing import Union
 from unittest import mock
 
+import pytest
 from django.core.management import call_command
 from django.db import DatabaseError
 from django.test import TestCase
@@ -400,8 +401,7 @@ class TestMail(
             attachments=2,
         )
 
-        account = MailAccount()
-        account.save()
+        account = MailAccount.objects.create()
         rule = MailRule(
             assign_title_from=MailRule.TitleSource.FROM_FILENAME,
             account=account,
@@ -445,8 +445,7 @@ class TestMail(
             ],
         )
 
-        account = MailAccount()
-        account.save()
+        account = MailAccount.objects.create()
         rule = MailRule(
             assign_title_from=MailRule.TitleSource.FROM_FILENAME,
             account=account,
@@ -475,8 +474,7 @@ class TestMail(
             ],
         )
 
-        account = MailAccount()
-        account.save()
+        account = MailAccount.objects.create()
         rule = MailRule(
             assign_title_from=MailRule.TitleSource.FROM_FILENAME,
             account=account,
@@ -504,8 +502,7 @@ class TestMail(
             ],
         )
 
-        account = MailAccount()
-        account.save()
+        account = MailAccount.objects.create()
         rule = MailRule(
             assign_title_from=MailRule.TitleSource.FROM_FILENAME,
             account=account,
@@ -696,6 +693,7 @@ class TestMail(
         self.assertEqual(len(self.bogus_mailbox.fetch("UNFLAGGED", False)), 1)
         self.assertEqual(len(self.bogus_mailbox.messages), 3)
 
+    @pytest.mark.flaky(reruns=4)
     def test_handle_mail_account_move(self):
         account = MailAccount.objects.create(
             name="test",
@@ -854,6 +852,7 @@ class TestMail(
         ):
             self.mail_account_handler.handle_mail_account(account)
 
+    @pytest.mark.flaky(reruns=4)
     def test_error_skip_account(self):
         _ = MailAccount.objects.create(
             name="test",


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Small change to hopefully reduce the number of random test failures from the mail.  I may add this to the Tika live testing as well

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (please explain):

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
