### PR TITLE
Fix: handle very old date strings in correspondent list

### DIFF
--- a/src-ui/src/app/components/document-detail/document-detail.component.spec.ts
+++ b/src-ui/src/app/components/document-detail/document-detail.component.spec.ts
@@ -668,7 +668,7 @@ describe('DocumentDetailComponent', () => {
     const object = {
       id: 22,
       name: 'Correspondent22',
-      last_correspondence: new Date(),
+      last_correspondence: new Date().toISOString(),
     } as PaperlessCorrespondent
     const qfSpy = jest.spyOn(documentListViewService, 'quickFilter')
     component.filterDocuments([object])

--- a/src-ui/src/app/components/manage/correspondent-list/correspondent-list.component.spec.ts
+++ b/src-ui/src/app/components/manage/correspondent-list/correspondent-list.component.spec.ts
@@ -31,8 +31,12 @@ describe('CorrespondentListComponent', () => {
         ReactiveFormsModule,
       ],
     }).compileComponents()
-
     correspondentsService = TestBed.inject(CorrespondentService)
+  })
+
+  // Tests are included in management-list.compontent.spec.ts
+
+  it('should use correct delete message', () => {
     jest.spyOn(correspondentsService, 'listFiltered').mockReturnValue(
       of({
         count: 3,
@@ -56,15 +60,30 @@ describe('CorrespondentListComponent', () => {
     fixture = TestBed.createComponent(CorrespondentListComponent)
     component = fixture.componentInstance
     fixture.detectChanges()
-  })
 
-  // Tests are included in management-list.compontent.spec.ts
-
-  it('should use correct delete message', () => {
     expect(
       component.getDeleteMessage({ id: 1, name: 'Correspondent1' })
     ).toEqual(
       'Do you really want to delete the correspondent "Correspondent1"?'
     )
+  })
+
+  it('should support very old date strings', () => {
+    jest.spyOn(correspondentsService, 'listFiltered').mockReturnValue(
+      of({
+        count: 1,
+        all: [1],
+        results: [
+          {
+            id: 1,
+            name: 'Correspondent1',
+            last_correspondence: '1832-12-31T15:32:54-07:52:58',
+          },
+        ],
+      })
+    )
+    fixture = TestBed.createComponent(CorrespondentListComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
   })
 })

--- a/src-ui/src/app/components/manage/correspondent-list/correspondent-list.component.ts
+++ b/src-ui/src/app/components/manage/correspondent-list/correspondent-list.component.ts
@@ -44,7 +44,19 @@ export class CorrespondentListComponent extends ManagementListComponent<Paperles
           key: 'last_correspondence',
           name: $localize`Last used`,
           valueFn: (c: PaperlessCorrespondent) => {
-            return this.datePipe.transform(c.last_correspondence)
+            if (c.last_correspondence) {
+              let date = new Date(c.last_correspondence)
+              if (date.toString() == 'Invalid Date') {
+                // very old date strings are unable to be parsed
+                date = new Date(
+                  c.last_correspondence
+                    ?.toString()
+                    .replace(/-(\d\d):\d\d:\d\d/gm, `-$1:00`)
+                )
+              }
+              return this.datePipe.transform(date)
+            }
+            return ''
           },
         },
       ]

--- a/src-ui/src/app/data/paperless-correspondent.ts
+++ b/src-ui/src/app/data/paperless-correspondent.ts
@@ -1,5 +1,5 @@
 import { MatchingModel } from './matching-model'
 
 export interface PaperlessCorrespondent extends MatchingModel {
-  last_correspondence?: Date
+  last_correspondence?: string // Date
 }


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Certainly an esoteric bug:

1. Have a timezone set (I think any)
2. Use a very old date on a doc e.g. `1833-01-01T00:00:00+00:34:08` in the example
3. Make sure that it is the _most recent_ doc for that correspondent
4. Open the management list

Its actually very similar to https://github.com/paperless-ngx/paperless-ngx/issues/818

Fixes #3944

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain):

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] ~~I have made corresponding changes to the documentation as needed.~~
- [x] I have checked my modifications for any breaking changes.
