### PR TITLE
docs: add note about polling when using double-sided collation

### DIFF
--- a/docs/advanced_usage.md
+++ b/docs/advanced_usage.md
@@ -589,6 +589,12 @@ case, Paperless will remove the staging copy as well as the scan, and give you a
 message asking you to restart the process from scratch, by scanning the odd pages again,
 followed by the even pages.
 
+It's important that the scan files get consumed in the correct order, and one at a time.
+You therefore need to make sure that Paperless is running while you upload the files into
+the directory; and if you're using [polling](/configuration#polling), make sure that
+`CONSUMER_POLLING` is set to a value lower than it takes for the second scan to appear,
+like 5-10 or even lower.
+
 Another thing that might happen is that you start a double sided scan, but then forget
 to upload the second file. To avoid collating the wrong documents if you then come back
 a day later to scan a new double-sided document, Paperless will only keep an "odd numbered
@@ -597,11 +603,11 @@ scan a completely new "odd numbered pages" one. The old staging file will get di
 
 ### Interaction with "subdirs as tags"
 
-The collation feature can be used together with the "subdirs as tags" feature (but this is not
-a requirement). Just create a correctly named double-sided subdir in the hierachy and upload
-your scans there. For example, both `double-sided/foo/bar` as well as `foo/bar/double-sided` will
-cause the collated document to be treated as if it were uploaded into `foo/bar` and receive both
-`foo` and `bar` tags, but not `double-sided`.
+The collation feature can be used together with the [subdirs as tags](/configuration#consume_config)
+feature (but this is not a requirement). Just create a correctly named double-sided subdir
+in the hierachy and upload your scans there. For example, both `double-sided/foo/bar` as
+well as `foo/bar/double-sided` will cause the collated document to be treated as if it
+were uploaded into `foo/bar` and receive both `foo` and `bar` tags, but not `double-sided`.
 
 ### Interaction with document splitting
 


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

This came up in a recent discussion in #3784, other people might run into this issue as well, so it's best to document it.

I also added a missing link to the "subdirs as tags" feature while I was at it. 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (please explain): Documentation improvement

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
