### PR TITLE
Fix: Increase the HTTP timeouts for Tika/Gotenberg to maximum task time

### DIFF
--- a/src/paperless_mail/parsers.py
+++ b/src/paperless_mail/parsers.py
@@ -215,7 +215,11 @@ class MailDocumentParser(DocumentParser):
                         file_multi_part[2],
                     )
 
-                response = httpx.post(url_merge, files=pdf_collection, timeout=30.0)
+                response = httpx.post(
+                    url_merge,
+                    files=pdf_collection,
+                    timeout=settings.CELERY_TASK_TIME_LIMIT,
+                )
                 response.raise_for_status()  # ensure we notice bad responses
 
                 archive_path.write_bytes(response.content)
@@ -330,7 +334,7 @@ class MailDocumentParser(DocumentParser):
                     files=files,
                     headers=headers,
                     data=data,
-                    timeout=30.0,
+                    timeout=settings.CELERY_TASK_TIME_LIMIT,
                 )
                 response.raise_for_status()  # ensure we notice bad responses
             except Exception as err:
@@ -409,7 +413,12 @@ class MailDocumentParser(DocumentParser):
                     file_multi_part[2],
                 )
 
-            response = httpx.post(url, files=files, data=data, timeout=30.0)
+            response = httpx.post(
+                url,
+                files=files,
+                data=data,
+                timeout=settings.CELERY_TASK_TIME_LIMIT,
+            )
             response.raise_for_status()  # ensure we notice bad responses
         except Exception as err:
             raise ParseError(f"Error while converting document to PDF: {err}") from err

--- a/src/paperless_tika/parsers.py
+++ b/src/paperless_tika/parsers.py
@@ -100,7 +100,7 @@ class TikaDocumentParser(DocumentParser):
                     files=files,
                     headers=headers,
                     data=data,
-                    timeout=30.0,
+                    timeout=settings.CELERY_TASK_TIME_LIMIT,
                 )
                 response.raise_for_status()  # ensure we notice bad responses
             except Exception as err:


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

I suspect this is the remaining issue discussed on #3678.  With this, the timeouts will be certainly large enough, and if the hardware if slower so a user has increased the task timeout, then I would expect Tika/Gotenberg are going to be as well.  So this makes it just a little simpler than another setting.

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain):

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
