### PR TITLE
Chore: Prepare for Python 3.11 support

### DIFF
--- a/src/documents/tests/test_migration_encrypted_webp_conversion.py
+++ b/src/documents/tests/test_migration_encrypted_webp_conversion.py
@@ -1,3 +1,4 @@
+import importlib
 import shutil
 import tempfile
 from pathlib import Path
@@ -10,12 +11,17 @@ from django.test import override_settings
 
 from documents.tests.utils import TestMigrations
 
+# https://github.com/python/cpython/issues/100950
+migration_1037_obj = importlib.import_module(
+    "documents.migrations.1037_webp_encrypted_thumbnail_conversion",
+)
+
 
 @override_settings(PASSPHRASE="test")
 @mock.patch(
-    "documents.migrations.1037_webp_encrypted_thumbnail_conversion.multiprocessing.pool.Pool.map",
+    f"{__name__}.migration_1037_obj.multiprocessing.pool.Pool.map",
 )
-@mock.patch("documents.migrations.1037_webp_encrypted_thumbnail_conversion.run_convert")
+@mock.patch(f"{__name__}.migration_1037_obj.run_convert")
 class TestMigrateToEncrytpedWebPThumbnails(TestMigrations):
     migrate_from = "1036_alter_savedviewfilterrule_rule_type"
     migrate_to = "1037_webp_encrypted_thumbnail_conversion"

--- a/src/documents/tests/test_migration_webp_conversion.py
+++ b/src/documents/tests/test_migration_webp_conversion.py
@@ -1,3 +1,4 @@
+import importlib
 import shutil
 import tempfile
 from pathlib import Path
@@ -10,11 +11,16 @@ from django.test import override_settings
 
 from documents.tests.utils import TestMigrations
 
+# https://github.com/python/cpython/issues/100950
+migration_1021_obj = importlib.import_module(
+    "documents.migrations.1021_webp_thumbnail_conversion",
+)
+
 
 @mock.patch(
-    "documents.migrations.1021_webp_thumbnail_conversion.multiprocessing.pool.Pool.map",
+    f"{__name__}.migration_1021_obj.multiprocessing.pool.Pool.map",
 )
-@mock.patch("documents.migrations.1021_webp_thumbnail_conversion.run_convert")
+@mock.patch(f"{__name__}.migration_1021_obj.run_convert")
 class TestMigrateWebPThumbnails(TestMigrations):
     migrate_from = "1020_merge_20220518_1839"
     migrate_to = "1021_webp_thumbnail_conversion"


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Though we can't yet upgrade to Python 3.11 due to PiWheels mostly, this fixes an error running the test suite when using 3.11, due to some changes (mostly inadvertent) in Python.  The issue is linked.  It's some import trickery, but the result is the same, without needing the test or migration to change.

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (please explain):

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
