### PR TITLE
Chore: Extend the live service utility for handling 503 errors

### DIFF
--- a/src/documents/tests/utils.py
+++ b/src/documents/tests/utils.py
@@ -119,7 +119,7 @@ def util_call_with_backoff(
             result = method_or_callable(*args)
 
             succeeded = True
-        except ParseError as e:
+        except ParseError as e:  # pragma: no cover
             cause_exec = e.__cause__
             if cause_exec is not None and isinstance(cause_exec, httpx.HTTPStatusError):
                 status_codes.append(cause_exec.response.status_code)
@@ -128,7 +128,7 @@ def util_call_with_backoff(
                 )
             else:
                 warnings.warn(f"Unexpected error: {e}")
-        except Exception as e:
+        except Exception as e:  # pragma: no cover
             warnings.warn(f"Unexpected error: {e}")
 
         retry_count = retry_count + 1
@@ -142,7 +142,7 @@ def util_call_with_backoff(
         and skip_on_50x_err
         and all(httpx.codes.is_server_error(code) for code in status_codes)
     ):
-        pytest.skip("Repeated HTTP 50x for service")
+        pytest.skip("Repeated HTTP 50x for service")  # pragma: no cover
 
     return succeeded, result
 

--- a/src/paperless_tika/tests/test_live_tika.py
+++ b/src/paperless_tika/tests/test_live_tika.py
@@ -1,11 +1,11 @@
 import os
-import time
 from pathlib import Path
 from typing import Final
 
 import pytest
 from django.test import TestCase
 
+from documents.tests.utils import util_call_with_backoff
 from paperless_tika.parsers import TikaDocumentParser
 
 
@@ -28,44 +28,6 @@ class TestTikaParserAgainstServer(TestCase):
     def tearDown(self) -> None:
         self.parser.cleanup()
 
-    def try_parse_with_wait(self, test_file: Path, mime_type: str):
-        """
-        For whatever reason, the image started during the test pipeline likes to
-        segfault sometimes, when run with the exact files that usually pass.
-
-        So, this function will retry the parsing up to 3 times, with larger backoff
-        periods between each attempt, in hopes the issue resolves itself during
-        one attempt to parse.
-
-        This will wait the following:
-            - Attempt 1 - 20s following failure
-            - Attempt 2 - 40s following failure
-            - Attempt 3 - 80s following failure
-
-        """
-        succeeded = False
-        retry_time = 20.0
-        retry_count = 0
-        max_retry_count = 3
-
-        while retry_count < max_retry_count and not succeeded:
-            try:
-                self.parser.parse(test_file, mime_type)
-
-                succeeded = True
-            except Exception as e:
-                print(f"{e} during try #{retry_count}", flush=True)
-
-                retry_count = retry_count + 1
-
-                time.sleep(retry_time)
-                retry_time = retry_time * 2.0
-
-        self.assertTrue(
-            succeeded,
-            "Continued Tika server errors after multiple retries",
-        )
-
     def test_basic_parse_odt(self):
         """
         GIVEN:
@@ -78,7 +40,10 @@ class TestTikaParserAgainstServer(TestCase):
         """
         test_file = self.SAMPLE_DIR / Path("sample.odt")
 
-        self.try_parse_with_wait(test_file, "application/vnd.oasis.opendocument.text")
+        util_call_with_backoff(
+            self.parser.parse,
+            [test_file, "application/vnd.oasis.opendocument.text"],
+        )
 
         self.assertEqual(
             self.parser.text,
@@ -104,9 +69,12 @@ class TestTikaParserAgainstServer(TestCase):
         """
         test_file = self.SAMPLE_DIR / Path("sample.docx")
 
-        self.try_parse_with_wait(
-            test_file,
-            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        util_call_with_backoff(
+            self.parser.parse,
+            [
+                test_file,
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            ],
         )
 
         self.assertEqual(
@@ -131,9 +99,9 @@ class TestTikaParserAgainstServer(TestCase):
         """
         test_file = self.SAMPLE_DIR / "sample.doc"
 
-        self.try_parse_with_wait(
-            test_file,
-            "application/msword",
+        util_call_with_backoff(
+            self.parser.parse,
+            [test_file, "application/msword"],
         )
 
         self.assertIn(


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

I'd written two of these utilities to handle HTTP errors when using Gotenberg/Tika in the CI test runs.  This combines them into a single place for usage.  It will probably fail right away, but it seemed to be more stable in my numerous re-runs.

The best change is probably the skipping if the calls all failed with HTTP 503 errors.  We don't really care if the server died in our tests.

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (please explain): - Code cleanup

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
