### PR TITLE
Feature: Official support for Python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
       - pre-commit
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
       fail-fast: false
     steps:
       -

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -255,7 +255,7 @@ supported.
 
 1.  Install dependencies. Paperless requires the following packages.
 
-    - `python3` 3.8, 3.9
+    - `python3` - 3.8 - 3.11 are supported
     - `python3-pip`
     - `python3-dev`
     - `default-libmysqlclient-dev` for MariaDB

--- a/src/documents/tests/test_migration_archive_files.py
+++ b/src/documents/tests/test_migration_archive_files.py
@@ -1,4 +1,5 @@
 import hashlib
+import importlib
 import os
 import shutil
 from pathlib import Path
@@ -14,6 +15,10 @@ from documents.tests.utils import FileSystemAssertsMixin
 from documents.tests.utils import TestMigrations
 
 STORAGE_TYPE_GPG = "gpg"
+
+migration_1012_obj = importlib.import_module(
+    "documents.migrations.1012_fix_archive_files",
+)
 
 
 def archive_name_from_filename(filename):
@@ -331,7 +336,7 @@ class TestMigrateArchiveFilesErrors(DirectoriesMixin, TestMigrations):
             self.performMigration,
         )
 
-    @mock.patch("documents.migrations.1012_fix_archive_files.parse_wrapper")
+    @mock.patch(f"{__name__}.migration_1012_obj.parse_wrapper")
     def test_parser_error(self, m):
         m.side_effect = ParseError()
         Document = self.apps.get_model("documents", "Document")
@@ -396,7 +401,7 @@ class TestMigrateArchiveFilesErrors(DirectoriesMixin, TestMigrations):
         self.assertIsNone(doc1.archive_filename)
         self.assertIsNone(doc2.archive_filename)
 
-    @mock.patch("documents.migrations.1012_fix_archive_files.parse_wrapper")
+    @mock.patch(f"{__name__}.migration_1012_obj.parse_wrapper")
     def test_parser_no_archive(self, m):
         m.side_effect = fake_parse_wrapper
 

--- a/src/setup.cfg
+++ b/src/setup.cfg
@@ -7,7 +7,7 @@ max-line-length = 88
 
 [tool:pytest]
 DJANGO_SETTINGS_MODULE=paperless.settings
-addopts = --pythonwarnings=all --cov --cov-report=html --cov-report=xml --numprocesses auto --quiet
+addopts = --pythonwarnings=all --cov --cov-report=html --cov-report=xml --numprocesses auto --quiet --durations=50
 env =
   PAPERLESS_DISABLE_DBHANDLER=true
 


### PR DESCRIPTION

## Proposed change

With dependencies updated now, we can actually install and test against Python 3.11.  Python 3.8 maybe could be dropped as well, though it doesn't seem that important?

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain):

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
