### PR TITLE
Fix: support `doc_pk` storage path placeholder via API

### DIFF
--- a/src/documents/serialisers.py
+++ b/src/documents/serialisers.py
@@ -835,6 +835,7 @@ class StoragePathSerializer(MatchingModelSerializer, OwnedObjectSerializer):
                 tag_list="tag_list",
                 owner_username="someone",
                 original_name="testfile",
+                dock_pk="doc_pk",
             )
 
         except KeyError as err:

--- a/src/documents/tests/test_api.py
+++ b/src/documents/tests/test_api.py
@@ -4463,7 +4463,7 @@ class TestApiStoragePaths(DirectoriesMixin, APITestCase):
                     "/{created_month_name_short}/{created_day}/{added}/{added_year}"
                     "/{added_year_short}/{added_month}/{added_month_name}"
                     "/{added_month_name_short}/{added_day}/{asn}/{tags}"
-                    "/{tag_list}/",
+                    "/{tag_list}/{owner_username}/{original_name}/{dock_pk}/",
                 },
             ),
             content_type="application/json",


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

Fixes #4178

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain):

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
