### PR TITLE
Fix: Trim unneeded libraries from Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,23 +67,11 @@ ARG RUNTIME_PACKAGES="\
   gnupg \
   icc-profiles-free \
   imagemagick \
-  # Image processing
-  liblept5 \
-  liblcms2-2 \
-  libtiff6 \
-  libfreetype6 \
-  libwebp7 \
-  libopenjp2-7 \
-  libimagequant0 \
-  libraqm0 \
-  libjpeg62-turbo \
   # PostgreSQL
   libpq5 \
   postgresql-client \
   # MySQL / MariaDB
   mariadb-client \
-  # For Numpy
-  libatlas3-base \
   # OCRmyPDF dependencies
   tesseract-ocr \
   tesseract-ocr-eng \
@@ -93,12 +81,11 @@ ARG RUNTIME_PACKAGES="\
   tesseract-ocr-spa \
   unpaper \
   pngquant \
-  # pikepdf / qpdf
   jbig2dec \
+  # lxml
   libxml2 \
   libxslt1.1 \
-  libgnutls30 \
-  libqpdf29 \
+  # itself
   qpdf \
   # Mime type detection
   file \
@@ -107,9 +94,7 @@ ARG RUNTIME_PACKAGES="\
   zlib1g \
   # Barcode splitter
   libzbar0 \
-  poppler-utils \
-  # RapidFuzz on armv7
-  libatomic1"
+  poppler-utils"
 
 # Install basic runtime packages.
 # These change very infrequently


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

I don't know these where ever actually needed, but they are no longer.  Most Python wheels include the shared libraries they need already and are not utilizing system libraries.  One exception is `lxml`, which does note required system libraries.  But Pillow doesn't, pikepdf doesn't, numpy/scipy don't.  Perhaps it was due to PiWheels, which I think didn't always build with libraries included.

I've checked out basic uploads of PDFs and images, barcode splitting and classifier training.  All appear to be working well still.  If something ends up actually required, it will be easy to return the necessary library.

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain):

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
