### PR TITLE
Enhancement: Allow the user the specifiy the export zip file name

### DIFF
--- a/docs/administration.md
+++ b/docs/administration.md
@@ -251,14 +251,15 @@ is not a TTY" errors. For example:
 document_exporter target [-c] [-d] [-f] [-na] [-nt] [-p] [-sm] [-z]
 
 optional arguments:
--c, --compare-checksums
--d, --delete
--f, --use-filename-format
+-c,  --compare-checksums
+-d,  --delete
+-f,  --use-filename-format
 -na, --no-archive
 -nt, --no-thumbnail
--p, --use-folder-prefix
+-p,  --use-folder-prefix
 -sm, --split-manifest
--z  --zip
+-z,  --zip
+-zn, --zip-name
 ```
 
 `target` is a folder to which the data gets written. This includes
@@ -314,7 +315,8 @@ manifest.json will still contain application wide information (e.g. tags, corres
 documenttype, etc)
 
 If `-z` or `--zip` is provided, the export will be a zip file
-in the target directory, named according to the current date.
+in the target directory, named according to the current local date or the
+value set in `-zn` or `--zip-name`.
 
 !!! warning
 

--- a/src/documents/management/commands/document_exporter.py
+++ b/src/documents/management/commands/document_exporter.py
@@ -126,6 +126,13 @@ class Command(BaseCommand):
         )
 
         parser.add_argument(
+            "-zn",
+            "--zip-name",
+            default=f"export-{timezone.localdate().isoformat()}",
+            help="Sets the export zip file name",
+        )
+
+        parser.add_argument(
             "--no-progress-bar",
             default=False,
             action="store_true",
@@ -147,13 +154,13 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         self.target = Path(options["target"]).resolve()
-        self.split_manifest = options["split_manifest"]
-        self.compare_checksums = options["compare_checksums"]
-        self.use_filename_format = options["use_filename_format"]
-        self.use_folder_prefix = options["use_folder_prefix"]
-        self.delete = options["delete"]
-        self.no_archive = options["no_archive"]
-        self.no_thumbnail = options["no_thumbnail"]
+        self.split_manifest: bool = options["split_manifest"]
+        self.compare_checksums: bool = options["compare_checksums"]
+        self.use_filename_format: bool = options["use_filename_format"]
+        self.use_folder_prefix: bool = options["use_folder_prefix"]
+        self.delete: bool = options["delete"]
+        self.no_archive: bool = options["no_archive"]
+        self.no_thumbnail: bool = options["no_thumbnail"]
         zip_export: bool = options["zip"]
 
         # If zipping, save the original target for later and
@@ -189,7 +196,7 @@ class Command(BaseCommand):
                     shutil.make_archive(
                         os.path.join(
                             original_target,
-                            f"export-{timezone.localdate().isoformat()}",
+                            options["zip_name"],
                         ),
                         format="zip",
                         root_dir=temp_dir.name,


### PR DESCRIPTION

## Proposed change

See #2652.  Simple change, keeping the default

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain):

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
