### PR TITLE
Added support for subdir as owner consumption

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -899,6 +899,19 @@ don't exist yet.
 
     Defaults to false.
 
+`PAPERLESS_CONSUMER_SUBDIR_AS_OWNER=<bool>`
+
+: Set the name of the first subdirectory as owner for consumed files. E.g.
+`<CONSUMPTION_DIR>/user1/file.pdf` will set the owner with username "user1" to the consumed
+file. Paperless will not create a user that don't exist yet and the file will not have an owner.
+
+    This is useful for if you have different users in your system. Each user places
+    their files in the their own folders. These folders won't be deleted.
+
+    PAPERLESS_CONSUMER_RECURSIVE must be enabled for this to work.
+
+    Defaults to false.
+
 `PAPERLESS_CONSUMER_IGNORE_PATTERNS=<json>`
 
 : By default, paperless ignores certain files and folders in the

--- a/src/documents/tests/test_consumer.py
+++ b/src/documents/tests/test_consumer.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock
 
 from dateutil import tz
 from django.conf import settings
+from django.contrib.auth.models import User
 from django.test import TestCase
 from django.test import override_settings
 from django.utils import timezone
@@ -444,6 +445,16 @@ class TestConsumer(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
         self.assertNotIn(t2, document.tags.all())
         self.assertIn(t3, document.tags.all())
         self._assert_first_last_send_progress()
+
+    def testOverrideOwner(self):
+        u1 = User.objects.create(username="u1")
+
+        document1 = self.consumer.try_consume_file(
+            self.get_test_file(),
+            override_owner_id=u1.pk,
+        )
+
+        self.assertEqual(document1.owner.pk, u1.pk)
 
     def testNotAFile(self):
         self.assertRaisesMessage(

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -819,6 +819,10 @@ CONSUMER_COLLATE_DOUBLE_SIDED_TIFF_SUPPORT: Final[bool] = __get_boolean(
     "PAPERLESS_CONSUMER_COLLATE_DOUBLE_SIDED_TIFF_SUPPORT",
 )
 
+CONSUMER_SUBDIR_AS_OWNER: Final[bool] = __get_boolean(
+    "PAPERLESS_CONSUMER_SUBDIR_AS_OWNER",
+)
+
 OCR_PAGES = int(os.getenv("PAPERLESS_OCR_PAGES", 0))
 
 # The default language that tesseract will attempt to use when parsing


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

This PR should implement a first way to enable the consumption of a document from a consume folder supporting different document owners. If this functionality is enabled via a setting, the consumer checks if the first sub-folder of a document to consume is equal to an existing username. If so, the owner of the document will be set to this user. If not, the sub-folder name is ignored and the document will have no owner. In combination with the subfolder as tag feature, the first part of the folder is checked if it matches to a username and if so, it is ignored for the tagging. If a username does not match, the first subfolder is treated as a tag (as is).

Use case is e.g. to point the destination folder of a scanner to a user specific sub-folder.

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

Fixes #2177

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain):

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
