### PR TITLE
Fix: application of theme color vars at root

### DIFF
--- a/src-ui/src/app/services/settings.service.spec.ts
+++ b/src-ui/src/app/services/settings.service.spec.ts
@@ -143,7 +143,9 @@ describe('SettingsService', () => {
     req.flush(ui_settings)
 
     expect(
-      document.body.style.getPropertyValue('--pngx-primary-lightness')
+      document.documentElement.style.getPropertyValue(
+        '--pngx-primary-lightness'
+      )
     ).toEqual('')
 
     const addClassSpy = jest.spyOn(settingsService.renderer, 'addClass')
@@ -157,7 +159,9 @@ describe('SettingsService', () => {
       'auto'
     )
     expect(
-      document.body.style.getPropertyValue('--pngx-primary-lightness')
+      document.documentElement.style.getPropertyValue(
+        '--pngx-primary-lightness'
+      )
     ).toEqual('50%')
 
     settingsService.updateAppearanceSettings(false, false, '#000000')
@@ -169,7 +173,9 @@ describe('SettingsService', () => {
     )
 
     expect(
-      document.body.style.getPropertyValue('--pngx-primary-lightness')
+      document.documentElement.style.getPropertyValue(
+        '--pngx-primary-lightness'
+      )
     ).toEqual('0%')
 
     settingsService.updateAppearanceSettings(false, true, '#ffffff')
@@ -180,7 +186,9 @@ describe('SettingsService', () => {
       'dark'
     )
     expect(
-      document.body.style.getPropertyValue('--pngx-primary-lightness')
+      document.documentElement.style.getPropertyValue(
+        '--pngx-primary-lightness'
+      )
     ).toEqual('100%')
   })
 

--- a/src-ui/src/app/services/settings.service.ts
+++ b/src-ui/src/app/services/settings.service.ts
@@ -7,7 +7,6 @@ import {
   LOCALE_ID,
   Renderer2,
   RendererFactory2,
-  RendererStyleFlags2,
 } from '@angular/core'
 import { Meta } from '@angular/platform-browser'
 import { CookieService } from 'ngx-cookie-service'
@@ -130,44 +129,17 @@ export class SettingsService {
         this._renderer.addClass(this.document.body, 'primary-light')
         this._renderer.removeClass(this.document.body, 'primary-dark')
       }
-      this._renderer.setStyle(
-        document.body,
+      document.documentElement.style.setProperty(
         '--pngx-primary',
-        `${+hsl.h * 360},${hsl.s * 100}%`,
-        RendererStyleFlags2.DashCase
+        `${+hsl.h * 360},${hsl.s * 100}%`
       )
-      this._renderer.setStyle(
-        document.body,
+      document.documentElement.style.setProperty(
         '--pngx-primary-lightness',
-        `${hsl.l * 100}%`,
-        RendererStyleFlags2.DashCase
-      )
-
-      /**
-       * Fix for not reflecting changed variables. (--bs-primary is at :root while here we set them to body)
-       */
-      this._renderer.setStyle(
-        document.body,
-        '--bs-primary',
-        'hsl(var(--pngx-primary), var(--pngx-primary-lightness))',
-        RendererStyleFlags2.DashCase
+        `${hsl.l * 100}%`
       )
     } else {
-      this._renderer.removeStyle(
-        document.body,
-        '--pngx-primary',
-        RendererStyleFlags2.DashCase
-      )
-      this._renderer.removeStyle(
-        document.body,
-        '--pngx-primary-lightness',
-        RendererStyleFlags2.DashCase
-      )
-      this._renderer.removeStyle(
-        document.body,
-        '--bs-primary',
-        RendererStyleFlags2.DashCase
-      )
+      document.documentElement.style.removeProperty('--pngx-primary')
+      document.documentElement.style.removeProperty('--pngx-primary-lightness')
     }
   }
 


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Fixes issue introduced in #4174 with hover colors
Before:
<img width="294" alt="Screenshot 2023-09-16 at 12 32 41 AM" src="https://github.com/paperless-ngx/paperless-ngx/assets/4887959/97296805-b0ba-4d36-9e04-aa449da8eca5">
After:
<img width="278" alt="Screenshot 2023-09-16 at 1 07 22 AM" src="https://github.com/paperless-ngx/paperless-ngx/assets/4887959/e90af2d7-4dcd-4785-a848-e6964ab2d367">


Fixes # (issue)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain):

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
