### PR TITLE
Fix: Set permissions before declaring volumes for rootless

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -228,11 +228,18 @@ COPY --from=compile-frontend /src/src/documents/static/frontend/ ./documents/sta
 # add users, setup scripts
 # Mount the compiled frontend to expected location
 RUN set -eux \
-  && addgroup --gid 1000 paperless \
-  && useradd --uid 1000 --gid paperless --home-dir /usr/src/paperless paperless \
-  && chown -R paperless:paperless /usr/src/paperless \
-  && gosu paperless python3 manage.py collectstatic --clear --no-input --link \
-  && gosu paperless python3 manage.py compilemessages
+  && echo "Setting up user/group" \
+    && addgroup --gid 1000 paperless \
+    && useradd --uid 1000 --gid paperless --home-dir /usr/src/paperless paperless \
+  && echo "Creating volume directories" \
+    && mkdir -p --verbose /usr/src/paperless/media \
+    && mkdir -p --verbose /usr/src/paperless/consume \
+    && mkdir -p --verbose /usr/src/paperless/export \
+  && echo "Adjusting all permissions" \
+    && chown -R paperless:paperless /usr/src/paperless \
+  && echo "Collecting static files" \
+    && gosu paperless python3 manage.py collectstatic --clear --no-input --link \
+    && gosu paperless python3 manage.py compilemessages
 
 VOLUME ["/usr/src/paperless/data", \
         "/usr/src/paperless/media", \


### PR DESCRIPTION
## Proposed change

Not really sure what changed, but this seems to work.  An `ls -ahl` after the volume declaration shows the folders are still owned by the paperless user and starting a container with `user:` also seemed to work.

Fixes #4191 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain):

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
