### PR TITLE
Fix: Ensures all old connections are closed in certain long lived places

### DIFF
--- a/src/documents/management/commands/document_consumer.py
+++ b/src/documents/management/commands/document_consumer.py
@@ -9,6 +9,7 @@ from time import monotonic
 from time import sleep
 from typing import Final
 
+from django import db
 from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.core.management.base import CommandError
@@ -38,6 +39,7 @@ def _tags_from_path(filepath) -> set[Tag]:
 
     Returns set of Tag models
     """
+    db.close_old_connections()
     tag_ids = set()
     path_parts = Path(filepath).relative_to(settings.CONSUMPTION_DIR).parent.parts
     for part in path_parts:

--- a/src/documents/signals/handlers.py
+++ b/src/documents/signals/handlers.py
@@ -14,6 +14,7 @@ from django.contrib.admin.models import LogEntry
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django.db import DatabaseError
+from django.db import close_old_connections
 from django.db import models
 from django.db.models import Q
 from django.dispatch import receiver
@@ -529,6 +530,8 @@ def before_task_publish_handler(sender=None, headers=None, body=None, **kwargs):
         return
 
     try:
+        close_old_connections()
+
         task_args = body[0]
         input_doc, _ = task_args
 
@@ -560,6 +563,7 @@ def task_prerun_handler(sender=None, task_id=None, task=None, **kwargs):
     https://docs.celeryq.dev/en/stable/userguide/signals.html#task-prerun
     """
     try:
+        close_old_connections()
         task_instance = PaperlessTask.objects.filter(task_id=task_id).first()
 
         if task_instance is not None:
@@ -587,6 +591,7 @@ def task_postrun_handler(
     https://docs.celeryq.dev/en/stable/userguide/signals.html#task-postrun
     """
     try:
+        close_old_connections()
         task_instance = PaperlessTask.objects.filter(task_id=task_id).first()
 
         if task_instance is not None:
@@ -615,6 +620,7 @@ def task_failure_handler(
     https://docs.celeryq.dev/en/stable/userguide/signals.html#task-failure
     """
     try:
+        close_old_connections()
         task_instance = PaperlessTask.objects.filter(task_id=task_id).first()
 
         if task_instance is not None and task_instance.result is None:


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

I don't *know* this fixes it, but perhaps closing out old connections for processes which live long (the consumer and the celery application) before using the DB might help.

Fixes #4262 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain):

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
