### PR TITLE
Fix: get highest ASN regardless of user

### DIFF
--- a/src-ui/src/app/components/common/input/number/number.component.spec.ts
+++ b/src-ui/src/app/components/common/input/number/number.component.spec.ts
@@ -30,39 +30,9 @@ describe('NumberComponent', () => {
     input = component.inputField.nativeElement
   })
 
-  // TODO: why doesnt this work?
-  // it('should support use of input field', () => {
-  //   expect(component.value).toBeUndefined()
-  //   input.stepUp()
-  //   console.log(input.value);
-
-  //   input.dispatchEvent(new Event('change'))
-  //   fixture.detectChanges()
-  //   expect(component.value).toEqual('3')
-  // })
-
   it('should support +1 ASN', () => {
-    const listAllSpy = jest.spyOn(documentService, 'listFiltered')
-    listAllSpy
-      .mockReturnValueOnce(
-        of({
-          count: 1,
-          all: [1],
-          results: [
-            {
-              id: 1,
-              archive_serial_number: 1000,
-            },
-          ],
-        })
-      )
-      .mockReturnValueOnce(
-        of({
-          count: 0,
-          all: [],
-          results: [],
-        })
-      )
+    const nextAsnSpy = jest.spyOn(documentService, 'getNextAsn')
+    nextAsnSpy.mockReturnValueOnce(of(1001)).mockReturnValueOnce(of(1))
     expect(component.value).toBeUndefined()
     component.nextAsn()
     expect(component.value).toEqual(1001)

--- a/src-ui/src/app/components/common/input/number/number.component.ts
+++ b/src-ui/src/app/components/common/input/number/number.component.ts
@@ -1,6 +1,5 @@
 import { Component, forwardRef, Input } from '@angular/core'
 import { NG_VALUE_ACCESSOR } from '@angular/forms'
-import { FILTER_ASN_ISNULL } from 'src/app/data/filter-rule-type'
 import { DocumentService } from 'src/app/services/rest/document.service'
 import { AbstractInputComponent } from '../abstract-input'
 
@@ -28,17 +27,9 @@ export class NumberComponent extends AbstractInputComponent<number> {
     if (this.value) {
       return
     }
-    this.documentService
-      .listFiltered(1, 1, 'archive_serial_number', true, [
-        { rule_type: FILTER_ASN_ISNULL, value: 'false' },
-      ])
-      .subscribe((results) => {
-        if (results.count > 0) {
-          this.value = results.results[0].archive_serial_number + 1
-        } else {
-          this.value = 1
-        }
-        this.onChange(this.value)
-      })
+    this.documentService.getNextAsn().subscribe((nextAsn) => {
+      this.value = nextAsn
+      this.onChange(this.value)
+    })
   }
 }

--- a/src-ui/src/app/services/rest/document.service.spec.ts
+++ b/src-ui/src/app/services/rest/document.service.spec.ts
@@ -229,6 +229,14 @@ describe(`DocumentService`, () => {
       `${environment.apiBaseUrl}${endpoint}/${documents[0].id}/preview/#search="${searchQuery}"`
     )
   })
+
+  it('should support get next asn', () => {
+    subscription = service.getNextAsn().subscribe((asn) => asn)
+    const req = httpTestingController.expectOne(
+      `${environment.apiBaseUrl}${endpoint}/next_asn/`
+    )
+    expect(req.request.method).toEqual('GET')
+  })
 })
 
 beforeEach(() => {

--- a/src-ui/src/app/services/rest/document.service.ts
+++ b/src-ui/src/app/services/rest/document.service.ts
@@ -143,6 +143,10 @@ export class DocumentService extends AbstractPaperlessService<PaperlessDocument>
     return url
   }
 
+  getNextAsn(): Observable<number> {
+    return this.http.get<number>(this.getResourceUrl(null, 'next_asn'))
+  }
+
   update(o: PaperlessDocument): Observable<PaperlessDocument> {
     // we want to only set created_date
     o.created = undefined

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -661,6 +661,19 @@ class UnifiedSearchViewSet(DocumentViewSet):
         else:
             return super().list(request)
 
+    @action(detail=False, methods=["GET"], name="Get Next ASN")
+    def next_asn(self, request, *args, **kwargs):
+        return Response(
+            (
+                Document.objects.filter(archive_serial_number__gte=0)
+                .order_by("archive_serial_number")
+                .last()
+                .archive_serial_number
+                or 0
+            )
+            + 1,
+        )
+
 
 class LogViewSet(ViewSet):
     permission_classes = (IsAuthenticated, PaperlessAdminPermissions)


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

This is the simple fix, we're not dealing with multiple ASN groups etc, for now.

Fixes #4325

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain):

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
