### PR TITLE
Fix: correct set owner API location in docs, additional test

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -272,19 +272,20 @@ consumption including the ID of a created document if consumption succeeded.
 ## Permissions
 
 All objects (documents, tags, etc.) allow setting object-level permissions
-with an optional `set_permissions` parameter which is of the form:
+with optional `owner` and / or a `set_permissions` parameters which are of
+the form:
 
 ```
-{
-  "owner": user_id,
-  "view": {
-      "users": [...],
-      "groups": [...],
-  },
-  "change": {
-      "users": [...],
-      "groups": [...],
-  },
+"owner": ...,
+"set_permissions": {
+    "view": {
+        "users": [...],
+        "groups": [...],
+    },
+    "change": {
+        "users": [...],
+        "groups": [...],
+    },
 }
 ```
 
@@ -292,7 +293,7 @@ with an optional `set_permissions` parameter which is of the form:
 
     Arrays should contain user or group ID numbers.
 
-If this parameter is supplied the object's permissions will be overwritten,
+If these parameters are supplied the object's permissions will be overwritten,
 assuming the authenticated user has permission to do so (the user must be
 the object owner or a superuser).
 


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Fixes docs owner location and adds another test, just to be explicit.

Fixes #4363

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (please explain): Docs

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
