### PR TITLE
Fix: update document modified time on note creation / deletion

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -6,7 +6,7 @@ provides a browsable API for most of its endpoints, which you can
 inspect at `http://<paperless-host>:<port>/api/`. This also documents
 most of the available filters and ordering fields.
 
-The API provides 7 main endpoints:
+The API provides the following main endpoints:
 
 - `/api/documents/`: Full CRUD support, except POSTing new documents.
   See below.
@@ -19,6 +19,7 @@ The API provides 7 main endpoints:
 - `/api/mail_rules/`: Full CRUD support.
 - `/api/users/`: Full CRUD support.
 - `/api/groups/`: Full CRUD support.
+- `/api/share_links/`: Full CRUD support.
 
 All of these endpoints except for the logging endpoint allow you to
 fetch (and edit and delete where appropriate) individual objects by
@@ -47,6 +48,7 @@ fields:
   Read-only.
 - `archived_file_name`: Verbose filename of the archived document.
   Read-only. Null if no archived document is available.
+- `notes`: Array of notes associated with the document.
 - `set_permissions`: Allows setting document permissions. Optional,
   write-only. See [below](#permissions).
 
@@ -123,6 +125,11 @@ File metadata is reported as a list of objects in the following form:
 `namespace` and `prefix` can be null. The actual metadata reported
 depends on the file type and the metadata available in that specific
 document. Paperless only reports PDF metadata at this point.
+
+## Documents additional endpoints
+
+- `/api/documents/<id>/notes/`: Retrieve notes for a document.
+- `/api/documents/<id>/share_links/`: Retrieve share links for a document.
 
 ## Authorization
 

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -522,6 +522,9 @@ class DocumentViewSet(
                 )
                 c.save()
 
+                doc.modified = timezone.now()
+                doc.save()
+
                 from documents import index
 
                 index.add_or_update_document(self.get_object())
@@ -544,6 +547,9 @@ class DocumentViewSet(
 
             note = Note.objects.get(id=int(request.GET.get("id")))
             note.delete()
+
+            doc.modified = timezone.now()
+            doc.save()
 
             from documents import index
 


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

This does seem consistent, modifying e.g. tags etc. does update the `modified` time for the doc, this wasn't obvious because Django handles that internally. Since notes are a separate table and thus dont technically update the document model I think we do this manually. Took the opportunity to update the docs.

Fixes #4370 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain):

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
