### PR TITLE
barcode logic: strip non-numeric characters from detected ASN string

### DIFF
--- a/src/documents/barcodes.py
+++ b/src/documents/barcodes.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
@@ -99,6 +100,9 @@ class BarcodeReader:
             logger.debug(f"Found ASN Barcode: {asn_text}")
             # remove the prefix and remove whitespace
             asn_text = asn_text[len(settings.CONSUMER_ASN_BARCODE_PREFIX) :].strip()
+
+            # remove non-numeric parts of the remaining string
+            asn_text = re.sub('[^0-9]','', asn_text)
 
             # now, try parsing the ASN number
             try:

--- a/src/documents/barcodes.py
+++ b/src/documents/barcodes.py
@@ -102,7 +102,7 @@ class BarcodeReader:
             asn_text = asn_text[len(settings.CONSUMER_ASN_BARCODE_PREFIX) :].strip()
 
             # remove non-numeric parts of the remaining string
-            asn_text = re.sub('[^0-9]','', asn_text)
+            asn_text = re.sub("[^0-9]", "", asn_text)
 
             # now, try parsing the ASN number
             try:


### PR DESCRIPTION
## Proposed change

legacy barcodes exist which still contain characters after the number the current logic did not truncate them. instead, int() was called from the remaining string. this does not work in this case. it is therefore sufficient to continue processing numeric characters.

![Bildschirmfoto 2023-10-15 um 18 56 33](https://github.com/paperless-ngx/paperless-ngx/assets/4228208/c9a960ff-933f-4952-a295-1b0ac1c09bed)
(containing *A*<ASN>* in the content of the barcode)

I have not found anything about the behavior of the function in the documentation. However, I would expect the behavior to be as it is after the change. I don't know if this is a bug-fix or a new feature.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain):

## Checklist:

- [X] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [X] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [X] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [X] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [X] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [X] I have made corresponding changes to the documentation as needed.
- [X] I have checked my modifications for any breaking changes.
