### PR TITLE
Documentation: note stripping of non-numeric characters from ASN barcode during processing

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1097,7 +1097,7 @@ barcode is detected.
 
     The barcode must consist of a (configurable) prefix and the ASN
     to be set, for instance `ASN00123`. The content after the prefix
-    is cleaned of non-digits and interpreted as an integer.
+    is cleaned of non-numeric characters.
 
     This option is compatible with barcode page separation, since
     pages will be split up before reading the ASN.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1096,7 +1096,8 @@ setting the ASN (archive serial number) if a properly formatted
 barcode is detected.
 
     The barcode must consist of a (configurable) prefix and the ASN
-    to be set, for instance `ASN00123`.
+    to be set, for instance `ASN00123`. The content after the prefix
+    is cleaned of non-digits and interpreted as an integer.
 
     This option is compatible with barcode page separation, since
     pages will be split up before reading the ASN.


### PR DESCRIPTION
## Proposed change

@shamoon correctly pointed out that cleaning up non-numbers in the ASN might 'silently' stop generating errors. #4379 

My life does not depend on this pull request. The request to change in the logic to interpret the ASN for barcodes comes from me and I can understand the hints from @shamoon.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (please explain): Documentation

## Checklist:

- [X] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [X] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
