### PR TITLE
Fix: Always return a list for audit log check

### DIFF
--- a/src/paperless/checks.py
+++ b/src/paperless/checks.py
@@ -203,13 +203,16 @@ def settings_values_check(app_configs, **kwargs):
 def audit_log_check(app_configs, **kwargs):
     db_conn = connections["default"]
     all_tables = db_conn.introspection.table_names()
+    result = []
 
     if ("auditlog_logentry" in all_tables) and not (settings.AUDIT_LOG_ENABLED):
-        return [
+        result.append(
             Critical(
                 (
                     "auditlog table was found but PAPERLESS_AUDIT_LOG_ENABLED"
                     " is not active.  This setting cannot be disabled after enabling"
                 ),
             ),
-        ]
+        )
+
+    return result


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

`TypeError: The function <function audit_log_check at 0x104bafd00> did not return a list. All functions registered with the checks registry must return a list.`

Fixes # (issue)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain):

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
