### PR TITLE
Chore: Close answered discussions

### DIFF
--- a/.github/workflows/repo-maintenance.yml
+++ b/.github/workflows/repo-maintenance.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   issues: write
   pull-requests: write
+  discussions: write
 
 concurrency:
   group: lock
@@ -45,3 +46,54 @@ jobs:
             This pull request has been automatically locked since there
             has not been any recent activity after it was closed.
             Please open a new discussion or issue for related concerns.
+  close-answered-discussions:
+    name: 'Close Answered Discussions'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            const query = `query($owner:String!, $name:String!) {
+              repository(owner:$owner, name:$name){
+                discussions(first:100, answered:true, states:[OPEN]) {
+                  nodes {
+                    id,
+                    number
+                  }
+                }
+              }
+            }`;
+            const variables = {
+              owner: context.repo.owner,
+              name: context.repo.repo,
+            }
+            const result = await github.graphql(query, variables)
+
+            console.log(`Found ${result.repository.discussions.nodes.length} open answered discussions`)
+
+            for (const discussion of result.repository.discussions.nodes) {
+              console.log(`Closing dicussion #${discussion.number} (${discussion.id})`)
+
+              const addCommentMutation = `mutation($discussion:ID!, $body:String!) {
+                addDiscussionComment(input:{discussionId:$discussion, body:$body}) {
+                  clientMutationId
+                }
+              }`;
+              const commentVariables = {
+                discussion: discussion.id,
+                body: 'This discussion has been automatically closed because it was marked as answered.',
+              }
+              await github.graphql(addCommentMutation, commentVariables)
+
+              const closeDiscussionMutation = `mutation($discussion:ID!, $reason:DiscussionCloseReason!) {
+                closeDiscussion(input:{discussionId:$discussion, reason:$reason}) {
+                  clientMutationId
+                }
+              }`;
+              const closeVariables = {
+                discussion: discussion.id,
+                reason: "RESOLVED",
+              }
+              await github.graphql(closeDiscussionMutation, closeVariables)
+
+            }


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Our discussions are a mess and the tools we use (stale, lock-threads) havent been updated to support them. So this uses the GraphQL API to do so. I think we could use a few of these but let's start with this one for now, pretty un-controversial, close "Answered" discussions e.g. support or FR that have been answered.

Screenshots are from a test repo:
<img width="422" alt="Screenshot 2023-11-12 at 11 34 38 PM" src="https://github.com/paperless-ngx/paperless-ngx/assets/4887959/35e2d833-6916-4d53-89a4-cdc287b79ee3">
<img width="1237" alt="Screenshot 2023-11-12 at 11 26 57 PM" src="https://github.com/paperless-ngx/paperless-ngx/assets/4887959/b14fd86e-82d5-4578-8d68-86b3159e243f">

Could consider (not implemented here):

- Closing old ( > 90 days?) FRs with e.g. < 10 up-votes
- Some kind of "stale" for old support threads
- Locking old discussions (feels less necessary than with issues)

Fixes # (issue)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain):

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
