### PR TITLE
Fix: Force UTF-8 for exporter manifests and don't allow escaping

### DIFF
--- a/src/documents/management/commands/document_exporter.py
+++ b/src/documents/management/commands/document_exporter.py
@@ -396,20 +396,31 @@ class Command(BaseCommand):
                         notes,
                     ),
                 )
-                manifest_name.write_text(json.dumps(content, indent=2))
+                manifest_name.write_text(
+                    json.dumps(content, indent=2, ensure_ascii=False),
+                    encoding="utf-8",
+                )
                 if manifest_name in self.files_in_export_dir:
                     self.files_in_export_dir.remove(manifest_name)
 
         # 4.1 write manifest to target folder
         manifest_path = (self.target / Path("manifest.json")).resolve()
-        manifest_path.write_text(json.dumps(manifest, indent=2))
+        manifest_path.write_text(
+            json.dumps(manifest, indent=2, ensure_ascii=False),
+            encoding="utf-8",
+        )
         if manifest_path in self.files_in_export_dir:
             self.files_in_export_dir.remove(manifest_path)
 
         # 4.2 write version information to target folder
         version_path = (self.target / Path("version.json")).resolve()
         version_path.write_text(
-            json.dumps({"version": version.__full_version_str__}, indent=2),
+            json.dumps(
+                {"version": version.__full_version_str__},
+                indent=2,
+                ensure_ascii=False,
+            ),
+            encoding="utf-8",
         )
         if version_path in self.files_in_export_dir:
             self.files_in_export_dir.remove(version_path)


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

I don't know this will 100% fix the issue, since I can't make the problematic umlaut containing title.  But try forcing the encoding to UTF-8, and removing the ensure_ascii setting, which is probably the important part.

Based on what I read [here](https://docs.python.org/3/library/json.html#character-encodings) it's that ensure_ascii setting that is at least causing the escape to be added.

Fixes #4485 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain):

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
