### PR TITLE
Fix: dashboard saved view mobile width in v.2.0.0 beta.rc1

### DIFF
--- a/src-ui/src/app/components/dashboard/dashboard.component.html
+++ b/src-ui/src/app/components/dashboard/dashboard.component.html
@@ -3,7 +3,7 @@
 </pngx-page-header>
 
 <div class="row">
-  <div class="col-auto col-lg-8 col-xl-9 mb-4">
+  <div class="col-12 col-lg-8 col-xl-9 mb-4">
     <div class="row row-cols-1 g-4" tourAnchor="tour.dashboard"
       cdkDropList
       [cdkDropListDisabled]="settingsService.globalDropzoneActive"


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Repro:
- FF
- empty saved view
- small window size

Fix:
<img width="542" alt="Screenshot 2023-11-22 at 11 38 44 AM" src="https://github.com/paperless-ngx/paperless-ngx/assets/4887959/a265286a-8a76-44fc-9139-394222e936da">
Before:
<img width="572" alt="Screenshot 2023-11-22 at 11 39 07 AM" src="https://github.com/paperless-ngx/paperless-ngx/assets/4887959/1d29fb3c-4f5e-4a35-bb99-7a91319c8d0e">


Fixes https://github.com/paperless-ngx/paperless-ngx/discussions/4579#discussioncomment-7608270

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain):

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
