### PR TITLE
Fix: Typo invalidates precondition for doctype, resulting in Exception

### DIFF
--- a/src/documents/consumer.py
+++ b/src/documents/consumer.py
@@ -657,7 +657,7 @@ class Consumer(LoggingMixin):
         )
         doc_type_name = (
             DocumentType.objects.get(pk=self.override_document_type_id).name
-            if self.override_correspondent_id is not None
+            if self.override_document_type_id is not None
             else None
         )
         owner_username = (


### PR DESCRIPTION
While importing a lot of documents (on the "beta" branch), and after adding some mail/template rules, importing documents was no longer possible and resulted in Exceptions. 

Obviously a typo has been introduced by copy&paste.

Without the fix,  the celery main task will raise this Exception cascade:

[2023-11-23 15:00:18,755] [ERROR] [paperless.consumer] The following error occurred while storing document KW4423.pdf after parsing: DocumentType matching query does not exist.
Traceback (most recent call last):
  File "/home/paperless/src/documents/consumer.py", line 504, in try_consume_file
    document = self._store(text=text, date=date, mime_type=mime_type)
  File "/home/paperless/src/documents/consumer.py", line 717, in _store
    self._parse_title_placeholders(self.override_title)
  File "/home/paperless/src/documents/consumer.py", line 659, in _parse_title_placeholders
    DocumentType.objects.get(pk=self.override_document_type_id).name
  File "/home/paperless/.local/share/virtualenvs/paperless-2KkMgMR_/lib/python3.10/site-packages/django/db/models/manager.py", line 87, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/home/paperless/.local/share/virtualenvs/paperless-2KkMgMR_/lib/python3.10/site-packages/django/db/models/query.py", line 637, in get
    raise self.model.DoesNotExist(
documents.models.DocumentType.DoesNotExist: DocumentType matching query does not exist.
[2023-11-23 15:00:18,779] [ERROR] [django_celery_results.backends.database] Chord '3171483f-2be8-4e17-b0b3-bffa96d729ba' raised: ConsumerError('Lieferschein2933954.pdf: The following error occurred while stor>
Traceback (most recent call last):
  File "/home/paperless/.local/share/virtualenvs/paperless-2KkMgMR_/lib/python3.10/site-packages/asgiref/sync.py", line 349, in main_wrap
    raise exc_info[1]
  File "/home/paperless/src/documents/consumer.py", line 504, in try_consume_file
    document = self._store(text=text, date=date, mime_type=mime_type)
  File "/home/paperless/src/documents/consumer.py", line 717, in _store
    self._parse_title_placeholders(self.override_title)
  File "/home/paperless/src/documents/consumer.py", line 659, in _parse_title_placeholders
    DocumentType.objects.get(pk=self.override_document_type_id).name
  File "/home/paperless/.local/share/virtualenvs/paperless-2KkMgMR_/lib/python3.10/site-packages/django/db/models/manager.py", line 87, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/home/paperless/.local/share/virtualenvs/paperless-2KkMgMR_/lib/python3.10/site-packages/django/db/models/query.py", line 637, in get
    raise self.model.DoesNotExist(
documents.models.DocumentType.DoesNotExist: DocumentType matching query does not exist.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/paperless/.local/share/virtualenvs/paperless-2KkMgMR_/lib/python3.10/site-packages/celery/app/trace.py", line 477, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/home/paperless/.local/share/virtualenvs/paperless-2KkMgMR_/lib/python3.10/site-packages/celery/app/trace.py", line 760, in __protected_call__
    return self.run(*args, **kwargs)
  File "/home/paperless/src/documents/tasks.py", line 167, in consume_file
    document = Consumer().try_consume_file(
  File "/home/paperless/src/documents/consumer.py", line 568, in try_consume_file
    self._fail(
  File "/home/paperless/src/documents/consumer.py", line 113, in _fail
    raise ConsumerError(f"{self.filename}: {log_message or message}") from exception
documents.consumer.ConsumerError: KW4423.pdf: The following error occurred while storing document KW4423.pdf after parsing: DocumentType matching query does not exist.


Fixes # (issue)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain):

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
