### PR TITLE
Fix: Add a warning about a low image DPI which may cause OCR to fail

### DIFF
--- a/src/paperless_tesseract/parsers.py
+++ b/src/paperless_tesseract/parsers.py
@@ -244,7 +244,7 @@ class RasterisedDocumentParser(DocumentParser):
                     f"no DPI information is present in this image and "
                     f"OCR_IMAGE_DPI is not set.",
                 )
-            if ocrmypdf_args["image_dpi"] < 70:  # pragma: nocover
+            if ocrmypdf_args["image_dpi"] < 70:  # pragma: no cover
                 self.log.warning(
                     f"Image DPI of {ocrmypdf_args['image_dpi']} is low, OCR may fail",
                 )

--- a/src/paperless_tesseract/parsers.py
+++ b/src/paperless_tesseract/parsers.py
@@ -244,6 +244,10 @@ class RasterisedDocumentParser(DocumentParser):
                     f"no DPI information is present in this image and "
                     f"OCR_IMAGE_DPI is not set.",
                 )
+            if ocrmypdf_args["image_dpi"] < 70:  # pragma: nocover
+                self.log.warning(
+                    f"Image DPI of {ocrmypdf_args['image_dpi']} is low, OCR may fail",
+                )
 
         if settings.OCR_USER_ARGS and not safe_fallback:
             try:


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

It's an odd case, but since the error raised is too generic to catch and report better, to me, this will have to do.  Didn't feel like adding a test case for something this edge.

Fixes #4636 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain):

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
