### PR TITLE
Chore: Fixes the image cleaner not running for the registry cache

### DIFF
--- a/.github/workflows/cleanup-tags.yml
+++ b/.github/workflows/cleanup-tags.yml
@@ -19,9 +19,13 @@ concurrency:
 
 jobs:
   cleanup-images:
-    name: Cleanup Image Tags for paperless-ngx
+    name: Cleanup Image Tags for ${{ matrix.primary-name }}
     if: github.repository_owner == 'paperless-ngx'
     runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        primary-name: ["paperless-ngx", "paperless-ngx/builder/cache/app"]
     env:
       # Requires a personal access token with the OAuth scope delete:packages
       TOKEN: ${{ secrets.GHA_CONTAINER_DELETE_TOKEN }}
@@ -34,7 +38,7 @@ jobs:
           token: "${{ env.TOKEN }}"
           owner: "${{ github.repository_owner }}"
           is_org: "true"
-          package_name: "paperless-ngx"
+          package_name: "${{ matrix.primary-name }}"
           scheme: "branch"
           repo_name: "paperless-ngx"
           match_regex: "feature-"
@@ -49,18 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - primary-name: "paperless-ngx"
-          - primary-name: "paperless-ngx/builder/cache/app"
-          # TODO: Remove the above and replace with the below
-          # - primary-name: "builder/qpdf"
-          # - primary-name: "builder/cache/qpdf"
-          # - primary-name: "builder/pikepdf"
-          # - primary-name: "builder/cache/pikepdf"
-          # - primary-name: "builder/jbig2enc"
-          # - primary-name: "builder/cache/jbig2enc"
-          # - primary-name: "builder/psycopg2"
-          # - primary-name: "builder/cache/psycopg2"
+        primary-name: ["paperless-ngx", "paperless-ngx/builder/cache/app"]
     env:
       # Requires a personal access token with the OAuth scope delete:packages
       TOKEN: ${{ secrets.GHA_CONTAINER_DELETE_TOKEN }}


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

This has been broken for a bit or since I made this.  Fixes the builder's registry cache tagged images also not being cleaned up.  Already ran and removed [89](https://github.com/paperless-ngx/paperless-ngx/actions/runs/7053581394/job/19200888143#step:2:135) tagged images from old branches.

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain):

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
