### PR TITLE
Fix: empty string for consumption template field should be interpreted as `None`

### DIFF
--- a/src/documents/serialisers.py
+++ b/src/documents/serialisers.py
@@ -1171,10 +1171,19 @@ class ConsumptionTemplateSerializer(serializers.ModelSerializer):
     def validate(self, attrs):
         if ("filter_mailrule") in attrs and attrs["filter_mailrule"] is not None:
             attrs["sources"] = {DocumentSource.MailFetch.value}
+
+        # Empty strings treated as None to avoid unexpected behavior
+        if ("assign_title") in attrs and len(attrs["assign_title"]) == 0:
+            attrs["assign_title"] = None
+        if "filter_filename" in attrs and len(attrs["filter_filename"]) == 0:
+            attrs["filter_filename"] = None
+        if "filter_path" in attrs and len(attrs["filter_path"]) == 0:
+            attrs["filter_path"] = None
+
         if (
-            ("filter_mailrule" not in attrs)
-            and ("filter_filename" not in attrs or len(attrs["filter_filename"]) == 0)
-            and ("filter_path" not in attrs or len(attrs["filter_path"]) == 0)
+            "filter_mailrule" not in attrs
+            and ("filter_filename" not in attrs or attrs["filter_filename"] is None)
+            and ("filter_path" not in attrs or attrs["filter_path"] is None)
         ):
             raise serializers.ValidationError(
                 "File name, path or mail rule filter are required",

--- a/src/documents/tests/test_api.py
+++ b/src/documents/tests/test_api.py
@@ -5740,7 +5740,55 @@ class TestApiConsumptionTemplates(DirectoriesMixin, APITestCase):
             content_type="application/json",
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(StoragePath.objects.count(), 1)
+        self.assertEqual(ConsumptionTemplate.objects.count(), 1)
+
+    def test_api_create_consumption_template_empty_fields(self):
+        """
+        GIVEN:
+            - API request to create a consumption template
+            - Path or filename filter or assign title are empty string
+        WHEN:
+            - API is called
+        THEN:
+            - Template is created but filter or title assignment is not set if ""
+        """
+        response = self.client.post(
+            self.ENDPOINT,
+            json.dumps(
+                {
+                    "name": "Template 2",
+                    "order": 1,
+                    "sources": [DocumentSource.ApiUpload],
+                    "filter_filename": "*test*",
+                    "filter_path": "",
+                    "assign_title": "",
+                },
+            ),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        ct = ConsumptionTemplate.objects.get(name="Template 2")
+        self.assertEqual(ct.filter_filename, "*test*")
+        self.assertIsNone(ct.filter_path)
+        self.assertIsNone(ct.assign_title)
+
+        response = self.client.post(
+            self.ENDPOINT,
+            json.dumps(
+                {
+                    "name": "Template 3",
+                    "order": 1,
+                    "sources": [DocumentSource.ApiUpload],
+                    "filter_filename": "",
+                    "filter_path": "*/test/*",
+                },
+            ),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        ct2 = ConsumptionTemplate.objects.get(name="Template 3")
+        self.assertEqual(ct2.filter_path, "*/test/*")
+        self.assertIsNone(ct2.filter_filename)
 
     def test_api_create_consumption_template_with_mailrule(self):
         """


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

I think a bug, or at least very unexpected, the test illustrates it I think.

The only funny thing is I cant really re-create this. The frontend does pass `null`, the serializer does `allow_null`, it's null in the DB and when I get a CT like that from Django, it does look like `assign_title` is `None`. So I dont totally get where it's becoming "" but still, this seems like a reasonable check to have. Let me know if theres another angle to this.

<img width="264" alt="Screenshot 2023-12-01 at 10 34 16 PM" src="https://github.com/paperless-ngx/paperless-ngx/assets/4887959/f7b3efdb-5d6a-47ef-8f86-202ba01d1b6b">
<img width="383" alt="Screenshot 2023-12-01 at 10 54 48 PM" src="https://github.com/paperless-ngx/paperless-ngx/assets/4887959/379d3fac-a9fc-47f8-8fca-f1a4eced2826">

Also, this test is fine:
```python
        response = self.client.post(
            self.ENDPOINT,
            json.dumps(
                {
                    "name": "Template 2",
                    "order": 1,
                    "sources": [DocumentSource.ApiUpload],
                    "filter_filename": "*test*",
                    "assign_title": None
                },
            ),
            content_type="application/json",
        )
        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
        ct = ConsumptionTemplate.objects.get(name="Template 2")
        self.assertIsNone(ct.assign_title)
```

Fixes #4761

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain):

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
