### PR TITLE
Fix: only show global drag-drop when files included

### DIFF
--- a/src-ui/src/app/components/file-drop/file-drop.component.spec.ts
+++ b/src-ui/src/app/components/file-drop/file-drop.component.spec.ts
@@ -84,7 +84,9 @@ describe('FileDropComponent', () => {
   it('should support drag drop, initiate upload', fakeAsync(() => {
     jest.spyOn(permissionsService, 'currentUserCan').mockReturnValue(true)
     expect(component.fileIsOver).toBeFalsy()
-    component.onDragOver(new Event('dragover') as DragEvent)
+    const overEvent = new Event('dragover') as DragEvent
+    ;(overEvent as any).dataTransfer = { types: ['Files'] }
+    component.onDragOver(overEvent)
     tick(1)
     fixture.detectChanges()
     expect(component.fileIsOver).toBeTruthy()
@@ -151,7 +153,9 @@ describe('FileDropComponent', () => {
     const leaveSpy = jest.spyOn(component, 'onDragLeave')
     jest.spyOn(permissionsService, 'currentUserCan').mockReturnValue(true)
     settingsService.globalDropzoneEnabled = true
-    component.onDragOver(new Event('dragover') as DragEvent)
+    const overEvent = new Event('dragover') as DragEvent
+    ;(overEvent as any).dataTransfer = { types: ['Files'] }
+    component.onDragOver(overEvent)
     tick(1)
     expect(component.hidden).toBeFalsy()
     expect(component.fileIsOver).toBeTruthy()
@@ -165,7 +169,9 @@ describe('FileDropComponent', () => {
     const leaveSpy = jest.spyOn(component, 'onDragLeave')
     jest.spyOn(permissionsService, 'currentUserCan').mockReturnValue(true)
     settingsService.globalDropzoneEnabled = true
-    component.onDragOver(new Event('dragover') as DragEvent)
+    const overEvent = new Event('dragover') as DragEvent
+    ;(overEvent as any).dataTransfer = { types: ['Files'] }
+    component.onDragOver(overEvent)
     tick(1)
     expect(component.hidden).toBeFalsy()
     expect(component.fileIsOver).toBeTruthy()

--- a/src-ui/src/app/components/file-drop/file-drop.component.ts
+++ b/src-ui/src/app/components/file-drop/file-drop.component.ts
@@ -38,8 +38,9 @@ export class FileDropComponent {
 
   @ViewChild('ngxFileDrop') ngxFileDrop: NgxFileDropComponent
 
-  @HostListener('dragover', ['$event ']) onDragOver(event: DragEvent) {
-    if (!this.dragDropEnabled) return
+  @HostListener('dragover', ['$event']) onDragOver(event: DragEvent) {
+    if (!this.dragDropEnabled || !event.dataTransfer?.types?.includes('Files'))
+      return
     event.preventDefault()
     event.stopImmediatePropagation()
     this.settings.globalDropzoneActive = true


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Tested in a few browsers, though there are lots of em. But this is old html spec, pretty well-supported https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer/types#browser_compatibility

New:

https://github.com/paperless-ngx/paperless-ngx/assets/4887959/da9e35f1-577a-4bc1-8462-9e9651281f62


Old:

https://github.com/paperless-ngx/paperless-ngx/assets/4887959/bdf558f9-f792-4699-a9da-62c6cbf7feb2


Fixes #4766

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain):

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
