### PR TITLE
Fix: use default permissions for objects created via dropdown

### DIFF
--- a/src-ui/src/app/components/common/edit-dialog/edit-dialog.component.spec.ts
+++ b/src-ui/src/app/components/common/edit-dialog/edit-dialog.component.spec.ts
@@ -131,6 +131,7 @@ describe('EditDialogComponent', () => {
   })
 
   it('should interpolate object permissions', () => {
+    component.getMatchingAlgorithms() // coverage
     component.object = tag
     component.dialogMode = EditDialogMode.EDIT
     component.ngOnInit()

--- a/src-ui/src/app/components/common/edit-dialog/edit-dialog.component.ts
+++ b/src-ui/src/app/components/common/edit-dialog/edit-dialog.component.ts
@@ -58,8 +58,8 @@ export abstract class EditDialogComponent<
   objectForm: FormGroup = this.getForm()
 
   ngOnInit(): void {
-    if (this.object != null) {
-      if (this.object['permissions']) {
+    if (this.object != null && this.dialogMode !== EditDialogMode.CREATE) {
+      if ((this.object as ObjectWithPermissions).permissions) {
         this.object['set_permissions'] = this.object['permissions']
       }
 
@@ -69,6 +69,8 @@ export abstract class EditDialogComponent<
       }
       this.objectForm.patchValue(this.object)
     } else {
+      // e.g. if name was set
+      this.objectForm.patchValue(this.object)
       // defaults from settings
       this.objectForm.patchValue({
         permissions_form: {

--- a/src-ui/src/app/components/common/input/tags/tags.component.spec.ts
+++ b/src-ui/src/app/components/common/input/tags/tags.component.spec.ts
@@ -32,11 +32,9 @@ import { CheckComponent } from '../check/check.component'
 import { IfOwnerDirective } from 'src/app/directives/if-owner.directive'
 import { TextComponent } from '../text/text.component'
 import { ColorComponent } from '../color/color.component'
-import { IfPermissionsDirective } from 'src/app/directives/if-permissions.directive'
 import { PermissionsFormComponent } from '../permissions/permissions-form/permissions-form.component'
 import { SelectComponent } from '../select/select.component'
-import { ColorSliderModule } from 'ngx-color/slider'
-import { By } from '@angular/platform-browser'
+import { SettingsService } from 'src/app/services/settings.service'
 
 const tags: PaperlessTag[] = [
   {
@@ -63,8 +61,8 @@ const tags: PaperlessTag[] = [
 describe('TagsComponent', () => {
   let component: TagsComponent
   let fixture: ComponentFixture<TagsComponent>
-  let input: HTMLInputElement
   let modalService: NgbModal
+  let settingsService: SettingsService
 
   beforeEach(async () => {
     TestBed.configureTestingModule({
@@ -110,6 +108,7 @@ describe('TagsComponent', () => {
     }).compileComponents()
 
     modalService = TestBed.inject(NgbModal)
+    settingsService = TestBed.inject(SettingsService)
     fixture = TestBed.createComponent(TagsComponent)
     fixture.debugElement.injector.get(NG_VALUE_ACCESSOR)
     component = fixture.componentInstance
@@ -139,6 +138,7 @@ describe('TagsComponent', () => {
   })
 
   it('should support create new using last search term and open a modal', () => {
+    settingsService.currentUser = { id: 1 }
     let activeInstances: NgbModalRef[]
     modalService.activeInstances.subscribe((v) => (activeInstances = v))
     component.select.searchTerm = 'foobar'

--- a/src-ui/src/app/components/document-detail/document-detail.component.spec.ts
+++ b/src-ui/src/app/components/document-detail/document-detail.component.spec.ts
@@ -263,6 +263,7 @@ describe('DocumentDetailComponent', () => {
     toastService = TestBed.inject(ToastService)
     documentListViewService = TestBed.inject(DocumentListViewService)
     settingsService = TestBed.inject(SettingsService)
+    settingsService.currentUser = { id: 1 }
     customFieldsService = TestBed.inject(CustomFieldsService)
     fixture = TestBed.createComponent(DocumentDetailComponent)
     component = fixture.componentInstance


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

I guess everybody's testing on the weekend =) 
Squirmy little one, only applies if you type into the dropdown and add that way (e.g. + button works as expected)

<img width="414" alt="Screenshot 2023-12-02 at 9 32 20 AM" src="https://github.com/paperless-ngx/paperless-ngx/assets/4887959/1bd20c80-0e50-4e20-8d58-a9932e2c4f16">
<img width="520" alt="Screenshot 2023-12-02 at 9 51 50 AM" src="https://github.com/paperless-ngx/paperless-ngx/assets/4887959/4f02b585-13e1-439b-a7e8-7f3ebe57052b">

Fixes #4777

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain):

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
