### PR TITLE
Fix: Alpha layer removal could allow duplicates

### DIFF
--- a/src/documents/consumer.py
+++ b/src/documents/consumer.py
@@ -519,7 +519,11 @@ class Consumer(LoggingMixin):
                     document.filename = generate_unique_filename(document)
                     create_source_path_directory(document.source_path)
 
-                    self._write(document.storage_type, self.path, document.source_path)
+                    self._write(
+                        document.storage_type,
+                        self.original_path,
+                        document.source_path,
+                    )
 
                     self._write(
                         document.storage_type,
@@ -711,21 +715,20 @@ class Consumer(LoggingMixin):
 
         storage_type = Document.STORAGE_TYPE_UNENCRYPTED
 
-        with open(self.path, "rb") as f:
-            document = Document.objects.create(
-                title=(
-                    self._parse_title_placeholders(self.override_title)
-                    if self.override_title is not None
-                    else file_info.title
-                )[:127],
-                content=text,
-                mime_type=mime_type,
-                checksum=hashlib.md5(f.read()).hexdigest(),
-                created=create_date,
-                modified=create_date,
-                storage_type=storage_type,
-                original_filename=self.filename,
-            )
+        document = Document.objects.create(
+            title=(
+                self._parse_title_placeholders(self.override_title)
+                if self.override_title is not None
+                else file_info.title
+            )[:127],
+            content=text,
+            mime_type=mime_type,
+            checksum=hashlib.md5(self.original_path.read_bytes()).hexdigest(),
+            created=create_date,
+            modified=create_date,
+            storage_type=storage_type,
+            original_filename=self.filename,
+        )
 
         self.apply_overrides(document)
 

--- a/src/documents/parsers.py
+++ b/src/documents/parsers.py
@@ -105,7 +105,7 @@ def get_supported_file_extensions() -> set[str]:
     return extensions
 
 
-def get_parser_class_for_mime_type(mime_type: str) -> Optional["DocumentParser"]:
+def get_parser_class_for_mime_type(mime_type: str) -> Optional[type["DocumentParser"]]:
     """
     Returns the best parser (by weight) for the given mimetype or
     None if no parser exists


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

The removal of the alpha layer is not deterministic, making every time appear like a new file.  To file this, make sure we checksum the _original_ and store the _original_ not the version which a parser may have manipulated.

Fixes #4775 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain):

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
