### PR TITLE
Enhancement: symmetric document links

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -345,7 +345,7 @@ The following custom field types are supported:
 - `Integer`: integer number e.g. 12
 - `Number`: float number e.g. 12.3456
 - `Monetary`: float number with exactly two decimals, e.g. 12.30
-- `Document Link`: reference(s) to other document(s), displayed as links
+- `Document Link`: reference(s) to other document(s) displayed as links, automatically creates a symmetrical link in reverse
 
 ## Share Links
 

--- a/src/documents/serialisers.py
+++ b/src/documents/serialisers.py
@@ -549,8 +549,8 @@ class CustomFieldInstanceSerializer(serializers.ModelSerializer):
             ["value_document_ids"],
         )
 
+    @staticmethod
     def remove_doclink(
-        self,
         document: Document,
         field: CustomField,
         target_doc_id: int,
@@ -625,16 +625,16 @@ class DocumentSerializer(
         if "created_date" in validated_data:
             validated_data.pop("created_date")
         if instance.custom_fields.count() > 0 and "custom_fields" in validated_data:
+            incoming_custom_fields = [
+                field["field"] for field in validated_data["custom_fields"]
+            ]
             for custom_field_instance in instance.custom_fields.filter(
                 field__data_type=CustomField.FieldDataType.DOCUMENTLINK,
             ):
-                if custom_field_instance.field not in [
-                    field["field"] for field in validated_data["custom_fields"]
-                ]:
+                if custom_field_instance.field not in incoming_custom_fields:
                     # Doc link field is being removed entirely
                     for doc_id in custom_field_instance.value:
                         CustomFieldInstanceSerializer.remove_doclink(
-                            None,
                             instance,
                             custom_field_instance.field,
                             doc_id,

--- a/src/documents/serialisers.py
+++ b/src/documents/serialisers.py
@@ -608,6 +608,21 @@ class DocumentSerializer(
             instance.save()
         if "created_date" in validated_data:
             validated_data.pop("created_date")
+        if instance.custom_fields.count() > 0 and "custom_fields" in validated_data:
+            for custom_field_instance in instance.custom_fields.filter(
+                field__data_type=CustomField.FieldDataType.DOCUMENTLINK,
+            ):
+                if custom_field_instance.field not in [
+                    field["field"] for field in validated_data["custom_fields"]
+                ]:
+                    # Doc link field is being removed entirely
+                    for doc_id in custom_field_instance.value:
+                        CustomFieldInstanceSerializer.remove_doclink(
+                            None,
+                            instance,
+                            custom_field_instance.field,
+                            doc_id,
+                        )
         super().update(instance, validated_data)
         return instance
 

--- a/src/documents/tests/test_api_custom_fields.py
+++ b/src/documents/tests/test_api_custom_fields.py
@@ -476,3 +476,17 @@ class TestCustomField(DirectoriesMixin, APITestCase):
         self.assertEqual(doc2.custom_fields.first().value, [1])
         self.assertEqual(doc3.custom_fields.first().value, [1])
         self.assertEqual(doc4.custom_fields.first().value, [])
+
+        # Removes the field entirely
+        resp = self.client.patch(
+            f"/api/documents/{doc1.id}/",
+            data={
+                "custom_fields": [],
+            },
+            format="json",
+        )
+
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(doc2.custom_fields.first().value, [])
+        self.assertEqual(doc3.custom_fields.first().value, [])
+        self.assertEqual(doc4.custom_fields.first().value, [])

--- a/src/documents/tests/test_api_custom_fields.py
+++ b/src/documents/tests/test_api_custom_fields.py
@@ -458,6 +458,23 @@ class TestCustomField(DirectoriesMixin, APITestCase):
         self.assertEqual(doc3.custom_fields.first().value, [1])
         self.assertEqual(doc4.custom_fields.first().value, [1])
 
+        # Add links appends if necessary
+        resp = self.client.patch(
+            f"/api/documents/{doc3.id}/",
+            data={
+                "custom_fields": [
+                    {
+                        "field": custom_field_doclink.id,
+                        "value": [1, 4],
+                    },
+                ],
+            },
+            format="json",
+        )
+
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(doc4.custom_fields.first().value, [1, 3])
+
         # Remove one of the links, removed on other doc
         resp = self.client.patch(
             f"/api/documents/{doc1.id}/",
@@ -474,8 +491,8 @@ class TestCustomField(DirectoriesMixin, APITestCase):
 
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         self.assertEqual(doc2.custom_fields.first().value, [1])
-        self.assertEqual(doc3.custom_fields.first().value, [1])
-        self.assertEqual(doc4.custom_fields.first().value, [])
+        self.assertEqual(doc3.custom_fields.first().value, [1, 4])
+        self.assertEqual(doc4.custom_fields.first().value, [3])
 
         # Removes the field entirely
         resp = self.client.patch(
@@ -488,5 +505,5 @@ class TestCustomField(DirectoriesMixin, APITestCase):
 
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         self.assertEqual(doc2.custom_fields.first().value, [])
-        self.assertEqual(doc3.custom_fields.first().value, [])
-        self.assertEqual(doc4.custom_fields.first().value, [])
+        self.assertEqual(doc3.custom_fields.first().value, [4])
+        self.assertEqual(doc4.custom_fields.first().value, [3])


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

I guess folks that wanted this feature feel this is pretty important. PR is all in the backend so welcome feedback. Notes:

- We have to support link added, link removed and when the entire field is removed
- For links added and removed we can use `CustomFieldInstanceSerializer`. I did find that the `custom_fields` field seems to only use `create`, not `update`, I couldn't find any docs or info about that, but basically an `update` method didnt seem to run ever and `create` always does.
- I also couldn't find much documentation about when the entire field is removed (there's no e.g. `delete` on a nested field I guess) so I implemented it on the `DocumentSerializer` by checking if the incoming data is going to remove a doc link field.

Fixes #4871

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain):

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
