### PR TITLE
Fix: Use the attachment filename so downstream template matching works

### DIFF
--- a/src/paperless_mail/mail.py
+++ b/src/paperless_mail/mail.py
@@ -8,6 +8,7 @@ import traceback
 from datetime import date
 from datetime import timedelta
 from fnmatch import fnmatch
+from pathlib import Path
 from typing import Optional
 from typing import Union
 
@@ -703,12 +704,15 @@ class MailAccountHandler(LoggingMixin):
 
             if is_mime_type_supported(mime_type):
                 os.makedirs(settings.SCRATCH_DIR, exist_ok=True)
-                _, temp_filename = tempfile.mkstemp(
-                    prefix="paperless-mail-",
-                    dir=settings.SCRATCH_DIR,
+
+                temp_dir = Path(
+                    tempfile.mkdtemp(
+                        prefix="paperless-mail-",
+                        dir=settings.SCRATCH_DIR,
+                    ),
                 )
-                with open(temp_filename, "wb") as f:
-                    f.write(att.payload)
+                temp_filename = temp_dir / pathvalidate.sanitize_filename(att.filename)
+                temp_filename.write_bytes(att.payload)
 
                 self.log.info(
                     f"Rule {rule}: "

--- a/src/paperless_mail/tests/test_mail.py
+++ b/src/paperless_mail/tests/test_mail.py
@@ -1271,7 +1271,10 @@ class TestMail(
         self.assertEqual(len(self.bogus_mailbox.fetch("UNSEEN", False)), 0)
         self.assertEqual(len(self.bogus_mailbox.messages), 3)
 
-    def assert_queue_consumption_tasks_call_args(self, expected_call_args: list):
+    def assert_queue_consumption_tasks_call_args(
+        self,
+        expected_call_args: list[list[dict[str, str]]],
+    ):
         """
         Verifies that queue_consumption_tasks has been called with the expected arguments.
 
@@ -1283,7 +1286,7 @@ class TestMail(
 
         """
 
-        # assert number of calls to queue_consumption_tasks mathc
+        # assert number of calls to queue_consumption_tasks match
         self.assertEqual(
             len(self._queue_consumption_tasks_mock.call_args_list),
             len(expected_call_args),


### PR DESCRIPTION

<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Instead of using a temporary file with a mostly random name, use a temporary directory with the sanitized attachment name instead.

Fixes #4929 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain):

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
