### PR TITLE
Fix: Don't attempt to parse none objects during date searching

### DIFF
--- a/src/documents/index.py
+++ b/src/documents/index.py
@@ -3,6 +3,7 @@ import math
 import os
 from collections import Counter
 from contextlib import contextmanager
+from datetime import datetime
 from typing import Optional
 
 from dateutil.parser import isoparse
@@ -371,7 +372,7 @@ class LocalDateParser(English):
         if isinstance(d, timespan):
             d.start = self.reverse_timezone_offset(d.start)
             d.end = self.reverse_timezone_offset(d.end)
-        else:
+        elif isinstance(d, datetime):
             d = self.reverse_timezone_offset(d)
         return d
 

--- a/src/documents/tests/test_api_search.py
+++ b/src/documents/tests/test_api_search.py
@@ -455,6 +455,31 @@ class TestDocumentSearchApi(DirectoriesMixin, APITestCase):
             # Assert subset in results
             self.assertDictEqual(result, {**result, **subset})
 
+    def test_search_added_invalid_date(self):
+        """
+        GIVEN:
+            - One document added right now
+        WHEN:
+            - Query with invalid added date
+        THEN:
+            - No documents returned
+        """
+        d1 = Document.objects.create(
+            title="invoice",
+            content="the thing i bought at a shop and paid with bank account",
+            checksum="A",
+            pk=1,
+        )
+
+        with index.open_index_writer() as writer:
+            index.update_document(writer, d1)
+
+        response = self.client.get("/api/documents/?query=added:invalid-date")
+        results = response.data["results"]
+
+        # Expect 0 document returned
+        self.assertEqual(len(results), 0)
+
     @mock.patch("documents.index.autocomplete")
     def test_search_autocomplete_limits(self, m):
         """


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

This PR fixes the following error:
```
[WARNING] [paperless.api] An error occurred listing search results: 'NoneType' object has no attribute 'replace'
```

To reproduce this bug:
 - in advanced search use any invalid date e.g `created:aaa`




<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

Fixes # (issue)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain):

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
