### PR TITLE
Add option to merge multiple files into single PDF when bulk downloading

### DIFF
--- a/src-ui/src/app/components/document-list/bulk-editor/bulk-editor.component.html
+++ b/src-ui/src/app/components/document-list/bulk-editor/bulk-editor.component.html
@@ -126,6 +126,12 @@
                 Use formatted filename
               </label>
             </div>
+            <div class="form-check">
+              <input type="checkbox" class="form-check-input" id="downloadAsSingleFile" formControlName="downloadAsSingleFile" />
+              <label class="form-check-label" for="downloadAsSingleFile" i18n>
+                Merge into single PDF
+              </label>
+            </div>
           </form>
         </div>
       </div>

--- a/src-ui/src/app/components/document-list/bulk-editor/bulk-editor.component.spec.ts
+++ b/src-ui/src/app/components/document-list/bulk-editor/bulk-editor.component.spec.ts
@@ -802,30 +802,37 @@ describe('BulkEditorComponent', () => {
       .spyOn(documentListViewService, 'documents', 'get')
       .mockReturnValue([{ id: 3 }, { id: 4 }])
     jest
-      .spyOn(documentListViewService, 'selected', 'get')
-      .mockReturnValue(new Set([3, 4]))
+      .spyOn(documentListViewService, 'getSelectedInOrder')
+      .mockReturnValue(new Array(3, 4))
     jest
       .spyOn(permissionsService, 'currentUserHasObjectPermissions')
       .mockReturnValue(true)
+    component.downloadForm.get('downloadAsSingleFile').patchValue(false)
     component.downloadForm.get('downloadFileTypeArchive').patchValue(true)
     fixture.detectChanges()
     let downloadSpy = jest.spyOn(documentService, 'bulkDownload')
     //archive
     component.downloadSelected()
-    expect(downloadSpy).toHaveBeenCalledWith([3, 4], 'archive', false)
+    expect(downloadSpy).toHaveBeenCalledWith([3, 4], 'archive', false, false)
     //originals
     component.downloadForm.get('downloadFileTypeArchive').patchValue(false)
     component.downloadForm.get('downloadFileTypeOriginals').patchValue(true)
     component.downloadSelected()
-    expect(downloadSpy).toHaveBeenCalledWith([3, 4], 'originals', false)
+    expect(downloadSpy).toHaveBeenCalledWith([3, 4], 'originals', false, false)
     //both
     component.downloadForm.get('downloadFileTypeArchive').patchValue(true)
     component.downloadSelected()
-    expect(downloadSpy).toHaveBeenCalledWith([3, 4], 'both', false)
+    expect(downloadSpy).toHaveBeenCalledWith([3, 4], 'both', false, false)
     //formatting
     component.downloadForm.get('downloadUseFormatting').patchValue(true)
     component.downloadSelected()
-    expect(downloadSpy).toHaveBeenCalledWith([3, 4], 'both', true)
+    expect(downloadSpy).toHaveBeenCalledWith([3, 4], 'both', false, true)
+    //merging
+    component.downloadForm.get('downloadFileTypeOriginals').patchValue(true)
+    component.downloadForm.get('downloadFileTypeArchive').patchValue(false)
+    component.downloadForm.get('downloadAsSingleFile').patchValue(true)
+    component.downloadSelected()
+    expect(downloadSpy).toHaveBeenCalledWith([3, 4], 'originals', true, false)
 
     httpTestingController.match(
       `${environment.apiBaseUrl}documents/bulk_download/`

--- a/src-ui/src/app/components/document-list/bulk-editor/bulk-editor.component.ts
+++ b/src-ui/src/app/components/document-list/bulk-editor/bulk-editor.component.ts
@@ -518,7 +518,12 @@ export class BulkEditorComponent
       )
       .pipe(first())
       .subscribe((result: any) => {
-        saveAs(result, 'documents.zip')
+        saveAs(
+          result,
+          this.downloadForm.get('downloadAsSingleFile').value
+            ? 'documents.pdf'
+            : 'documents.zip'
+        )
         this.awaitingDownload = false
       })
   }

--- a/src-ui/src/app/components/document-list/bulk-editor/bulk-editor.component.ts
+++ b/src-ui/src/app/components/document-list/bulk-editor/bulk-editor.component.ts
@@ -511,7 +511,7 @@ export class BulkEditorComponent
           : 'originals'
     this.documentService
       .bulkDownload(
-        Array.from(this.list.selected),
+        this.list.getSelectedInOrder(),
         downloadFileType,
         this.downloadForm.get('downloadAsSingleFile').value,
         this.downloadForm.get('downloadUseFormatting').value

--- a/src-ui/src/app/components/document-list/bulk-editor/bulk-editor.component.ts
+++ b/src-ui/src/app/components/document-list/bulk-editor/bulk-editor.component.ts
@@ -65,6 +65,7 @@ export class BulkEditorComponent
     downloadFileTypeArchive: new FormControl(true),
     downloadFileTypeOriginals: new FormControl(false),
     downloadUseFormatting: new FormControl(false),
+    downloadAsSingleFile: new FormControl(false),
   })
 
   constructor(
@@ -136,7 +137,11 @@ export class BulkEditorComponent
       .get('downloadFileTypeArchive')
       .valueChanges.pipe(takeUntil(this.unsubscribeNotifier))
       .subscribe((newValue) => {
-        if (!newValue) {
+        if (newValue && this.downloadForm.get('downloadAsSingleFile').value) {
+          this.downloadForm
+            .get('downloadFileTypeOriginals')
+            .patchValue(false, { emitEvent: false })
+        } else if (!newValue) {
           this.downloadForm
             .get('downloadFileTypeOriginals')
             .patchValue(true, { emitEvent: false })
@@ -146,10 +151,36 @@ export class BulkEditorComponent
       .get('downloadFileTypeOriginals')
       .valueChanges.pipe(takeUntil(this.unsubscribeNotifier))
       .subscribe((newValue) => {
-        if (!newValue) {
+        if (newValue && this.downloadForm.get('downloadAsSingleFile').value) {
+          this.downloadForm
+            .get('downloadFileTypeArchive')
+            .patchValue(false, { emitEvent: false })
+        } else if (!newValue) {
           this.downloadForm
             .get('downloadFileTypeArchive')
             .patchValue(true, { emitEvent: false })
+        }
+      })
+    this.downloadForm
+      .get('downloadAsSingleFile')
+      .valueChanges.pipe(takeUntil(this.unsubscribeNotifier))
+      .subscribe((newValue) => {
+        if (newValue) {
+          this.downloadForm
+            .get('downloadUseFormatting')
+            .patchValue(false, { emitEvent: false })
+          this.downloadForm.get('downloadUseFormatting').disable()
+
+          if (
+            this.downloadForm.get('downloadFileTypeArchive').value &&
+            this.downloadForm.get('downloadFileTypeOriginals').value
+          ) {
+            this.downloadForm
+              .get('downloadFileTypeArchive')
+              .patchValue(false, { emitEvent: false })
+          }
+        } else {
+          this.downloadForm.get('downloadUseFormatting').enable()
         }
       })
   }

--- a/src-ui/src/app/components/document-list/bulk-editor/bulk-editor.component.ts
+++ b/src-ui/src/app/components/document-list/bulk-editor/bulk-editor.component.ts
@@ -513,6 +513,7 @@ export class BulkEditorComponent
       .bulkDownload(
         Array.from(this.list.selected),
         downloadFileType,
+        this.downloadForm.get('downloadAsSingleFile').value,
         this.downloadForm.get('downloadUseFormatting').value
       )
       .pipe(first())

--- a/src-ui/src/app/services/document-list-view.service.ts
+++ b/src-ui/src/app/services/document-list-view.service.ts
@@ -358,6 +358,12 @@ export class DocumentListViewService {
     return this.activeListViewState.selected
   }
 
+  getSelectedInOrder(): number[] {
+    return this.activeListViewState.documents
+      .filter((item) => this.activeListViewState.selected.has(item.id))
+      .map((item) => item.id)
+  }
+
   setSort(field: string, reverse: boolean) {
     this.activeListViewState.sortField = field
     this.activeListViewState.sortReverse = reverse

--- a/src-ui/src/app/services/rest/document.service.spec.ts
+++ b/src-ui/src/app/services/rest/document.service.spec.ts
@@ -137,10 +137,11 @@ describe(`DocumentService`, () => {
 
   it('should call appropriate api endpoint for bulk download', () => {
     const ids = [1, 2, 3]
-    const content = 'both'
+    const content = 'originals'
+    const mergeIntoSingleFile = false
     const useFilenameFormatting = false
     subscription = service
-      .bulkDownload(ids, content, useFilenameFormatting)
+      .bulkDownload(ids, content, mergeIntoSingleFile, useFilenameFormatting)
       .subscribe()
     const req = httpTestingController.expectOne(
       `${environment.apiBaseUrl}${endpoint}/bulk_download/`
@@ -149,6 +150,7 @@ describe(`DocumentService`, () => {
     expect(req.request.body).toEqual({
       documents: ids,
       content,
+      single_file: mergeIntoSingleFile,
       follow_formatting: useFilenameFormatting,
     })
   })

--- a/src-ui/src/app/services/rest/document.service.ts
+++ b/src-ui/src/app/services/rest/document.service.ts
@@ -191,6 +191,7 @@ export class DocumentService extends AbstractPaperlessService<PaperlessDocument>
   bulkDownload(
     ids: number[],
     content = 'both',
+    mergeIntoSingleFile: boolean = false,
     useFilenameFormatting: boolean = false
   ) {
     return this.http.post(
@@ -198,6 +199,7 @@ export class DocumentService extends AbstractPaperlessService<PaperlessDocument>
       {
         documents: ids,
         content: content,
+        single_file: mergeIntoSingleFile,
         follow_formatting: useFilenameFormatting,
       },
       { responseType: 'blob' }

--- a/src/documents/bulk_download.py
+++ b/src/documents/bulk_download.py
@@ -1,12 +1,30 @@
 import os
-from zipfile import ZipFile
 
 from documents.models import Document
+from documents.parsers import merge_pdfs
+
+
+class MergedPdfFile:
+    def __init__(self, output_file_path):
+        self._output_file_path = output_file_path
+        self._input_file_paths = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        merge_pdfs(self._input_file_paths, self._output_file_path)
+
+    def namelist(self):
+        return self._input_file_paths
+
+    def write(self, document_path, _):
+        self._input_file_paths.append(document_path)
 
 
 class BulkArchiveStrategy:
-    def __init__(self, zipf: ZipFile, follow_formatting: bool = False):
-        self.zipf = zipf
+    def __init__(self, writer, follow_formatting: bool = False):
+        self.writer = writer
         if follow_formatting:
             self.make_unique_filename = self._formatted_filepath
         else:
@@ -27,7 +45,7 @@ class BulkArchiveStrategy:
         counter = 0
         while True:
             filename = folder + doc.get_public_filename(archive, counter)
-            if filename in self.zipf.namelist():
+            if filename in self.writer.namelist():
                 counter += 1
             else:
                 return filename
@@ -57,29 +75,29 @@ class BulkArchiveStrategy:
 
 class OriginalsOnlyStrategy(BulkArchiveStrategy):
     def add_document(self, doc: Document):
-        self.zipf.write(doc.source_path, self.make_unique_filename(doc))
+        self.writer.write(doc.source_path, self.make_unique_filename(doc))
 
 
 class ArchiveOnlyStrategy(BulkArchiveStrategy):
     def add_document(self, doc: Document):
         if doc.has_archive_version:
-            self.zipf.write(
+            self.writer.write(
                 doc.archive_path,
                 self.make_unique_filename(doc, archive=True),
             )
         else:
-            self.zipf.write(doc.source_path, self.make_unique_filename(doc))
+            self.writer.write(doc.source_path, self.make_unique_filename(doc))
 
 
 class OriginalAndArchiveStrategy(BulkArchiveStrategy):
     def add_document(self, doc: Document):
         if doc.has_archive_version:
-            self.zipf.write(
+            self.writer.write(
                 doc.archive_path,
                 self.make_unique_filename(doc, archive=True, folder="archive/"),
             )
 
-        self.zipf.write(
+        self.writer.write(
             doc.source_path,
             self.make_unique_filename(doc, folder="originals/"),
         )

--- a/src/documents/parsers.py
+++ b/src/documents/parsers.py
@@ -166,6 +166,19 @@ def run_convert(
         raise ParseError(f"Convert failed at {args}")
 
 
+def merge_pdfs(input_files, output_file):
+    cmd = [settings.GS_BINARY]
+    cmd += ["-sDEVICE=pdfwrite"]
+    cmd += ["-dBATCH"]
+    cmd += ["-dNOPAUSE"]
+    cmd += ["-q"]
+    cmd += [f"-sOutputFile={output_file}"]
+    cmd += input_files
+
+    if not subprocess.Popen(cmd).wait() == 0:
+        raise ParseError(f"Merge failed at {cmd}")
+
+
 def get_default_thumbnail() -> Path:
     """
     Returns the path to a generic thumbnail

--- a/src/documents/serialisers.py
+++ b/src/documents/serialisers.py
@@ -874,6 +874,10 @@ class BulkDownloadSerializer(DocumentListSerializer):
         default="none",
     )
 
+    single_file = serializers.BooleanField(
+        default=False,
+    )
+
     follow_formatting = serializers.BooleanField(
         default=False,
     )

--- a/src/documents/tests/test_api_bulk_download.py
+++ b/src/documents/tests/test_api_bulk_download.py
@@ -337,7 +337,7 @@ class TestBulkDownload(DirectoriesMixin, APITestCase):
                     zipf.read("originals/statement/Title 2 - Doc 3.jpg"),
                 )
 
-    @mock.patch("documents.parsers.merge_pdfs")
+    @mock.patch("documents.bulk_download.merge_pdfs")
     def test_download_single_file_from_originals(self, merge_pdfs_mock):
         """
         GIVEN:
@@ -381,7 +381,7 @@ class TestBulkDownload(DirectoriesMixin, APITestCase):
             mock.ANY,
         )
 
-    @mock.patch("documents.parsers.merge_pdfs")
+    @mock.patch("documents.bulk_download.merge_pdfs")
     def test_download_single_file_from_archives(self, merge_pdfs_mock):
         """
         GIVEN:

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -1106,8 +1106,12 @@ class BulkDownloadView(GenericAPIView):
                 strategy.add_document(doc)
 
         with open(temp.name, "rb") as f:
-            response = HttpResponse(f, content_type="application/zip")
-            response["Content-Disposition"] = "attachment"
+            file_extension = "pdf" if single_file else "zip"
+
+            response = HttpResponse(f, content_type=f"application/{file_extension}")
+            response[
+                "Content-Disposition"
+            ] = f'attachment; filename="documents.{file_extension}"'
 
             return response
 


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change
I'm using paperless-ngx for document sorting and periodic reports generation. Currently, the workflow requires from the user to select documents, download them as zipped collection, unpacking them and manually merging them in external file. I propose adding an option to automatically create single PDF when downloading multiple documents.

Changes in the front-end:

- Following checkbox in bulk download component: ![image](https://github.com/paperless-ngx/paperless-ngx/assets/35401835/4c81bbe2-d890-4347-826b-08d07db62d2b)
- Document IDs passed to **BulkDownloadView** are now passed in the same order as displayed to the user (useful when user wants the documents in a specific order)

Changes in the back-end:

- **BulkDownloadView**: Selection between **ZipFile** and new **MergedPdfFile** as writer
- Parsers: Added **merge_pdfs** method that uses already available ghostscript binary
 
Fixes # (issue)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain):

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
