### PR TITLE
Documentation: setup: Add notes regarding podman and SELinux

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -98,6 +98,10 @@ steps described in [Docker setup](#docker_hub) automatically.
     Don't change the part after the colon or paperless wont find your
     documents.
 
+    !!! note
+
+        When running with SELinux, this may need be taken into account e.g. by adding :Z for consume and export.
+
     You may also need to change the default port that the webserver will
     use from the default (8000):
 
@@ -136,6 +140,10 @@ steps described in [Docker setup](#docker_hub) automatically.
     >   image: ghcr.io/paperless-ngx/paperless-ngx:latest
     >   user: <user_id>
     > ```
+
+    !!! note
+
+        This is not required for podman and will break things. Similarly `USERMAP_UID` and `USERMAP_GID` should be unset or set to 0.
 
 5.  Modify `docker-compose.env`, following the comments in the file. The
     most important change is to set `USERMAP_UID` and `USERMAP_GID` to


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

The setup instructions are wrong for (rootless) podman. Add notes helping with getting paperless-ngx setup with podman. For rootless podman the process inside the container should be running as root (uid 0), which corresponds to the user running the container. The setup as described may lead to SELinux preventing access to consume and export which prevents the container from accessing those.

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (please explain): Documentation

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
