### PR TITLE
Elaborate on retagger for open documents

### DIFF
--- a/docs/administration.md
+++ b/docs/administration.md
@@ -405,6 +405,14 @@ assigned. `-f` works differently for tags: By default, only additional
 tags get added to documents, no tags will be removed. With `-f`, tags
 that don't match a document anymore get removed as well.
 
+!!! note
+
+    The retagger does not immediately assign or remove tags, correspondents
+    and document types in documents which are currently opened for editing.
+    If a document which is currently being edited gets examined by the
+    retagger, the changes will instead get reflected as suggestions below
+    the edit fields.
+
 ### Managing the Automatic matching algorithm
 
 The _Auto_ matching algorithm requires a trained neural network to work.


### PR DESCRIPTION
## Proposed change

If the retagger changes tags, correspondents or doc types for documents which are currently being edited, the changes will appear in the document overview as if they had been applied.

However, in the actual editing view, they are only displayed as suggestions, as long as the document is not saved again.

The pull request clarifies that in the docs.

See the following two screenshots as a reference

![overview](https://github.com/paperless-ngx/paperless-ngx/assets/2217280/ca9ea477-2555-4d40-b0a7-986297c9ce2d)

![edit](https://github.com/paperless-ngx/paperless-ngx/assets/2217280/a460d9b3-cb5b-43bd-812f-422db2a84222)

Fixes # (issue)

## Type of change

- [X] Other (please explain): documentation

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [~] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [~] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [~] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
```
check docstring is first.............................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check yaml...........................................(no files to check)Skipped
check toml...........................................(no files to check)Skipped
check that executables have shebangs.................(no files to check)Skipped
fix end of files.........................................................Passed
mixed line ending........................................................Passed
trim trailing whitespace.................................................Passed
check for case conflicts.................................................Passed
detect private key.......................................................Passed
prettier.................................................................Passed
ruff.................................................(no files to check)Skipped
black................................................(no files to check)Skipped
Hadolint.............................................(no files to check)Skipped
beautysh.............................................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
```
- [x] I have made corresponding changes to the documentation as needed.
- [~] I have checked my modifications for any breaking changes.
