### PR TITLE
Fix: Make the admin panel accessible when using a large number of documents

### DIFF
--- a/src/documents/admin.py
+++ b/src/documents/admin.py
@@ -108,7 +108,7 @@ class SavedViewAdmin(GuardedModelAdmin):
 
     inlines = [RuleInline]
 
-    def get_queryset(self, request):
+    def get_queryset(self, request):  # pragma: no cover
         return super().get_queryset(request).select_related("owner")
 
 
@@ -145,7 +145,7 @@ class NotesAdmin(GuardedModelAdmin):
     raw_id_fields = ("document",)
     search_fields = ("document__title",)
 
-    def get_queryset(self, request):
+    def get_queryset(self, request):  # pragma: no cover
         return (
             super()
             .get_queryset(request)
@@ -159,7 +159,7 @@ class ShareLinksAdmin(GuardedModelAdmin):
     list_display_links = ("created",)
     raw_id_fields = ("document",)
 
-    def get_queryset(self, request):
+    def get_queryset(self, request):  # pragma: no cover
         return super().get_queryset(request).select_related("document__correspondent")
 
 
@@ -177,7 +177,7 @@ class CustomFieldInstancesAdmin(GuardedModelAdmin):
     search_fields = ("document__title",)
     list_filter = ("created", "field")
 
-    def get_queryset(self, request):
+    def get_queryset(self, request):  # pragma: no cover
         return (
             super()
             .get_queryset(request)

--- a/src/documents/admin.py
+++ b/src/documents/admin.py
@@ -28,8 +28,9 @@ class CorrespondentAdmin(GuardedModelAdmin):
 
 class TagAdmin(GuardedModelAdmin):
     list_display = ("name", "color", "match", "matching_algorithm")
-    list_filter = ("color", "matching_algorithm")
+    list_filter = ("matching_algorithm",)
     list_editable = ("color", "match", "matching_algorithm")
+    search_fields = ("color", "name")
 
 
 class DocumentTypeAdmin(GuardedModelAdmin):
@@ -107,6 +108,9 @@ class SavedViewAdmin(GuardedModelAdmin):
 
     inlines = [RuleInline]
 
+    def get_queryset(self, request):
+        return super().get_queryset(request).select_related("owner")
+
 
 class StoragePathInline(admin.TabularInline):
     model = StoragePath
@@ -120,8 +124,8 @@ class StoragePathAdmin(GuardedModelAdmin):
 
 class TaskAdmin(admin.ModelAdmin):
     list_display = ("task_id", "task_file_name", "task_name", "date_done", "status")
-    list_filter = ("status", "date_done", "task_file_name", "task_name")
-    search_fields = ("task_name", "task_id", "status")
+    list_filter = ("status", "date_done", "task_name")
+    search_fields = ("task_name", "task_id", "status", "task_file_name")
     readonly_fields = (
         "task_id",
         "task_file_name",
@@ -138,12 +142,25 @@ class NotesAdmin(GuardedModelAdmin):
     list_display = ("user", "created", "note", "document")
     list_filter = ("created", "user")
     list_display_links = ("created",)
+    raw_id_fields = ("document",)
+    search_fields = ("document__title",)
+
+    def get_queryset(self, request):
+        return (
+            super()
+            .get_queryset(request)
+            .select_related("user", "document__correspondent")
+        )
 
 
 class ShareLinksAdmin(GuardedModelAdmin):
     list_display = ("created", "expiration", "document")
     list_filter = ("created", "expiration", "owner")
     list_display_links = ("created",)
+    raw_id_fields = ("document",)
+
+    def get_queryset(self, request):
+        return super().get_queryset(request).select_related("document__correspondent")
 
 
 class CustomFieldsAdmin(GuardedModelAdmin):
@@ -157,7 +174,15 @@ class CustomFieldInstancesAdmin(GuardedModelAdmin):
     fields = ("field", "document", "created", "value")
     readonly_fields = ("field", "document", "created", "value")
     list_display = ("field", "document", "value", "created")
-    list_filter = ("document", "created")
+    search_fields = ("document__title",)
+    list_filter = ("created", "field")
+
+    def get_queryset(self, request):
+        return (
+            super()
+            .get_queryset(request)
+            .select_related("field", "document__correspondent")
+        )
 
 
 admin.site.register(Correspondent, CorrespondentAdmin)

--- a/src/paperless_mail/admin.py
+++ b/src/paperless_mail/admin.py
@@ -119,7 +119,7 @@ class MailRuleAdmin(GuardedModelAdmin):
 
     ordering = ["order"]
 
-    raw_id_fields = ("assign_correspondent",)
+    raw_id_fields = ("assign_correspondent", "assign_document_type")
 
     filter_horizontal = ("assign_tags",)
 

--- a/src/paperless_mail/admin.py
+++ b/src/paperless_mail/admin.py
@@ -119,6 +119,10 @@ class MailRuleAdmin(GuardedModelAdmin):
 
     ordering = ["order"]
 
+    raw_id_fields = ("assign_correspondent",)
+
+    filter_horizontal = ("assign_tags",)
+
 
 class ProcessedMailAdmin(admin.ModelAdmin):
     class Meta:


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

This PR makes `Django Admin Panel` accessible when using a large number of documents. It removes huge document lists and optimizes db queries.

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

Fixes # (issue)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please explain):

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
