### PR TITLE
Fix: allow multiple consumption templates to assign the same custom field

### DIFF
--- a/src/documents/data_models.py
+++ b/src/documents/data_models.py
@@ -80,6 +80,7 @@ class DocumentMetadataOverrides:
             self.custom_field_ids = other.custom_field_ids
         elif other.custom_field_ids is not None:
             self.custom_field_ids.extend(other.custom_field_ids)
+            self.custom_field_ids = list(set(self.custom_field_ids))
 
         return self
 

--- a/src/documents/data_models.py
+++ b/src/documents/data_models.py
@@ -55,26 +55,31 @@ class DocumentMetadataOverrides:
             self.tag_ids = other.tag_ids
         elif other.tag_ids is not None:
             self.tag_ids.extend(other.tag_ids)
+            self.tag_ids = list(set(self.tag_ids))
 
         if self.view_users is None:
             self.view_users = other.view_users
         elif other.view_users is not None:
             self.view_users.extend(other.view_users)
+            self.view_users = list(set(self.view_users))
 
         if self.view_groups is None:
             self.view_groups = other.view_groups
         elif other.view_groups is not None:
             self.view_groups.extend(other.view_groups)
+            self.view_groups = list(set(self.view_groups))
 
         if self.change_users is None:
             self.change_users = other.change_users
         elif other.change_users is not None:
             self.change_users.extend(other.change_users)
+            self.change_users = list(set(self.change_users))
 
         if self.change_groups is None:
             self.change_groups = other.change_groups
         elif other.change_groups is not None:
             self.change_groups.extend(other.change_groups)
+            self.change_groups = list(set(self.change_groups))
 
         if self.custom_field_ids is None:
             self.custom_field_ids = other.custom_field_ids


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Not sure if this truly needs a test, happy to remove it if needed.

Closes #5140 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
