### PR TITLE
Fix: type casting of db values for 'shared by me' filter

### DIFF
--- a/src/documents/filters.py
+++ b/src/documents/filters.py
@@ -1,7 +1,9 @@
 from django.contrib.contenttypes.models import ContentType
+from django.db.models import CharField
 from django.db.models import Count
 from django.db.models import OuterRef
 from django.db.models import Q
+from django.db.models.functions import Cast
 from django_filters.rest_framework import BooleanFilter
 from django_filters.rest_framework import Filter
 from django_filters.rest_framework import FilterSet
@@ -119,7 +121,7 @@ class SharedByUser(Filter):
                 num_shared_users=Count(
                     UserObjectPermission.objects.filter(
                         content_type=ctype,
-                        object_pk=OuterRef("pk"),
+                        object_pk=Cast(OuterRef("pk"), CharField()),
                     ).values("user_id"),
                 ),
             )
@@ -127,7 +129,7 @@ class SharedByUser(Filter):
                 num_shared_groups=Count(
                     GroupObjectPermission.objects.filter(
                         content_type=ctype,
-                        object_pk=OuterRef("pk"),
+                        object_pk=Cast(OuterRef("pk"), CharField()),
                     ).values("group_id"),
                 ),
             )


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Well this was a new one for me, this issue only happens on non-SQLite DBs. In short:
```
Error while loading documents: ProgrammingError at /api/documents/ operator does not exist: character varying = integer LINE 1: …ERE (UO."content_type_id" = 11 AND UO."object_pk" = ("docume… ^ HINT: No operator matches the given name and argument types. You might need to add explicit type casts.
```

happens because `object_pk` is varchar and pk is of course integer. As the error says, we need to explicitly type cast: https://stackoverflow.com/questions/67699841/how-to-annotate-django-queryset-with-the-same-value-but-with-a-different-data-ty

Closes #5152

Before:
<img width="1446" alt="Screenshot 2023-12-29 at 12 26 38 AM" src="https://github.com/paperless-ngx/paperless-ngx/assets/4887959/5cc00cf2-d907-4489-a14b-4ff4127324a9">

After:
<img width="1702" alt="Screenshot 2023-12-29 at 12 29 36 AM" src="https://github.com/paperless-ngx/paperless-ngx/assets/4887959/919c0f8c-5463-4819-a999-e9e4448749ae">


## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
