### PR TITLE
Fix: Disable custom field remove button if user does not have permissions

### DIFF
--- a/src-ui/src/app/components/document-detail/document-detail.component.html
+++ b/src-ui/src/app/components/document-detail/document-detail.component.html
@@ -123,28 +123,73 @@
                         <div [formGroup]="customFieldFormFields.controls[i]">
                           @switch (getCustomFieldFromInstance(fieldInstance)?.data_type) {
                             @case (PaperlessCustomFieldDataType.String) {
-                              <pngx-input-text formControlName="value" [title]="getCustomFieldFromInstance(fieldInstance)?.name" [removable]="true" (removed)="removeField(fieldInstance)" [horizontal]="true" [error]="getCustomFieldError(i)"></pngx-input-text>
+                              <pngx-input-text formControlName="value"
+                              [title]="getCustomFieldFromInstance(fieldInstance)?.name"
+                              [removable]="userIsOwner"
+                              (removed)="removeField(fieldInstance)"
+                              [horizontal]="true"
+                              [error]="getCustomFieldError(i)"></pngx-input-text>
                             }
                             @case (PaperlessCustomFieldDataType.Date) {
-                              <pngx-input-date formControlName="value" [title]="getCustomFieldFromInstance(fieldInstance)?.name" [removable]="true" (removed)="removeField(fieldInstance)" [horizontal]="true" [error]="getCustomFieldError(i)"></pngx-input-date>
+                              <pngx-input-date formControlName="value"
+                              [title]="getCustomFieldFromInstance(fieldInstance)?.name"
+                              [removable]="userIsOwner"
+                              (removed)="removeField(fieldInstance)"
+                              [horizontal]="true"
+                              [error]="getCustomFieldError(i)"></pngx-input-date>
                             }
                             @case (PaperlessCustomFieldDataType.Integer) {
-                              <pngx-input-number formControlName="value" [title]="getCustomFieldFromInstance(fieldInstance)?.name" [removable]="true" (removed)="removeField(fieldInstance)" [horizontal]="true" [showAdd]="false" [error]="getCustomFieldError(i)"></pngx-input-number>
+                              <pngx-input-number formControlName="value"
+                              [title]="getCustomFieldFromInstance(fieldInstance)?.name"
+                              [removable]="userIsOwner"
+                              (removed)="removeField(fieldInstance)"
+                              [horizontal]="true"
+                              [showAdd]="false"
+                              [error]="getCustomFieldError(i)"></pngx-input-number>
                             }
                             @case (PaperlessCustomFieldDataType.Float) {
-                              <pngx-input-number formControlName="value" [title]="getCustomFieldFromInstance(fieldInstance)?.name" [removable]="true" (removed)="removeField(fieldInstance)" [horizontal]="true" [showAdd]="false" [step]=".1" [error]="getCustomFieldError(i)"></pngx-input-number>
+                              <pngx-input-number formControlName="value"
+                              [title]="getCustomFieldFromInstance(fieldInstance)?.name"
+                              [removable]="userIsOwner"
+                              (removed)="removeField(fieldInstance)"
+                              [horizontal]="true"
+                              [showAdd]="false"
+                              [step]=".1"
+                              [error]="getCustomFieldError(i)"></pngx-input-number>
                             }
                             @case (PaperlessCustomFieldDataType.Monetary) {
-                              <pngx-input-number formControlName="value" [title]="getCustomFieldFromInstance(fieldInstance)?.name" [removable]="true" (removed)="removeField(fieldInstance)" [horizontal]="true" [showAdd]="false" [step]=".01" [error]="getCustomFieldError(i)"></pngx-input-number>
+                              <pngx-input-number formControlName="value"
+                              [title]="getCustomFieldFromInstance(fieldInstance)?.name"
+                              [removable]="userIsOwner"
+                              (removed)="removeField(fieldInstance)"
+                              [horizontal]="true"
+                              [showAdd]="false"
+                              [step]=".01"
+                              [error]="getCustomFieldError(i)"></pngx-input-number>
                             }
                             @case (PaperlessCustomFieldDataType.Boolean) {
-                              <pngx-input-check formControlName="value" [title]="getCustomFieldFromInstance(fieldInstance)?.name" [removable]="true" (removed)="removeField(fieldInstance)" [horizontal]="true"></pngx-input-check>
+                              <pngx-input-check formControlName="value"
+                              [title]="getCustomFieldFromInstance(fieldInstance)?.name"
+                              [removable]="userIsOwner"
+                              (removed)="removeField(fieldInstance)"
+                              [horizontal]="true"></pngx-input-check>
                             }
                             @case (PaperlessCustomFieldDataType.Url) {
-                              <pngx-input-url formControlName="value" [title]="getCustomFieldFromInstance(fieldInstance)?.name" [removable]="true" (removed)="removeField(fieldInstance)" [horizontal]="true" [error]="getCustomFieldError(i)"></pngx-input-url>
+                              <pngx-input-url formControlName="value"
+                              [title]="getCustomFieldFromInstance(fieldInstance)?.name"
+                              [removable]="userIsOwner"
+                              (removed)="removeField(fieldInstance)"
+                              [horizontal]="true"
+                              [error]="getCustomFieldError(i)"></pngx-input-url>
                             }
                             @case (PaperlessCustomFieldDataType.DocumentLink) {
-                              <pngx-input-document-link formControlName="value" [title]="getCustomFieldFromInstance(fieldInstance)?.name" [parentDocumentID]="documentId" [removable]="true" (removed)="removeField(fieldInstance)" [horizontal]="true" [error]="getCustomFieldError(i)"></pngx-input-document-link>
+                              <pngx-input-document-link formControlName="value"
+                              [title]="getCustomFieldFromInstance(fieldInstance)?.name"
+                              [parentDocumentID]="documentId"
+                              [removable]="userIsOwner"
+                              (removed)="removeField(fieldInstance)"
+                              [horizontal]="true"
+                              [error]="getCustomFieldError(i)"></pngx-input-document-link>
                             }
                           }
                         </div>


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

I reformatted the lines but the only change is `[removable]=“userIsOwner”`, which is what it should have been before. It's just a visual bug i.e. only show that button if the user really can.

Closes #5192 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
