### PR TITLE
Fix: filename format remove none when part of directory

### DIFF
--- a/src/documents/file_handling.py
+++ b/src/documents/file_handling.py
@@ -222,7 +222,7 @@ def generate_filename(
             ).strip()
 
             if settings.FILENAME_FORMAT_REMOVE_NONE:
-                path = path.replace("-none-/", "")  # remove empty directories
+                path = path.replace("/-none-/", "/")  # remove empty directories
                 path = path.replace(" -none-", "")  # remove when spaced, with space
                 path = path.replace("-none-", "")  # remove rest of the occurences
 

--- a/src/documents/tests/test_file_handling.py
+++ b/src/documents/tests/test_file_handling.py
@@ -1007,6 +1007,9 @@ class TestFilenameGeneration(DirectoriesMixin, TestCase):
         self.assertEqual(generate_filename(doc_a), "ThisIsAFolder/4/2020-06-25.pdf")
         self.assertEqual(generate_filename(doc_b), "SomeImportantNone/2020-07-25.pdf")
 
+    @override_settings(
+        FILENAME_FORMAT=None,
+    )
     def test_no_path_fallback(self):
         """
         GIVEN:
@@ -1157,3 +1160,28 @@ class TestFilenameGeneration(DirectoriesMixin, TestCase):
 
         self.assertEqual(generate_filename(text_doc), "logs.txt")
         self.assertEqual(generate_filename(text_doc, archive_filename=True), "logs.pdf")
+
+    @override_settings(
+        FILENAME_FORMAT="XX{correspondent}/{title}",
+        FILENAME_FORMAT_REMOVE_NONE=True,
+    )
+    def test_remove_none_not_dir(self):
+        """
+        GIVEN:
+            - A document with & filename format that includes correspondent as part of directory name
+            - FILENAME_FORMAT_REMOVE_NONE is True
+        WHEN:
+            - the filename is generated for the document
+        THEN:
+            - the missing correspondent is removed but directory structure retained
+        """
+        document = Document.objects.create(
+            title="doc1",
+            mime_type="application/pdf",
+        )
+        document.storage_type = Document.STORAGE_TYPE_UNENCRYPTED
+        document.save()
+
+        # Ensure that filename is properly generated
+        document.filename = generate_filename(document)
+        self.assertEqual(document.filename, "XX/doc1.pdf")


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

I think this is OK, even if it were to be `-none-/something` that would still get replaced, and this does seem more like what it should do.

Closes #5202

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
