### PR TITLE
Change: Use fnmatch for more sane workflow path matching

### DIFF
--- a/src/documents/matching.py
+++ b/src/documents/matching.py
@@ -296,7 +296,10 @@ def consumable_document_matches_workflow(
     if (
         trigger.filter_path is not None
         and len(trigger.filter_path) > 0
-        and not document.original_file.match(trigger.filter_path)
+        and not fnmatch(
+            document.original_file,
+            trigger.filter_path,
+        )
     ):
         reason = (
             f"Document path {document.original_file}"


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

In discussing fancier ideas for this I tried a couple things but in the end I did find `fnmatch` was more reasonable and simple. As you can see, none of the current tests needed to be changed but it's possible this could alter people's current setups. That said, in the same move to workflows I think this kinda makes sense, it's one big transition.

The added test demonstrates an example of what feels way more sane to me, e.g. `*sample*` will now match `/samples/simple.pdf`, whereas that fails with current pathlib.match

Again, Im not the lead python dev around these parts, obviously its a very simple change but welcome any thoughts / improvements or even NBD if a superseding PR

Closes #(issue or discussion)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [x] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
