### PR TITLE
Fix: Crash in barcode ASN reading when the file type isn't supported

### DIFF
--- a/src/documents/barcodes.py
+++ b/src/documents/barcodes.py
@@ -90,6 +90,9 @@ class BarcodeReader:
         """
         asn = None
 
+        if not self.supported_mime_type:
+            return None
+
         # Ensure the barcodes have been read
         self.detect()
 
@@ -215,7 +218,7 @@ class BarcodeReader:
         # This file is really borked, allow the consumption to continue
         # but it may fail further on
         except Exception as e:  # pragma: no cover
-            logger.warning(
+            logger.exception(
                 f"Exception during barcode scanning: {e}",
             )
 

--- a/src/documents/tasks.py
+++ b/src/documents/tasks.py
@@ -152,10 +152,13 @@ def consume_file(
                 return "File successfully split"
 
             # try reading the ASN from barcode
-            if settings.CONSUMER_ENABLE_ASN_BARCODE and reader.asn is not None:
+            if (
+                settings.CONSUMER_ENABLE_ASN_BARCODE
+                and (located_asn := reader.asn) is not None
+            ):
                 # Note this will take precedence over an API provided ASN
                 # But it's from a physical barcode, so that's good
-                overrides.asn = reader.asn
+                overrides.asn = located_asn
                 logger.info(f"Found ASN in barcode: {overrides.asn}")
 
     template_overrides = Consumer().get_workflow_overrides(


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

<!--
⚠️ Important: Pull requests that implement a new feature *should almost always target an existing feature request*. This is in order to balance the work of implementing and maintaining new features vs. community-interest. If that is not currently the case, please open a feature request instead of this PR to gather feedback from both users and the project maintainers.
-->

Quick shortcut to not try and read barcodes if we don't support that mime type.  Prevents reading from `temp_dir` when it is None, which only happens if the mime is not supported.  

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
