### PR TITLE
Fix: edit workflow form not displaying trigger settings

### DIFF
--- a/src-ui/src/app/components/common/edit-dialog/workflow-edit-dialog/workflow-edit-dialog.component.ts
+++ b/src-ui/src/app/components/common/edit-dialog/workflow-edit-dialog/workflow-edit-dialog.component.ts
@@ -179,9 +179,9 @@ export class WorkflowEditDialogComponent
           filter_filename: new FormControl(trigger.filter_filename),
           filter_path: new FormControl(trigger.filter_path),
           filter_mailrule: new FormControl(trigger.filter_mailrule),
-          matching_algorithm: new FormControl(MATCH_NONE),
-          match: new FormControl(''),
-          is_insensitive: new FormControl(true),
+          matching_algorithm: new FormControl(trigger.matching_algorithm),
+          match: new FormControl(trigger.match),
+          is_insensitive: new FormControl(trigger.is_insensitive),
           filter_has_tags: new FormControl(trigger.filter_has_tags),
           filter_has_correspondent: new FormControl(
             trigger.filter_has_correspondent
@@ -242,6 +242,9 @@ export class WorkflowEditDialogComponent
       filter_has_tags: [],
       filter_has_correspondent: null,
       filter_has_document_type: null,
+      matching_algorithm: MATCH_NONE,
+      match: null,
+      is_insensitive: true,
     })
 
     this.updateTriggerActionFields()


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

copypasta error, the edit dialog is using defaults for these and not the actual trigger settings

https://github.com/paperless-ngx/paperless-ngx/assets/4887959/0a4fd033-3745-45bd-8062-f3b37cf970de



Closes #5274 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
