### PR TITLE
Enhancement: title assignment placeholder error handling, fallback

### DIFF
--- a/src-ui/src/app/components/common/edit-dialog/workflow-edit-dialog/workflow-edit-dialog.component.html
+++ b/src-ui/src/app/components/common/edit-dialog/workflow-edit-dialog/workflow-edit-dialog.component.html
@@ -99,7 +99,7 @@
                         <input type="hidden" formControlName="id" />
                         <div class="row">
                           <div class="col">
-                            <pngx-input-text i18n-title title="Assign title" formControlName="assign_title" i18n-hint hint="Can include some placeholders, see <a target='_blank' href='https://docs.paperless-ngx.com/usage/#workflows'>documentation</a>." [error]="error?.assign_title"></pngx-input-text>
+                            <pngx-input-text i18n-title title="Assign title" formControlName="assign_title" i18n-hint hint="Can include some placeholders, see <a target='_blank' href='https://docs.paperless-ngx.com/usage/#workflows'>documentation</a>." [error]="error?.actions?.[i]?.assign_title"></pngx-input-text>
                             <pngx-input-tags [allowCreate]="false" i18n-title title="Assign tags" formControlName="assign_tags"></pngx-input-tags>
                             <pngx-input-select i18n-title title="Assign document type" [items]="documentTypes" [allowNull]="true" formControlName="assign_document_type"></pngx-input-select>
                             <pngx-input-select i18n-title title="Assign correspondent" [items]="correspondents" [allowNull]="true" formControlName="assign_correspondent"></pngx-input-select>

--- a/src/documents/consumer.py
+++ b/src/documents/consumer.py
@@ -730,9 +730,9 @@ class Consumer(LoggingMixin):
         if self.override_title is not None:
             try:
                 title = self._parse_title_placeholders(self.override_title)
-            except Exception:
+            except Exception as e:
                 self.log.error(
-                    f"Error occurred parsing title override '{self.override_title}', falling back to original",
+                    f"Error occurred parsing title override '{self.override_title}', falling back to original. Exception: {e}",
                 )
 
         document = Document.objects.create(

--- a/src/documents/consumer.py
+++ b/src/documents/consumer.py
@@ -726,12 +726,17 @@ class Consumer(LoggingMixin):
 
         storage_type = Document.STORAGE_TYPE_UNENCRYPTED
 
+        title = file_info.title[:127]
+        if self.override_title is not None:
+            try:
+                title = self._parse_title_placeholders(self.override_title)
+            except Exception:
+                self.log.error(
+                    f"Error occurred parsing title override '{self.override_title}', falling back to original",
+                )
+
         document = Document.objects.create(
-            title=(
-                self._parse_title_placeholders(self.override_title)
-                if self.override_title is not None
-                else file_info.title
-            )[:127],
+            title=title,
             content=text,
             mime_type=mime_type,
             checksum=hashlib.md5(self.working_copy.read_bytes()).hexdigest(),

--- a/src/documents/serialisers.py
+++ b/src/documents/serialisers.py
@@ -1414,9 +1414,9 @@ class WorkflowActionSerializer(serializers.ModelSerializer):
                         created_day="",
                         created_time="",
                     )
-                except ValueError as e:
+                except (ValueError, KeyError) as e:
                     raise serializers.ValidationError(
-                        {"assign_title": f"Invalid f-string detected: {e.args[0]}"},
+                        {"assign_title": f'Invalid f-string detected: "{e.args[0]}"'},
                     )
 
         return attrs

--- a/src/documents/serialisers.py
+++ b/src/documents/serialisers.py
@@ -1386,12 +1386,38 @@ class WorkflowActionSerializer(serializers.ModelSerializer):
 
     def validate(self, attrs):
         # Empty strings treated as None to avoid unexpected behavior
-        if (
-            "assign_title" in attrs
-            and attrs["assign_title"] is not None
-            and len(attrs["assign_title"]) == 0
-        ):
-            attrs["assign_title"] = None
+        if "assign_title" in attrs:
+            if attrs["assign_title"] is not None and len(attrs["assign_title"]) == 0:
+                attrs["assign_title"] = None
+            else:
+                try:
+                    # test against all placeholders, see consumer.py `parse_doc_title_w_placeholders`
+                    attrs["assign_title"].format(
+                        correspondent="",
+                        document_type="",
+                        added="",
+                        added_year="",
+                        added_year_short="",
+                        added_month="",
+                        added_month_name="",
+                        added_month_name_short="",
+                        added_day="",
+                        added_time="",
+                        owner_username="",
+                        original_filename="",
+                        created="",
+                        created_year="",
+                        created_year_short="",
+                        created_month="",
+                        created_month_name="",
+                        created_month_name_short="",
+                        created_day="",
+                        created_time="",
+                    )
+                except ValueError as e:
+                    raise serializers.ValidationError(
+                        {"assign_title": f"Invalid f-string detected: {e.args[0]}"},
+                    )
 
         return attrs
 

--- a/src/documents/signals/handlers.py
+++ b/src/documents/signals/handlers.py
@@ -570,19 +570,27 @@ def run_workflow(
                     document.owner = action.assign_owner
 
                 if action.assign_title is not None:
-                    document.title = parse_doc_title_w_placeholders(
-                        action.assign_title,
-                        document.correspondent.name
-                        if document.correspondent is not None
-                        else "",
-                        document.document_type.name
-                        if document.document_type is not None
-                        else "",
-                        document.owner.username if document.owner is not None else "",
-                        timezone.localtime(document.added),
-                        document.original_filename,
-                        timezone.localtime(document.created),
-                    )
+                    try:
+                        document.title = parse_doc_title_w_placeholders(
+                            action.assign_title,
+                            document.correspondent.name
+                            if document.correspondent is not None
+                            else "",
+                            document.document_type.name
+                            if document.document_type is not None
+                            else "",
+                            document.owner.username
+                            if document.owner is not None
+                            else "",
+                            document.added,
+                            document.original_filename,
+                            document.created,
+                        )
+                    except Exception:
+                        logger.error(
+                            f"Error occurred parsing title assignment '{action.assign_title}', falling back to original",
+                            extra={"group": logging_group},
+                        )
 
                 if (
                     action.assign_view_users is not None

--- a/src/documents/signals/handlers.py
+++ b/src/documents/signals/handlers.py
@@ -587,7 +587,7 @@ def run_workflow(
                             document.created,
                         )
                     except Exception:
-                        logger.error(
+                        logger.exception(
                             f"Error occurred parsing title assignment '{action.assign_title}', falling back to original",
                             extra={"group": logging_group},
                         )

--- a/src/documents/tests/test_api_workflows.py
+++ b/src/documents/tests/test_api_workflows.py
@@ -248,6 +248,45 @@ class TestApiWorkflows(DirectoriesMixin, APITestCase):
 
         self.assertEqual(WorkflowTrigger.objects.count(), 1)
 
+    def test_api_create_invalid_assign_title(self):
+        """
+        GIVEN:
+            - API request to create a workflow
+            - Invalid f-string for assign_title
+        WHEN:
+            - API is called
+        THEN:
+            - Correct HTTP 400 response
+            - No objects are created
+        """
+        response = self.client.post(
+            self.ENDPOINT,
+            json.dumps(
+                {
+                    "name": "Workflow 1",
+                    "order": 1,
+                    "triggers": [
+                        {
+                            "type": WorkflowTrigger.WorkflowTriggerType.DOCUMENT_UPDATED,
+                        },
+                    ],
+                    "actions": [
+                        {
+                            "assign_title": "{created_year]",
+                        },
+                    ],
+                },
+            ),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn(
+            "Invalid f-string detected",
+            response.data["actions"][0]["assign_title"][0],
+        )
+
+        self.assertEqual(Workflow.objects.count(), 1)
+
     def test_api_create_workflow_trigger_action_empty_fields(self):
         """
         GIVEN:

--- a/src/documents/tests/test_consumer.py
+++ b/src/documents/tests/test_consumer.py
@@ -423,6 +423,16 @@ class TestConsumer(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
         self.assertEqual(document.title, "Override Title")
         self._assert_first_last_send_progress()
 
+    def testOverrideTitleInvalidPlaceholders(self):
+        with self.assertLogs("paperless.consumer", level="ERROR") as cm:
+            document = self.consumer.try_consume_file(
+                self.get_test_file(),
+                override_title="Override {correspondent]",
+            )
+            self.assertEqual(document.title, "sample")
+            expected_str = "Error occurred parsing title override 'Override {correspondent]', falling back to original"
+            self.assertIn(expected_str, cm.output[0])
+
     def testOverrideCorrespondent(self):
         c = Correspondent.objects.create(name="test")
 


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

This handles errors and falls back to the original title. Welcome any thoughts.

Neither of these are bugs IMHO, but worth improving I think
Closes #5277
Closes #5321

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [x] Other. Please explain: Error handling

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
