### PR TITLE
Fix: triggered workflow assignment of customfield fails if field exists in v2.3.1

### DIFF
--- a/src/documents/signals/handlers.py
+++ b/src/documents/signals/handlers.py
@@ -610,10 +610,18 @@ def run_workflow(
 
                 if action.assign_custom_fields is not None:
                     for field in action.assign_custom_fields.all():
-                        CustomFieldInstance.objects.create(
-                            field=field,
-                            document=document,
-                        )  # adds to document
+                        if (
+                            CustomFieldInstance.objects.filter(
+                                field=field,
+                                document=document,
+                            ).count()
+                            == 0
+                        ):
+                            # can be triggered on existing docs, so only add the field if it doesnt already exist
+                            CustomFieldInstance.objects.create(
+                                field=field,
+                                document=document,
+                            )
 
             document.save()
 

--- a/src/documents/tests/test_workflows.py
+++ b/src/documents/tests/test_workflows.py
@@ -13,6 +13,7 @@ from documents.data_models import DocumentSource
 from documents.matching import document_matches_workflow
 from documents.models import Correspondent
 from documents.models import CustomField
+from documents.models import CustomFieldInstance
 from documents.models import Document
 from documents.models import DocumentType
 from documents.models import MatchingModel
@@ -985,6 +986,39 @@ class TestWorkflows(DirectoriesMixin, FileSystemAssertsMixin, APITestCase):
             correspondent=self.c,
             original_filename="sample.pdf",
         )
+
+        superuser = User.objects.create_superuser("superuser")
+        self.client.force_authenticate(user=superuser)
+
+        self.client.patch(
+            f"/api/documents/{doc.id}/",
+            {"document_type": self.dt.id},
+            format="json",
+        )
+
+        self.assertEqual(doc.custom_fields.all().count(), 1)
+
+    def test_document_updated_workflow_existing_custom_field(self):
+        trigger = WorkflowTrigger.objects.create(
+            type=WorkflowTrigger.WorkflowTriggerType.DOCUMENT_UPDATED,
+            filter_has_document_type=self.dt,
+        )
+        action = WorkflowAction.objects.create()
+        action.assign_custom_fields.add(self.cf1)
+        w = Workflow.objects.create(
+            name="Workflow 1",
+            order=0,
+        )
+        w.triggers.add(trigger)
+        w.actions.add(action)
+        w.save()
+
+        doc = Document.objects.create(
+            title="sample test",
+            correspondent=self.c,
+            original_filename="sample.pdf",
+        )
+        CustomFieldInstance.objects.create(document=doc, field=self.cf1)
 
         superuser = User.objects.create_superuser("superuser")
         self.client.force_authenticate(user=superuser)

--- a/src/documents/tests/test_workflows.py
+++ b/src/documents/tests/test_workflows.py
@@ -999,6 +999,14 @@ class TestWorkflows(DirectoriesMixin, FileSystemAssertsMixin, APITestCase):
         self.assertEqual(doc.custom_fields.all().count(), 1)
 
     def test_document_updated_workflow_existing_custom_field(self):
+        """
+        GIVEN:
+            - Existing workflow with UPDATED trigger and action that adds a custom field
+        WHEN:
+            - Document is updated that already contains the field
+        THEN:
+            - Document update succeeds without trying to re-create the field
+        """
         trigger = WorkflowTrigger.objects.create(
             type=WorkflowTrigger.WorkflowTriggerType.DOCUMENT_UPDATED,
             filter_has_document_type=self.dt,


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Now I get it, since actions can run on `document updated` the field may already exist on the doc. E.g. the added test here fails in v2.3.1

Closes #5293

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
