### PR TITLE
Chore: Initial refactor of consume task

### DIFF
--- a/src/documents/double_sided.py
+++ b/src/documents/double_sided.py
@@ -3,127 +3,145 @@ import logging
 import os
 import shutil
 from pathlib import Path
+from typing import Final
+from typing import Optional
 
 from django.conf import settings
 from pikepdf import Pdf
 
 from documents.consumer import ConsumerError
 from documents.converters import convert_from_tiff_to_pdf
-from documents.data_models import ConsumableDocument
+from documents.plugins.base import ConsumeTaskPlugin
+from documents.plugins.base import NoCleanupPluginMixin
+from documents.plugins.base import NoSetupPluginMixin
+from documents.plugins.base import StopConsumeTaskError
 
 logger = logging.getLogger("paperless.double_sided")
 
 # Hardcoded for now, could be made a configurable setting if needed
-TIMEOUT_MINUTES = 30
+TIMEOUT_MINUTES: Final[int] = 30
+TIMEOUT_SECONDS: Final[int] = TIMEOUT_MINUTES * 60
 
 # Used by test cases
 STAGING_FILE_NAME = "double-sided-staging.pdf"
 
 
-def collate(input_doc: ConsumableDocument) -> str:
-    """
-    Tries to collate pages from 2 single sided scans of a double sided
-    document.
+class CollatePlugin(NoCleanupPluginMixin, NoSetupPluginMixin, ConsumeTaskPlugin):
+    NAME: str = "CollatePlugin"
 
-    When called with a file, it checks whether or not a staging file
-    exists, if not, the current file is turned into that staging file
-    containing the odd numbered pages.
-
-    If a staging file exists, and it is not too old, the current file is
-    considered to be the second part (the even numbered pages) and it will
-    collate the pages of both, the pages of the second file will be added
-    in reverse order, since the ADF will have scanned the pages from bottom
-    to top.
-
-    Returns a status message on success, or raises a ConsumerError
-    in case of failure.
-    """
-
-    # Make sure scratch dir exists, Consumer might not have run yet
-    settings.SCRATCH_DIR.mkdir(exist_ok=True)
-
-    if input_doc.mime_type == "application/pdf":
-        pdf_file = input_doc.original_file
-    elif (
-        input_doc.mime_type == "image/tiff"
-        and settings.CONSUMER_COLLATE_DOUBLE_SIDED_TIFF_SUPPORT
-    ):
-        pdf_file = convert_from_tiff_to_pdf(
-            input_doc.original_file,
-            settings.SCRATCH_DIR,
-        )
-        input_doc.original_file.unlink()
-    else:
-        raise ConsumerError("Unsupported file type for collation of double-sided scans")
-
-    staging = settings.SCRATCH_DIR / STAGING_FILE_NAME
-
-    valid_staging_exists = False
-    if staging.exists():
-        stats = os.stat(str(staging))
-        # if the file is older than the timeout, we don't consider
-        # it valid
-        if dt.datetime.now().timestamp() - stats.st_mtime > TIMEOUT_MINUTES * 60:
-            logger.warning("Outdated double sided staging file exists, deleting it")
-            os.unlink(str(staging))
-        else:
-            valid_staging_exists = True
-
-    if valid_staging_exists:
-        try:
-            # Collate pages from second PDF in reverse order
-            with Pdf.open(staging) as pdf1, Pdf.open(pdf_file) as pdf2:
-                pdf2.pages.reverse()
-                try:
-                    for i, page in enumerate(pdf2.pages):
-                        pdf1.pages.insert(2 * i + 1, page)
-                except IndexError:
-                    raise ConsumerError(
-                        "This second file (even numbered pages) contains more "
-                        "pages than the first/odd numbered one. This means the "
-                        "two uploaded files don't belong to the same double-"
-                        "sided scan. Please retry, starting with the odd "
-                        "numbered pages again.",
-                    )
-                # Merged file has the same path, but without the
-                # double-sided subdir. Therefore, it is also in the
-                # consumption dir and will be picked up for processing
-                old_file = input_doc.original_file
-                new_file = Path(
-                    *(
-                        part
-                        for part in old_file.with_name(
-                            f"{old_file.stem}-collated.pdf",
-                        ).parts
-                        if part != settings.CONSUMER_COLLATE_DOUBLE_SIDED_SUBDIR_NAME
-                    ),
-                )
-                # If the user didn't create the subdirs yet, do it for them
-                new_file.parent.mkdir(parents=True, exist_ok=True)
-                pdf1.save(new_file)
-            logger.info("Collated documents into new file %s", new_file)
-            return (
-                "Success. Even numbered pages of double sided scan collated "
-                "with odd pages"
-            )
-        finally:
-            # Delete staging and recently uploaded file no matter what.
-            # If any error occurs, the user needs to be able to restart
-            # the process from scratch; after all, the staging file
-            # with the odd numbered pages might be the culprit
-            pdf_file.unlink()
-            staging.unlink()
-
-    else:
-        shutil.move(pdf_file, staging)
-        # update access to modification time so we know if the file
-        # is outdated when another file gets uploaded
-        os.utime(staging, (dt.datetime.now().timestamp(),) * 2)
-        logger.info(
-            "Got scan with odd numbered pages of double-sided scan, moved it to %s",
-            staging,
-        )
+    @property
+    def able_to_run(self) -> bool:
         return (
-            "Received odd numbered pages of double sided scan, waiting up to "
-            f"{TIMEOUT_MINUTES} minutes for even numbered pages"
+            settings.CONSUMER_ENABLE_COLLATE_DOUBLE_SIDED
+            and settings.CONSUMER_COLLATE_DOUBLE_SIDED_SUBDIR_NAME
+            in self.input_doc.original_file.parts
         )
+
+    def run(self) -> Optional[str]:
+        """
+        Tries to collate pages from 2 single sided scans of a double sided
+        document.
+
+        When called with a file, it checks whether or not a staging file
+        exists, if not, the current file is turned into that staging file
+        containing the odd numbered pages.
+
+        If a staging file exists, and it is not too old, the current file is
+        considered to be the second part (the even numbered pages) and it will
+        collate the pages of both, the pages of the second file will be added
+        in reverse order, since the ADF will have scanned the pages from bottom
+        to top.
+
+        Returns a status message on success, or raises a ConsumerError
+        in case of failure.
+        """
+
+        if self.input_doc.mime_type == "application/pdf":
+            pdf_file = self.input_doc.original_file
+        elif (
+            self.input_doc.mime_type == "image/tiff"
+            and settings.CONSUMER_COLLATE_DOUBLE_SIDED_TIFF_SUPPORT
+        ):
+            pdf_file = convert_from_tiff_to_pdf(
+                self.input_doc.original_file,
+                self.base_tmp_dir,
+            )
+            self.input_doc.original_file.unlink()
+        else:
+            raise ConsumerError(
+                "Unsupported file type for collation of double-sided scans",
+            )
+
+        staging: Path = settings.SCRATCH_DIR / STAGING_FILE_NAME
+
+        valid_staging_exists = False
+        if staging.exists():
+            stats = staging.stat()
+            # if the file is older than the timeout, we don't consider
+            # it valid
+            if (dt.datetime.now().timestamp() - stats.st_mtime) > TIMEOUT_SECONDS:
+                logger.warning("Outdated double sided staging file exists, deleting it")
+                staging.unlink()
+            else:
+                valid_staging_exists = True
+
+        if valid_staging_exists:
+            try:
+                # Collate pages from second PDF in reverse order
+                with Pdf.open(staging) as pdf1, Pdf.open(pdf_file) as pdf2:
+                    pdf2.pages.reverse()
+                    try:
+                        for i, page in enumerate(pdf2.pages):
+                            pdf1.pages.insert(2 * i + 1, page)
+                    except IndexError:
+                        raise ConsumerError(
+                            "This second file (even numbered pages) contains more "
+                            "pages than the first/odd numbered one. This means the "
+                            "two uploaded files don't belong to the same double-"
+                            "sided scan. Please retry, starting with the odd "
+                            "numbered pages again.",
+                        )
+                    # Merged file has the same path, but without the
+                    # double-sided subdir. Therefore, it is also in the
+                    # consumption dir and will be picked up for processing
+                    old_file = self.input_doc.original_file
+                    new_file = Path(
+                        *(
+                            part
+                            for part in old_file.with_name(
+                                f"{old_file.stem}-collated.pdf",
+                            ).parts
+                            if part
+                            != settings.CONSUMER_COLLATE_DOUBLE_SIDED_SUBDIR_NAME
+                        ),
+                    )
+                    # If the user didn't create the subdirs yet, do it for them
+                    new_file.parent.mkdir(parents=True, exist_ok=True)
+                    pdf1.save(new_file)
+                logger.info("Collated documents into new file %s", new_file)
+                raise StopConsumeTaskError(
+                    "Success. Even numbered pages of double sided scan collated "
+                    "with odd pages",
+                )
+            finally:
+                # Delete staging and recently uploaded file no matter what.
+                # If any error occurs, the user needs to be able to restart
+                # the process from scratch; after all, the staging file
+                # with the odd numbered pages might be the culprit
+                pdf_file.unlink()
+                staging.unlink()
+
+        else:
+            shutil.move(pdf_file, staging)
+            # update access to modification time so we know if the file
+            # is outdated when another file gets uploaded
+            timestamp = dt.datetime.now().timestamp()
+            os.utime(staging, (timestamp, timestamp))
+            logger.info(
+                "Got scan with odd numbered pages of double-sided scan, moved it to %s",
+                staging,
+            )
+            raise StopConsumeTaskError(
+                "Received odd numbered pages of double sided scan, waiting up to "
+                f"{TIMEOUT_MINUTES} minutes for even numbered pages",
+            )

--- a/src/documents/plugins/base.py
+++ b/src/documents/plugins/base.py
@@ -1,0 +1,131 @@
+import abc
+from pathlib import Path
+from typing import Final
+from typing import Optional
+
+from documents.data_models import ConsumableDocument
+from documents.data_models import DocumentMetadataOverrides
+from documents.plugins.helpers import ProgressManager
+
+
+class StopConsumeTaskError(Exception):
+    """
+    A plugin setup or run may raise this to exit the asynchronous consume task.
+
+    Most likely, this means it has created one or more new tasks to execute instead,
+    such as when a barcode has been used to create new documents
+    """
+
+    def __init__(self, message: str) -> None:
+        self.message = message
+        super().__init__(message)
+
+
+class ConsumeTaskPlugin(abc.ABC):
+    """
+    Defines the interface for a plugin for the document consume task
+    Meanings as per RFC2119 (https://datatracker.ietf.org/doc/html/rfc2119)
+
+    Plugin Implementation
+
+    The plugin SHALL implement property able_to_run and methods setup, run and cleanup.
+    The plugin property able_to_run SHALL return True if the plugin is able to run, given the conditions, settings and document information.
+    The plugin property able_to_run MAY be hardcoded to return True.
+    The plugin setup SHOULD perform any resource creation or additional initialization needed to run the document.
+    The plugin setup MAY be a non-operation.
+    The plugin cleanup SHOULD perform resource cleanup, including in the event of an error.
+    The plugin cleanup MAY be a non-operation.
+    The plugin run SHALL perform any operations against the document or system state required for the plugin.
+    The plugin run MAY update the document metadata.
+    The plugin run MAY return an informational message.
+    The plugin run MAY raise StopConsumeTaskError to cease any further operations against the document.
+
+    Plugin Manager Implementation
+
+    The plugin manager SHALL provide the plugin with the input document, document metadata, progress manager and a created temporary directory.
+    The plugin manager SHALL execute the plugin setup, run and cleanup, in that order IF the plugin property able_to_run is True.
+    The plugin manager SHOULD log the return message of executing a plugin's run.
+    The plugin manager SHALL always execute the plugin cleanup, IF the plugin property able_to_run is True.
+    The plugin manager SHALL cease calling plugins and exit the task IF a plugin raises StopConsumeTaskError.
+    The plugin manager SHOULD return the StopConsumeTaskError message IF a plugin raises StopConsumeTaskError.
+    """
+
+    NAME: str = "ConsumeTaskPlugin"
+
+    def __init__(
+        self,
+        input_doc: ConsumableDocument,
+        metadata: DocumentMetadataOverrides,
+        status_mgr: ProgressManager,
+        base_tmp_dir: Path,
+        task_id: str,
+    ) -> None:
+        super().__init__()
+        self.input_doc = input_doc
+        self.metadata = metadata
+        self.base_tmp_dir: Final = base_tmp_dir
+        self.status_mgr = status_mgr
+        self.task_id: Final = task_id
+
+    @abc.abstractproperty
+    def able_to_run(self) -> bool:
+        """
+        Return True if the conditions are met for the plugin to run, False otherwise
+
+        If False, setup(), run() and cleanup() will not be called
+        """
+
+    @abc.abstractmethod
+    def setup(self) -> None:
+        """
+        Allows the plugin to perform any additional setup it may need, such as creating
+        a temporary directory, copying a file somewhere, etc.
+
+        Executed before run()
+
+        In general, this should be the "light" work, not the bulk of processing
+        """
+
+    @abc.abstractmethod
+    def run(self) -> Optional[str]:
+        """
+        The bulk of plugin processing, this does whatever action the plugin is for.
+
+        Executed after setup() and before cleanup()
+        """
+
+    @abc.abstractmethod
+    def cleanup(self) -> None:
+        """
+        Allows the plugin to execute any cleanup it may require
+
+        Executed after run(), even in the case of error
+        """
+
+
+class AlwaysRunPluginMixin(ConsumeTaskPlugin):
+    """
+    A plugin which is always able to run
+    """
+
+    @property
+    def able_to_run(self) -> bool:
+        return True
+
+
+class NoSetupPluginMixin(ConsumeTaskPlugin):
+    """
+    A plugin which requires no setup
+    """
+
+    def setup(self) -> None:
+        pass
+
+
+class NoCleanupPluginMixin(ConsumeTaskPlugin):
+    """
+    A plugin which needs to clean up no files
+    """
+
+    def cleanup(self) -> None:
+        pass

--- a/src/documents/plugins/helpers.py
+++ b/src/documents/plugins/helpers.py
@@ -1,0 +1,82 @@
+import enum
+from typing import TYPE_CHECKING
+from typing import Optional
+from typing import Union
+
+from asgiref.sync import async_to_sync
+from channels.layers import get_channel_layer
+from channels_redis.pubsub import RedisPubSubChannelLayer
+
+
+class ProgressStatusOptions(str, enum.Enum):
+    STARTED = "STARTED"
+    WORKING = "WORKING"
+    SUCCESS = "SUCCESS"
+    FAILED = "FAILED"
+
+
+class ProgressManager:
+    """
+    Handles sending of progress information via the channel layer, with proper management
+    of the open/close of the layer to ensure messages go out and everything is cleaned up
+    """
+
+    def __init__(self, filename: str, task_id: Optional[str] = None) -> None:
+        self.filename = filename
+        self._channel: Optional[RedisPubSubChannelLayer] = None
+        self.task_id = task_id
+
+    def __enter__(self):
+        self.open()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
+    def open(self) -> None:
+        """
+        If not already opened, gets the default channel layer
+        opened and ready to send messages
+        """
+        if self._channel is None:
+            self._channel = get_channel_layer()
+
+    def close(self) -> None:
+        """
+        If it was opened, flushes the channel layer
+        """
+        if self._channel is not None:
+            async_to_sync(self._channel.flush)
+            self._channel = None
+
+    def send_progress(
+        self,
+        status: ProgressStatusOptions,
+        message: str,
+        current_progress: int,
+        max_progress: int,
+        extra_args: Optional[dict[str, Union[str, int]]] = None,
+    ) -> None:
+        # Ensure the layer is open
+        self.open()
+
+        # Just for IDEs
+        if TYPE_CHECKING:
+            assert self._channel is not None
+
+        payload = {
+            "type": "status_update",
+            "data": {
+                "filename": self.filename,
+                "task_id": self.task_id,
+                "current_progress": current_progress,
+                "max_progress": max_progress,
+                "status": status,
+                "message": message,
+            },
+        }
+        if extra_args is not None:
+            payload["data"].update(extra_args)
+
+        # Construct and send the update
+        async_to_sync(self._channel.group_send)("status_updates", payload)

--- a/src/documents/tests/test_barcodes.py
+++ b/src/documents/tests/test_barcodes.py
@@ -1,4 +1,7 @@
 import shutil
+from collections.abc import Generator
+from contextlib import contextmanager
+from pathlib import Path
 from unittest import mock
 
 import pytest
@@ -7,14 +10,13 @@ from django.test import TestCase
 from django.test import override_settings
 
 from documents import tasks
-from documents.barcodes import BarcodeReader
-from documents.consumer import ConsumerError
+from documents.barcodes import BarcodePlugin
 from documents.data_models import ConsumableDocument
 from documents.data_models import DocumentMetadataOverrides
 from documents.data_models import DocumentSource
-from documents.models import Document
 from documents.tests.utils import DirectoriesMixin
 from documents.tests.utils import DocumentConsumeDelayMixin
+from documents.tests.utils import DummyProgressManager
 from documents.tests.utils import FileSystemAssertsMixin
 from documents.tests.utils import SampleDirMixin
 
@@ -26,8 +28,29 @@ except ImportError:
     HAS_ZXING_LIB = False
 
 
+class GetReaderPluginMixin:
+    @contextmanager
+    def get_reader(self, filepath: Path) -> Generator[BarcodePlugin, None, None]:
+        reader = BarcodePlugin(
+            ConsumableDocument(DocumentSource.ConsumeFolder, original_file=filepath),
+            DocumentMetadataOverrides(),
+            DummyProgressManager(filepath.name, None),
+            self.dirs.scratch_dir,
+            "task-id",
+        )
+        reader.setup()
+        yield reader
+        reader.cleanup()
+
+
 @override_settings(CONSUMER_BARCODE_SCANNER="PYZBAR")
-class TestBarcode(DirectoriesMixin, FileSystemAssertsMixin, SampleDirMixin, TestCase):
+class TestBarcode(
+    DirectoriesMixin,
+    FileSystemAssertsMixin,
+    SampleDirMixin,
+    GetReaderPluginMixin,
+    TestCase,
+):
     def test_scan_file_for_separating_barcodes(self):
         """
         GIVEN:
@@ -39,7 +62,7 @@ class TestBarcode(DirectoriesMixin, FileSystemAssertsMixin, SampleDirMixin, Test
         """
         test_file = self.BARCODE_SAMPLE_DIR / "patch-code-t.pdf"
 
-        with BarcodeReader(test_file, "application/pdf") as reader:
+        with self.get_reader(test_file) as reader:
             reader.detect()
             separator_page_numbers = reader.get_separation_pages()
 
@@ -60,7 +83,7 @@ class TestBarcode(DirectoriesMixin, FileSystemAssertsMixin, SampleDirMixin, Test
         """
         test_file = self.BARCODE_SAMPLE_DIR / "patch-code-t-middle.tiff"
 
-        with BarcodeReader(test_file, "image/tiff") as reader:
+        with self.get_reader(test_file) as reader:
             reader.detect()
             separator_page_numbers = reader.get_separation_pages()
 
@@ -80,7 +103,7 @@ class TestBarcode(DirectoriesMixin, FileSystemAssertsMixin, SampleDirMixin, Test
         """
         test_file = self.BARCODE_SAMPLE_DIR / "patch-code-t-middle-alpha.tiff"
 
-        with BarcodeReader(test_file, "image/tiff") as reader:
+        with self.get_reader(test_file) as reader:
             reader.detect()
             separator_page_numbers = reader.get_separation_pages()
 
@@ -97,7 +120,7 @@ class TestBarcode(DirectoriesMixin, FileSystemAssertsMixin, SampleDirMixin, Test
             - No pages to split on
         """
         test_file = self.SAMPLE_DIR / "simple.pdf"
-        with BarcodeReader(test_file, "application/pdf") as reader:
+        with self.get_reader(test_file) as reader:
             reader.detect()
             separator_page_numbers = reader.get_separation_pages()
 
@@ -115,7 +138,7 @@ class TestBarcode(DirectoriesMixin, FileSystemAssertsMixin, SampleDirMixin, Test
         """
         test_file = self.BARCODE_SAMPLE_DIR / "patch-code-t-middle.pdf"
 
-        with BarcodeReader(test_file, "application/pdf") as reader:
+        with self.get_reader(test_file) as reader:
             reader.detect()
             separator_page_numbers = reader.get_separation_pages()
 
@@ -133,7 +156,7 @@ class TestBarcode(DirectoriesMixin, FileSystemAssertsMixin, SampleDirMixin, Test
         """
         test_file = self.BARCODE_SAMPLE_DIR / "several-patcht-codes.pdf"
 
-        with BarcodeReader(test_file, "application/pdf") as reader:
+        with self.get_reader(test_file) as reader:
             reader.detect()
             separator_page_numbers = reader.get_separation_pages()
 
@@ -158,7 +181,7 @@ class TestBarcode(DirectoriesMixin, FileSystemAssertsMixin, SampleDirMixin, Test
         ]:
             test_file = self.BARCODE_SAMPLE_DIR / test_file
 
-            with BarcodeReader(test_file, "application/pdf") as reader:
+            with self.get_reader(test_file) as reader:
                 reader.detect()
                 separator_page_numbers = reader.get_separation_pages()
 
@@ -177,7 +200,7 @@ class TestBarcode(DirectoriesMixin, FileSystemAssertsMixin, SampleDirMixin, Test
         """
         test_file = self.BARCODE_SAMPLE_DIR / "patch-code-t-middle-unreadable.pdf"
 
-        with BarcodeReader(test_file, "application/pdf") as reader:
+        with self.get_reader(test_file) as reader:
             reader.detect()
             separator_page_numbers = reader.get_separation_pages()
 
@@ -195,7 +218,7 @@ class TestBarcode(DirectoriesMixin, FileSystemAssertsMixin, SampleDirMixin, Test
         """
         test_file = self.BARCODE_SAMPLE_DIR / "barcode-fax-image.pdf"
 
-        with BarcodeReader(test_file, "application/pdf") as reader:
+        with self.get_reader(test_file) as reader:
             reader.detect()
             separator_page_numbers = reader.get_separation_pages()
 
@@ -214,7 +237,7 @@ class TestBarcode(DirectoriesMixin, FileSystemAssertsMixin, SampleDirMixin, Test
         """
         test_file = self.BARCODE_SAMPLE_DIR / "patch-code-t-qr.pdf"
 
-        with BarcodeReader(test_file, "application/pdf") as reader:
+        with self.get_reader(test_file) as reader:
             reader.detect()
             separator_page_numbers = reader.get_separation_pages()
 
@@ -234,7 +257,7 @@ class TestBarcode(DirectoriesMixin, FileSystemAssertsMixin, SampleDirMixin, Test
         """
         test_file = self.BARCODE_SAMPLE_DIR / "barcode-39-custom.pdf"
 
-        with BarcodeReader(test_file, "application/pdf") as reader:
+        with self.get_reader(test_file) as reader:
             reader.detect()
             separator_page_numbers = reader.get_separation_pages()
 
@@ -255,7 +278,7 @@ class TestBarcode(DirectoriesMixin, FileSystemAssertsMixin, SampleDirMixin, Test
         """
         test_file = self.BARCODE_SAMPLE_DIR / "barcode-qr-custom.pdf"
 
-        with BarcodeReader(test_file, "application/pdf") as reader:
+        with self.get_reader(test_file) as reader:
             reader.detect()
             separator_page_numbers = reader.get_separation_pages()
 
@@ -276,7 +299,7 @@ class TestBarcode(DirectoriesMixin, FileSystemAssertsMixin, SampleDirMixin, Test
         """
         test_file = self.BARCODE_SAMPLE_DIR / "barcode-128-custom.pdf"
 
-        with BarcodeReader(test_file, "application/pdf") as reader:
+        with self.get_reader(test_file) as reader:
             reader.detect()
             separator_page_numbers = reader.get_separation_pages()
 
@@ -296,7 +319,7 @@ class TestBarcode(DirectoriesMixin, FileSystemAssertsMixin, SampleDirMixin, Test
         """
         test_file = self.BARCODE_SAMPLE_DIR / "barcode-39-custom.pdf"
 
-        with BarcodeReader(test_file, "application/pdf") as reader:
+        with self.get_reader(test_file) as reader:
             reader.detect()
             separator_page_numbers = reader.get_separation_pages()
 
@@ -315,7 +338,7 @@ class TestBarcode(DirectoriesMixin, FileSystemAssertsMixin, SampleDirMixin, Test
         """
         test_file = self.BARCODE_SAMPLE_DIR / "many-qr-codes.pdf"
 
-        with BarcodeReader(test_file, "application/pdf") as reader:
+        with self.get_reader(test_file) as reader:
             reader.detect()
             separator_page_numbers = reader.get_separation_pages()
 
@@ -334,7 +357,7 @@ class TestBarcode(DirectoriesMixin, FileSystemAssertsMixin, SampleDirMixin, Test
         """
         test_file = self.SAMPLE_DIR / "password-is-test.pdf"
         with self.assertLogs("paperless.barcodes", level="WARNING") as cm:
-            with BarcodeReader(test_file, "application/pdf") as reader:
+            with self.get_reader(test_file) as reader:
                 reader.detect()
                 warning = cm.output[0]
                 expected_str = "WARNING:paperless.barcodes:File is likely password protected, not checking for barcodes"
@@ -356,7 +379,7 @@ class TestBarcode(DirectoriesMixin, FileSystemAssertsMixin, SampleDirMixin, Test
         """
         test_file = self.BARCODE_SAMPLE_DIR / "patch-code-t-middle.pdf"
 
-        with BarcodeReader(test_file, "application/pdf") as reader:
+        with self.get_reader(test_file) as reader:
             documents = reader.separate_pages({1: False})
 
             self.assertEqual(reader.pdf_file, test_file)
@@ -373,7 +396,7 @@ class TestBarcode(DirectoriesMixin, FileSystemAssertsMixin, SampleDirMixin, Test
         """
         test_file = self.BARCODE_SAMPLE_DIR / "patch-code-t-double.pdf"
 
-        with BarcodeReader(test_file, "application/pdf") as reader:
+        with self.get_reader(test_file) as reader:
             documents = reader.separate_pages({1: False, 2: False})
 
             self.assertEqual(len(documents), 2)
@@ -385,32 +408,18 @@ class TestBarcode(DirectoriesMixin, FileSystemAssertsMixin, SampleDirMixin, Test
         WHEN:
             - No separation pages are provided
         THEN:
-            - No new documents are produced
-            - A warning is logged
+            - Nothing happens
         """
         test_file = self.SAMPLE_DIR / "simple.pdf"
 
-        with self.assertLogs("paperless.barcodes", level="WARNING") as cm:
-            with BarcodeReader(test_file, "application/pdf") as reader:
-                self.assertFalse(
-                    reader.separate(
-                        DocumentSource.ApiUpload,
-                        DocumentMetadataOverrides(),
-                    ),
-                )
-                self.assertEqual(
-                    cm.output,
-                    [
-                        "WARNING:paperless.barcodes:No pages to split on!",
-                    ],
-                )
+        with self.get_reader(test_file) as reader:
+            self.assertEqual("No pages to split on!", reader.run())
 
     @override_settings(
         CONSUMER_ENABLE_BARCODES=True,
         CONSUMER_BARCODE_TIFF_SUPPORT=True,
     )
-    @mock.patch("documents.consumer.Consumer.try_consume_file")
-    def test_consume_barcode_unsupported_jpg_file(self, m):
+    def test_consume_barcode_unsupported_jpg_file(self):
         """
         GIVEN:
             - JPEG image as input
@@ -422,35 +431,8 @@ class TestBarcode(DirectoriesMixin, FileSystemAssertsMixin, SampleDirMixin, Test
         """
         test_file = self.SAMPLE_DIR / "simple.jpg"
 
-        dst = settings.SCRATCH_DIR / "simple.jpg"
-        shutil.copy(test_file, dst)
-
-        with self.assertLogs("paperless.barcodes", level="WARNING") as cm:
-            self.assertIn(
-                "Success",
-                tasks.consume_file(
-                    ConsumableDocument(
-                        source=DocumentSource.ConsumeFolder,
-                        original_file=dst,
-                    ),
-                    None,
-                ),
-            )
-
-        self.assertListEqual(
-            cm.output,
-            [
-                "WARNING:paperless.barcodes:Unsupported file format for barcode reader: image/jpeg",
-            ],
-        )
-        m.assert_called_once()
-
-        args, kwargs = m.call_args
-        self.assertIsNone(kwargs["override_filename"])
-        self.assertIsNone(kwargs["override_title"])
-        self.assertIsNone(kwargs["override_correspondent_id"])
-        self.assertIsNone(kwargs["override_document_type_id"])
-        self.assertIsNone(kwargs["override_tag_ids"])
+        with self.get_reader(test_file) as reader:
+            self.assertFalse(reader.able_to_run)
 
     @override_settings(
         CONSUMER_ENABLE_BARCODES=True,
@@ -467,7 +449,7 @@ class TestBarcode(DirectoriesMixin, FileSystemAssertsMixin, SampleDirMixin, Test
         """
         test_file = self.BARCODE_SAMPLE_DIR / "split-by-asn-2.pdf"
 
-        with BarcodeReader(test_file, "application/pdf") as reader:
+        with self.get_reader(test_file) as reader:
             reader.detect()
             separator_page_numbers = reader.get_separation_pages()
 
@@ -504,7 +486,7 @@ class TestBarcode(DirectoriesMixin, FileSystemAssertsMixin, SampleDirMixin, Test
         """
         test_file = self.BARCODE_SAMPLE_DIR / "split-by-asn-1.pdf"
 
-        with BarcodeReader(test_file, "application/pdf") as reader:
+        with self.get_reader(test_file) as reader:
             reader.detect()
             separator_page_numbers = reader.get_separation_pages()
 
@@ -550,7 +532,7 @@ class TestBarcodeNewConsume(
 
         overrides = DocumentMetadataOverrides(tag_ids=[1, 2, 9])
 
-        with mock.patch("documents.tasks.async_to_sync") as progress_mocker:
+        with mock.patch("documents.tasks.ProgressManager", DummyProgressManager):
             self.assertEqual(
                 tasks.consume_file(
                     ConsumableDocument(
@@ -559,10 +541,8 @@ class TestBarcodeNewConsume(
                     ),
                     overrides,
                 ),
-                "File successfully split",
+                "Barcode splitting complete!",
             )
-            # We let the consumer know progress is done
-            progress_mocker.assert_called_once()
             # 2 new document consume tasks created
             self.assertEqual(self.consume_file_mock.call_count, 2)
 
@@ -580,7 +560,20 @@ class TestBarcodeNewConsume(
                 self.assertEqual(overrides, new_doc_overrides)
 
 
-class TestAsnBarcode(DirectoriesMixin, SampleDirMixin, TestCase):
+class TestAsnBarcode(DirectoriesMixin, SampleDirMixin, GetReaderPluginMixin, TestCase):
+    @contextmanager
+    def get_reader(self, filepath: Path) -> BarcodePlugin:
+        reader = BarcodePlugin(
+            ConsumableDocument(DocumentSource.ConsumeFolder, original_file=filepath),
+            DocumentMetadataOverrides(),
+            DummyProgressManager(filepath.name, None),
+            self.dirs.scratch_dir,
+            "task-id",
+        )
+        reader.setup()
+        yield reader
+        reader.cleanup()
+
     @override_settings(CONSUMER_ASN_BARCODE_PREFIX="CUSTOM-PREFIX-")
     def test_scan_file_for_asn_custom_prefix(self):
         """
@@ -594,7 +587,7 @@ class TestAsnBarcode(DirectoriesMixin, SampleDirMixin, TestCase):
             - The ASN integer value is correct
         """
         test_file = self.BARCODE_SAMPLE_DIR / "barcode-39-asn-custom-prefix.pdf"
-        with BarcodeReader(test_file, "application/pdf") as reader:
+        with self.get_reader(test_file) as reader:
             asn = reader.asn
 
             self.assertEqual(reader.pdf_file, test_file)
@@ -613,7 +606,7 @@ class TestAsnBarcode(DirectoriesMixin, SampleDirMixin, TestCase):
         """
         test_file = self.BARCODE_SAMPLE_DIR / "barcode-39-asn-123.pdf"
 
-        with BarcodeReader(test_file, "application/pdf") as reader:
+        with self.get_reader(test_file) as reader:
             asn = reader.asn
 
             self.assertEqual(reader.pdf_file, test_file)
@@ -630,54 +623,11 @@ class TestAsnBarcode(DirectoriesMixin, SampleDirMixin, TestCase):
         """
         test_file = self.BARCODE_SAMPLE_DIR / "patch-code-t.pdf"
 
-        with BarcodeReader(test_file, "application/pdf") as reader:
+        with self.get_reader(test_file) as reader:
             asn = reader.asn
 
             self.assertEqual(reader.pdf_file, test_file)
             self.assertEqual(asn, None)
-
-    @override_settings(CONSUMER_ENABLE_ASN_BARCODE=True)
-    def test_scan_file_for_asn_already_exists(self):
-        """
-        GIVEN:
-            - PDF with an ASN barcode
-            - ASN value already exists
-        WHEN:
-            - File is scanned for barcodes
-        THEN:
-            - ASN is retrieved from the document
-            - Consumption fails
-        """
-
-        Document.objects.create(
-            title="WOW",
-            content="the content",
-            archive_serial_number=123,
-            checksum="456",
-            mime_type="application/pdf",
-        )
-
-        test_file = self.BARCODE_SAMPLE_DIR / "barcode-39-asn-123.pdf"
-
-        dst = settings.SCRATCH_DIR / "barcode-39-asn-123.pdf"
-        shutil.copy(test_file, dst)
-
-        with mock.patch("documents.consumer.Consumer._send_progress"):
-            with self.assertRaises(ConsumerError) as cm, self.assertLogs(
-                "paperless.consumer",
-                level="ERROR",
-            ) as logs_cm:
-                tasks.consume_file(
-                    ConsumableDocument(
-                        source=DocumentSource.ConsumeFolder,
-                        original_file=dst,
-                    ),
-                    None,
-                )
-            self.assertIn("Not consuming barcode-39-asn-123.pdf", str(cm.exception))
-            error_str = logs_cm.output[0]
-            expected_str = "ERROR:paperless.consumer:Not consuming barcode-39-asn-123.pdf: Given ASN already exists!"
-            self.assertEqual(expected_str, error_str)
 
     def test_scan_file_for_asn_barcode_invalid(self):
         """
@@ -692,7 +642,7 @@ class TestAsnBarcode(DirectoriesMixin, SampleDirMixin, TestCase):
         """
         test_file = self.BARCODE_SAMPLE_DIR / "barcode-39-asn-invalid.pdf"
 
-        with BarcodeReader(test_file, "application/pdf") as reader:
+        with self.get_reader(test_file) as reader:
             asn = reader.asn
 
             self.assertEqual(reader.pdf_file, test_file)
@@ -718,7 +668,9 @@ class TestAsnBarcode(DirectoriesMixin, SampleDirMixin, TestCase):
         dst = settings.SCRATCH_DIR / "barcode-39-asn-123.pdf"
         shutil.copy(test_file, dst)
 
-        with mock.patch("documents.consumer.Consumer.try_consume_file") as mocked_call:
+        with mock.patch(
+            "documents.consumer.Consumer.try_consume_file",
+        ) as mocked_consumer:
             tasks.consume_file(
                 ConsumableDocument(
                     source=DocumentSource.ConsumeFolder,
@@ -726,39 +678,10 @@ class TestAsnBarcode(DirectoriesMixin, SampleDirMixin, TestCase):
                 ),
                 None,
             )
-
-            args, kwargs = mocked_call.call_args
+            mocked_consumer.assert_called_once()
+            args, kwargs = mocked_consumer.call_args
 
             self.assertEqual(kwargs["override_asn"], 123)
-
-    @override_settings(CONSUMER_ENABLE_ASN_BARCODE=True)
-    def test_asn_too_large(self):
-        """
-        GIVEN:
-            - ASN from barcode enabled
-            - Barcode contains too large an ASN value
-        WHEN:
-            - ASN from barcode checked for correctness
-        THEN:
-            - Exception is raised regarding size limits
-        """
-        src = self.BARCODE_SAMPLE_DIR / "barcode-128-asn-too-large.pdf"
-
-        dst = self.dirs.scratch_dir / "barcode-128-asn-too-large.pdf"
-        shutil.copy(src, dst)
-
-        input_doc = ConsumableDocument(
-            source=DocumentSource.ConsumeFolder,
-            original_file=dst,
-        )
-
-        with mock.patch("documents.consumer.Consumer._send_progress"):
-            self.assertRaisesMessage(
-                ConsumerError,
-                "Given ASN 4294967296 is out of range [0, 4,294,967,295]",
-                tasks.consume_file,
-                input_doc,
-            )
 
     @override_settings(CONSUMER_BARCODE_SCANNER="PYZBAR")
     def test_scan_file_for_qrcode_without_upscale(self):
@@ -774,7 +697,7 @@ class TestAsnBarcode(DirectoriesMixin, SampleDirMixin, TestCase):
 
         test_file = self.BARCODE_SAMPLE_DIR / "barcode-qr-asn-000123-upscale-dpi.pdf"
 
-        with BarcodeReader(test_file, "application/pdf") as reader:
+        with self.get_reader(test_file) as reader:
             reader.detect()
             self.assertEqual(len(reader.barcodes), 0)
 
@@ -796,7 +719,7 @@ class TestAsnBarcode(DirectoriesMixin, SampleDirMixin, TestCase):
 
         test_file = self.BARCODE_SAMPLE_DIR / "barcode-qr-asn-000123-upscale-dpi.pdf"
 
-        with BarcodeReader(test_file, "application/pdf") as reader:
+        with self.get_reader(test_file) as reader:
             reader.detect()
             self.assertEqual(len(reader.barcodes), 1)
             self.assertEqual(reader.asn, 123)

--- a/src/documents/tests/test_workflows.py
+++ b/src/documents/tests/test_workflows.py
@@ -24,6 +24,7 @@ from documents.models import WorkflowAction
 from documents.models import WorkflowTrigger
 from documents.signals import document_consumption_finished
 from documents.tests.utils import DirectoriesMixin
+from documents.tests.utils import DummyProgressManager
 from documents.tests.utils import FileSystemAssertsMixin
 from paperless_mail.models import MailAccount
 from paperless_mail.models import MailRule
@@ -126,7 +127,7 @@ class TestWorkflows(DirectoriesMixin, FileSystemAssertsMixin, APITestCase):
 
         test_file = self.SAMPLE_DIR / "simple.pdf"
 
-        with mock.patch("documents.tasks.async_to_sync"):
+        with mock.patch("documents.tasks.ProgressManager", DummyProgressManager):
             with self.assertLogs("paperless.matching", level="INFO") as cm:
                 tasks.consume_file(
                     ConsumableDocument(
@@ -203,7 +204,7 @@ class TestWorkflows(DirectoriesMixin, FileSystemAssertsMixin, APITestCase):
         w.save()
 
         test_file = self.SAMPLE_DIR / "simple.pdf"
-        with mock.patch("documents.tasks.async_to_sync"):
+        with mock.patch("documents.tasks.ProgressManager", DummyProgressManager):
             with self.assertLogs("paperless.matching", level="INFO") as cm:
                 tasks.consume_file(
                     ConsumableDocument(
@@ -294,7 +295,7 @@ class TestWorkflows(DirectoriesMixin, FileSystemAssertsMixin, APITestCase):
 
         test_file = self.SAMPLE_DIR / "simple.pdf"
 
-        with mock.patch("documents.tasks.async_to_sync"):
+        with mock.patch("documents.tasks.ProgressManager", DummyProgressManager):
             with self.assertLogs("paperless.matching", level="INFO") as cm:
                 tasks.consume_file(
                     ConsumableDocument(
@@ -356,7 +357,7 @@ class TestWorkflows(DirectoriesMixin, FileSystemAssertsMixin, APITestCase):
 
         test_file = self.SAMPLE_DIR / "simple.pdf"
 
-        with mock.patch("documents.tasks.async_to_sync"):
+        with mock.patch("documents.tasks.ProgressManager", DummyProgressManager):
             with self.assertLogs("paperless.matching", level="DEBUG") as cm:
                 tasks.consume_file(
                     ConsumableDocument(
@@ -407,7 +408,7 @@ class TestWorkflows(DirectoriesMixin, FileSystemAssertsMixin, APITestCase):
 
         test_file = self.SAMPLE_DIR / "simple.pdf"
 
-        with mock.patch("documents.tasks.async_to_sync"):
+        with mock.patch("documents.tasks.ProgressManager", DummyProgressManager):
             with self.assertLogs("paperless.matching", level="DEBUG") as cm:
                 tasks.consume_file(
                     ConsumableDocument(
@@ -468,7 +469,7 @@ class TestWorkflows(DirectoriesMixin, FileSystemAssertsMixin, APITestCase):
 
         test_file = self.SAMPLE_DIR / "simple.pdf"
 
-        with mock.patch("documents.tasks.async_to_sync"):
+        with mock.patch("documents.tasks.ProgressManager", DummyProgressManager):
             with self.assertLogs("paperless.matching", level="DEBUG") as cm:
                 tasks.consume_file(
                     ConsumableDocument(
@@ -529,7 +530,7 @@ class TestWorkflows(DirectoriesMixin, FileSystemAssertsMixin, APITestCase):
 
         test_file = self.SAMPLE_DIR / "simple.pdf"
 
-        with mock.patch("documents.tasks.async_to_sync"):
+        with mock.patch("documents.tasks.ProgressManager", DummyProgressManager):
             with self.assertLogs("paperless.matching", level="DEBUG") as cm:
                 tasks.consume_file(
                     ConsumableDocument(
@@ -591,7 +592,7 @@ class TestWorkflows(DirectoriesMixin, FileSystemAssertsMixin, APITestCase):
 
         test_file = self.SAMPLE_DIR / "simple.pdf"
 
-        with mock.patch("documents.tasks.async_to_sync"):
+        with mock.patch("documents.tasks.ProgressManager", DummyProgressManager):
             with self.assertLogs("paperless.matching", level="DEBUG") as cm:
                 tasks.consume_file(
                     ConsumableDocument(
@@ -686,7 +687,7 @@ class TestWorkflows(DirectoriesMixin, FileSystemAssertsMixin, APITestCase):
 
         test_file = self.SAMPLE_DIR / "simple.pdf"
 
-        with mock.patch("documents.tasks.async_to_sync"):
+        with mock.patch("documents.tasks.ProgressManager", DummyProgressManager):
             with self.assertLogs("paperless.matching", level="INFO") as cm:
                 tasks.consume_file(
                     ConsumableDocument(


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

This makes the consume_file task know much less about the inner working of things like barcodes and collation, by implementing a plugin like system, with a defined structure of calls and data flow between the task and things it calls.  This is just the initial work, the Consumer will be next, but so many things rely on the behavior of `try_consume_file` that made the diff way too large.

The benefits:

- Defined way to request the task exits, rather than needing to know what a return means
- Single connection for websocket data, which is always flushed and closed at the end
- One time creation of a temporary directory, which will be cleaned up
- Eventual easier integration of new features to consume, such as password removal or decryption (maybe even allow from the 

Despite my best efforts, git insisted files were deleted when they were just moved.

Closes #(issue or discussion)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [x] Other. Please explain: Refactoring for new features

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
