### PR TITLE
fix: remove " from FILENAME_FORMAT

### DIFF
--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -927,7 +927,7 @@ for t in json.loads(os.getenv("PAPERLESS_FILENAME_PARSE_TRANSFORMS", "[]")):
     FILENAME_PARSE_TRANSFORMS.append((re.compile(t["pattern"]), t["repl"]))
 
 # Specify the filename format for out files
-FILENAME_FORMAT = os.getenv("PAPERLESS_FILENAME_FORMAT").replace("\"", "")
+FILENAME_FORMAT = os.getenv("PAPERLESS_FILENAME_FORMAT").replace('\"', "")
 
 # If this is enabled, variables in filename format will resolve to
 # empty-string instead of 'none'.

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -927,7 +927,7 @@ for t in json.loads(os.getenv("PAPERLESS_FILENAME_PARSE_TRANSFORMS", "[]")):
     FILENAME_PARSE_TRANSFORMS.append((re.compile(t["pattern"]), t["repl"]))
 
 # Specify the filename format for out files
-FILENAME_FORMAT = os.getenv("PAPERLESS_FILENAME_FORMAT")
+FILENAME_FORMAT = os.getenv("PAPERLESS_FILENAME_FORMAT").replace("\"", "")
 
 # If this is enabled, variables in filename format will resolve to
 # empty-string instead of 'none'.


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

When setting the FILENAME_FORMAT variable using docker, often the " will be included. This should be ignored. Currently my directory is "Correspondent which is frustrating.

## Type of change

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
