### PR TITLE
Change: merge workflow permissions assignments instead of overwrite

### DIFF
--- a/src/documents/signals/handlers.py
+++ b/src/documents/signals/handlers.py
@@ -593,10 +593,22 @@ def run_workflow(
                         )
 
                 if (
-                    action.assign_view_users is not None
-                    or action.assign_view_groups is not None
-                    or action.assign_change_users is not None
-                    or action.assign_change_groups is not None
+                    (
+                        action.assign_view_users is not None
+                        and action.assign_view_users.count() > 0
+                    )
+                    or (
+                        action.assign_view_groups is not None
+                        and action.assign_view_groups.count() > 0
+                    )
+                    or (
+                        action.assign_change_users is not None
+                        and action.assign_change_users.count() > 0
+                    )
+                    or (
+                        action.assign_change_groups is not None
+                        and action.assign_change_groups.count() > 0
+                    )
                 ):
                     permissions = {
                         "view": {
@@ -614,7 +626,11 @@ def run_workflow(
                             or [],
                         },
                     }
-                    set_permissions_for_object(permissions=permissions, object=document)
+                    set_permissions_for_object(
+                        permissions=permissions,
+                        object=document,
+                        merge=True,
+                    )
 
                 if action.assign_custom_fields is not None:
                     for field in action.assign_custom_fields.all():


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

I realize this technically would change existing behavior but my hunch is that most are expecting it to work this way, since this is also how e.g. tag assignments in a workflow action work.

Closes #(issue or discussion)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [x] Other. Change

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
