### PR TITLE
Fix: tweak doc detail component behavior while awaiting metadata

### DIFF
--- a/src-ui/src/app/components/document-detail/document-detail.component.html
+++ b/src-ui/src/app/components/document-detail/document-detail.component.html
@@ -324,44 +324,45 @@
         <ng-container i18n>Loading...</ng-container>
       </div>
     </div>
-  }
-  @switch (contentRenderType) {
-    @case (ContentRenderType.PDF) {
-      @if (!useNativePdfViewer) {
-        <div class="preview-sticky pdf-viewer-container">
-          <pngx-pdf-viewer
-            [src]="{ url: previewUrl, password: password }"
-            [original-size]="false"
-            [show-borders]="true"
-            [show-all]="true"
-            [(page)]="previewCurrentPage"
-            [zoom-scale]="previewZoomScale"
-            [zoom]="previewZoomSetting"
-            (error)="onError($event)"
-            (after-load-complete)="pdfPreviewLoaded($event)">
-          </pngx-pdf-viewer>
+  } @else {
+    @switch (contentRenderType) {
+      @case (ContentRenderType.PDF) {
+        @if (!useNativePdfViewer) {
+          <div class="preview-sticky pdf-viewer-container">
+            <pngx-pdf-viewer
+              [src]="{ url: previewUrl, password: password }"
+              [original-size]="false"
+              [show-borders]="true"
+              [show-all]="true"
+              [(page)]="previewCurrentPage"
+              [zoom-scale]="previewZoomScale"
+              [zoom]="previewZoomSetting"
+              (error)="onError($event)"
+              (after-load-complete)="pdfPreviewLoaded($event)">
+            </pngx-pdf-viewer>
+          </div>
+        } @else {
+          <object [data]="previewUrl | safeUrl" class="preview-sticky" width="100%"></object>
+        }
+      }
+      @case (ContentRenderType.Text) {
+        <div class="preview-sticky bg-light p-3 overflow-auto" width="100%">{{previewText}}</div>
+      }
+      @case (ContentRenderType.Image) {
+        <div class="preview-sticky">
+          <img [src]="previewUrl | safeUrl" width="100%" height="100%" alt="{{title}}" />
         </div>
-      } @else {
+      }
+      @case (ContentRenderType.Other) {
         <object [data]="previewUrl | safeUrl" class="preview-sticky" width="100%"></object>
       }
     }
-    @case (ContentRenderType.Text) {
-      <div class="preview-sticky bg-light p-3 overflow-auto" width="100%">{{previewText}}</div>
-    }
-    @case (ContentRenderType.Image) {
-      <div class="preview-sticky">
-        <img [src]="previewUrl | safeUrl" width="100%" height="100%" alt="{{title}}" />
+    @if (requiresPassword) {
+      <div class="password-prompt">
+        <form>
+          <input autocomplete="" autofocus="true" class="form-control" i18n-placeholder placeholder="Enter Password" type="password" (keyup)="onPasswordKeyUp($event)" />
+        </form>
       </div>
     }
-    @case (ContentRenderType.Other) {
-      <object [data]="previewUrl | safeUrl" class="preview-sticky" width="100%"></object>
-    }
-  }
-  @if (requiresPassword) {
-    <div class="password-prompt">
-      <form>
-        <input autocomplete="" autofocus="true" class="form-control" i18n-placeholder placeholder="Enter Password" type="password" (keyup)="onPasswordKeyUp($event)" />
-      </form>
-    </div>
   }
 </ng-template>

--- a/src-ui/src/app/components/document-detail/document-detail.component.spec.ts
+++ b/src-ui/src/app/components/document-detail/document-detail.component.spec.ts
@@ -681,6 +681,7 @@ describe('DocumentDetailComponent', () => {
 
   it('should support Enter key in password field', () => {
     initNormally()
+    component.metadata = { has_archive_version: true }
     component.onError({ name: 'PasswordException' }) // normally dispatched by pdf viewer
     fixture.detectChanges()
     expect(component.password).toBeUndefined()

--- a/src-ui/src/app/components/document-detail/document-detail.component.ts
+++ b/src-ui/src/app/components/document-detail/document-detail.component.ts
@@ -82,6 +82,7 @@ enum ContentRenderType {
   Image = 'image',
   Text = 'text',
   Other = 'other',
+  Unknown = 'unknown',
 }
 
 enum ZoomSetting {
@@ -211,6 +212,7 @@ export class DocumentDetailComponent
   }
 
   get contentRenderType(): ContentRenderType {
+    if (!this.metadata) return ContentRenderType.Unknown
     const contentType = this.metadata?.has_archive_version
       ? 'application/pdf'
       : this.metadata?.original_mime_type


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Im still not clear if / why this is an issue in Safari (again I cant repro) but these changes are very minimal, just making more explicit some things in the doc-details HTML template, for example moving all of the PDF viewer stuff inside an `else` if metadata hasn't returned yet.

Closes #5541

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
