### PR TITLE
Feature: option for auto-remove inbox tags on save

### DIFF
--- a/src-ui/messages.xlf
+++ b/src-ui/messages.xlf
@@ -1967,7 +1967,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/document-detail/document-detail.component.ts</context>
-          <context context-type="linenumber">733</context>
+          <context context-type="linenumber">735</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/document-list/bulk-editor/bulk-editor.component.ts</context>
@@ -2006,7 +2006,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/document-detail/document-detail.component.ts</context>
-          <context context-type="linenumber">735</context>
+          <context context-type="linenumber">737</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/document-list/bulk-editor/bulk-editor.component.ts</context>
@@ -4856,78 +4856,78 @@
         <source>An error occurred loading content: <x id="PH" equiv-text="err.message ?? err.toString()"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/document-detail/document-detail.component.ts</context>
-          <context context-type="linenumber">298,300</context>
+          <context context-type="linenumber">300,302</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3200733026060976258" datatype="html">
         <source>Document changes detected</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/document-detail/document-detail.component.ts</context>
-          <context context-type="linenumber">321</context>
+          <context context-type="linenumber">323</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2887155916749964" datatype="html">
         <source>The version of this document in your browser session appears older than the existing version.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/document-detail/document-detail.component.ts</context>
-          <context context-type="linenumber">322</context>
+          <context context-type="linenumber">324</context>
         </context-group>
       </trans-unit>
       <trans-unit id="237142428785956348" datatype="html">
         <source>Saving the document here may overwrite other changes that were made. To restore the existing version, discard your changes or close the document.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/document-detail/document-detail.component.ts</context>
-          <context context-type="linenumber">323</context>
+          <context context-type="linenumber">325</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8720977247725652816" datatype="html">
         <source>Ok</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/document-detail/document-detail.component.ts</context>
-          <context context-type="linenumber">325</context>
+          <context context-type="linenumber">327</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5758784066858623886" datatype="html">
         <source>Error retrieving metadata</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/document-detail/document-detail.component.ts</context>
-          <context context-type="linenumber">465</context>
+          <context context-type="linenumber">467</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3456881259945295697" datatype="html">
         <source>Error retrieving suggestions.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/document-detail/document-detail.component.ts</context>
-          <context context-type="linenumber">490</context>
+          <context context-type="linenumber">492</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8348337312757497317" datatype="html">
         <source>Document saved successfully.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/document-detail/document-detail.component.ts</context>
-          <context context-type="linenumber">608</context>
+          <context context-type="linenumber">610</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/document-detail/document-detail.component.ts</context>
-          <context context-type="linenumber">617</context>
+          <context context-type="linenumber">619</context>
         </context-group>
       </trans-unit>
       <trans-unit id="448882439049417053" datatype="html">
         <source>Error saving document</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/document-detail/document-detail.component.ts</context>
-          <context context-type="linenumber">621</context>
+          <context context-type="linenumber">623</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/document-detail/document-detail.component.ts</context>
-          <context context-type="linenumber">662</context>
+          <context context-type="linenumber">664</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9021887951960049161" datatype="html">
         <source>Confirm delete</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/document-detail/document-detail.component.ts</context>
-          <context context-type="linenumber">688</context>
+          <context context-type="linenumber">690</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/manage/management-list/management-list.component.ts</context>
@@ -4938,35 +4938,35 @@
         <source>Do you really want to delete document &quot;<x id="PH" equiv-text="this.document.title"/>&quot;?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/document-detail/document-detail.component.ts</context>
-          <context context-type="linenumber">689</context>
+          <context context-type="linenumber">691</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6691075929777935948" datatype="html">
         <source>The files for this document will be deleted permanently. This operation cannot be undone.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/document-detail/document-detail.component.ts</context>
-          <context context-type="linenumber">690</context>
+          <context context-type="linenumber">692</context>
         </context-group>
       </trans-unit>
       <trans-unit id="719892092227206532" datatype="html">
         <source>Delete document</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/document-detail/document-detail.component.ts</context>
-          <context context-type="linenumber">692</context>
+          <context context-type="linenumber">694</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7295637485862454066" datatype="html">
         <source>Error deleting document</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/document-detail/document-detail.component.ts</context>
-          <context context-type="linenumber">711</context>
+          <context context-type="linenumber">713</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7362691899087997122" datatype="html">
         <source>Redo OCR confirm</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/document-detail/document-detail.component.ts</context>
-          <context context-type="linenumber">731</context>
+          <context context-type="linenumber">733</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/document-list/bulk-editor/bulk-editor.component.ts</context>
@@ -4977,28 +4977,28 @@
         <source>This operation will permanently redo OCR for this document.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/document-detail/document-detail.component.ts</context>
-          <context context-type="linenumber">732</context>
+          <context context-type="linenumber">734</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5729001209753056399" datatype="html">
         <source>Redo OCR operation will begin in the background. Close and re-open or reload this document after the operation has completed to see new content.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/document-detail/document-detail.component.ts</context>
-          <context context-type="linenumber">743</context>
+          <context context-type="linenumber">745</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4409560272830824468" datatype="html">
         <source>Error executing operation</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/document-detail/document-detail.component.ts</context>
-          <context context-type="linenumber">754</context>
+          <context context-type="linenumber">756</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4458954481601077369" datatype="html">
         <source>Page Fit</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/document-detail/document-detail.component.ts</context>
-          <context context-type="linenumber">823</context>
+          <context context-type="linenumber">825</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6857598786757174736" datatype="html">

--- a/src-ui/src/app/components/admin/settings/settings.component.html
+++ b/src-ui/src/app/components/admin/settings/settings.component.html
@@ -158,6 +158,14 @@
           </div>
         </div>
 
+        <h4 class="mt-4" i18n>Document editing</h4>
+
+        <div class="row mb-3">
+          <div class="offset-md-3 col">
+            <pngx-input-check i18n-title title="Automatically remove inbox tag(s) on save" formControlName="documentEditingRemoveInboxTags"></pngx-input-check>
+          </div>
+        </div>
+
         <h4 class="mt-4" i18n>Bulk editing</h4>
 
         <div class="row mb-3">

--- a/src-ui/src/app/components/admin/settings/settings.component.spec.ts
+++ b/src-ui/src/app/components/admin/settings/settings.component.spec.ts
@@ -289,7 +289,7 @@ describe('SettingsComponent', () => {
     expect(toastErrorSpy).toHaveBeenCalled()
     expect(storeSpy).toHaveBeenCalled()
     expect(appearanceSettingsSpy).not.toHaveBeenCalled()
-    expect(setSpy).toHaveBeenCalledTimes(24)
+    expect(setSpy).toHaveBeenCalledTimes(25)
 
     // succeed
     storeSpy.mockReturnValueOnce(of(true))

--- a/src-ui/src/app/components/admin/settings/settings.component.ts
+++ b/src-ui/src/app/components/admin/settings/settings.component.ts
@@ -88,6 +88,7 @@ export class SettingsComponent
     defaultPermsViewGroups: new FormControl(null),
     defaultPermsEditUsers: new FormControl(null),
     defaultPermsEditGroups: new FormControl(null),
+    documentEditingRemoveInboxTags: new FormControl(null),
 
     notificationsConsumerNewDocument: new FormControl(null),
     notificationsConsumerSuccess: new FormControl(null),
@@ -270,6 +271,9 @@ export class SettingsComponent
       ),
       defaultPermsEditGroups: this.settings.get(
         SETTINGS_KEYS.DEFAULT_PERMS_EDIT_GROUPS
+      ),
+      documentEditingRemoveInboxTags: this.settings.get(
+        SETTINGS_KEYS.DOCUMENT_EDITING_REMOVE_INBOX_TAGS
       ),
       savedViews: {},
     }
@@ -483,6 +487,10 @@ export class SettingsComponent
     this.settings.set(
       SETTINGS_KEYS.DEFAULT_PERMS_EDIT_GROUPS,
       this.settingsForm.value.defaultPermsEditGroups
+    )
+    this.settings.set(
+      SETTINGS_KEYS.DOCUMENT_EDITING_REMOVE_INBOX_TAGS,
+      this.settingsForm.value.documentEditingRemoveInboxTags
     )
     this.settings.setLanguage(this.settingsForm.value.displayLanguage)
     this.settings

--- a/src-ui/src/app/components/document-detail/document-detail.component.ts
+++ b/src-ui/src/app/components/document-detail/document-detail.component.ts
@@ -630,7 +630,9 @@ export class DocumentDetailComponent
       .update(this.document)
       .pipe(first())
       .subscribe({
-        next: () => {
+        next: (docValues) => {
+          // in case data changed while saving eg removing inbox_tags
+          this.documentForm.patchValue(docValues)
           this.store.next(this.documentForm.value)
           this.toastService.showInfo($localize`Document saved successfully.`)
           close && this.close()

--- a/src-ui/src/app/data/document.ts
+++ b/src-ui/src/app/data/document.ts
@@ -63,4 +63,7 @@ export interface Document extends ObjectWithPermissions {
   __search_hit__?: SearchHit
 
   custom_fields?: CustomFieldInstance[]
+
+  // write-only field
+  remove_inbox_tags?: boolean
 }

--- a/src-ui/src/app/data/ui-settings.ts
+++ b/src-ui/src/app/data/ui-settings.ts
@@ -53,6 +53,8 @@ export const SETTINGS_KEYS = {
   DEFAULT_PERMS_VIEW_GROUPS: 'general-settings:permissions:default-view-groups',
   DEFAULT_PERMS_EDIT_USERS: 'general-settings:permissions:default-edit-users',
   DEFAULT_PERMS_EDIT_GROUPS: 'general-settings:permissions:default-edit-groups',
+  DOCUMENT_EDITING_REMOVE_INBOX_TAGS:
+    'general-settings:document-editing:remove-inbox-tags',
 }
 
 export const SETTINGS: UiSetting[] = [
@@ -205,5 +207,10 @@ export const SETTINGS: UiSetting[] = [
     key: SETTINGS_KEYS.APP_TITLE,
     type: 'string',
     default: '',
+  },
+  {
+    key: SETTINGS_KEYS.DOCUMENT_EDITING_REMOVE_INBOX_TAGS,
+    type: 'boolean',
+    default: false,
   },
 ]

--- a/src-ui/src/app/services/rest/document.service.spec.ts
+++ b/src-ui/src/app/services/rest/document.service.spec.ts
@@ -7,10 +7,13 @@ import { TestBed } from '@angular/core/testing'
 import { environment } from 'src/environments/environment'
 import { DocumentService } from './document.service'
 import { FILTER_TITLE } from 'src/app/data/filter-rule-type'
+import { SettingsService } from '../settings.service'
+import { SETTINGS_KEYS } from 'src/app/data/ui-settings'
 
 let httpTestingController: HttpTestingController
 let service: DocumentService
 let subscription: Subscription
+let settingsService: SettingsService
 const endpoint = 'documents'
 const documents = [
   {
@@ -33,6 +36,17 @@ const documents = [
     content: 'some content',
   },
 ]
+
+beforeEach(() => {
+  TestBed.configureTestingModule({
+    providers: [DocumentService],
+    imports: [HttpClientTestingModule],
+  })
+
+  httpTestingController = TestBed.inject(HttpTestingController)
+  service = TestBed.inject(DocumentService)
+  settingsService = TestBed.inject(SettingsService)
+})
 
 describe(`DocumentService`, () => {
   // common tests e.g. commonAbstractPaperlessServiceTests differ slightly
@@ -237,16 +251,21 @@ describe(`DocumentService`, () => {
     )
     expect(req.request.method).toEqual('GET')
   })
-})
 
-beforeEach(() => {
-  TestBed.configureTestingModule({
-    providers: [DocumentService],
-    imports: [HttpClientTestingModule],
+  it('should pass remove_inbox_tags setting to update', () => {
+    subscription = service.update(documents[0]).subscribe()
+    let req = httpTestingController.expectOne(
+      `${environment.apiBaseUrl}${endpoint}/${documents[0].id}/`
+    )
+    expect(req.request.body.remove_inbox_tags).toEqual(false)
+
+    settingsService.set(SETTINGS_KEYS.DOCUMENT_EDITING_REMOVE_INBOX_TAGS, true)
+    subscription = service.update(documents[0]).subscribe()
+    req = httpTestingController.expectOne(
+      `${environment.apiBaseUrl}${endpoint}/${documents[0].id}/`
+    )
+    expect(req.request.body.remove_inbox_tags).toEqual(true)
   })
-
-  httpTestingController = TestBed.inject(HttpTestingController)
-  service = TestBed.inject(DocumentService)
 })
 
 afterEach(() => {

--- a/src-ui/src/app/services/rest/document.service.ts
+++ b/src-ui/src/app/services/rest/document.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core'
 import { Document } from 'src/app/data/document'
 import { DocumentMetadata } from 'src/app/data/document-metadata'
 import { AbstractPaperlessService } from './abstract-paperless-service'
-import { HttpClient, HttpParams } from '@angular/common/http'
+import { HttpClient } from '@angular/common/http'
 import { Observable } from 'rxjs'
 import { Results } from 'src/app/data/results'
 import { FilterRule } from 'src/app/data/filter-rule'
@@ -18,6 +18,8 @@ import {
   PermissionType,
   PermissionsService,
 } from '../permissions.service'
+import { SettingsService } from '../settings.service'
+import { SETTINGS, SETTINGS_KEYS } from 'src/app/data/ui-settings'
 
 export const DOCUMENT_SORT_FIELDS = [
   { field: 'archive_serial_number', name: $localize`ASN` },
@@ -63,7 +65,8 @@ export class DocumentService extends AbstractPaperlessService<Document> {
     private documentTypeService: DocumentTypeService,
     private tagService: TagService,
     private storagePathService: StoragePathService,
-    private permissionsService: PermissionsService
+    private permissionsService: PermissionsService,
+    private settingsService: SettingsService
   ) {
     super(http, 'documents')
   }
@@ -180,6 +183,9 @@ export class DocumentService extends AbstractPaperlessService<Document> {
   update(o: Document): Observable<Document> {
     // we want to only set created_date
     o.created = undefined
+    o.remove_inbox_tags = this.settingsService.get(
+      SETTINGS_KEYS.DOCUMENT_EDITING_REMOVE_INBOX_TAGS
+    )
     return super.update(o)
   }
 

--- a/src/documents/serialisers.py
+++ b/src/documents/serialisers.py
@@ -638,6 +638,11 @@ class DocumentSerializer(
         allow_null=True,
     )
 
+    remove_inbox_tags = serializers.BooleanField(
+        default=False,
+        write_only=True,
+    )
+
     def get_original_file_name(self, obj):
         return obj.original_filename
 
@@ -681,11 +686,47 @@ class DocumentSerializer(
                             custom_field_instance.field,
                             doc_id,
                         )
+        if (
+            "remove_inbox_tags" in validated_data
+            and validated_data["remove_inbox_tags"]
+        ):
+            tag_ids_being_added = (
+                [
+                    tag.id
+                    for tag in validated_data["tags"]
+                    if tag not in instance.tags.all()
+                ]
+                if "tags" in validated_data
+                else []
+            )
+            inbox_tags_not_being_added = Tag.objects.filter(is_inbox_tag=True).exclude(
+                id__in=tag_ids_being_added,
+            )
+            if "tags" in validated_data:
+                validated_data["tags"] = [
+                    tag
+                    for tag in validated_data["tags"]
+                    if tag not in inbox_tags_not_being_added
+                ]
+            else:
+                validated_data["tags"] = [
+                    tag
+                    for tag in instance.tags.all()
+                    if tag not in inbox_tags_not_being_added
+                ]
         super().update(instance, validated_data)
         return instance
 
     def __init__(self, *args, **kwargs):
         self.truncate_content = kwargs.pop("truncate_content", False)
+
+        # return full permissions if we're doing a PATCH or PUT
+        context = kwargs.get("context")
+        if (
+            context.get("request").method == "PATCH"
+            or context.get("request").method == "PUT"
+        ):
+            kwargs.__setitem__("full_perms", True)
 
         super().__init__(*args, **kwargs)
 
@@ -714,6 +755,7 @@ class DocumentSerializer(
             "set_permissions",
             "notes",
             "custom_fields",
+            "remove_inbox_tags",
         )
 
 

--- a/src/documents/serialisers.py
+++ b/src/documents/serialisers.py
@@ -726,7 +726,7 @@ class DocumentSerializer(
             context.get("request").method == "PATCH"
             or context.get("request").method == "PUT"
         ):
-            kwargs.__setitem__("full_perms", True)
+            kwargs["full_perms"] = True
 
         super().__init__(*args, **kwargs)
 


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

I debated making this work with app config but I think this is cleaner. Again, non-breaking if user doesnt explicitly set this. Only thing worth noting is that I realized users may want to _add_ an inbox tag so this allows that.

https://github.com/paperless-ngx/paperless-ngx/assets/4887959/c28ec135-fecd-460f-9ee0-3929311a67a0

Closes #4454 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [x] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
