### PR TITLE
Enhancement: allow paperless to run in read-only filesystem

### DIFF
--- a/docker/paperless_cmd.sh
+++ b/docker/paperless_cmd.sh
@@ -1,14 +1,15 @@
 #!/usr/bin/env bash
 
+SUPERVISORD_WORKING_DIR="${PAPERLESS_SUPERVISORD_WORKING_DIR:-$PWD}"
 rootless_args=()
 if [ "$(id -u)" == "$(id -u paperless)" ]; then
 	rootless_args=(
 		--user
 		paperless
 		--logfile
-		supervisord.log
+		"${SUPERVISORD_WORKING_DIR}/supervisord.log"
 		--pidfile
-		supervisord.pid
+		"${SUPERVISORD_WORKING_DIR}/supervisord.pid"
 	)
 fi
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1329,6 +1329,12 @@ started by the container.
 
     You can read more about this in the [advanced documentation](advanced_usage.md#celery-monitoring).
 
+#### [`PAPERLESS_SUPERVISORD_WORKING_DIR=<defined>`](#PAPERLESS_SUPERVISORD_WORKING_DIR) {#PAPERLESS_SUPERVISORD_WORKING_DIR}
+
+: If this environment variable is defined, the `supervisord.log` and `supervisord.pid` file will be created under the specified path in `PAPERLESS_SUPERVISORD_WORKING_DIR`. Setting `PAPERLESS_SUPERVISORD_WORKING_DIR=/tmp` and `PYTHONPYCACHEPREFIX=/tmp/pycache` would allow paperless to work on a read-only filesystem.
+
+    Please take note that the `PAPERLESS_DATA_DIR` and `PAPERLESS_MEDIA_ROOT` paths still have to be writable, just like the `PAPERLESS_SUPERVISORD_WORKING_DIR`. The can be archived by using bind or volume mounts. Only works in the container is run as user *paperless*
+
 ## Frontend Settings
 
 #### [`PAPERLESS_APP_TITLE=<bool>`](#PAPERLESS_APP_TITLE) {#PAPERLESS_APP_TITLE}


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

<!--
⚠️ Important: Pull requests that implement a new feature or enhancement *should almost always target an existing feature request* with evidence of community interest and discussion. This is in order to balance the work of implementing and maintaining new features / enhancements. If that is not currently the case, please open a feature request instead of this PR to gather feedback from both users and the project maintainers.
-->

Closes #4020

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [x] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.

## What changed
Currently it is not possible to run paperless-ngx in a read-only filesystem/container. On startup is writes `supervisord` log and pid's in the projects source files. Python also writes binary cache files in the `__pycache__` folder. The creation of the `__pycache__` folder can be disabled or changed. One way is to set the `PYTHONPYCACHEPREFIX` environment variable. All persistent data stores can also either be changed via env's and most people use volume or bind mounts.  

For additional security and for idempotence you might want to run the container in read-only to prevent any unwanted changes. This PR enables it by also allowing to change `supervisord` log and pid file location via the `PAPERLESS_SUPERVISORD_WORKING_DIR` env.

**Example:**
````yaml
version: "3.4"
services:
  webserver:
    image: ghcr.io/paperless-ngx/paperless-ngx:latest
    read_only: true                                                      # what we primary want
    user: paperless                                                      # need the paperless user
    depends_on:
      - broker
    ports:
      - "8000:8000"
    volumes:
      - tmp:/tmp
      - data:/usr/src/paperless/data
      - media:/usr/src/paperless/media
      - ./export:/usr/src/paperless/export
      - ./consume:/usr/src/paperless/consume
    env_file: docker-compose.env
    environment:
      PAPERLESS_REDIS: redis://broker:6379
      PAPERLESS_SUPERVISORD_WORKING_DIR: /tmp                            # supervisord
      PYTHONPYCACHEPREFIX: /tmp/pycache                                  # py-cache
      PAPERLESS_ADMIN_USER: "admin"
      PAPERLESS_ADMIN_PASSWORD: "geheim"

volumes:
  data:
  media:
  tmp:
```