### PR TITLE
Fix: frontend validation of number fields fails upon save

### DIFF
--- a/src-ui/src/app/components/common/input/number/number.component.spec.ts
+++ b/src-ui/src/app/components/common/input/number/number.component.spec.ts
@@ -47,22 +47,25 @@ describe('NumberComponent', () => {
     expect(component.value).toEqual(1002)
   })
 
-  it('should support float & monetary values', () => {
-    component.writeValue(11.13)
-    expect(component.value).toEqual(11)
+  it('should support float, monetary values & scientific notation', () => {
+    const mockFn = jest.fn()
+    component.registerOnChange(mockFn)
+
+    component.step = 1
+    component.onChange(11.13)
+    expect(mockFn).toHaveBeenCalledWith(11)
+
+    component.onChange(1.23456789e8)
+    expect(mockFn).toHaveBeenCalledWith(123456789)
+
+    component.step = 0.01
+    component.onChange(11.1)
+    expect(mockFn).toHaveBeenCalledWith('11.10')
+  })
+
+  it('should display monetary values fixed to 2 decimals', () => {
     component.step = 0.01
     component.writeValue(11.1)
     expect(component.value).toEqual('11.10')
-    component.step = 0.1
-    component.writeValue(12.3456)
-    expect(component.value).toEqual(12.3456)
-    // float (step = .1) doesn't force 2 decimals
-    component.writeValue(11.1)
-    expect(component.value).toEqual(11.1)
-  })
-
-  it('should support scientific notation', () => {
-    component.writeValue(1.23456789e8)
-    expect(component.value).toEqual(123456789)
   })
 })

--- a/src-ui/src/app/components/common/input/number/number.component.ts
+++ b/src-ui/src/app/components/common/input/number/number.component.ts
@@ -36,9 +36,18 @@ export class NumberComponent extends AbstractInputComponent<number> {
     })
   }
 
+  registerOnChange(fn: any): void {
+    this.onChange = (newValue: any) => {
+      // number validation
+      if (this.step === 1 && newValue?.toString().indexOf('e') === -1)
+        newValue = parseInt(newValue, 10)
+      if (this.step === 0.01) newValue = parseFloat(newValue).toFixed(2)
+      fn(newValue)
+    }
+  }
+
   writeValue(newValue: any): void {
-    if (this.step === 1 && newValue?.toString().indexOf('e') === -1)
-      newValue = parseInt(newValue, 10)
+    // Allow monetary values to be displayed with 2 decimals
     if (this.step === 0.01) newValue = parseFloat(newValue).toFixed(2)
     super.writeValue(newValue)
   }


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

This is sort of in-the-weeds thing about Angular reactive forms, tl;dr just do the validation in a slightly different method of the NG_VALUE_ACCESSOR. Again, the OP issue says "123,00" which in American (😜) is "123.00" which can in fact lead to the issue described.

See video.


https://github.com/paperless-ngx/paperless-ngx/assets/4887959/38531b79-35ad-4839-a483-87a0f33b557f



Closes #5644

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
