### PR TITLE
Documentation: Include example redis URI with database index (fix typo)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,7 +35,7 @@ matcher.
     -   With the requirepass option PAPERLESS_REDIS =
         `redis://:<password>@<host>:<port>`
     -   To include the redis database index PAPERLESS_REDIS =
-        `redis://<username>:<password>@<host>:<port>\<DBIndex>`
+        `redis://<username>:<password>@<host>:<port>/<DBIndex>`
 
     [More information on securing your Redis
     Instance](https://redis.io/docs/getting-started/#securing-redis).


### PR DESCRIPTION
Closes #5642

fixes slash not backslash in redis url