### PR TITLE
Fix: only check workflow trigger source if not empty

### DIFF
--- a/src/documents/matching.py
+++ b/src/documents/matching.py
@@ -258,7 +258,9 @@ def consumable_document_matches_workflow(
     reason = ""
 
     # Document source vs trigger source
-    if document.source not in [int(x) for x in list(trigger.sources)]:
+    if len(trigger.sources) > 0 and document.source not in [
+        int(x) for x in list(trigger.sources)
+    ]:
         reason = (
             f"Document source {document.source.name} not in"
             f" {[DocumentSource(int(x)).name for x in trigger.sources]}",

--- a/src/documents/serialisers.py
+++ b/src/documents/serialisers.py
@@ -1410,9 +1410,6 @@ class WorkflowTriggerSerializer(serializers.ModelSerializer):
         ]
 
     def validate(self, attrs):
-        if ("filter_mailrule") in attrs and attrs["filter_mailrule"] is not None:
-            attrs["sources"] = {DocumentSource.MailFetch.value}
-
         # Empty strings treated as None to avoid unexpected behavior
         if (
             "filter_filename" in attrs

--- a/src/documents/tests/test_api_workflows.py
+++ b/src/documents/tests/test_api_workflows.py
@@ -15,8 +15,6 @@ from documents.models import Workflow
 from documents.models import WorkflowAction
 from documents.models import WorkflowTrigger
 from documents.tests.utils import DirectoriesMixin
-from paperless_mail.models import MailAccount
-from paperless_mail.models import MailRule
 
 
 class TestApiWorkflows(DirectoriesMixin, APITestCase):
@@ -343,56 +341,6 @@ class TestApiWorkflows(DirectoriesMixin, APITestCase):
         trigger2 = WorkflowTrigger.objects.get(id=response.data["id"])
         self.assertEqual(trigger2.filter_path, "*/test/*")
         self.assertIsNone(trigger2.filter_filename)
-
-    def test_api_create_workflow_trigger_with_mailrule(self):
-        """
-        GIVEN:
-            - API request to create a workflow trigger with a mail rule but no MailFetch source
-        WHEN:
-            - API is called
-        THEN:
-            - New trigger is created with MailFetch as source
-        """
-        account1 = MailAccount.objects.create(
-            name="Email1",
-            username="username1",
-            password="password1",
-            imap_server="server.example.com",
-            imap_port=443,
-            imap_security=MailAccount.ImapSecurity.SSL,
-            character_set="UTF-8",
-        )
-        rule1 = MailRule.objects.create(
-            name="Rule1",
-            account=account1,
-            folder="INBOX",
-            filter_from="from@example.com",
-            filter_to="someone@somewhere.com",
-            filter_subject="subject",
-            filter_body="body",
-            filter_attachment_filename_include="file.pdf",
-            maximum_age=30,
-            action=MailRule.MailAction.MARK_READ,
-            assign_title_from=MailRule.TitleSource.FROM_SUBJECT,
-            assign_correspondent_from=MailRule.CorrespondentSource.FROM_NOTHING,
-            order=0,
-            attachment_type=MailRule.AttachmentProcessing.ATTACHMENTS_ONLY,
-        )
-        response = self.client.post(
-            self.ENDPOINT_TRIGGERS,
-            json.dumps(
-                {
-                    "type": WorkflowTrigger.WorkflowTriggerType.CONSUMPTION,
-                    "sources": [DocumentSource.ApiUpload],
-                    "filter_mailrule": rule1.pk,
-                },
-            ),
-            content_type="application/json",
-        )
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(WorkflowTrigger.objects.count(), 2)
-        trigger = WorkflowTrigger.objects.get(id=response.data["id"])
-        self.assertEqual(trigger.sources, [int(DocumentSource.MailFetch).__str__()])
 
     def test_api_update_workflow_nested_triggers_actions(self):
         """


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

I think this is essentially a regression from the migration from consumption templates, it used to require at least 1 source type but now I think its ok to make it not required and behave like other things i.e. only try to check it if its not empty.

Closes #5695

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
