### PR TITLE
Fix: Assign ASN from barcode only after any splitting

### DIFF
--- a/src/documents/barcodes.py
+++ b/src/documents/barcodes.py
@@ -87,14 +87,6 @@ class BarcodePlugin(ConsumeTaskPlugin):
         # Locate any barcodes in the files
         self.detect()
 
-        # Update/overwrite an ASN if possible
-        if (
-            settings.CONSUMER_ENABLE_ASN_BARCODE
-            and (located_asn := self.asn) is not None
-        ):
-            logger.info(f"Found ASN in barcode: {located_asn}")
-            self.metadata.asn = located_asn
-
         # try reading tags from barcodes
         if (
             settings.CONSUMER_ENABLE_TAG_BARCODE
@@ -153,6 +145,15 @@ class BarcodePlugin(ConsumeTaskPlugin):
 
             # Request the consume task stops
             raise StopConsumeTaskError(msg)
+
+        # Update/overwrite an ASN if possible
+        # After splitting, as otherwise each split document gets the same ASN
+        if (
+            settings.CONSUMER_ENABLE_ASN_BARCODE
+            and (located_asn := self.asn) is not None
+        ):
+            logger.info(f"Found ASN in barcode: {located_asn}")
+            self.metadata.asn = located_asn
 
     def cleanup(self) -> None:
         self.temp_dir.cleanup()


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

I think this is the last logic on the barcodes.  Currently, every split document is assigned the same ASN, because that logic ran first.  What should happen is the splitting, then any assignment (on the second pass).

That's more inline with how it used to work: https://github.com/paperless-ngx/paperless-ngx/blob/c075642d78fbc229a3f932252b7527dc95007dcb/src/documents/tasks.py#L139-L158

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
