### PR TITLE
Fix: handle document notes user format api change

### DIFF
--- a/src-ui/src/app/components/document-detail/document-detail.component.spec.ts
+++ b/src-ui/src/app/components/document-detail/document-detail.component.spec.ts
@@ -95,12 +95,12 @@ const doc: Document = {
     {
       created: new Date(),
       note: 'note 1',
-      user: 1,
+      user: { id: 1, username: 'user1' },
     },
     {
       created: new Date(),
       note: 'note 2',
-      user: 2,
+      user: { id: 2, username: 'user2' },
     },
   ],
   custom_fields: [

--- a/src-ui/src/app/components/document-notes/document-notes.component.spec.ts
+++ b/src-ui/src/app/components/document-notes/document-notes.component.spec.ts
@@ -19,22 +19,32 @@ const notes: DocumentNote[] = [
   {
     id: 23,
     note: 'Note 23',
-    user: 1,
+    user: {
+      id: 1,
+      username: 'user1',
+      first_name: 'User1',
+      last_name: 'Lastname1',
+    },
   },
   {
     id: 24,
     note: 'Note 24',
-    user: 1,
+    user: {
+      id: 1,
+      username: 'user1',
+      first_name: 'User1',
+      last_name: 'Lastname1',
+    },
   },
   {
     id: 25,
     note: 'Note 25',
-    user: 2,
+    user: { id: 2, username: 'user2' },
   },
   {
     id: 30,
     note: 'Note 30',
-    user: 3,
+    user: { id: 3, username: 'user3' },
   },
 ]
 
@@ -123,11 +133,24 @@ describe('DocumentNotesComponent', () => {
   })
 
   it('should handle note user display in all situations', () => {
-    expect(component.displayName({ id: 1, user: 1 })).toEqual(
-      'User1 Lastname1 (user1)'
-    )
-    expect(component.displayName({ id: 1, user: 2 })).toEqual('user2')
-    expect(component.displayName({ id: 1, user: 4 })).toEqual('')
+    expect(
+      component.displayName({
+        id: 1,
+        user: {
+          id: 1,
+          username: 'user1',
+          first_name: 'User1',
+          last_name: 'Lastname1',
+        },
+      })
+    ).toEqual('User1 Lastname1 (user1)')
+    expect(
+      component.displayName({ id: 1, user: { id: 2, username: 'user2' } })
+    ).toEqual('user2')
+    expect(component.displayName({ id: 1, user: 2 } as any)).toEqual('user2')
+    expect(
+      component.displayName({ id: 1, user: { id: 4, username: 'user4' } })
+    ).toEqual('')
     expect(component.displayName({ id: 1 })).toEqual('')
   })
 
@@ -146,7 +169,9 @@ describe('DocumentNotesComponent', () => {
     expect(addSpy).toHaveBeenCalledWith(12, note)
     expect(toastsSpy).toHaveBeenCalled()
 
-    addSpy.mockReturnValueOnce(of([...notes, { id: 31, note, user: 1 }]))
+    addSpy.mockReturnValueOnce(
+      of([...notes, { id: 31, note, user: { id: 1 } }])
+    )
     addButton.triggerEventHandler('click')
     fixture.detectChanges()
     expect(fixture.debugElement.nativeElement.textContent).toContain(note)

--- a/src-ui/src/app/components/document-notes/document-notes.component.ts
+++ b/src-ui/src/app/components/document-notes/document-notes.component.ts
@@ -84,7 +84,8 @@ export class DocumentNotesComponent extends ComponentWithPermissions {
 
   displayName(note: DocumentNote): string {
     if (!note.user) return ''
-    const user = this.users?.find((u) => u.id === note.user)
+    const user_id = typeof note.user === 'number' ? note.user : note.user.id
+    const user = this.users?.find((u) => u.id === user_id)
     if (!user) return ''
     const nameComponents = []
     if (user.first_name) nameComponents.push(user.first_name)

--- a/src-ui/src/app/data/document-note.ts
+++ b/src-ui/src/app/data/document-note.ts
@@ -1,7 +1,8 @@
 import { ObjectWithId } from './object-with-id'
+import { User } from './user'
 
 export interface DocumentNote extends ObjectWithId {
   created?: Date
   note?: string
-  user?: number // User
+  user?: User
 }


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Im not certain which backend change introduced this (any ideas?), I left some legacy handling of the case that it returns the simple int

Closes #5747 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
