### PR TITLE
Fix: moved ssl_mode parameter for mysql backend engine

### DIFF
--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -586,8 +586,8 @@ def _parse_db_settings() -> dict:
             options = {
                 "read_default_file": "/etc/mysql/my.cnf",
                 "charset": "utf8mb4",
+                "ssl_mode": os.getenv("PAPERLESS_DBSSLMODE", "PREFERRED"),
                 "ssl": {
-                    "ssl_mode": os.getenv("PAPERLESS_DBSSLMODE", "PREFERRED"),
                     "ca": os.getenv("PAPERLESS_DBSSLROOTCERT", None),
                     "cert": os.getenv("PAPERLESS_DBSSLCERT", None),
                     "key": os.getenv("PAPERLESS_DBSSLKEY", None),


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

The introduced change corrects a bug in which the `ssl_mode` parameter was not taken into account by the MySQLdb engine. The `ssl_mode` parameter is not taken from the `ssl` parameter as can be verified in MySQLdb code and documentation. The easiest way to confirm the error is to set the `PAPERLESS_DBSSLMODE` environment variable to `REQUIRED` and start the MySQL database by setting the `require_secure_transport=on` variable. Although `ssl_mode` was set to `REQUIRED` the MySQLdb engine does not see this setting and we get an error 

`MySQLdb.OperationalError: (3159, 'Connections using insecure transport are prohibited while --require_secure_transport=ON.')`

If the `ssl_mode` parameter is set correctly, this error should not occur.

<!--
⚠️ Important: Pull requests that implement a new feature or enhancement *should almost always target an existing feature request* with evidence of community interest and discussion. This is in order to balance the work of implementing and maintaining new features / enhancements. If that is not currently the case, please open a feature request instead of this PR to gather feedback from both users and the project maintainers.
-->

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [X] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [X] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [X] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [X] I have checked my modifications for any breaking changes.
