### PR TITLE
Fix: inotify read timeout not in ms

### DIFF
--- a/src/documents/management/commands/document_consumer.py
+++ b/src/documents/management/commands/document_consumer.py
@@ -286,10 +286,10 @@ class Command(BaseCommand):
     def handle_inotify(self, directory, recursive, is_testing: bool):
         logger.info(f"Using inotify to watch directory for changes: {directory}")
 
-        timeout = None
+        timeout_ms = None
         if is_testing:
-            timeout = self.testing_timeout_ms
-            logger.debug(f"Configuring timeout to {timeout}ms")
+            timeout_ms = self.testing_timeout_ms
+            logger.debug(f"Configuring timeout to {timeout_ms}ms")
 
         inotify = INotify()
         inotify_flags = flags.CLOSE_WRITE | flags.MOVED_TO | flags.MODIFY
@@ -298,7 +298,8 @@ class Command(BaseCommand):
         else:
             descriptor = inotify.add_watch(directory, inotify_flags)
 
-        inotify_debounce: Final[float] = settings.CONSUMER_INOTIFY_DELAY
+        inotify_debounce_secs: Final[float] = settings.CONSUMER_INOTIFY_DELAY
+        inotify_debounce_ms: Final[int] = inotify_debounce_secs * 1000
 
         finished = False
 
@@ -306,7 +307,7 @@ class Command(BaseCommand):
 
         while not finished:
             try:
-                for event in inotify.read(timeout=timeout):
+                for event in inotify.read(timeout=timeout_ms):
                     path = inotify.get_path(event.wd) if recursive else directory
                     filepath = os.path.join(path, event.name)
                     if flags.MODIFY in flags.from_mask(event.mask):
@@ -323,7 +324,7 @@ class Command(BaseCommand):
                     # Current time - last time over the configured timeout
                     waited_long_enough = (
                         monotonic() - last_event_time
-                    ) > inotify_debounce
+                    ) > inotify_debounce_secs
 
                     # Also make sure the file exists still, some scanners might write a
                     # temporary file first
@@ -342,11 +343,11 @@ class Command(BaseCommand):
                 # If files are waiting, need to exit read() to check them
                 # Otherwise, go back to infinite sleep time, but only if not testing
                 if len(notified_files) > 0:
-                    timeout = inotify_debounce * 1000
+                    timeout_ms = inotify_debounce_ms
                 elif is_testing:
-                    timeout = self.testing_timeout_ms
+                    timeout_ms = self.testing_timeout_ms
                 else:
-                    timeout = None
+                    timeout_ms = None
 
                 if self.stop_flag.is_set():
                     logger.debug("Finishing because event is set")

--- a/src/documents/management/commands/document_consumer.py
+++ b/src/documents/management/commands/document_consumer.py
@@ -342,7 +342,7 @@ class Command(BaseCommand):
                 # If files are waiting, need to exit read() to check them
                 # Otherwise, go back to infinite sleep time, but only if not testing
                 if len(notified_files) > 0:
-                    timeout = inotify_debounce
+                    timeout = inotify_debounce * 1000
                 elif is_testing:
                     timeout = self.testing_timeout_ms
                 else:


### PR DESCRIPTION
This was off by a factor of 1000, leading to a lot more invocations of the loop body than necessary.

## Proposed change

Calculate the timeout passed to inotify.read to be in milliseconds (as required by the function) instead of seconds.

The issue becomes easily perceivable when setting `PAPERLESS_CONSUMER_INOTIFY_DELAY` to a high number, so that the while loop becomes obvious in tools like top.

## Type of change

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
