### PR TITLE
Fix: Better handling of a corrupted index

### DIFF
--- a/src/documents/index.py
+++ b/src/documents/index.py
@@ -5,6 +5,7 @@ from collections import Counter
 from contextlib import contextmanager
 from datetime import datetime
 from datetime import timezone
+from shutil import rmtree
 from typing import Optional
 
 from dateutil.parser import isoparse
@@ -36,7 +37,6 @@ from whoosh.searching import Searcher
 from whoosh.util.times import timespan
 from whoosh.writing import AsyncWriter
 
-# from documents.models import CustomMetadata
 from documents.models import CustomFieldInstance
 from documents.models import Document
 from documents.models import Note
@@ -87,8 +87,11 @@ def open_index(recreate=False) -> FileIndex:
     except Exception:
         logger.exception("Error while opening the index, recreating.")
 
-    if not os.path.isdir(settings.INDEX_DIR):
-        settings.INDEX_DIR.mkdir(parents=True, exist_ok=True)
+    # create_in doesn't handle corrupted indexes very well, remove the directory entirely first
+    if os.path.isdir(settings.INDEX_DIR):
+        rmtree(settings.INDEX_DIR)
+    settings.INDEX_DIR.mkdir(parents=True, exist_ok=True)
+
     return create_in(settings.INDEX_DIR, get_schema())
 
 

--- a/src/documents/tests/test_matchables.py
+++ b/src/documents/tests/test_matchables.py
@@ -1,6 +1,7 @@
 import shutil
 import tempfile
 from collections.abc import Iterable
+from pathlib import Path
 from random import randint
 
 from django.contrib.admin.models import LogEntry
@@ -396,7 +397,7 @@ class TestDocumentConsumptionFinishedSignal(TestCase):
             mime_type="application/pdf",
         )
 
-        self.index_dir = tempfile.mkdtemp()
+        self.index_dir = Path(tempfile.mkdtemp())
         # TODO: we should not need the index here.
         override_settings(INDEX_DIR=self.index_dir).enable()
 


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

<!--
⚠️ Important: Pull requests that implement a new feature or enhancement *should almost always target an existing feature request* with evidence of community interest and discussion. This is in order to balance the work of implementing and maintaining new features / enhancements. If that is not currently the case, please open a feature request instead of this PR to gather feedback from both users and the project maintainers.
-->

Based on that exception, `exists_in` raised `FileNotFoundError` and then `create_in` also raised that for the same error.  So `create_in` doesn't handle corrupted indexes.

Instead, if the index directory exists, remove it and all files, then create it again, before using `create_in`

Closes #5884

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
