### PR TITLE
Change: tweaks to system status

### DIFF
--- a/src-ui/messages.xlf
+++ b/src-ui/messages.xlf
@@ -4281,7 +4281,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/common/system-status-dialog/system-status-dialog.component.html</context>
-          <context context-type="linenumber">152</context>
+          <context context-type="linenumber">156</context>
         </context-group>
       </trans-unit>
       <trans-unit id="595732867213154214" datatype="html">
@@ -4652,7 +4652,7 @@
         <source>Last Trained</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/common/system-status-dialog/system-status-dialog.component.html</context>
-          <context context-type="linenumber">135</context>
+          <context context-type="linenumber">139</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6732151329960766506" datatype="html">

--- a/src-ui/src/app/components/common/system-status-dialog/system-status-dialog.component.html
+++ b/src-ui/src/app/components/common/system-status-dialog/system-status-dialog.component.html
@@ -128,7 +128,11 @@
                     <i-bs name="check-circle-fill" class="text-primary ms-2 lh-1" [ngbPopover]="classifierStatus" triggers="mouseenter:mouseleave"></i-bs>
                   }
                 } @else {
-                  <i-bs name="exclamation-triangle-fill" class="text-danger ms-2 lh-1" ngbPopover="{{status.tasks.classifier_error}}" triggers="mouseenter:mouseleave"></i-bs>
+                    <i-bs name="exclamation-triangle-fill" class="ms-2 lh-1"
+                    [class.text-danger]="status.tasks.classifier_status === SystemStatusItemStatus.ERROR"
+                    [class.text-warning]="status.tasks.classifier_status === SystemStatusItemStatus.WARNING"
+                    ngbPopover="{{status.tasks.classifier_error}}"
+                    triggers="mouseenter:mouseleave"></i-bs>
                 }
               </dd>
               <ng-template #classifierStatus>

--- a/src-ui/src/app/components/common/system-status-dialog/system-status-dialog.component.ts
+++ b/src-ui/src/app/components/common/system-status-dialog/system-status-dialog.component.ts
@@ -1,6 +1,9 @@
 import { Component, Input } from '@angular/core'
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap'
-import { SystemStatus } from 'src/app/data/system-status'
+import {
+  SystemStatus,
+  SystemStatusItemStatus,
+} from 'src/app/data/system-status'
 import { SystemStatusService } from 'src/app/services/system-status.service'
 import { Clipboard } from '@angular/cdk/clipboard'
 
@@ -10,6 +13,7 @@ import { Clipboard } from '@angular/cdk/clipboard'
   styleUrl: './system-status-dialog.component.scss',
 })
 export class SystemStatusDialogComponent {
+  public SystemStatusItemStatus = SystemStatusItemStatus
   public status: SystemStatus
 
   public copied: boolean = false

--- a/src-ui/src/app/data/system-status.ts
+++ b/src-ui/src/app/data/system-status.ts
@@ -6,6 +6,7 @@ export enum InstallType {
 export enum SystemStatusItemStatus {
   OK = 'OK',
   ERROR = 'ERROR',
+  WARNING = 'WARNING',
 }
 
 export interface SystemStatus {

--- a/src/documents/tests/test_api_status.py
+++ b/src/documents/tests/test_api_status.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 from pathlib import Path
 from unittest import mock
 
@@ -7,6 +8,7 @@ from django.test import override_settings
 from rest_framework import status
 from rest_framework.test import APITestCase
 
+from documents.classifier import ClassifierModelCorruptError
 from documents.classifier import DocumentClassifier
 from documents.classifier import load_classifier
 from documents.models import Document
@@ -160,7 +162,7 @@ class TestSystemStatus(APITestCase):
         WHEN:
             - The user requests the system status
         THEN:
-            - The response contains the correct classifier status
+            - The response contains an OK classifier status
         """
         load_classifier()
         test_classifier = DocumentClassifier()
@@ -171,15 +173,15 @@ class TestSystemStatus(APITestCase):
         self.assertEqual(response.data["tasks"]["classifier_status"], "OK")
         self.assertIsNone(response.data["tasks"]["classifier_error"])
 
-    def test_system_status_classifier_error(self):
+    def test_system_status_classifier_warning(self):
         """
         GIVEN:
-            - The classifier does not exist
+            - The classifier does not exist yet
             - > 0 documents and tags with auto matching exist
         WHEN:
             - The user requests the system status
         THEN:
-            - The response contains an error classifier status
+            - The response contains an WARNING classifier status
         """
         with override_settings(MODEL_FILE="does_not_exist"):
             Document.objects.create(
@@ -189,8 +191,35 @@ class TestSystemStatus(APITestCase):
             self.client.force_login(self.user)
             response = self.client.get(self.ENDPOINT)
             self.assertEqual(response.status_code, status.HTTP_200_OK)
-            self.assertEqual(response.data["tasks"]["classifier_status"], "ERROR")
+            self.assertEqual(response.data["tasks"]["classifier_status"], "WARNING")
             self.assertIsNotNone(response.data["tasks"]["classifier_error"])
+
+    def test_system_status_classifier_error(self):
+        """
+        GIVEN:
+            - The classifier does exist but is corrupt
+            - > 0 documents and tags with auto matching exist
+        WHEN:
+            - The user requests the system status
+        THEN:
+            - The response contains an ERROR classifier status
+        """
+        does_exist = tempfile.NamedTemporaryFile(
+            dir="/tmp",
+            delete=False,
+        )
+        with override_settings(MODEL_FILE=does_exist):
+            with mock.patch("documents.classifier.load_classifier") as mock_load:
+                mock_load.side_effect = ClassifierModelCorruptError()
+                Document.objects.create(
+                    title="Test Document",
+                )
+                Tag.objects.create(name="Test Tag", matching_algorithm=Tag.MATCH_AUTO)
+                self.client.force_login(self.user)
+                response = self.client.get(self.ENDPOINT)
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+                self.assertEqual(response.data["tasks"]["classifier_status"], "ERROR")
+                self.assertIsNotNone(response.data["tasks"]["classifier_error"])
 
     def test_system_status_classifier_ok_no_objects(self):
         """

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -1581,7 +1581,9 @@ class SystemStatusView(GenericAPIView, PassUserMixin):
         except Exception as e:  # pragma: no cover
             applied_migrations = []
             db_status = "ERROR"
-            logger.exception(f"System status error connecting to database: {e}")
+            logger.exception(
+                f"System status detected a possible problem while connecting to the database: {e}",
+            )
             db_error = "Error connecting to database, check logs for more detail."
 
         media_stats = os.statvfs(settings.MEDIA_ROOT)
@@ -1594,7 +1596,9 @@ class SystemStatusView(GenericAPIView, PassUserMixin):
                 redis_status = "OK"
             except Exception as e:
                 redis_status = "ERROR"
-                logger.exception(f"System status error connecting to redis: {e}")
+                logger.exception(
+                    f"System status detected a possible problem while connecting to redis: {e}",
+                )
                 redis_error = "Error connecting to redis, check logs for more detail."
 
         try:
@@ -1615,7 +1619,9 @@ class SystemStatusView(GenericAPIView, PassUserMixin):
         except Exception as e:
             index_status = "ERROR"
             index_error = "Error opening index, check logs for more detail."
-            logger.exception(f"System status error opening index: {e}")
+            logger.exception(
+                f"System status detected a possible problem while opening the index: {e}",
+            )
             index_last_modified = None
 
         classifier_error = None
@@ -1656,7 +1662,9 @@ class SystemStatusView(GenericAPIView, PassUserMixin):
             classifier_status = "ERROR"
             classifier_last_trained = None
             classifier_error = "Error loading classifier, check logs for more detail."
-            logger.exception(f"System status error loading classifier: {e}")
+            logger.exception(
+                f"System status detected a possible problem while loading the classifier: {e}",
+            )
 
         return Response(
             {

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -1622,7 +1622,23 @@ class SystemStatusView(GenericAPIView, PassUserMixin):
         try:
             classifier = load_classifier()
             if classifier is None:
-                raise Exception("Classifier not loaded")
+                # Check if classifier should exist
+                docs_queryset = Document.objects.exclude(
+                    tags__is_inbox_tag=True,
+                )
+                if docs_queryset.count() > 0 and (
+                    Tag.objects.filter(matching_algorithm=Tag.MATCH_AUTO).exists()
+                    or DocumentType.objects.filter(
+                        matching_algorithm=Tag.MATCH_AUTO,
+                    ).exists()
+                    or Correspondent.objects.filter(
+                        matching_algorithm=Tag.MATCH_AUTO,
+                    ).exists()
+                    or StoragePath.objects.filter(
+                        matching_algorithm=Tag.MATCH_AUTO,
+                    ).exists()
+                ):
+                    raise Exception("Classifier not loaded")
             classifier_status = "OK"
             task_result_model = apps.get_model("django_celery_results", "taskresult")
             result = (


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

1. If there are 0 documents and 0 auto matching items the classifier actually shouldn't exist, so show that as 'OK'
2. Change the logging language to better communicate whats happening.
3. <img width="316" alt="Screenshot 2024-03-05 at 12 11 27 AM" src="https://github.com/paperless-ngx/paperless-ngx/assets/4887959/5e946955-3e6f-42f5-b538-ca923bb6cc60">


Closes #6007

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [x] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
