### PR TITLE
Enhancement: better detection of default currency code

### DIFF
--- a/src-ui/src/app/components/common/input/monetary/monetary.component.spec.ts
+++ b/src-ui/src/app/components/common/input/monetary/monetary.component.spec.ts
@@ -56,4 +56,10 @@ describe('MonetaryComponent', () => {
     component.monetaryValue = 10.5
     expect(component.value).toEqual('EUR10.50')
   })
+
+  it('should set the default currency code based on LOCALE_ID', () => {
+    expect(component.defaultCurrencyCode).toEqual('USD') // default
+    component = new MonetaryComponent('pt-BR')
+    expect(component.defaultCurrencyCode).toEqual('BRL')
+  })
 })

--- a/src-ui/src/app/components/common/input/monetary/monetary.component.ts
+++ b/src-ui/src/app/components/common/input/monetary/monetary.component.ts
@@ -1,13 +1,14 @@
 import {
   Component,
-  DEFAULT_CURRENCY_CODE,
   ElementRef,
   forwardRef,
   Inject,
+  LOCALE_ID,
   ViewChild,
 } from '@angular/core'
 import { NG_VALUE_ACCESSOR } from '@angular/forms'
 import { AbstractInputComponent } from '../abstract-input'
+import { getLocaleCurrencyCode } from '@angular/common'
 
 @Component({
   providers: [
@@ -24,11 +25,12 @@ import { AbstractInputComponent } from '../abstract-input'
 export class MonetaryComponent extends AbstractInputComponent<string> {
   @ViewChild('currencyField')
   currencyField: ElementRef
+  defaultCurrencyCode: string
 
-  constructor(
-    @Inject(DEFAULT_CURRENCY_CODE) public defaultCurrencyCode: string
-  ) {
+  constructor(@Inject(LOCALE_ID) currentLocale: string) {
     super()
+
+    this.defaultCurrencyCode = getLocaleCurrencyCode(currentLocale)
   }
 
   get currencyCode(): string {


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Again, this is just for the initial default currency.

<img width="526" alt="Bildschirmfoto 2024-03-05 um 20 14 48" src="https://github.com/paperless-ngx/paperless-ngx/assets/4887959/c401bf1c-f6a7-4e6e-830f-b92d12c95b95">
<img width="600" alt="Bildschirmfoto 2024-03-05 um 20 15 18" src="https://github.com/paperless-ngx/paperless-ngx/assets/4887959/53956c9a-2181-4f5f-9525-dfa218f17474">


Closes #6016 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [x] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
