### PR TITLE
Enhancement: add a built-in redis to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,6 +96,7 @@ ARG RUNTIME_PACKAGES="\
   tesseract-ocr-spa \
   unpaper \
   pngquant \
+  redis \
   jbig2dec \
   # lxml
   libxml2 \

--- a/docker/docker-prepare.sh
+++ b/docker/docker-prepare.sh
@@ -53,6 +53,11 @@ wait_for_mariadb() {
 	done
 }
 
+start_redis() {
+	echo "Starting Redis Server"
+	redis-server &
+}
+
 wait_for_redis() {
 	# We use a Python script to send the Redis ping
 	# instead of installing redis-tools just for 1 thing
@@ -101,6 +106,11 @@ do_work() {
 		wait_for_mariadb
 	elif [[ -n "${PAPERLESS_DBHOST}" ]]; then
 		wait_for_postgres
+	fi
+
+	if [[ -n "${PAPERLESS_START_REDIS}" ]]; then
+		export PAPERLESS_REDIS="redis://localhost:6379"
+		start_redis
 	fi
 
 	wait_for_redis

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1405,6 +1405,17 @@ one pod).
 
     Defaults to 8000.
 
+
+#### [`PAPERLESS_START_REDIS`](#PAPERLESS_START_REDIS) {#PAPERLESS_START_REDIS}
+
+: Set to non-empty to start a built-in redis server inside the container.
+This option will override the `PAPERLESS_REDIS` option.
+
+    This option has no effect when not using Docker.
+
+    Defaults to '' (do not run built-in redis).
+
+
 #### [`USERMAP_UID=<uid>`](#USERMAP_UID) {#USERMAP_UID}
 
 : The ID of the paperless user in the container. Set this to your


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

<!--
⚠️ Important: Pull requests that implement a new feature or enhancement *should almost always target an existing feature request* with evidence of community interest and discussion. This is in order to balance the work of implementing and maintaining new features / enhancements. If that is not currently the case, please open a feature request instead of this PR to gather feedback from both users and the project maintainers.
-->

Inspired by #3755

This change adds an optional built-in redis server to the docker image and a new environment variable `PAPERLESS_START_REDIS`.

This allows a minimum paperless-ngx setup to run within a single container. I generally agree with the sentiment that services should be isolated in their own containers, however I think having redis (optionally) built-in is reasonable for the following reasons.

- This allows setups without docker-compose (e.g. podman, some NAS systems) to easily run / test out paperless-ngx.
- Persistence of the redis is not as important as the persisting the DB - having the lifecycle of redis-server bound to the paperless-ngx container will not cause data loss.
- Redis is a small dependency, so it does not increase the image size by much.
- This behavior is opt-in, so it will not break existing setups.

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [x] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
