### PR TITLE
Documentation: correct bulk edit documents endpoint

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -340,7 +340,7 @@ The API supports various bulk-editing operations which are executed asynchronous
 
 ### Documents
 
-For bulk operations on documents, use the endpoint `/api/bulk_edit/` which accepts
+For bulk operations on documents, use the endpoint `/api/documents/bulk_edit/` which accepts
 a json payload of the format:
 
 ```json

--- a/docs/api.md
+++ b/docs/api.md
@@ -366,7 +366,7 @@ The following methods are supported:
 - `modify_tags`
   - Requires `parameters`: `{ "add_tags": [LIST_OF_TAG_IDS] }` and / or `{ "remove_tags": [LIST_OF_TAG_IDS] }`
 - `delete`
-  - No `parameters` required
+  - Empty `parameters` required: `{ }`
 - `redo_ocr`
   - No `parameters` required
 - `set_permissions`

--- a/docs/api.md
+++ b/docs/api.md
@@ -366,7 +366,7 @@ The following methods are supported:
 - `modify_tags`
   - Requires `parameters`: `{ "add_tags": [LIST_OF_TAG_IDS] }` and / or `{ "remove_tags": [LIST_OF_TAG_IDS] }`
 - `delete`
-  - Empty `parameters` required: `{ }`
+  - No `parameters` required
 - `redo_ocr`
   - No `parameters` required
 - `set_permissions`


### PR DESCRIPTION
## Proposed change

Fix error in the URL for document bulk edits in the API docs; clarify that the `delete` operation still requires the parameters key to be present in the JSON body, even though it should contain an empty JSON object.


## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [X] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [X] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [X] I have made corresponding changes to the documentation as needed.
- [X] I have checked my modifications for any breaking changes.
