### PR TITLE
Change: dont require empty bulk edit parameters

### DIFF
--- a/src/documents/serialisers.py
+++ b/src/documents/serialisers.py
@@ -874,7 +874,7 @@ class BulkEditSerializer(DocumentListSerializer, SetPermissionsMixin):
         write_only=True,
     )
 
-    parameters = serializers.DictField(allow_empty=True)
+    parameters = serializers.DictField(allow_empty=True, default={}, write_only=True)
 
     def _validate_tag_id_list(self, tags, name="tags"):
         if not isinstance(tags, list):

--- a/src/documents/tests/test_api_bulk_edit.py
+++ b/src/documents/tests/test_api_bulk_edit.py
@@ -6,7 +6,6 @@ from guardian.shortcuts import assign_perm
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from documents import bulk_edit
 from documents.models import Correspondent
 from documents.models import Document
 from documents.models import DocumentType
@@ -15,7 +14,7 @@ from documents.models import Tag
 from documents.tests.utils import DirectoriesMixin
 
 
-class TestBulkEdit(DirectoriesMixin, APITestCase):
+class TestBulkEditAPI(DirectoriesMixin, APITestCase):
     def setUp(self):
         super().setUp()
 
@@ -50,144 +49,6 @@ class TestBulkEdit(DirectoriesMixin, APITestCase):
         self.doc3.tags.add(self.t2)
         self.doc4.tags.add(self.t1, self.t2)
         self.sp1 = StoragePath.objects.create(name="sp1", path="Something/{checksum}")
-
-    def test_set_correspondent(self):
-        self.assertEqual(Document.objects.filter(correspondent=self.c2).count(), 1)
-        bulk_edit.set_correspondent(
-            [self.doc1.id, self.doc2.id, self.doc3.id],
-            self.c2.id,
-        )
-        self.assertEqual(Document.objects.filter(correspondent=self.c2).count(), 3)
-        self.async_task.assert_called_once()
-        args, kwargs = self.async_task.call_args
-        self.assertCountEqual(kwargs["document_ids"], [self.doc1.id, self.doc2.id])
-
-    def test_unset_correspondent(self):
-        self.assertEqual(Document.objects.filter(correspondent=self.c2).count(), 1)
-        bulk_edit.set_correspondent([self.doc1.id, self.doc2.id, self.doc3.id], None)
-        self.assertEqual(Document.objects.filter(correspondent=self.c2).count(), 0)
-        self.async_task.assert_called_once()
-        args, kwargs = self.async_task.call_args
-        self.assertCountEqual(kwargs["document_ids"], [self.doc2.id, self.doc3.id])
-
-    def test_set_document_type(self):
-        self.assertEqual(Document.objects.filter(document_type=self.dt2).count(), 1)
-        bulk_edit.set_document_type(
-            [self.doc1.id, self.doc2.id, self.doc3.id],
-            self.dt2.id,
-        )
-        self.assertEqual(Document.objects.filter(document_type=self.dt2).count(), 3)
-        self.async_task.assert_called_once()
-        args, kwargs = self.async_task.call_args
-        self.assertCountEqual(kwargs["document_ids"], [self.doc1.id, self.doc2.id])
-
-    def test_unset_document_type(self):
-        self.assertEqual(Document.objects.filter(document_type=self.dt2).count(), 1)
-        bulk_edit.set_document_type([self.doc1.id, self.doc2.id, self.doc3.id], None)
-        self.assertEqual(Document.objects.filter(document_type=self.dt2).count(), 0)
-        self.async_task.assert_called_once()
-        args, kwargs = self.async_task.call_args
-        self.assertCountEqual(kwargs["document_ids"], [self.doc2.id, self.doc3.id])
-
-    def test_set_document_storage_path(self):
-        """
-        GIVEN:
-            - 5 documents without defined storage path
-        WHEN:
-            - Bulk edit called to add storage path to 1 document
-        THEN:
-            - Single document storage path update
-        """
-        self.assertEqual(Document.objects.filter(storage_path=None).count(), 5)
-
-        bulk_edit.set_storage_path(
-            [self.doc1.id],
-            self.sp1.id,
-        )
-
-        self.assertEqual(Document.objects.filter(storage_path=None).count(), 4)
-
-        self.async_task.assert_called_once()
-        args, kwargs = self.async_task.call_args
-
-        self.assertCountEqual(kwargs["document_ids"], [self.doc1.id])
-
-    def test_unset_document_storage_path(self):
-        """
-        GIVEN:
-            - 4 documents without defined storage path
-            - 1 document with a defined storage
-        WHEN:
-            - Bulk edit called to remove storage path from 1 document
-        THEN:
-            - Single document storage path removed
-        """
-        self.assertEqual(Document.objects.filter(storage_path=None).count(), 5)
-
-        bulk_edit.set_storage_path(
-            [self.doc1.id],
-            self.sp1.id,
-        )
-
-        self.assertEqual(Document.objects.filter(storage_path=None).count(), 4)
-
-        bulk_edit.set_storage_path(
-            [self.doc1.id],
-            None,
-        )
-
-        self.assertEqual(Document.objects.filter(storage_path=None).count(), 5)
-
-        self.async_task.assert_called()
-        args, kwargs = self.async_task.call_args
-
-        self.assertCountEqual(kwargs["document_ids"], [self.doc1.id])
-
-    def test_add_tag(self):
-        self.assertEqual(Document.objects.filter(tags__id=self.t1.id).count(), 2)
-        bulk_edit.add_tag(
-            [self.doc1.id, self.doc2.id, self.doc3.id, self.doc4.id],
-            self.t1.id,
-        )
-        self.assertEqual(Document.objects.filter(tags__id=self.t1.id).count(), 4)
-        self.async_task.assert_called_once()
-        args, kwargs = self.async_task.call_args
-        self.assertCountEqual(kwargs["document_ids"], [self.doc1.id, self.doc3.id])
-
-    def test_remove_tag(self):
-        self.assertEqual(Document.objects.filter(tags__id=self.t1.id).count(), 2)
-        bulk_edit.remove_tag([self.doc1.id, self.doc3.id, self.doc4.id], self.t1.id)
-        self.assertEqual(Document.objects.filter(tags__id=self.t1.id).count(), 1)
-        self.async_task.assert_called_once()
-        args, kwargs = self.async_task.call_args
-        self.assertCountEqual(kwargs["document_ids"], [self.doc4.id])
-
-    def test_modify_tags(self):
-        tag_unrelated = Tag.objects.create(name="unrelated")
-        self.doc2.tags.add(tag_unrelated)
-        self.doc3.tags.add(tag_unrelated)
-        bulk_edit.modify_tags(
-            [self.doc2.id, self.doc3.id],
-            add_tags=[self.t2.id],
-            remove_tags=[self.t1.id],
-        )
-
-        self.assertCountEqual(list(self.doc2.tags.all()), [self.t2, tag_unrelated])
-        self.assertCountEqual(list(self.doc3.tags.all()), [self.t2, tag_unrelated])
-
-        self.async_task.assert_called_once()
-        args, kwargs = self.async_task.call_args
-        # TODO: doc3 should not be affected, but the query for that is rather complicated
-        self.assertCountEqual(kwargs["document_ids"], [self.doc2.id, self.doc3.id])
-
-    def test_delete(self):
-        self.assertEqual(Document.objects.count(), 5)
-        bulk_edit.delete([self.doc1.id, self.doc2.id])
-        self.assertEqual(Document.objects.count(), 3)
-        self.assertCountEqual(
-            [doc.id for doc in Document.objects.all()],
-            [self.doc3.id, self.doc4.id, self.doc5.id],
-        )
 
     @mock.patch("documents.serialisers.bulk_edit.set_correspondent")
     def test_api_set_correspondent(self, m):

--- a/src/documents/tests/test_api_bulk_edit.py
+++ b/src/documents/tests/test_api_bulk_edit.py
@@ -228,7 +228,7 @@ class TestBulkEditAPI(DirectoriesMixin, APITestCase):
         response = self.client.post(
             "/api/documents/bulk_edit/",
             json.dumps(
-                {"documents": [self.doc1.id], "method": "delete", "parameters": {}},
+                {"documents": [self.doc1.id], "method": "delete"},
             ),
             content_type="application/json",
         )
@@ -354,7 +354,7 @@ class TestBulkEditAPI(DirectoriesMixin, APITestCase):
         self.assertEqual(Document.objects.count(), 5)
         response = self.client.post(
             "/api/documents/bulk_edit/",
-            json.dumps({"documents": [-235], "method": "delete", "parameters": {}}),
+            json.dumps({"documents": [-235], "method": "delete"}),
             content_type="application/json",
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -461,7 +461,7 @@ class TestBulkEditAPI(DirectoriesMixin, APITestCase):
         response = self.client.post(
             "/api/documents/bulk_edit/",
             json.dumps(
-                {"documents": [self.doc2.id], "method": "add_tag", "parameters": {}},
+                {"documents": [self.doc2.id], "method": "add_tag"},
             ),
             content_type="application/json",
         )
@@ -488,7 +488,7 @@ class TestBulkEditAPI(DirectoriesMixin, APITestCase):
         response = self.client.post(
             "/api/documents/bulk_edit/",
             json.dumps(
-                {"documents": [self.doc2.id], "method": "remove_tag", "parameters": {}},
+                {"documents": [self.doc2.id], "method": "remove_tag"},
             ),
             content_type="application/json",
         )

--- a/src/documents/tests/test_bulk_edit.py
+++ b/src/documents/tests/test_bulk_edit.py
@@ -7,24 +7,191 @@ from guardian.shortcuts import assign_perm
 from guardian.shortcuts import get_groups_with_perms
 from guardian.shortcuts import get_users_with_perms
 
-from documents.bulk_edit import set_permissions
+from documents import bulk_edit
+from documents.models import Correspondent
 from documents.models import Document
+from documents.models import DocumentType
+from documents.models import StoragePath
+from documents.models import Tag
 from documents.tests.utils import DirectoriesMixin
 
 
-class TestBulkEditPermissions(DirectoriesMixin, TestCase):
+class TestBulkEdit(DirectoriesMixin, TestCase):
     def setUp(self):
         super().setUp()
-
-        self.doc1 = Document.objects.create(checksum="A", title="A")
-        self.doc2 = Document.objects.create(checksum="B", title="B")
-        self.doc3 = Document.objects.create(checksum="C", title="C")
 
         self.owner = User.objects.create(username="test_owner")
         self.user1 = User.objects.create(username="user1")
         self.user2 = User.objects.create(username="user2")
         self.group1 = Group.objects.create(name="group1")
         self.group2 = Group.objects.create(name="group2")
+
+        patcher = mock.patch("documents.bulk_edit.bulk_update_documents.delay")
+        self.async_task = patcher.start()
+        self.addCleanup(patcher.stop)
+        self.c1 = Correspondent.objects.create(name="c1")
+        self.c2 = Correspondent.objects.create(name="c2")
+        self.dt1 = DocumentType.objects.create(name="dt1")
+        self.dt2 = DocumentType.objects.create(name="dt2")
+        self.t1 = Tag.objects.create(name="t1")
+        self.t2 = Tag.objects.create(name="t2")
+        self.doc1 = Document.objects.create(checksum="A", title="A")
+        self.doc2 = Document.objects.create(
+            checksum="B",
+            title="B",
+            correspondent=self.c1,
+            document_type=self.dt1,
+        )
+        self.doc3 = Document.objects.create(
+            checksum="C",
+            title="C",
+            correspondent=self.c2,
+            document_type=self.dt2,
+        )
+        self.doc4 = Document.objects.create(checksum="D", title="D")
+        self.doc5 = Document.objects.create(checksum="E", title="E")
+        self.doc2.tags.add(self.t1)
+        self.doc3.tags.add(self.t2)
+        self.doc4.tags.add(self.t1, self.t2)
+        self.sp1 = StoragePath.objects.create(name="sp1", path="Something/{checksum}")
+
+    def test_set_correspondent(self):
+        self.assertEqual(Document.objects.filter(correspondent=self.c2).count(), 1)
+        bulk_edit.set_correspondent(
+            [self.doc1.id, self.doc2.id, self.doc3.id],
+            self.c2.id,
+        )
+        self.assertEqual(Document.objects.filter(correspondent=self.c2).count(), 3)
+        self.async_task.assert_called_once()
+        args, kwargs = self.async_task.call_args
+        self.assertCountEqual(kwargs["document_ids"], [self.doc1.id, self.doc2.id])
+
+    def test_unset_correspondent(self):
+        self.assertEqual(Document.objects.filter(correspondent=self.c2).count(), 1)
+        bulk_edit.set_correspondent([self.doc1.id, self.doc2.id, self.doc3.id], None)
+        self.assertEqual(Document.objects.filter(correspondent=self.c2).count(), 0)
+        self.async_task.assert_called_once()
+        args, kwargs = self.async_task.call_args
+        self.assertCountEqual(kwargs["document_ids"], [self.doc2.id, self.doc3.id])
+
+    def test_set_document_type(self):
+        self.assertEqual(Document.objects.filter(document_type=self.dt2).count(), 1)
+        bulk_edit.set_document_type(
+            [self.doc1.id, self.doc2.id, self.doc3.id],
+            self.dt2.id,
+        )
+        self.assertEqual(Document.objects.filter(document_type=self.dt2).count(), 3)
+        self.async_task.assert_called_once()
+        args, kwargs = self.async_task.call_args
+        self.assertCountEqual(kwargs["document_ids"], [self.doc1.id, self.doc2.id])
+
+    def test_unset_document_type(self):
+        self.assertEqual(Document.objects.filter(document_type=self.dt2).count(), 1)
+        bulk_edit.set_document_type([self.doc1.id, self.doc2.id, self.doc3.id], None)
+        self.assertEqual(Document.objects.filter(document_type=self.dt2).count(), 0)
+        self.async_task.assert_called_once()
+        args, kwargs = self.async_task.call_args
+        self.assertCountEqual(kwargs["document_ids"], [self.doc2.id, self.doc3.id])
+
+    def test_set_document_storage_path(self):
+        """
+        GIVEN:
+            - 5 documents without defined storage path
+        WHEN:
+            - Bulk edit called to add storage path to 1 document
+        THEN:
+            - Single document storage path update
+        """
+        self.assertEqual(Document.objects.filter(storage_path=None).count(), 5)
+
+        bulk_edit.set_storage_path(
+            [self.doc1.id],
+            self.sp1.id,
+        )
+
+        self.assertEqual(Document.objects.filter(storage_path=None).count(), 4)
+
+        self.async_task.assert_called_once()
+        args, kwargs = self.async_task.call_args
+
+        self.assertCountEqual(kwargs["document_ids"], [self.doc1.id])
+
+    def test_unset_document_storage_path(self):
+        """
+        GIVEN:
+            - 4 documents without defined storage path
+            - 1 document with a defined storage
+        WHEN:
+            - Bulk edit called to remove storage path from 1 document
+        THEN:
+            - Single document storage path removed
+        """
+        self.assertEqual(Document.objects.filter(storage_path=None).count(), 5)
+
+        bulk_edit.set_storage_path(
+            [self.doc1.id],
+            self.sp1.id,
+        )
+
+        self.assertEqual(Document.objects.filter(storage_path=None).count(), 4)
+
+        bulk_edit.set_storage_path(
+            [self.doc1.id],
+            None,
+        )
+
+        self.assertEqual(Document.objects.filter(storage_path=None).count(), 5)
+
+        self.async_task.assert_called()
+        args, kwargs = self.async_task.call_args
+
+        self.assertCountEqual(kwargs["document_ids"], [self.doc1.id])
+
+    def test_add_tag(self):
+        self.assertEqual(Document.objects.filter(tags__id=self.t1.id).count(), 2)
+        bulk_edit.add_tag(
+            [self.doc1.id, self.doc2.id, self.doc3.id, self.doc4.id],
+            self.t1.id,
+        )
+        self.assertEqual(Document.objects.filter(tags__id=self.t1.id).count(), 4)
+        self.async_task.assert_called_once()
+        args, kwargs = self.async_task.call_args
+        self.assertCountEqual(kwargs["document_ids"], [self.doc1.id, self.doc3.id])
+
+    def test_remove_tag(self):
+        self.assertEqual(Document.objects.filter(tags__id=self.t1.id).count(), 2)
+        bulk_edit.remove_tag([self.doc1.id, self.doc3.id, self.doc4.id], self.t1.id)
+        self.assertEqual(Document.objects.filter(tags__id=self.t1.id).count(), 1)
+        self.async_task.assert_called_once()
+        args, kwargs = self.async_task.call_args
+        self.assertCountEqual(kwargs["document_ids"], [self.doc4.id])
+
+    def test_modify_tags(self):
+        tag_unrelated = Tag.objects.create(name="unrelated")
+        self.doc2.tags.add(tag_unrelated)
+        self.doc3.tags.add(tag_unrelated)
+        bulk_edit.modify_tags(
+            [self.doc2.id, self.doc3.id],
+            add_tags=[self.t2.id],
+            remove_tags=[self.t1.id],
+        )
+
+        self.assertCountEqual(list(self.doc2.tags.all()), [self.t2, tag_unrelated])
+        self.assertCountEqual(list(self.doc3.tags.all()), [self.t2, tag_unrelated])
+
+        self.async_task.assert_called_once()
+        args, kwargs = self.async_task.call_args
+        # TODO: doc3 should not be affected, but the query for that is rather complicated
+        self.assertCountEqual(kwargs["document_ids"], [self.doc2.id, self.doc3.id])
+
+    def test_delete(self):
+        self.assertEqual(Document.objects.count(), 5)
+        bulk_edit.delete([self.doc1.id, self.doc2.id])
+        self.assertEqual(Document.objects.count(), 3)
+        self.assertCountEqual(
+            [doc.id for doc in Document.objects.all()],
+            [self.doc3.id, self.doc4.id, self.doc5.id],
+        )
 
     @mock.patch("documents.tasks.bulk_update_documents.delay")
     def test_set_permissions(self, m):
@@ -43,7 +210,7 @@ class TestBulkEditPermissions(DirectoriesMixin, TestCase):
             },
         }
 
-        set_permissions(
+        bulk_edit.set_permissions(
             doc_ids,
             set_permissions=permissions,
             owner=self.owner,
@@ -85,7 +252,7 @@ class TestBulkEditPermissions(DirectoriesMixin, TestCase):
                 "groups": [self.group2.id],
             },
         }
-        set_permissions(
+        bulk_edit.set_permissions(
             doc_ids,
             set_permissions=permissions,
             owner=self.owner,


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Also just noticed a few tests should be in a different location.

See #6057

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [x] Other. Please explain: non-breaking change

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
