### PR TITLE
Enhancement: always place search term first in autocomplete results

### DIFF
--- a/src/documents/index.py
+++ b/src/documents/index.py
@@ -468,9 +468,13 @@ def autocomplete(
         termCounts = Counter()
         if results.has_matched_terms():
             for hit in results:
-                for _, term in hit.matched_terms():
-                    termCounts[term] += 1
+                for _, match in hit.matched_terms():
+                    termCounts[match] += 1
             terms = [t for t, _ in termCounts.most_common(limit)]
+
+        term_encoded = term.encode("UTF-8")
+        if term_encoded in terms:
+            terms.insert(0, terms.pop(terms.index(term_encoded)))
 
     return terms
 

--- a/src/documents/tests/test_api_search.py
+++ b/src/documents/tests/test_api_search.py
@@ -595,6 +595,28 @@ class TestDocumentSearchApi(DirectoriesMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data, [])
 
+    def test_search_autocomplete_search_term(self):
+        """
+        GIVEN:
+            - Search results for autocomplete include the exact search term
+        WHEN:
+            - API request for autocomplete
+        THEN:
+            - The search term is returned first in the autocomplete results
+        """
+        d1 = Document.objects.create(
+            title="doc1",
+            content="automobile automatic autobots automobile auto",
+            checksum="1",
+        )
+
+        with AsyncWriter(index.open_index()) as writer:
+            index.update_document(writer, d1)
+
+        response = self.client.get("/api/search/autocomplete/?term=auto")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data[0], b"auto")
+
     @pytest.mark.skip(reason="Not implemented yet")
     def test_search_spelling_correction(self):
         with AsyncWriter(index.open_index()) as writer:


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Small thing but I think on balance this is slightly more intuitive. Basically if the entire exact search term is in the results put it at the top of the list. Of course happy to discuss if folks disagree.

With PR:
<img width="198" alt="Screenshot 2024-03-19 at 9 29 19 PM" src="https://github.com/paperless-ngx/paperless-ngx/assets/4887959/85c413ae-092a-4a00-ab96-1fc23a19a9c9">


Current:
<img width="199" alt="Screenshot 2024-03-19 at 9 29 43 PM" src="https://github.com/paperless-ngx/paperless-ngx/assets/4887959/417beecd-7018-42aa-bb47-2c058d91eb70">


See #6139

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [x] Other. Please explain: change

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
