### PR TITLE
Fix: catch sessionStorage errors for large documents

### DIFF
--- a/src-ui/setup-jest.ts
+++ b/src-ui/setup-jest.ts
@@ -76,7 +76,10 @@ const mock = () => {
   let storage: { [key: string]: string } = {}
   return {
     getItem: (key: string) => (key in storage ? storage[key] : null),
-    setItem: (key: string, value: string) => (storage[key] = value || ''),
+    setItem: (key: string, value: string) => {
+      if (value.length > 1000000) throw new Error('localStorage overflow')
+      storage[key] = value || ''
+    },
     removeItem: (key: string) => delete storage[key],
     clear: () => (storage = {}),
   }

--- a/src-ui/src/app/services/open-documents.service.spec.ts
+++ b/src-ui/src/app/services/open-documents.service.spec.ts
@@ -5,10 +5,11 @@ import {
   HttpTestingController,
 } from '@angular/common/http/testing'
 import { environment } from 'src/environments/environment'
-import { Subscription } from 'rxjs'
+import { Subscription, throwError } from 'rxjs'
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap'
 import { ConfirmDialogComponent } from '../components/common/confirm-dialog/confirm-dialog.component'
 import { OPEN_DOCUMENT_SERVICE } from '../data/storage-keys'
+import { wind } from 'ngx-bootstrap-icons'
 
 const documents = [
   {
@@ -232,5 +233,13 @@ describe('OpenDocumentsService', () => {
     expect(req.request.method).toEqual('GET')
     req.error(new ErrorEvent('timeout'))
     expect(openDocumentsService.getOpenDocuments()).toHaveLength(0)
+  })
+
+  it('should log error on sessionStorage save', () => {
+    const doc = { ...documents[0] }
+    doc.content = 'a'.repeat(1000000)
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation()
+    openDocumentsService.openDocument(doc)
+    expect(consoleSpy).toHaveBeenCalled()
   })
 })

--- a/src-ui/src/app/services/open-documents.service.ts
+++ b/src-ui/src/app/services/open-documents.service.ts
@@ -152,9 +152,13 @@ export class OpenDocumentsService {
   }
 
   save() {
-    sessionStorage.setItem(
-      OPEN_DOCUMENT_SERVICE.DOCUMENTS,
-      JSON.stringify(this.openDocuments)
-    )
+    try {
+      sessionStorage.setItem(
+        OPEN_DOCUMENT_SERVICE.DOCUMENTS,
+        JSON.stringify(this.openDocuments)
+      )
+    } catch (e) {
+      console.error('Error saving open documents to session storage', e)
+    }
   }
 }


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

This certainly seems to be an edge case since no one's reported it before because it comes down to extremely large documents (example is 7.7mb of purely text, i.e. 986k words / 6.6million characters, i.e. perhaps absurd) which exceed the browser [storage quota](https://developer.mozilla.org/en-US/docs/Web/API/Storage_API/Storage_quotas_and_eviction_criteria#how_much_data_can_be_stored). So Im fine (obviously) with the fix here which is just to catch the error and continue along.

Closes #6144

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
