### PR TITLE
Documentation: note importer does not support zip files

### DIFF
--- a/docs/administration.md
+++ b/docs/administration.md
@@ -357,6 +357,16 @@ extract the files inside the `export` folder first.
 
     Importing from a previous version of Paperless may work, but for best
     results it is suggested to match the versions.
+	
+!!! warning
+    The [Document importer](#importer) is meant to be run against a completely empty database
+	and a set of empty paperless folders.
+    Unless you take great care in making sure that there will be no collisions
+	(with the existing items in your paperless database) caused by the manifest data you
+	place in the `export` folder, the document_importer script may crash on duplicate items/files.
+	You run the risk of corrupting your target paperless instance if you import
+	items into a paperless instance that is not completely empty. 
+	
 
 ### Document retagger {#retagger}
 

--- a/docs/administration.md
+++ b/docs/administration.md
@@ -359,13 +359,7 @@ extract the files inside the `export` folder first.
     results it is suggested to match the versions.
 	
 !!! warning
-    The [Document importer](#importer) is meant to be run against a completely empty database
-	and a set of empty paperless folders.
-    Unless you take great care in making sure that there will be no collisions
-	(with the existing items in your paperless database) caused by the manifest data you
-	place in the `export` folder, the document_importer script may crash on duplicate items/files.
-	You run the risk of corrupting your target paperless instance if you import
-	items into a paperless instance that is not completely empty. 
+    The importer should be run against a completely empty installation (database and directories) of Paperless-ngx.
 	
 
 ### Document retagger {#retagger}

--- a/docs/administration.md
+++ b/docs/administration.md
@@ -357,6 +357,7 @@ Note that .zip files (as can be generated from the exporter) are not supported.
     results it is suggested to match the versions.
 
 !!! warning
+
     The importer should be run against a completely empty installation (database and directories) of Paperless-ngx.
 
 ### Document retagger {#retagger}

--- a/docs/administration.md
+++ b/docs/administration.md
@@ -359,7 +359,6 @@ Note that .zip files (as can be generated from the exporter) are not supported.
 !!! warning
     The importer should be run against a completely empty installation (database and directories) of Paperless-ngx.
 
-
 ### Document retagger {#retagger}
 
 Say you've imported a few hundred documents and now want to introduce a

--- a/docs/administration.md
+++ b/docs/administration.md
@@ -349,6 +349,10 @@ When you use the provided docker compose script, put the export inside
 the `export` folder in your paperless source directory. Specify
 `../export` as the `source`.
 
+If you have zipped the data and manifest 
+with the [Document exporter](#exporter) using the `-z` or `--zip` option, please
+extract the files inside the `export` folder first.
+
 !!! note
 
     Importing from a previous version of Paperless may work, but for best

--- a/docs/administration.md
+++ b/docs/administration.md
@@ -355,10 +355,10 @@ Note that .zip files (as can be generated from the exporter) are not supported.
 
     Importing from a previous version of Paperless may work, but for best
     results it is suggested to match the versions.
-	
+
 !!! warning
     The importer should be run against a completely empty installation (database and directories) of Paperless-ngx.
-	
+
 
 ### Document retagger {#retagger}
 

--- a/docs/administration.md
+++ b/docs/administration.md
@@ -349,9 +349,7 @@ When you use the provided docker compose script, put the export inside
 the `export` folder in your paperless source directory. Specify
 `../export` as the `source`.
 
-If you have zipped the data and manifest 
-with the [Document exporter](#exporter) using the `-z` or `--zip` option, please
-extract the files inside the `export` folder first.
+Note that .zip files (as can be generated from the exporter) are not supported.
 
 !!! note
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -341,6 +341,16 @@ If you want to build the documentation locally, this is how you do it:
     ```bash
     $ pipenv install --dev
     ```
+You may need to install the follow extensions manually, if you find that mkdocs is complaining about missing modules, plugins or themes:
+    ```bash
+    $ pip install pymdown-extensions
+    ```
+    ```bash
+    $ pip install mkdocs-material-extensions mkdocs-material
+    ```
+    ```bash
+    $ pip install mkdocs-glightbox
+    ```		
 
 2.  Build the documentation
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -341,16 +341,6 @@ If you want to build the documentation locally, this is how you do it:
     ```bash
     $ pipenv install --dev
     ```
-You may need to install the follow extensions manually, if you find that mkdocs is complaining about missing modules, plugins or themes:
-    ```bash
-    $ pip install pymdown-extensions
-    ```
-    ```bash
-    $ pip install mkdocs-material-extensions mkdocs-material
-    ```
-    ```bash
-    $ pip install mkdocs-glightbox
-    ```		
 
 2.  Build the documentation
 


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

<!--
⚠️ Important: Pull requests that implement a new feature or enhancement *should almost always target an existing feature request* with evidence of community interest and discussion. This is in order to balance the work of implementing and maintaining new features / enhancements. If that is not currently the case, please open a feature request instead of this PR to gather feedback from both users and the project maintainers.
-->

Follow up to discussion https://github.com/paperless-ngx/paperless-ngx/discussions/6178#discussioncomment-8918600
In this discussion I mentioned I would try having two homes for my paperless database and some experimentation led me to the following errors
```
biocoder@diskstation:~$ sudo docker exec -it paperless-ngx document_importer ..                                                                                                                                                             /export
Password:
Found file 0000001.pdf, this might indicate a non-empty installation
Found file 0000001.pdf, this might indicate a non-empty installation
Found existing user(s), this might indicate a non-empty installation
Found existing documents(s), this might indicate a non-empty installation
CommandError: That directory doesn't appear to contain a manifest.json file.
biocoder@diskstation:~$ sudo docker exec -it paperless-ngx document_importer ..                                                                                                                                                             /export
Found file 0000001.pdf, this might indicate a non-empty installation
Found file 0000001.pdf, this might indicate a non-empty installation
Found existing user(s), this might indicate a non-empty installation
Found existing documents(s), this might indicate a non-empty installation
Checking the manifest
Installed 198 object(s) from 1 fixture(s)
Installed 1 object(s) from 1 fixture(s)
Installed 1 object(s) from 1 fixture(s)
Installed 1 object(s) from 1 fixture(s)
Installed 1 object(s) from 1 fixture(s)
Installed 1 object(s) from 1 fixture(s)
Installed 1 object(s) from 1 fixture(s)
Copy files into paperless...
 50%|██████████████████████▌                      | 3/6 [00:00<00:00,  6.94it/s]
Traceback (most recent call last):
  File "/usr/src/paperless/src/manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File "/usr/local/lib/python3.11/site-packages/django/core/management/__init__.                                                                                                                                                             py", line 442, in execute_from_command_line
    utility.execute()
  File "/usr/local/lib/python3.11/site-packages/django/core/management/__init__.                                                                                                                                                             py", line 436, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/usr/local/lib/python3.11/site-packages/django/core/management/base.py",                                                                                                                                                              line 412, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/usr/local/lib/python3.11/site-packages/django/core/management/base.py",                                                                                                                                                              line 458, in execute
    output = self.handle(*args, **options)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/paperless/src/documents/management/commands/document_importer.p                                                                                                                                                             y", line 182, in handle
    self._import_files_from_manifest(options["no_progress_bar"])
  File "/usr/src/paperless/src/documents/management/commands/document_importer.p                                                                                                                                                             y", line 278, in _import_files_from_manifest
    raise FileExistsError(document.source_path)
FileExistsError: /usr/src/paperless/media/documents/originals/0000002.pdf
biocoder@diskstation:~$
```
The first invocation of document_importer failed harmlessly, I followed the documentation literally and sort of expected a ZIP file to be opened automatically. 
The second invocation of document_importer failed because I attempted to restore 6 items from my workstation instance in the instance on my NAS that still had 1 other item in its database. The result was that item 1 kept the original scan but got its metadata from the first item scanned on my workstation. One of the other 6 items had no scans attached to it anymore.
Figuring that changing the "non-empty installation" warning into a fatal error might break someones workflow(s), I thought "let's also update the documentation for that as well"

I also added some notes of additional steps I had to do in my Ubuntu WSL installation on Windows to serve the documentation as I was preparing this PR.
## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [x] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
