### PR TITLE
Enhancement: add ASN to consume rejection message

### DIFF
--- a/src/documents/consumer.py
+++ b/src/documents/consumer.py
@@ -368,7 +368,7 @@ class Consumer(LoggingMixin):
         if Document.objects.filter(archive_serial_number=self.override_asn).exists():
             self._fail(
                 ConsumerStatusShortMessage.ASN_ALREADY_EXISTS,
-                f"Not consuming {self.filename}: Given ASN already exists!",
+                f"Not consuming {self.filename}: Given ASN {self.override_asn} already exists!",
             )
 
     def run_pre_consume_script(self):


### PR DESCRIPTION
## Proposed change
When not consuming a document since its ASN collides with an already existing one, make the ASN part of the message to make it easier for the user to find out which document causes the collision.

See also the 1st item in the list at the end of the comment: https://github.com/paperless-ngx/paperless-ngx/discussions/2054#discussioncomment-8946263

## Type of change

- [ ] Bug fix: non-breaking change which fixes an issue.
- [x] New feature / Enhancement: non-breaking change which adds functionality. (minor message string change)
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
