### PR TITLE
Fix: spacing in reset and incorrect display in saved views

### DIFF
--- a/src-ui/src/app/components/document-list/document-list.component.html
+++ b/src-ui/src/app/components/document-list/document-list.component.html
@@ -99,7 +99,7 @@
         @if (list.selected.size === 0) {
           <span i18n>{list.collectionSize, plural, =1 {One document} other {{{list.collectionSize || 0}} documents}}</span>
           }&nbsp;@if (isFiltered) {
-          <span i18n>(filtered)</span>
+            &nbsp;<span i18n>(filtered)</span>
         }
       }
       @if (!list.isReloading && isFiltered) {

--- a/src-ui/src/app/components/document-list/document-list.component.ts
+++ b/src-ui/src/app/components/document-list/document-list.component.ts
@@ -86,7 +86,7 @@ export class DocumentListComponent
   }
 
   get isFiltered() {
-    return this.list.filterRules?.length > 0
+    return this.filterEditor.rulesModified
   }
 
   getTitle() {


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Sorry, two more small things I randomly just noticed:

- no space between "X documents" and "(filtered)"
- on saved views the "(filtered)" reset button above the list (not the big button in the editor) should be hidden, just like the big button is disabled

See screenshots, with fix:
<img width="1840" alt="Screenshot 2024-04-07 at 11 58 36 AM" src="https://github.com/paperless-ngx/paperless-ngx/assets/4887959/a5b7c72b-d82f-4ec4-b66a-afadce7a3652">
<img width="1840" alt="Screenshot 2024-04-07 at 11 59 39 AM" src="https://github.com/paperless-ngx/paperless-ngx/assets/4887959/27ae3752-accb-4e83-bbbc-ce22fdfa60fc">


Current:
<img width="1840" alt="Screenshot 2024-04-07 at 11 58 45 AM" src="https://github.com/paperless-ngx/paperless-ngx/assets/4887959/2048eccb-a52e-4a54-bdf3-e4154c3891ba">


## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
