### PR TITLE
Fix: add timezone fallback to install script

### DIFF
--- a/docker/compose/docker-compose.postgres.yml
+++ b/docker/compose/docker-compose.postgres.yml
@@ -43,6 +43,7 @@ services:
       POSTGRES_DB: paperless
       POSTGRES_USER: paperless
       POSTGRES_PASSWORD: paperless
+      POSTGRES_HOST_AUTH_METHOD: trust
 
   webserver:
     image: ghcr.io/paperless-ngx/paperless-ngx:latest

--- a/docker/compose/docker-compose.postgres.yml
+++ b/docker/compose/docker-compose.postgres.yml
@@ -43,7 +43,6 @@ services:
       POSTGRES_DB: paperless
       POSTGRES_USER: paperless
       POSTGRES_PASSWORD: paperless
-      POSTGRES_HOST_AUTH_METHOD: trust
 
   webserver:
     image: ghcr.io/paperless-ngx/paperless-ngx:latest

--- a/install-paperless-ngx.sh
+++ b/install-paperless-ngx.sh
@@ -72,12 +72,12 @@ if ! docker stats --no-stream &> /dev/null ; then
 fi
 
 # Added handling for timezone for busybox based linux, not having timedatectl available (i.e. QNAP QTS)
-# if neither timedatectl or /etc/TZ is suceeding, defaulting to GMT.
+# if neither timedatectl nor /etc/TZ is suceeding, defaulting to GMT.
 if  command -v timedatectl &> /dev/null ; then
         default_time_zone=$(timedatectl show -p Timezone --value)
 elif [ -f /etc/TZ ] && [ -f /etc/tzlist ] ; then
-        TZ=`cat /etc/TZ`
-        default_time_zone=$(grep -B 1 -m 1 $TZ /etc/tzlist | head -1 | cut -f 2 -d =)
+        TZ=$(cat /etc/TZ)
+        default_time_zone=$(grep -B 1 -m 1 "$TZ" /etc/tzlist | head -1 | cut -f 2 -d =)
 else
         default_time_zone="Europe/London"
 fi

--- a/install-paperless-ngx.sh
+++ b/install-paperless-ngx.sh
@@ -72,7 +72,7 @@ if ! docker stats --no-stream &> /dev/null ; then
 fi
 
 # Added handling for timezone for busybox based linux, not having timedatectl available (i.e. QNAP QTS)
-# if neither timedatectl nor /etc/TZ is suceeding, defaulting to GMT.
+# if neither timedatectl nor /etc/TZ is succeeding, defaulting to GMT.
 if  command -v timedatectl &> /dev/null ; then
 	default_time_zone=$(timedatectl show -p Timezone --value)
 elif [ -f /etc/TZ ] && [ -f /etc/tzlist ] ; then

--- a/install-paperless-ngx.sh
+++ b/install-paperless-ngx.sh
@@ -71,7 +71,16 @@ if ! docker stats --no-stream &> /dev/null ; then
 	sleep 3
 fi
 
-default_time_zone=$(timedatectl show -p Timezone --value)
+# Added handling for timezone for busybox based linux, not having timedatectl available (i.e. QNAP QTS)
+# if neither timedatectl or /etc/TZ is suceeding, defaulting to GMT.
+if  command -v timedatectl &> /dev/null ; then
+        default_time_zone=$(timedatectl show -p Timezone --value)
+elif [ -f /etc/TZ ] && [ -f /etc/tzlist ] ; then
+        TZ=`cat /etc/TZ`
+        default_time_zone=$(grep -B 1 -m 1 $TZ /etc/tzlist | head -1 | cut -f 2 -d =)
+else
+        default_time_zone="Europe/London"
+fi
 
 set -e
 

--- a/install-paperless-ngx.sh
+++ b/install-paperless-ngx.sh
@@ -74,12 +74,13 @@ fi
 # Added handling for timezone for busybox based linux, not having timedatectl available (i.e. QNAP QTS)
 # if neither timedatectl nor /etc/TZ is suceeding, defaulting to GMT.
 if  command -v timedatectl &> /dev/null ; then
-        default_time_zone=$(timedatectl show -p Timezone --value)
+	default_time_zone=$(timedatectl show -p Timezone --value)
 elif [ -f /etc/TZ ] && [ -f /etc/tzlist ] ; then
-        TZ=$(cat /etc/TZ)
-        default_time_zone=$(grep -B 1 -m 1 "$TZ" /etc/tzlist | head -1 | cut -f 2 -d =)
+	TZ=$(cat /etc/TZ)
+	default_time_zone=$(grep -B 1 -m 1 "$TZ" /etc/tzlist | head -1 | cut -f 2 -d =)
 else
-        default_time_zone="Europe/London"
+	echo "WARN: unable to detect timezone, defaulting to Etc/UTC"
+	default_time_zone="Etc/UTC"
 fi
 
 set -e


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

The PR adresses two issues I came across when trying to run the installation script on a QNAP NAS, having installed QTS. Both issues can be overcome easy, but I propose to fix it.

1. the default timezone proposed during the installation script is empty. It's caused by the unavailable command timedatectl on QTS. I assume this is the case with many busybox based linux. When both ways to identify a default timezone are not available, it will default to GMT Europe/London.

2. After a fresh install via docker compose with an separated subnet the webserver fails to connect to a postgres db container. This is rooted in the host authentication method of postgres, being set to trust only for localhost (loopback interface). The change adds for all hosts the trust authentication method in the postgres container. 
I guess it could also be worth to change the db setup from the web container to use password authentication, and afterwards remove this option again from the compose file. But till then this should fix the setup issue.

Feel free to select only one change or edit it. You can also get back to me if you think something should be adapted.

If you are not ok with the changes, it's ok to reject the PR.

I have tested the changes, and they solve the issue with keeping everything else working. Of course I only tested installation.

(Closes) #4033 and #6318  (I guess addresses the issues mentioned there fits better)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [X] Bug fix: non-breaking change which fixes an issue.
- [X] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [X] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [X] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [X] I have checked my modifications for any breaking changes.
