### PR TITLE
Fix: remove admin.logentry perm, use admin (staff) status

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -241,6 +241,11 @@ permissions can be granted to limit access to certain parts of the UI (and corre
 
     Superusers can access all parts of the front and backend application as well as any and all objects.
 
+#### Admin Status
+
+Admin status (Django 'staff status') grants access to viewing the paperless logs and the system status dialog
+as well as accessing the Django backend.
+
 #### Detailed Explanation of Global Permissions {#global-permissions}
 
 Global permissions define what areas of the app and API endpoints the user can access. For example, they
@@ -249,7 +254,6 @@ still have "object-level" permissions.
 
 | Type          | Details                                                                                                                                                                                             |
 | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Admin         | _View_ or higher permissions grants access to the logs view as well as the system status.                                                                                                           |
 | AppConfig     | _Change_ or higher permissions grants access to the "Application Configuration" area.                                                                                                               |
 | Correspondent | Grants global permissions to add, edit, delete or view Correspondents.                                                                                                                              |
 | CustomField   | Grants global permissions to add, edit, delete or view Custom Fields.                                                                                                                               |

--- a/src-ui/src/app/app-routing.module.ts
+++ b/src-ui/src/app/app-routing.module.ts
@@ -141,10 +141,7 @@ export const routes: Routes = [
         component: LogsComponent,
         canActivate: [PermissionsGuard],
         data: {
-          requiredPermission: {
-            action: PermissionAction.View,
-            type: PermissionType.Admin,
-          },
+          requireAdmin: true,
         },
       },
       // redirect old paths

--- a/src-ui/src/app/components/admin/settings/settings.component.html
+++ b/src-ui/src/app/components/admin/settings/settings.component.html
@@ -7,29 +7,30 @@
   <button class="btn btn-sm btn-outline-primary" (click)="tourService.start()">
     <i-bs class="me-1" name="airplane"></i-bs>&nbsp;<ng-container i18n>Start tour</ng-container>
   </button>
-  <button class="btn btn-sm btn-outline-primary position-relative ms-md-5 me-1" (click)="showSystemStatus()"
-    [disabled]="!systemStatus"
-    *pngxIfPermissions="{ action: PermissionAction.View, type: PermissionType.Admin }">
-    @if (!systemStatus) {
-      <div class="spinner-border spinner-border-sm me-1 h-75" role="status"></div>
-    } @else {
-      <i-bs class="me-2" name="card-checklist"></i-bs>
-      @if (systemStatusHasErrors) {
-        <span class="badge bg-body position-absolute top-0 start-100 translate-middle rounded-pill p-0">
-          <i-bs name="exclamation-circle-fill" class="text-danger" width="1.75em" height="1.75em"></i-bs>
-        </span>
+  @if (permissionsService.isAdmin()) {
+    <button class="btn btn-sm btn-outline-primary position-relative ms-md-5 me-1" (click)="showSystemStatus()"
+      [disabled]="!systemStatus">
+      @if (!systemStatus) {
+        <div class="spinner-border spinner-border-sm me-1 h-75" role="status"></div>
       } @else {
-        <span class="badge bg-body position-absolute top-0 start-100 translate-middle rounded-pill p-0">
-          <i-bs name="check-circle-fill" class="text-primary" width="1.75em" height="1.75em"></i-bs>
-        </span>
+        <i-bs class="me-2" name="card-checklist"></i-bs>
+        @if (systemStatusHasErrors) {
+          <span class="badge bg-body position-absolute top-0 start-100 translate-middle rounded-pill p-0">
+            <i-bs name="exclamation-circle-fill" class="text-danger" width="1.75em" height="1.75em"></i-bs>
+          </span>
+        } @else {
+          <span class="badge bg-body position-absolute top-0 start-100 translate-middle rounded-pill p-0">
+            <i-bs name="check-circle-fill" class="text-primary" width="1.75em" height="1.75em"></i-bs>
+          </span>
+        }
       }
-    }
-    <ng-container i18n>System Status</ng-container>
-  </button>
-  <a *pngxIfPermissions="{ action: PermissionAction.View, type: PermissionType.Admin }" class="btn btn-sm btn-primary" href="admin/" target="_blank">
-    <ng-container i18n>Open Django Admin</ng-container>
-    &nbsp;<i-bs name="arrow-up-right"></i-bs>
-  </a>
+      <ng-container i18n>System Status</ng-container>
+    </button>
+    <a class="btn btn-sm btn-primary" href="admin/" target="_blank">
+      <ng-container i18n>Open Django Admin</ng-container>
+      &nbsp;<i-bs name="arrow-up-right"></i-bs>
+    </a>
+  }
 </pngx-page-header>
 
 <form [formGroup]="settingsForm" (ngSubmit)="saveSettings()">

--- a/src-ui/src/app/components/admin/settings/settings.component.spec.ts
+++ b/src-ui/src/app/components/admin/settings/settings.component.spec.ts
@@ -418,6 +418,7 @@ describe('SettingsComponent', () => {
       },
     }
     jest.spyOn(systemStatusService, 'get').mockReturnValue(of(status))
+    jest.spyOn(permissionsService, 'isAdmin').mockReturnValue(true)
     completeSetup()
     expect(component['systemStatus']).toEqual(status) // private
     expect(component.systemStatusHasErrors).toBeTruthy()

--- a/src-ui/src/app/components/admin/settings/settings.component.ts
+++ b/src-ui/src/app/components/admin/settings/settings.component.ts
@@ -121,7 +121,7 @@ export class SettingsComponent
   users: User[]
   groups: Group[]
 
-  private systemStatus: SystemStatus
+  public systemStatus: SystemStatus
 
   get systemStatusHasErrors(): boolean {
     return (
@@ -385,12 +385,7 @@ export class SettingsComponent
       this.settingsForm.patchValue(currentFormValue)
     }
 
-    if (
-      this.permissionsService.currentUserCan(
-        PermissionAction.View,
-        PermissionType.Admin
-      )
-    ) {
+    if (this.permissionsService.isAdmin()) {
       this.systemStatusService.get().subscribe((status) => {
         this.systemStatus = status
       })

--- a/src-ui/src/app/components/app-frame/app-frame.component.html
+++ b/src-ui/src/app/components/app-frame/app-frame.component.html
@@ -267,13 +267,15 @@
                 }
               </a>
             </li>
-            <li class="nav-item app-link" *pngxIfPermissions="{ action: PermissionAction.View, type: PermissionType.Admin }">
-              <a class="nav-link" routerLink="logs" routerLinkActive="active" (click)="closeMenu()" ngbPopover="Logs"
-                i18n-ngbPopover [disablePopover]="!slimSidebarEnabled" placement="end" container="body"
-                triggers="mouseenter:mouseleave" popoverClass="popover-slim">
-                <i-bs class="me-1" name="text-left"></i-bs><span>&nbsp;<ng-container i18n>Logs</ng-container></span>
-              </a>
-            </li>
+            @if (permissionsService.isAdmin()) {
+              <li class="nav-item app-link">
+                <a class="nav-link" routerLink="logs" routerLinkActive="active" (click)="closeMenu()" ngbPopover="Logs"
+                  i18n-ngbPopover [disablePopover]="!slimSidebarEnabled" placement="end" container="body"
+                  triggers="mouseenter:mouseleave" popoverClass="popover-slim">
+                  <i-bs class="me-1" name="text-left"></i-bs><span>&nbsp;<ng-container i18n>Logs</ng-container></span>
+                </a>
+              </li>
+            }
             <li class="nav-item mt-2" tourAnchor="tour.outro">
               <a class="px-3 py-2 text-muted small d-flex align-items-center flex-wrap text-decoration-none"
                 target="_blank" rel="noopener noreferrer" href="https://docs.paperless-ngx.com" ngbPopover="Documentation"

--- a/src-ui/src/app/components/common/edit-dialog/user-edit-dialog/user-edit-dialog.component.html
+++ b/src-ui/src/app/components/common/edit-dialog/user-edit-dialog/user-edit-dialog.component.html
@@ -16,10 +16,14 @@
           <pngx-input-text i18n-title title="First name" formControlName="first_name" [error]="error?.first_name"></pngx-input-text>
           <pngx-input-text i18n-title title="Last name" formControlName="last_name" [error]="error?.first_name"></pngx-input-text>
 
-          <div class="mb-2">
+          <div class="mb-2 d-flex flex-column">
             <div class="form-check form-switch form-check-inline">
               <input type="checkbox" class="form-check-input" id="is_active" formControlName="is_active">
               <label class="form-check-label" for="is_active" i18n>Active</label>
+            </div>
+            <div class="form-check form-switch form-check-inline">
+              <input type="checkbox" class="form-check-input" id="is_staff" formControlName="is_staff">
+              <label class="form-check-label" for="is_staff"><ng-container i18n>Admin</ng-container> <small class="form-text text-muted ms-1" i18n>Access logs, Django backend</small></label>
             </div>
             <div class="form-check form-switch form-check-inline">
               <input type="checkbox" class="form-check-input" id="is_superuser" formControlName="is_superuser" (change)="onToggleSuperUser()">

--- a/src-ui/src/app/components/common/edit-dialog/user-edit-dialog/user-edit-dialog.component.ts
+++ b/src-ui/src/app/components/common/edit-dialog/user-edit-dialog/user-edit-dialog.component.ts
@@ -56,6 +56,7 @@ export class UserEditDialogComponent
       first_name: new FormControl(''),
       last_name: new FormControl(''),
       is_active: new FormControl(true),
+      is_staff: new FormControl(true),
       is_superuser: new FormControl(false),
       groups: new FormControl([]),
       user_permissions: new FormControl([]),

--- a/src-ui/src/app/guards/permissions.guard.ts
+++ b/src-ui/src/app/guards/permissions.guard.ts
@@ -23,10 +23,12 @@ export class PermissionsGuard {
     state: RouterStateSnapshot
   ): boolean | UrlTree {
     if (
-      !this.permissionsService.currentUserCan(
-        route.data.requiredPermission.action,
-        route.data.requiredPermission.type
-      )
+      (route.data.requireAdmin && !this.permissionsService.isAdmin()) ||
+      (route.data.requiredPermission &&
+        !this.permissionsService.currentUserCan(
+          route.data.requiredPermission.action,
+          route.data.requiredPermission.type
+        ))
     ) {
       // Check if tour is running 1 = TourState.ON
       if (this.tourService.getStatus() !== 1) {

--- a/src-ui/src/app/services/permissions.service.spec.ts
+++ b/src-ui/src/app/services/permissions.service.spec.ts
@@ -418,4 +418,25 @@ describe('PermissionsService', () => {
       )
     ).toBeTruthy()
   })
+
+  it('correctly checks admin status', () => {
+    permissionsService.initialize([], {
+      username: 'testuser',
+      last_name: 'User',
+      first_name: 'Test',
+      id: 1,
+      is_staff: true,
+    })
+
+    expect(permissionsService.isAdmin()).toBeTruthy()
+
+    permissionsService.initialize([], {
+      username: 'testuser',
+      last_name: 'User',
+      first_name: 'Test',
+      id: 1,
+    })
+
+    expect(permissionsService.isAdmin()).toBeFalsy()
+  })
 })

--- a/src-ui/src/app/services/permissions.service.ts
+++ b/src-ui/src/app/services/permissions.service.ts
@@ -24,7 +24,6 @@ export enum PermissionType {
   MailRule = '%s_mailrule',
   User = '%s_user',
   Group = '%s_group',
-  Admin = '%s_logentry',
   ShareLink = '%s_sharelink',
   CustomField = '%s_customfield',
   Workflow = '%s_workflow',
@@ -50,6 +49,10 @@ export class PermissionsService {
       this.currentUser?.is_superuser ||
       this.permissions?.includes(this.getPermissionCode(action, type))
     )
+  }
+
+  public isAdmin(): boolean {
+    return this.currentUser?.is_staff
   }
 
   public currentUserOwnsObject(object: ObjectWithPermissions): boolean {

--- a/src/documents/permissions.py
+++ b/src/documents/permissions.py
@@ -40,7 +40,7 @@ class PaperlessObjectPermissions(DjangoObjectPermissions):
 
 class PaperlessAdminPermissions(BasePermission):
     def has_permission(self, request, view):
-        return request.user.has_perm("admin.view_logentry")
+        return request.user.is_staff
 
 
 def get_groups_with_only_permission(obj, codename):

--- a/src/documents/tests/test_api_permissions.py
+++ b/src/documents/tests/test_api_permissions.py
@@ -131,6 +131,7 @@ class TestApiAuth(DirectoriesMixin, APITestCase):
     def test_api_sufficient_permissions(self):
         user = User.objects.create_user(username="test")
         user.user_permissions.add(*Permission.objects.all())
+        user.is_staff = True
         self.client.force_authenticate(user)
 
         Document.objects.create(title="Test")

--- a/src/documents/tests/test_api_uisettings.py
+++ b/src/documents/tests/test_api_uisettings.py
@@ -27,6 +27,7 @@ class TestApiUiSettings(DirectoriesMixin, APITestCase):
             {
                 "id": self.test_user.id,
                 "username": self.test_user.username,
+                "is_staff": True,
                 "is_superuser": True,
                 "groups": [],
                 "first_name": self.test_user.first_name,

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -1270,6 +1270,7 @@ class UiSettingsView(GenericAPIView):
         user_resp = {
             "id": user.id,
             "username": user.username,
+            "is_staff": user.is_staff,
             "is_superuser": user.is_superuser,
             "groups": list(user.groups.values_list("id", flat=True)),
         }


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

This turned out to be a bit more complicated than I expected. 

The problem: we now have a collision for permissions named `add_logentry` because there is both `admin.add_logentry` and `auditlog.add_logentry`,  and the problem is our serializer [uses the codename as the slugfield](https://github.com/paperless-ngx/paperless-ngx/blob/caa0d826db3376247865b00d4a57f78fec279f7e/src/paperless/serialisers.py#L28-L33). Perhaps there is an easier way to be able to differentiate the two (e.g. the frontend can specify `admin.add_logentry`) but didnt see a way to do that. So....

1. We remove the 'Admin' View/Edit etc. permission which was a weird proxy anyway and replace it with the pre-existing `is_staff` setting from Django. Note that `is_staff` is what actually determines backend access by Django, so this really is more accurate. I did rename it `Admin` in the web UI for clarity.
2. The rest of this PR is really just accommodating that change, again it's more than I expected but not so crazy.
3. To be transparent about this I think we should label it a breaking change.

Welcome any other thoughts, of course.

See https://matrix.to/#/!lxUkPrXfbmPsCrNwHb:adnidor.de/$raooANjAp2c-24DvBD_6OvIedMqs3bGu56V9XxGAQfg?via=adnidor.de&via=matrix.org&via=tchncs.de

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [x] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
