### PR TITLE
Apply default permissions to uploaded documents

### DIFF
--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -947,6 +947,17 @@ class PostDocumentView(GenericAPIView):
             source=DocumentSource.ApiUpload,
             original_file=temp_file_path,
         )
+
+        user = User.objects.get(pk=request.user.id)
+        permissions = {
+            "default_view_users": [],
+            "default_view_groups": [],
+            "default_edit_users": [],
+            "default_edit_groups": [],
+        }
+        if hasattr(user, "ui_settings"):
+            permissions = user.ui_settings.settings["permissions"]
+
         input_doc_overrides = DocumentMetadataOverrides(
             filename=doc_name,
             title=title,
@@ -957,6 +968,10 @@ class PostDocumentView(GenericAPIView):
             created=created,
             asn=archive_serial_number,
             owner_id=request.user.id,
+            view_users=permissions["default_view_users"],
+            view_groups=permissions["default_view_groups"],
+            change_users=permissions["default_edit_users"],
+            change_groups=permissions["default_edit_groups"],
             custom_field_ids=custom_field_ids,
         )
 


### PR DESCRIPTION
## Proposed change

Apply default permissions to uploaded documents.

## Type of change

- [X] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

- [X] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [X] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [X] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [X] I have checked my modifications for any breaking changes.
