### PR TITLE
Fix: table view doesnt immediately display custom fields on app startup

### DIFF
--- a/src-ui/src/app/components/document-list/document-list.component.ts
+++ b/src-ui/src/app/components/document-list/document-list.component.ts
@@ -209,6 +209,7 @@ export class DocumentListComponent
         takeUntil(this.unsubscribeNotifier)
       )
       .subscribe((queryParams) => {
+        this.updateDisplayCustomFields()
         if (queryParams.has('view')) {
           // loading a saved view on /documents
           this.loadViewConfig(parseInt(queryParams.get('view')))

--- a/src-ui/src/app/services/document-list-view.service.spec.ts
+++ b/src-ui/src/app/services/document-list-view.service.spec.ts
@@ -591,4 +591,18 @@ describe('DocumentListViewService', () => {
       )
     )
   })
+
+  it('should not filter out custom fields if settings not initialized', () => {
+    const customFields = ['custom_field_1', 'custom_field_2']
+    documentListViewService.displayFields = customFields as any
+    settingsService.displayFieldsInitialized = false
+    expect(documentListViewService.displayFields).toEqual(customFields)
+    jest.spyOn(settingsService, 'allDisplayFields', 'get').mockReturnValue([
+      { id: DisplayField.ADDED, name: 'Added' },
+      { id: DisplayField.TITLE, name: 'Title' },
+      { id: 'custom_field_1', name: 'Custom Field 1' },
+    ] as any)
+    settingsService.displayFieldsInitialized = true
+    expect(documentListViewService.displayFields).toEqual(['custom_field_1'])
+  })
 })

--- a/src-ui/src/app/services/document-list-view.service.ts
+++ b/src-ui/src/app/services/document-list-view.service.ts
@@ -420,10 +420,13 @@ export class DocumentListViewService {
     if (!this.activeListViewState.displayFields) {
       fields = fields.filter((f) => f !== DisplayField.ADDED)
     }
-    return fields.filter(
-      (field) =>
-        this.settings.allDisplayFields.find((f) => f.id === field) !== undefined
-    )
+    return this.settings.displayFieldsInitialized
+      ? fields.filter(
+          (field) =>
+            this.settings.allDisplayFields.find((f) => f.id === field) !==
+            undefined
+        )
+      : fields
   }
 
   set displayFields(fields: DisplayField[]) {

--- a/src-ui/src/app/services/settings.service.ts
+++ b/src-ui/src/app/services/settings.service.ts
@@ -268,6 +268,7 @@ export class SettingsService {
   public get allDisplayFields(): Array<{ id: DisplayField; name: string }> {
     return this._allDisplayFields
   }
+  public displayFieldsInitialized: boolean = false
 
   constructor(
     rendererFactory: RendererFactory2,
@@ -361,7 +362,10 @@ export class SettingsService {
             }
           })
         )
+        this.displayFieldsInitialized = true
       })
+    } else {
+      this.displayFieldsInitialized = true
     }
   }
 


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Slightly tricky, this is a race condition when you load /documents directly at startup where custom fields havent loaded from the API yet so theyre getting filtered out.

<!--
⚠️ Important: Pull requests that implement a new feature or enhancement *should almost always target an existing feature request* with evidence of community interest and discussion. This is in order to balance the work of implementing and maintaining new features / enhancements. If that is not currently the case, please open a feature request instead of this PR to gather feedback from both users and the project maintainers.
-->

Closes https://github.com/paperless-ngx/paperless-ngx/issues/6596#issuecomment-2097635394

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
