### PR TITLE
Enhancement: show custom field name on cards if empty, add tooltip

### DIFF
--- a/src-ui/messages.xlf
+++ b/src-ui/messages.xlf
@@ -498,6 +498,10 @@
           <context context-type="linenumber">14,15</context>
         </context-group>
         <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/common/custom-field-display/custom-field-display.component.html</context>
+          <context context-type="linenumber">32</context>
+        </context-group>
+        <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/common/input/drag-drop-select/drag-drop-select.component.html</context>
           <context context-type="linenumber">12</context>
         </context-group>
@@ -2977,7 +2981,7 @@
         <source>View</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/common/custom-field-display/custom-field-display.component.html</context>
-          <context context-type="linenumber">15</context>
+          <context context-type="linenumber">21</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/common/input/permissions/permissions-form/permissions-form.component.html</context>

--- a/src-ui/src/app/components/common/custom-field-display/custom-field-display.component.html
+++ b/src-ui/src/app/components/common/custom-field-display/custom-field-display.component.html
@@ -1,25 +1,34 @@
 @if (field) {
-    @switch (field.data_type) {
-        @case (CustomFieldDataType.Monetary) {
-            <span>{{value | currency: currency}}</span>
-        }
-        @case (CustomFieldDataType.Date) {
-            <span>{{value | customDate}}</span>
-        }
-        @case (CustomFieldDataType.Url) {
-            <a [href]="value" class="btn-link text-dark text-decoration-none" target="_blank">{{value}}</a>
-        }
-        @case (CustomFieldDataType.DocumentLink) {
-            <div class="d-flex gap-1 flex-wrap">
-                @for (docId of value; track docId) {
-                    <a routerLink="/documents/{{docId}}" class="badge bg-dark text-primary" title="View" i18n-title>
-                        <i-bs width="0.9em" height="0.9em" name="file-text"></i-bs>&nbsp;<span>{{ getDocumentTitle(docId) }}</span>
-                    </a>
-                }
+    @if (value?.toString().length > 0) {
+        <ng-template #nameTooltip>
+            <div class="d-flex flex-column text-light">
+                {{field.name}}
             </div>
+        </ng-template>
+        @switch (field.data_type) {
+            @case (CustomFieldDataType.Monetary) {
+                <span [ngbTooltip]="nameTooltip">{{value | currency: currency}}</span>
+            }
+            @case (CustomFieldDataType.Date) {
+                <span [ngbTooltip]="nameTooltip">{{value | customDate}}</span>
+            }
+            @case (CustomFieldDataType.Url) {
+                <a [ngbTooltip]="nameTooltip" [href]="value" class="btn-link text-dark text-decoration-none" target="_blank">{{value}}</a>
+            }
+            @case (CustomFieldDataType.DocumentLink) {
+                <div [ngbTooltip]="nameTooltip" class="d-flex gap-1 flex-wrap">
+                    @for (docId of value; track docId) {
+                        <a routerLink="/documents/{{docId}}" class="badge bg-dark text-primary" title="View" i18n-title>
+                            <i-bs width="0.9em" height="0.9em" name="file-text"></i-bs>&nbsp;<span>{{ getDocumentTitle(docId) }}</span>
+                        </a>
+                    }
+                </div>
+            }
+            @default {
+              <span [ngbTooltip]="nameTooltip">{{value}}</span>
+            }
         }
-        @default {
-          <span>{{value}}</span>
-        }
+    } @else if (showNameIfEmpty) {
+        <span class="fst-italic text-muted" i18n>{{field.name}}</span>
     }
 }

--- a/src-ui/src/app/components/common/custom-field-display/custom-field-display.component.ts
+++ b/src-ui/src/app/components/common/custom-field-display/custom-field-display.component.ts
@@ -41,6 +41,9 @@ export class CustomFieldDisplayComponent implements OnInit, OnDestroy {
     this.fieldId = parseInt(key.replace(DisplayField.CUSTOM_FIELD, ''), 10)
   }
 
+  @Input()
+  showNameIfEmpty: boolean = false
+
   value: any
   currency: string
 

--- a/src-ui/src/app/components/document-list/document-card-large/document-card-large.component.html
+++ b/src-ui/src/app/components/document-list/document-card-large/document-card-large.component.html
@@ -132,7 +132,7 @@
                   <div class="list-group-item bg-light text-dark p-1 border-0 d-flex align-items-center">
                     <i-bs width=".9em" height=".9em" class="me-2 text-muted" name="ui-radios"></i-bs>
                     <small>
-                      <pngx-custom-field-display [document]="document" [fieldId]="field.field"></pngx-custom-field-display>
+                      <pngx-custom-field-display [document]="document" [fieldId]="field.field" showNameIfEmpty="true"></pngx-custom-field-display>
                     </small>
                   </div>
                 }

--- a/src-ui/src/app/components/document-list/document-card-small/document-card-small.component.html
+++ b/src-ui/src/app/components/document-list/document-card-small/document-card-small.component.html
@@ -110,7 +110,7 @@
           @if (displayFields.includes(DisplayField.CUSTOM_FIELD + field.field)) {
             <div class="ps-0 p-1 d-flex align-items-center overflow-hidden">
               <i-bs width="1em" height="1em" class="me-2 text-muted" name="ui-radios"></i-bs>
-              <small><pngx-custom-field-display [document]="document" [fieldId]="field.field"></pngx-custom-field-display></small>
+              <small><pngx-custom-field-display [document]="document" [fieldId]="field.field" showNameIfEmpty="true"></pngx-custom-field-display></small>
             </div>
           }
         }


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Small tweak now that custom fields can be displayed. On cards (small / large) an empty field value is sorta confusing so this will show the name (italic & muted to differentiate). IMHO this addresses the concern in #6597 but doesnt implement that FR, I dont want to hide them just yet without getting a better sense from users.

<img width="629" alt="Screenshot 2024-05-07 at 10 49 53 AM" src="https://github.com/paperless-ngx/paperless-ngx/assets/4887959/7e959926-f133-4593-8399-6397825ba345">

<img width="220" alt="Screenshot 2024-05-07 at 10 49 59 AM" src="https://github.com/paperless-ngx/paperless-ngx/assets/4887959/b7fa4aa0-2313-4aec-94b8-ba30d8707c78">


Currently:
<img width="412" alt="Screenshot 2024-05-07 at 10 41 20 AM" src="https://github.com/paperless-ngx/paperless-ngx/assets/4887959/ea7ec392-fcef-495e-a229-aeec3359e6b4">


## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [x] Other. Please explain: change

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
