### PR TITLE
Fix: make backend monetary validation accept unpadded decimals

### DIFF
--- a/src-ui/src/app/components/common/input/monetary/monetary.component.ts
+++ b/src-ui/src/app/components/common/input/monetary/monetary.component.ts
@@ -17,7 +17,15 @@ import { getLocaleCurrencyCode } from '@angular/common'
 })
 export class MonetaryComponent extends AbstractInputComponent<string> {
   public currency: string = ''
-  public monetaryValue: string = ''
+
+  public _monetaryValue: string = ''
+  public get monetaryValue(): string {
+    return this._monetaryValue
+  }
+  public set monetaryValue(value: string) {
+    if (value) this._monetaryValue = value
+  }
+
   defaultCurrencyCode: string
 
   constructor(@Inject(LOCALE_ID) currentLocale: string) {

--- a/src/documents/serialisers.py
+++ b/src/documents/serialisers.py
@@ -547,7 +547,7 @@ class CustomFieldInstanceSerializer(serializers.ModelSerializer):
                 except Exception:
                     # If that fails, try to validate as a monetary string
                     RegexValidator(
-                        regex=r"^[A-Z]{3}-?\d+(\.\d{2,2})$",
+                        regex=r"^[A-Z]{3}-?\d+(\.\d{1,2})$",
                         message="Must be a two-decimal number with optional currency code e.g. GBP123.45",
                     )(data["value"])
             elif field.data_type == CustomField.FieldDataType.STRING:

--- a/src/documents/tests/test_api_custom_fields.py
+++ b/src/documents/tests/test_api_custom_fields.py
@@ -505,22 +505,6 @@ class TestCustomFieldsAPI(DirectoriesMixin, APITestCase):
                 "custom_fields": [
                     {
                         "field": custom_field_money.id,
-                        # Too few places past decimal
-                        "value": "GBP12.1",
-                    },
-                ],
-            },
-            format="json",
-        )
-
-        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
-
-        resp = self.client.patch(
-            f"/api/documents/{doc.id}/",
-            data={
-                "custom_fields": [
-                    {
-                        "field": custom_field_money.id,
                         # Too many places past decimal
                         "value": "GBP12.123",
                     },


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

This thing might have been more trouble than its worth. In the end this change seems simplest. I can't recreate the linked issue but the frontend will coerce the value to e.g. `.50` anyway when its read back in. I dont see any downside here (famous last words?)

Closes #6621

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
