### PR TITLE
Fix: doc links and more illegible in light mode

### DIFF
--- a/src-ui/src/app/components/common/custom-field-display/custom-field-display.component.html
+++ b/src-ui/src/app/components/common/custom-field-display/custom-field-display.component.html
@@ -18,7 +18,7 @@
             @case (CustomFieldDataType.DocumentLink) {
                 <div [ngbTooltip]="nameTooltip" class="d-flex gap-1 flex-wrap">
                     @for (docId of value; track docId) {
-                        <a routerLink="/documents/{{docId}}" class="badge bg-dark text-primary" title="View" i18n-title>
+                        <a routerLink="/documents/{{docId}}" class="badge bg-body text-primary" title="View" i18n-title>
                             <i-bs width="0.9em" height="0.9em" name="file-text"></i-bs>&nbsp;<span>{{ getDocumentTitle(docId) }}</span>
                         </a>
                     }

--- a/src-ui/src/app/components/common/input/drag-drop-select/drag-drop-select.component.html
+++ b/src-ui/src/app/components/common/input/drag-drop-select/drag-drop-select.component.html
@@ -9,7 +9,7 @@
             <div class="badge bg-primary" cdkDrag>{{item.name}}</div>
         }
         @if (selectedItems.length === 0) {
-            <div class="badge bg-light fst-italic" i18n>{{emptyText}}</div>
+            <div class="badge bg-light text-secondary fst-italic" i18n>{{emptyText}}</div>
         }
     </div>
 </div>

--- a/src-ui/src/theme.scss
+++ b/src-ui/src/theme.scss
@@ -174,6 +174,10 @@ $form-check-radio-checked-bg-image-dark: url("data:image/svg+xml,<svg xmlns='htt
     border-color: rgba(0,0,0,0) !important;
   }
 
+  .badge.bg-body {
+    background-color: rgba(var(--bs-dark-rgb), var(--bs-bg-opacity)) !important;
+  }
+
   .document-card .card-body.bg-light {
     background-color: var(--bs-body-bg);
   }


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Purely visual fixes:
<img width="221" alt="Screenshot 2024-05-08 at 7 00 59 PM" src="https://github.com/paperless-ngx/paperless-ngx/assets/4887959/c196be93-e76b-4f79-8a53-e3e21f206d56">
<img width="134" alt="Screenshot 2024-05-08 at 7 02 18 PM" src="https://github.com/paperless-ngx/paperless-ngx/assets/4887959/7b422bb8-eaef-4373-a67c-07dd0948e64c">


Closes #6640

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
