### PR TITLE
Fix: consistent monetary field display in list and cards

### DIFF
--- a/src-ui/src/app/components/common/custom-field-display/custom-field-display.component.spec.ts
+++ b/src-ui/src/app/components/common/custom-field-display/custom-field-display.component.spec.ts
@@ -17,7 +17,7 @@ const document: Document = {
   title: 'Doc 1',
   custom_fields: [
     { field: 1, document: 1, created: null, value: 'Text value' },
-    { field: 2, document: 1, created: null, value: '100 USD' },
+    { field: 2, document: 1, created: null, value: 'USD100' },
     { field: 3, document: 1, created: null, value: '1,2,3' },
   ],
 }
@@ -85,5 +85,17 @@ describe('CustomFieldDisplayComponent', () => {
     expect(title1).toEqual('Document 1')
     expect(title2).toEqual('Document 2')
     expect(title3).toEqual('Document 3')
+  })
+
+  it('should fallback to default currency', () => {
+    component['defaultCurrencyCode'] = 'EUR' // mock default locale injection
+    component.fieldId = 2
+    component.document = {
+      id: 1,
+      title: 'Doc 1',
+      custom_fields: [{ field: 2, document: 1, created: null, value: '100' }],
+    }
+    expect(component.currency).toEqual('EUR')
+    expect(component.value).toEqual(100)
   })
 })

--- a/src-ui/src/app/components/common/custom-field-display/custom-field-display.component.ts
+++ b/src-ui/src/app/components/common/custom-field-display/custom-field-display.component.ts
@@ -1,4 +1,12 @@
-import { Component, Input, OnDestroy, OnInit } from '@angular/core'
+import { getLocaleCurrencyCode } from '@angular/common'
+import {
+  Component,
+  Inject,
+  Input,
+  LOCALE_ID,
+  OnDestroy,
+  OnInit,
+} from '@angular/core'
 import { Subject, takeUntil } from 'rxjs'
 import { CustomField, CustomFieldDataType } from 'src/app/data/custom-field'
 import { DisplayField, Document } from 'src/app/data/document'
@@ -54,11 +62,14 @@ export class CustomFieldDisplayComponent implements OnInit, OnDestroy {
   private docLinkDocuments: Document[] = []
 
   private unsubscribeNotifier: Subject<any> = new Subject()
+  private defaultCurrencyCode: any
 
   constructor(
     private customFieldService: CustomFieldsService,
-    private documentService: DocumentService
+    private documentService: DocumentService,
+    @Inject(LOCALE_ID) currentLocale: string
   ) {
+    this.defaultCurrencyCode = getLocaleCurrencyCode(currentLocale)
     this.customFieldService.listAll().subscribe((r) => {
       this.customFields = r.results
       this.init()
@@ -78,7 +89,8 @@ export class CustomFieldDisplayComponent implements OnInit, OnDestroy {
       (f) => f.field === this._fieldId
     )?.value
     if (this.value && this.field.data_type === CustomFieldDataType.Monetary) {
-      this.currency = this.value.match(/([A-Z]{3})/)?.[0]
+      this.currency =
+        this.value.match(/([A-Z]{3})/)?.[0] ?? this.defaultCurrencyCode
       this.value = parseFloat(this.value.replace(this.currency, ''))
     } else if (
       this.value?.length &&


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Another little thing, see linked issue, basically should behave the same as in detail view with legacy values (screenshot is just `123.00`):
<img width="202" alt="Screenshot 2024-05-08 at 20 14 48" src="https://github.com/paperless-ngx/paperless-ngx/assets/4887959/ad02fd9b-8655-4778-b894-65e33d5255b2">

Closes #6629

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
