### PR TITLE
Fix: allow 0 in monetary field

### DIFF
--- a/src-ui/src/app/components/common/input/monetary/monetary.component.spec.ts
+++ b/src-ui/src/app/components/common/input/monetary/monetary.component.spec.ts
@@ -74,4 +74,13 @@ describe('MonetaryComponent', () => {
     expect(component.currency).toEqual('USD')
     expect(component.monetaryValue).toEqual('')
   })
+
+  it('should handle zero values', () => {
+    component.writeValue('USD0.00')
+    expect(component.currency).toEqual('USD')
+    expect(component.monetaryValue).toEqual('0.00')
+    component.monetaryValue = '0'
+    component.monetaryValueChange()
+    expect(component.value).toEqual('USD0.00')
+  })
 })

--- a/src-ui/src/app/components/common/input/monetary/monetary.component.ts
+++ b/src-ui/src/app/components/common/input/monetary/monetary.component.ts
@@ -22,8 +22,9 @@ export class MonetaryComponent extends AbstractInputComponent<string> {
   public get monetaryValue(): string {
     return this._monetaryValue
   }
-  public set monetaryValue(value: string) {
-    if (value) this._monetaryValue = value
+  public set monetaryValue(value: any) {
+    if (value || value?.toString() === '0')
+      this._monetaryValue = value.toString()
   }
 
   defaultCurrencyCode: string
@@ -44,6 +45,9 @@ export class MonetaryComponent extends AbstractInputComponent<string> {
 
   public monetaryValueChange(fixed: boolean = false): void {
     this.monetaryValue = this.parseMonetaryValue(this.monetaryValue, fixed)
+    if (this.monetaryValue === '0') {
+      this.monetaryValue = '0.00'
+    }
     this.onChange(this.currency + this.monetaryValue)
   }
 


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Sigh. Looking forward to being done with this little thing.
<img width="485" alt="Screenshot 2024-05-09 at 10 15 10 AM" src="https://github.com/paperless-ngx/paperless-ngx/assets/4887959/4e905efa-3bf1-4e04-a431-8cb78e33292e">

Closes #6656

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
