### PR TITLE
Fix: respect superuser for document history

### DIFF
--- a/src/documents/tests/test_api_documents.py
+++ b/src/documents/tests/test_api_documents.py
@@ -423,16 +423,18 @@ class TestDocumentApi(DirectoriesMixin, DocumentConsumeDelayMixin, APITestCase):
     def test_document_history_insufficient_perms(self):
         """
         GIVEN:
-            - Audit log is disabled
+            - Audit log is enabled
         WHEN:
-            - Document is updated
-            - Audit log is requested
+            - History is requested without auditlog permissions
+            - Or is requested as superuser on document with another owner
         THEN:
-            - Audit log returns HTTP 400 Bad Request
+            - History endpoint returns HTTP 403 Forbidden
+            - History is returned
         """
+        # No auditlog permissions
         user = User.objects.create_user(username="test")
         user.user_permissions.add(*Permission.objects.filter(codename="view_document"))
-        self.client.force_login(user=user)
+        self.client.force_authenticate(user=user)
         doc = Document.objects.create(
             title="First title",
             checksum="123",
@@ -442,6 +444,19 @@ class TestDocumentApi(DirectoriesMixin, DocumentConsumeDelayMixin, APITestCase):
 
         response = self.client.get(f"/api/documents/{doc.pk}/history/")
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        # superuser
+        user.is_superuser = True
+        user.save()
+        user2 = User.objects.create_user(username="test2")
+        doc2 = Document.objects.create(
+            title="Second title",
+            checksum="456",
+            mime_type="application/pdf",
+            owner=user2,
+        )
+        response = self.client.get(f"/api/documents/{doc2.pk}/history/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_document_filters(self):
         doc1 = Document.objects.create(

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -767,7 +767,9 @@ class DocumentViewSet(
         try:
             doc = Document.objects.get(pk=pk)
             if not request.user.has_perm("auditlog.view_logentry") or (
-                doc.owner is not None and doc.owner != request.user
+                doc.owner is not None
+                and doc.owner != request.user
+                and not request.user.is_superuser
             ):
                 return HttpResponseForbidden(
                     "Insufficient permissions",


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Forgot to check the other half of the `or`

Closes #6660

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
