### PR TITLE
Fix: some buttons incorrectly aligned in 2.8.4

### DIFF
--- a/src-ui/src/app/components/app-frame/global-search/global-search.component.scss
+++ b/src-ui/src/app/components/app-frame/global-search/global-search.component.scss
@@ -31,6 +31,9 @@ form {
   .input-group .btn {
     border-color: rgba(255, 255, 255, 0.2);
     color: var(--pngx-primary-text-contrast);
+    padding-top: .15rem;
+    padding-bottom: .15rem;
+    min-height: calc(1.3em + 0.5rem + calc(var(--bs-border-width) * 2)) !important;
   }
 
   .form-control {

--- a/src-ui/src/styles.scss
+++ b/src-ui/src/styles.scss
@@ -332,8 +332,7 @@ textarea,
   }
 }
 
-.input-group .form-control-sm,
-.input-group .btn-sm {
+.input-group .form-control-sm {
   // accommodate larger font size on mobile
   padding-top: .15rem;
   padding-bottom: .15rem;


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

With:
<img width="412" alt="Screenshot 2024-05-13 at 5 25 12 PM" src="https://github.com/paperless-ngx/paperless-ngx/assets/4887959/c0aa6daf-7fc8-400e-be44-5051801e1d5c">

Current:
<img width="402" alt="Screenshot 2024-05-13 at 5 25 02 PM" src="https://github.com/paperless-ngx/paperless-ngx/assets/4887959/3aa03a46-8920-4b90-a8b4-2bff1d2d3255">


Closes #(issue or discussion)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
