### PR TITLE
Fix: retain sort field from global search filtering, use `FILTER_HAS_TAGS_ALL`

### DIFF
--- a/src-ui/src/app/components/app-frame/global-search/global-search.component.spec.ts
+++ b/src-ui/src/app/components/app-frame/global-search/global-search.component.spec.ts
@@ -24,7 +24,7 @@ import {
   FILTER_HAS_CORRESPONDENT_ANY,
   FILTER_HAS_DOCUMENT_TYPE_ANY,
   FILTER_HAS_STORAGE_PATH_ANY,
-  FILTER_HAS_TAGS_ANY,
+  FILTER_HAS_TAGS_ALL,
 } from 'src/app/data/filter-rule-type'
 import { NgxBootstrapIconsModule, allIcons } from 'ngx-bootstrap-icons'
 import { DocumentService } from 'src/app/services/rest/document.service'
@@ -294,36 +294,67 @@ describe('GlobalSearchComponent', () => {
 
     component.primaryAction(DataType.Correspondent, object)
     expect(routerSpy).toHaveBeenCalledWith(['/documents'], {
-      queryParams: queryParamsFromFilterRules([
+      queryParams: Object.assign(
         {
-          rule_type: FILTER_HAS_CORRESPONDENT_ANY,
-          value: object.id.toString(),
+          page: 1,
+          reverse: 1,
+          sort: 'created',
         },
-      ]),
+        queryParamsFromFilterRules([
+          {
+            rule_type: FILTER_HAS_CORRESPONDENT_ANY,
+            value: object.id.toString(),
+          },
+        ])
+      ),
     })
 
     component.primaryAction(DataType.DocumentType, object)
     expect(routerSpy).toHaveBeenCalledWith(['/documents'], {
-      queryParams: queryParamsFromFilterRules([
+      queryParams: Object.assign(
         {
-          rule_type: FILTER_HAS_DOCUMENT_TYPE_ANY,
-          value: object.id.toString(),
+          page: 1,
+          reverse: 1,
+          sort: 'created',
         },
-      ]),
+        queryParamsFromFilterRules([
+          {
+            rule_type: FILTER_HAS_DOCUMENT_TYPE_ANY,
+            value: object.id.toString(),
+          },
+        ])
+      ),
     })
 
     component.primaryAction(DataType.StoragePath, object)
     expect(routerSpy).toHaveBeenCalledWith(['/documents'], {
-      queryParams: queryParamsFromFilterRules([
-        { rule_type: FILTER_HAS_STORAGE_PATH_ANY, value: object.id.toString() },
-      ]),
+      queryParams: Object.assign(
+        {
+          page: 1,
+          reverse: 1,
+          sort: 'created',
+        },
+        queryParamsFromFilterRules([
+          {
+            rule_type: FILTER_HAS_STORAGE_PATH_ANY,
+            value: object.id.toString(),
+          },
+        ])
+      ),
     })
 
     component.primaryAction(DataType.Tag, object)
     expect(routerSpy).toHaveBeenCalledWith(['/documents'], {
-      queryParams: queryParamsFromFilterRules([
-        { rule_type: FILTER_HAS_TAGS_ANY, value: object.id.toString() },
-      ]),
+      queryParams: Object.assign(
+        {
+          page: 1,
+          reverse: 1,
+          sort: 'created',
+        },
+        queryParamsFromFilterRules([
+          { rule_type: FILTER_HAS_TAGS_ALL, value: object.id.toString() },
+        ])
+      ),
     })
 
     component.primaryAction(DataType.User, object)

--- a/src-ui/src/app/components/app-frame/global-search/global-search.component.ts
+++ b/src-ui/src/app/components/app-frame/global-search/global-search.component.ts
@@ -41,7 +41,7 @@ import { TagEditDialogComponent } from '../../common/edit-dialog/tag-edit-dialog
 import { UserEditDialogComponent } from '../../common/edit-dialog/user-edit-dialog/user-edit-dialog.component'
 import { WorkflowEditDialogComponent } from '../../common/edit-dialog/workflow-edit-dialog/workflow-edit-dialog.component'
 import { HotKeyService } from 'src/app/services/hot-key.service'
-import { queryParamsFromFilterRules } from 'src/app/utils/query-params'
+import { paramsFromViewState } from 'src/app/utils/query-params'
 
 @Component({
   selector: 'pngx-global-search',
@@ -160,9 +160,14 @@ export class GlobalSearchComponent implements OnInit {
     }
 
     if (filterRuleType) {
-      let params = queryParamsFromFilterRules([
-        { rule_type: filterRuleType, value: object.id.toString() },
-      ])
+      let params = paramsFromViewState({
+        filterRules: [
+          { rule_type: filterRuleType, value: object.id.toString() },
+        ],
+        currentPage: 1,
+        sortField: this.documentListViewService.sortField ?? 'created',
+        sortReverse: this.documentListViewService.sortReverse,
+      })
       this.navigateOrOpenInNewWindow(['/documents'], newWindow, {
         queryParams: params,
       })

--- a/src-ui/src/app/components/app-frame/global-search/global-search.component.ts
+++ b/src-ui/src/app/components/app-frame/global-search/global-search.component.ts
@@ -14,7 +14,7 @@ import {
   FILTER_HAS_CORRESPONDENT_ANY,
   FILTER_HAS_DOCUMENT_TYPE_ANY,
   FILTER_HAS_STORAGE_PATH_ANY,
-  FILTER_HAS_TAGS_ANY,
+  FILTER_HAS_TAGS_ALL,
 } from 'src/app/data/filter-rule-type'
 import { DataType } from 'src/app/data/datatype'
 import { ObjectWithId } from 'src/app/data/object-with-id'
@@ -132,7 +132,7 @@ export class GlobalSearchComponent implements OnInit {
         filterRuleType = FILTER_HAS_STORAGE_PATH_ANY
         break
       case DataType.Tag:
-        filterRuleType = FILTER_HAS_TAGS_ANY
+        filterRuleType = FILTER_HAS_TAGS_ALL
         break
       case DataType.User:
         editDialogComponent = UserEditDialogComponent


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

This is another unintended consequence of the 'new window' functionality of #6008 , tl;dr the `quickFilter` function would inherently retain the sort but now that we might open in a new window we need to include those query params, there's already a function for that though so no big deal.

The tags to all thing is a change which is more consistent with the default filter editing.

Closes #6736 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
