### PR TITLE
Fix: consistently use created_date for doc display

### DIFF
--- a/src-ui/src/app/components/document-list/document-card-large/document-card-large.component.html
+++ b/src-ui/src/app/components/document-list/document-card-large/document-card-large.component.html
@@ -95,7 +95,7 @@
               @if (displayFields.includes(DisplayField.CREATED) || displayFields.includes(DisplayField.ADDED)) {
                 <ng-template #dateTooltip>
                   <div class="d-flex flex-column text-light">
-                    <span i18n>Created: {{ document.created | customDate }}</span>
+                    <span i18n>Created: {{ document.created_date | customDate }}</span>
                     <span i18n>Added: {{ document.added | customDate }}</span>
                     <span i18n>Modified: {{ document.modified | customDate }}</span>
                   </div>

--- a/src-ui/src/app/components/document-list/document-card-small/document-card-small.component.html
+++ b/src-ui/src/app/components/document-list/document-card-small/document-card-small.component.html
@@ -62,14 +62,14 @@
           <div class="list-group-item bg-transparent p-0 border-0 d-flex flex-wrap-reverse justify-content-between">
             <ng-template #dateTooltip>
               <div class="d-flex flex-column text-light">
-                <span i18n>Created: {{ document.created | customDate }}</span>
+                <span i18n>Created: {{ document.created_date | customDate }}</span>
                 <span i18n>Added: {{ document.added | customDate }}</span>
                 <span i18n>Modified: {{ document.modified | customDate }}</span>
               </div>
             </ng-template>
             <div class="ps-0 p-1" placement="top" [ngbTooltip]="dateTooltip">
               <i-bs width="1em" height="1em" class="me-2 text-muted" name="calendar-event"></i-bs>
-              <small>{{document.created | customDate:'mediumDate'}}</small>
+              <small>{{document.created_date | customDate:'mediumDate'}}</small>
             </div>
           </div>
         }


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

This was a hilarious rabbit hole to fall down again just to end up with a 3-line diff, but such are dates. To summarize:

- https://github.com/dateutil/dateutil/issues/878#issuecomment-467483211 is the root of this.
- https://github.com/paperless-ngx/paperless-ngx/issues/818
- **But then** #957
- So I think basically the small cards weren't changed (or maybe got reverted somewhere along the way) to use `created_date` instead of `created`
    - Note that the [document list](https://github.com/paperless-ngx/paperless-ngx/blob/3fa448ecb5d8a3dc74b395047e751e2b16b098d4/src-ui/src/app/components/document-list/document-list.component.html#L323) and [large cards](https://github.com/paperless-ngx/paperless-ngx/blob/3fa448ecb5d8a3dc74b395047e751e2b16b098d4/src-ui/src/app/components/document-list/document-card-large/document-card-large.component.html#L105) (in one of two places its supposed to) both use `created_date` so this really I think is just an inconsistency.
    - As you can see from the screenshots below, this does it.

<img width="209" alt="Screenshot 2024-05-17 at 10 04 35 AM" src="https://github.com/paperless-ngx/paperless-ngx/assets/4887959/ca033127-48de-4244-be53-6ad41a1cb1c7">
<img width="224" alt="Screenshot 2024-05-17 at 10 06 12 AM" src="https://github.com/paperless-ngx/paperless-ngx/assets/4887959/037b81b7-4fed-4ee0-9ae0-06caf6dcea16">


Closes #6749

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
