### PR TITLE
Enhancement: only include correspondent 'last_correspondence' if requested

### DIFF
--- a/src-ui/src/app/components/document-detail/document-detail.component.html
+++ b/src-ui/src/app/components/document-detail/document-detail.component.html
@@ -105,13 +105,13 @@
               <pngx-input-number i18n-title title="Archive serial number" [error]="error?.archive_serial_number" [horizontal]="true" formControlName='archive_serial_number'></pngx-input-number>
               <pngx-input-date i18n-title title="Date created" formControlName="created_date" [suggestions]="suggestions?.dates" [showFilter]="true" [horizontal]="true" (filterDocuments)="filterDocuments($event)"
               [error]="error?.created_date"></pngx-input-date>
-              <pngx-input-select [items]="correspondents" i18n-title title="Correspondent" formControlName="correspondent" [allowNull]="true" [showFilter]="true" [horizontal]="true" (filterDocuments)="filterDocuments($event)"
+              <pngx-input-select [items]="correspondents" i18n-title title="Correspondent" formControlName="correspondent" [allowNull]="true" [showFilter]="true" [horizontal]="true" (filterDocuments)="filterDocuments($event, DataType.Correspondent)"
               (createNew)="createCorrespondent($event)" [suggestions]="suggestions?.correspondents" *pngxIfPermissions="{ action: PermissionAction.View, type: PermissionType.Correspondent }"></pngx-input-select>
-              <pngx-input-select [items]="documentTypes" i18n-title title="Document type" formControlName="document_type" [allowNull]="true" [showFilter]="true" [horizontal]="true" (filterDocuments)="filterDocuments($event)"
+              <pngx-input-select [items]="documentTypes" i18n-title title="Document type" formControlName="document_type" [allowNull]="true" [showFilter]="true" [horizontal]="true" (filterDocuments)="filterDocuments($event, DataType.DocumentType)"
               (createNew)="createDocumentType($event)" [suggestions]="suggestions?.document_types" *pngxIfPermissions="{ action: PermissionAction.View, type: PermissionType.DocumentType }"></pngx-input-select>
-              <pngx-input-select [items]="storagePaths" i18n-title title="Storage path" formControlName="storage_path" [allowNull]="true" [showFilter]="true" [horizontal]="true" (filterDocuments)="filterDocuments($event)"
+              <pngx-input-select [items]="storagePaths" i18n-title title="Storage path" formControlName="storage_path" [allowNull]="true" [showFilter]="true" [horizontal]="true" (filterDocuments)="filterDocuments($event, DataType.StoragePath)"
               (createNew)="createStoragePath($event)" [suggestions]="suggestions?.storage_paths" i18n-placeholder placeholder="Default" *pngxIfPermissions="{ action: PermissionAction.View, type: PermissionType.StoragePath }"></pngx-input-select>
-              <pngx-input-tags formControlName="tags" [suggestions]="suggestions?.tags" [showFilter]="true" [horizontal]="true" (filterDocuments)="filterDocuments($event)" *pngxIfPermissions="{ action: PermissionAction.View, type: PermissionType.Tag }"></pngx-input-tags>
+              <pngx-input-tags formControlName="tags" [suggestions]="suggestions?.tags" [showFilter]="true" [horizontal]="true" (filterDocuments)="filterDocuments($event, DataType.Tag)" *pngxIfPermissions="{ action: PermissionAction.View, type: PermissionType.Tag }"></pngx-input-tags>
               @for (fieldInstance of document?.custom_fields; track fieldInstance.field; let i = $index) {
                 <div [formGroup]="customFieldFormFields.controls[i]">
                   @switch (getCustomFieldFromInstance(fieldInstance)?.data_type) {

--- a/src-ui/src/app/components/document-detail/document-detail.component.spec.ts
+++ b/src-ui/src/app/components/document-detail/document-detail.component.spec.ts
@@ -81,6 +81,7 @@ import { environment } from 'src/environments/environment'
 import { RotateConfirmDialogComponent } from '../common/confirm-dialog/rotate-confirm-dialog/rotate-confirm-dialog.component'
 import { SplitConfirmDialogComponent } from '../common/confirm-dialog/split-confirm-dialog/split-confirm-dialog.component'
 import { PdfViewerModule } from 'ng2-pdf-viewer'
+import { DataType } from 'src/app/data/datatype'
 
 const doc: Document = {
   id: 3,
@@ -781,10 +782,9 @@ describe('DocumentDetailComponent', () => {
     const object = {
       id: 22,
       name: 'Correspondent22',
-      last_correspondence: new Date().toISOString(),
     } as Correspondent
     const qfSpy = jest.spyOn(documentListViewService, 'quickFilter')
-    component.filterDocuments([object])
+    component.filterDocuments([object], DataType.Correspondent)
     expect(qfSpy).toHaveBeenCalledWith([
       {
         rule_type: FILTER_CORRESPONDENT,
@@ -797,7 +797,7 @@ describe('DocumentDetailComponent', () => {
     initNormally()
     const object = { id: 22, name: 'DocumentType22' } as DocumentType
     const qfSpy = jest.spyOn(documentListViewService, 'quickFilter')
-    component.filterDocuments([object])
+    component.filterDocuments([object], DataType.DocumentType)
     expect(qfSpy).toHaveBeenCalledWith([
       {
         rule_type: FILTER_DOCUMENT_TYPE,
@@ -814,7 +814,7 @@ describe('DocumentDetailComponent', () => {
       path: '/foo/bar/',
     } as StoragePath
     const qfSpy = jest.spyOn(documentListViewService, 'quickFilter')
-    component.filterDocuments([object])
+    component.filterDocuments([object], DataType.StoragePath)
     expect(qfSpy).toHaveBeenCalledWith([
       {
         rule_type: FILTER_STORAGE_PATH,
@@ -840,7 +840,7 @@ describe('DocumentDetailComponent', () => {
       text_color: '#000000',
     } as Tag
     const qfSpy = jest.spyOn(documentListViewService, 'quickFilter')
-    component.filterDocuments([object1, object2])
+    component.filterDocuments([object1, object2], DataType.Tag)
     expect(qfSpy).toHaveBeenCalledWith([
       {
         rule_type: FILTER_HAS_TAGS_ALL,

--- a/src-ui/src/app/components/document-detail/document-detail.component.ts
+++ b/src-ui/src/app/components/document-detail/document-detail.component.ts
@@ -70,6 +70,7 @@ import { SplitConfirmDialogComponent } from '../common/confirm-dialog/split-conf
 import { RotateConfirmDialogComponent } from '../common/confirm-dialog/rotate-confirm-dialog/rotate-confirm-dialog.component'
 import { HotKeyService } from 'src/app/services/hot-key.service'
 import { PDFDocumentProxy } from 'ng2-pdf-viewer'
+import { DataType } from 'src/app/data/datatype'
 
 enum DocumentDetailNavIDs {
   Details = 1,
@@ -169,6 +170,8 @@ export class DocumentDetailComponent
   public readonly CustomFieldDataType = CustomFieldDataType
 
   public readonly ContentRenderType = ContentRenderType
+
+  public readonly DataType = DataType
 
   @ViewChild('nav') nav: NgbNav
   @ViewChild('pdfPreview') set pdfPreview(element) {
@@ -989,7 +992,7 @@ export class DocumentDetailComponent
     )
   }
 
-  filterDocuments(items: ObjectWithId[] | NgbDateStruct[]) {
+  filterDocuments(items: ObjectWithId[] | NgbDateStruct[], type?: DataType) {
     const filterRules: FilterRule[] = items.flatMap((i) => {
       if (i.hasOwnProperty('year')) {
         const isoDateAdapter = new ISODateAdapter()
@@ -1008,30 +1011,28 @@ export class DocumentDetailComponent
             value: dateBefore.toISOString().substring(0, 10),
           },
         ]
-      } else if (i.hasOwnProperty('last_correspondence')) {
-        // Correspondent
-        return {
-          rule_type: FILTER_CORRESPONDENT,
-          value: (i as Correspondent).id.toString(),
-        }
-      } else if (i.hasOwnProperty('path')) {
-        // Storage Path
-        return {
-          rule_type: FILTER_STORAGE_PATH,
-          value: (i as StoragePath).id.toString(),
-        }
-      } else if (i.hasOwnProperty('is_inbox_tag')) {
-        // Tag
-        return {
-          rule_type: FILTER_HAS_TAGS_ALL,
-          value: (i as Tag).id.toString(),
-        }
-      } else {
-        // Document Type, has no specific props
-        return {
-          rule_type: FILTER_DOCUMENT_TYPE,
-          value: (i as DocumentType).id.toString(),
-        }
+      }
+      switch (type) {
+        case DataType.Correspondent:
+          return {
+            rule_type: FILTER_CORRESPONDENT,
+            value: (i as Correspondent).id.toString(),
+          }
+        case DataType.DocumentType:
+          return {
+            rule_type: FILTER_DOCUMENT_TYPE,
+            value: (i as DocumentType).id.toString(),
+          }
+        case DataType.StoragePath:
+          return {
+            rule_type: FILTER_STORAGE_PATH,
+            value: (i as StoragePath).id.toString(),
+          }
+        case DataType.Tag:
+          return {
+            rule_type: FILTER_HAS_TAGS_ALL,
+            value: (i as Tag).id.toString(),
+          }
       }
     })
 

--- a/src-ui/src/app/components/manage/correspondent-list/correspondent-list.component.ts
+++ b/src-ui/src/app/components/manage/correspondent-list/correspondent-list.component.ts
@@ -12,6 +12,7 @@ import { CorrespondentService } from 'src/app/services/rest/correspondent.servic
 import { ToastService } from 'src/app/services/toast.service'
 import { CorrespondentEditDialogComponent } from '../../common/edit-dialog/correspondent-edit-dialog/correspondent-edit-dialog.component'
 import { ManagementListComponent } from '../management-list/management-list.component'
+import { takeUntil } from 'rxjs'
 
 @Component({
   selector: 'pngx-correspondent-list',
@@ -61,6 +62,26 @@ export class CorrespondentListComponent extends ManagementListComponent<Correspo
         },
       ]
     )
+  }
+
+  public reloadData(): void {
+    this.isLoading = true
+    this.service
+      .listFiltered(
+        this.page,
+        null,
+        this.sortField,
+        this.sortReverse,
+        this._nameFilter,
+        true,
+        { last_correspondence: true }
+      )
+      .pipe(takeUntil(this.unsubscribeNotifier))
+      .subscribe((c) => {
+        this.data = c.results
+        this.collectionSize = c.count
+        this.isLoading = false
+      })
   }
 
   getDeleteMessage(object: Correspondent) {

--- a/src-ui/src/app/components/manage/management-list/management-list.component.ts
+++ b/src-ui/src/app/components/manage/management-list/management-list.component.ts
@@ -52,7 +52,7 @@ export abstract class ManagementListComponent<T extends ObjectWithId>
   implements OnInit, OnDestroy
 {
   constructor(
-    private service: AbstractNameFilterService<T>,
+    protected service: AbstractNameFilterService<T>,
     private modalService: NgbModal,
     private editDialogComponent: any,
     private toastService: ToastService,
@@ -81,8 +81,8 @@ export abstract class ManagementListComponent<T extends ObjectWithId>
   public isLoading: boolean = false
 
   private nameFilterDebounce: Subject<string>
-  private unsubscribeNotifier: Subject<any> = new Subject()
-  private _nameFilter: string
+  protected unsubscribeNotifier: Subject<any> = new Subject()
+  protected _nameFilter: string
 
   public selectedObjects: Set<number> = new Set()
   public togggleAll: boolean = false

--- a/src-ui/src/app/services/rest/abstract-name-filter-service.ts
+++ b/src-ui/src/app/services/rest/abstract-name-filter-service.ts
@@ -17,9 +17,10 @@ export abstract class AbstractNameFilterService<
     sortField?: string,
     sortReverse?: boolean,
     nameFilter?: string,
-    fullPerms?: boolean
+    fullPerms?: boolean,
+    extraParams?: { [key: string]: any }
   ) {
-    let params = {}
+    let params = extraParams ?? {}
     if (nameFilter) {
       params['name__icontains'] = nameFilter
     }

--- a/src/documents/serialisers.py
+++ b/src/documents/serialisers.py
@@ -291,7 +291,7 @@ class OwnedObjectSerializer(
 
 
 class CorrespondentSerializer(MatchingModelSerializer, OwnedObjectSerializer):
-    last_correspondence = serializers.DateTimeField(read_only=True)
+    last_correspondence = serializers.DateTimeField(read_only=True, required=False)
 
     class Meta:
         model = Correspondent

--- a/src/documents/tests/test_api_objects.py
+++ b/src/documents/tests/test_api_objects.py
@@ -1,8 +1,10 @@
+import datetime
 import json
 from unittest import mock
 
 from django.contrib.auth.models import Permission
 from django.contrib.auth.models import User
+from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APITestCase
 
@@ -88,6 +90,46 @@ class TestApiObjects(DirectoriesMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         results = response.data["results"]
         self.assertEqual(len(results), 2)
+
+    def test_correspondent_last_correspondence(self):
+        """
+        GIVEN:
+            - Correspondent with documents
+        WHEN:
+            - API is called
+        THEN:
+            - Last correspondence date is returned only if requested
+        """
+
+        Document.objects.create(
+            mime_type="application/pdf",
+            correspondent=self.c1,
+            created=timezone.make_aware(datetime.datetime(2022, 1, 1)),
+            checksum="123",
+        )
+        Document.objects.create(
+            mime_type="application/pdf",
+            correspondent=self.c1,
+            created=timezone.make_aware(datetime.datetime(2022, 1, 2)),
+            checksum="456",
+        )
+
+        response = self.client.get(
+            "/api/correspondents/",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.data["results"]
+        self.assertNotIn("last_correspondence", results[0])
+
+        response = self.client.get(
+            "/api/correspondents/?last_correspondence=true",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.data["results"]
+        self.assertIn(
+            "2022-01-02",
+            results[0]["last_correspondence"],
+        )
 
 
 class TestApiStoragePaths(DirectoriesMixin, APITestCase):

--- a/src/documents/tests/test_api_objects.py
+++ b/src/documents/tests/test_api_objects.py
@@ -98,7 +98,7 @@ class TestApiObjects(DirectoriesMixin, APITestCase):
         WHEN:
             - API is called
         THEN:
-            - Last correspondence date is returned only if requested
+            - Last correspondence date is returned only if requested for list, and for detail
         """
 
         Document.objects.create(
@@ -114,6 +114,7 @@ class TestApiObjects(DirectoriesMixin, APITestCase):
             checksum="456",
         )
 
+        # Only if requested for list
         response = self.client.get(
             "/api/correspondents/",
         )
@@ -129,6 +130,16 @@ class TestApiObjects(DirectoriesMixin, APITestCase):
         self.assertIn(
             "2022-01-02",
             results[0]["last_correspondence"],
+        )
+
+        # Included in detail by default
+        response = self.client.get(
+            f"/api/correspondents/{self.c1.id}/",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn(
+            "2022-01-02",
+            response.data["last_correspondence"],
         )
 
 

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -253,14 +253,7 @@ class PermissionsAwareDocumentCountMixin(PassUserMixin):
 class CorrespondentViewSet(ModelViewSet, PermissionsAwareDocumentCountMixin):
     model = Correspondent
 
-    queryset = (
-        Correspondent.objects.prefetch_related("documents")
-        .annotate(
-            last_correspondence=Max("documents__created"),
-        )
-        .select_related("owner")
-        .order_by(Lower("name"))
-    )
+    queryset = Correspondent.objects.select_related("owner").order_by(Lower("name"))
 
     serializer_class = CorrespondentSerializer
     pagination_class = StandardPagination
@@ -278,6 +271,13 @@ class CorrespondentViewSet(ModelViewSet, PermissionsAwareDocumentCountMixin):
         "document_count",
         "last_correspondence",
     )
+
+    def list(self, request, *args, **kwargs):
+        if request.query_params.get("last_correspondence", None):
+            self.queryset = self.queryset.annotate(
+                last_correspondence=Max("documents__created"),
+            )
+        return super().list(request, *args, **kwargs)
 
 
 class TagViewSet(ModelViewSet, PermissionsAwareDocumentCountMixin):

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -279,6 +279,12 @@ class CorrespondentViewSet(ModelViewSet, PermissionsAwareDocumentCountMixin):
             )
         return super().list(request, *args, **kwargs)
 
+    def retrieve(self, request, *args, **kwargs):
+        self.queryset = self.queryset.annotate(
+            last_correspondence=Max("documents__created"),
+        )
+        return super().retrieve(request, *args, **kwargs)
+
 
 class TagViewSet(ModelViewSet, PermissionsAwareDocumentCountMixin):
     model = Tag


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

After reading the linked issues, I wondered if the annotation query to pull out 'last_correspondence' is unnecessarily slowing things down. Im not really sure how to test other than asking the users (at least one seems briefly to confirm so far) but I think this would still be an improvement for all users (e.g. faster) and we only use `last_correspondence` in one place currently (I think), in the list of correspondents, in which case the records are paginated already.

I suppose there's the question of whether this qualifies as a breaking change as getting the value in a list of correspondents would now require passing `last_correspondence=true`. As always welcome any thoughts in general or of course if I'm missing anything.

Note: the changes to document-detail here are just a side-effect of this, we previously used the presence of `last_correspondence` on an object to check what type it was, but didnt actually use it there. That is significantly cleaner now anyway.

Closes #6782 (and perhaps relevant to #4872?)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [x] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
