### PR TITLE
Run "Title & content" search from global search instead of advanced

### DIFF
--- a/src-ui/src/app/components/app-frame/global-search/global-search.component.html
+++ b/src-ui/src/app/components/app-frame/global-search/global-search.component.html
@@ -19,8 +19,8 @@
                 </div>
             </div>
             @if (query) {
-                <button class="btn btn-sm btn-outline-secondary" type="button" (click)="runAdvanedSearch()">
-                    <ng-container i18n>Advanced search</ng-container>
+                <button class="btn btn-sm btn-outline-secondary" type="button" (click)="runContentSearch()">
+                    <ng-container i18n>Search contents</ng-container>
                     <i-bs width="1em" height="1em" name="arrow-right-short"></i-bs>
                 </button>
             }

--- a/src-ui/src/app/components/app-frame/global-search/global-search.component.spec.ts
+++ b/src-ui/src/app/components/app-frame/global-search/global-search.component.spec.ts
@@ -20,11 +20,11 @@ import { DocumentListViewService } from 'src/app/services/document-list-view.ser
 import { HttpClientTestingModule } from '@angular/common/http/testing'
 import { FormsModule, ReactiveFormsModule } from '@angular/forms'
 import {
-  FILTER_FULLTEXT_QUERY,
   FILTER_HAS_CORRESPONDENT_ANY,
   FILTER_HAS_DOCUMENT_TYPE_ANY,
   FILTER_HAS_STORAGE_PATH_ANY,
   FILTER_HAS_TAGS_ALL,
+  FILTER_TITLE_CONTENT,
 } from 'src/app/data/filter-rule-type'
 import { NgxBootstrapIconsModule, allIcons } from 'ngx-bootstrap-icons'
 import { DocumentService } from 'src/app/services/rest/document.service'
@@ -262,9 +262,9 @@ describe('GlobalSearchComponent', () => {
     component.searchResults = searchResults as any
     component.resultsDropdown.open()
     component.query = 'test'
-    const advancedSearchSpy = jest.spyOn(component, 'runAdvanedSearch')
+    const contentsSearchSpy = jest.spyOn(component, 'runContentSearch')
     component.searchInputKeyDown(new KeyboardEvent('keydown', { key: 'Enter' }))
-    expect(advancedSearchSpy).toHaveBeenCalled()
+    expect(contentsSearchSpy).toHaveBeenCalled()
   })
 
   it('should search on query debounce', fakeAsync(() => {
@@ -499,12 +499,12 @@ describe('GlobalSearchComponent', () => {
     expect(focusSpy).toHaveBeenCalled()
   })
 
-  it('should support explicit advanced search', () => {
+  it('should support explicit contents search', () => {
     const qfSpy = jest.spyOn(documentListViewService, 'quickFilter')
     component.query = 'test'
-    component.runAdvanedSearch()
+    component.runContentSearch()
     expect(qfSpy).toHaveBeenCalledWith([
-      { rule_type: FILTER_FULLTEXT_QUERY, value: 'test' },
+      { rule_type: FILTER_TITLE_CONTENT, value: 'test' },
     ])
   })
 

--- a/src-ui/src/app/components/app-frame/global-search/global-search.component.ts
+++ b/src-ui/src/app/components/app-frame/global-search/global-search.component.ts
@@ -10,7 +10,7 @@ import { Router } from '@angular/router'
 import { NgbDropdown, NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap'
 import { Subject, debounceTime, distinctUntilChanged, filter, map } from 'rxjs'
 import {
-  FILTER_FULLTEXT_QUERY,
+  FILTER_TITLE_CONTENT,
   FILTER_HAS_CORRESPONDENT_ANY,
   FILTER_HAS_DOCUMENT_TYPE_ANY,
   FILTER_HAS_STORAGE_PATH_ANY,
@@ -282,7 +282,7 @@ export class GlobalSearchComponent implements OnInit {
         this.primaryButtons.first.nativeElement.click()
         this.searchInput.nativeElement.blur()
       } else if (this.query?.length) {
-        this.runAdvanedSearch()
+        this.runContentSearch()
         this.reset(true)
       }
     } else if (event.key === 'Escape' && !this.resultsDropdown.isOpen()) {
@@ -378,9 +378,9 @@ export class GlobalSearchComponent implements OnInit {
     )
   }
 
-  public runAdvanedSearch() {
+  public runContentSearch() {
     this.documentListViewService.quickFilter([
-      { rule_type: FILTER_FULLTEXT_QUERY, value: this.query },
+      { rule_type: FILTER_TITLE_CONTENT, value: this.query },
     ])
     this.reset(true)
   }


### PR DESCRIPTION
## Proposed change

This changes the full-text-search built into the global search bar from "advanced" to "title & content".

Here are the reasons why I believe this change is sensible:

- This is in line with the default for the "documents" view (such as after "Reset filters")
- It's more intuitive for new users
- It yields the most search results (advanced won't match parts of words)

It is technically a breaking change as the top search bar did default to "advanced" in 2.7 and before, but this was offset by the autocomplete (which did match incomplete words and allowed users to choose a "full" word before running the search).

Ref. paperless-ngx/paperless-ngx#6632

I've recreated a PR mostly to have a place to talk about this and to touch some front-end code again. Feel free to close this without much discussion if you don't like it.

## Type of change

- [ ] Bug fix: non-breaking change which fixes an issue.
- [X] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [X] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

- [X] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [X] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [X] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [X] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [X] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [X] I have checked my modifications for any breaking changes.
