### PR TITLE
Fix: including ordering param for id__in retrievals

### DIFF
--- a/src-ui/src/app/components/common/custom-field-display/custom-field-display.component.spec.ts
+++ b/src-ui/src/app/components/common/custom-field-display/custom-field-display.component.spec.ts
@@ -18,7 +18,7 @@ const document: Document = {
   custom_fields: [
     { field: 1, document: 1, created: null, value: 'Text value' },
     { field: 2, document: 1, created: null, value: 'USD100' },
-    { field: 3, document: 1, created: null, value: '1,2,3' },
+    { field: 3, document: 1, created: null, value: [1, 2, 3] },
   ],
 }
 

--- a/src-ui/src/app/components/common/custom-field-display/custom-field-display.component.ts
+++ b/src-ui/src/app/components/common/custom-field-display/custom-field-display.component.ts
@@ -105,7 +105,9 @@ export class CustomFieldDisplayComponent implements OnInit, OnDestroy {
       .getFew(this.value, { fields: 'id,title' })
       .pipe(takeUntil(this.unsubscribeNotifier))
       .subscribe((result: Results<Document>) => {
-        this.docLinkDocuments = result.results
+        this.docLinkDocuments = this.value.map((id) =>
+          result.results.find((d) => d.id === id)
+        )
       })
   }
 

--- a/src-ui/src/app/components/common/input/document-link/document-link.component.spec.ts
+++ b/src-ui/src/app/components/common/input/document-link/document-link.component.spec.ts
@@ -66,6 +66,20 @@ describe('DocumentLinkComponent', () => {
     expect(getSpy).toHaveBeenCalled()
   })
 
+  it('shoud maintain ordering of selected documents', () => {
+    const getSpy = jest.spyOn(documentService, 'getFew')
+    getSpy.mockImplementation((ids) => {
+      const docs = documents.filter((d) => ids.includes(d.id))
+      return of({
+        count: docs.length,
+        all: docs.map((d) => d.id),
+        results: docs,
+      })
+    })
+    component.writeValue([12, 1])
+    expect(component.selectedDocuments).toEqual([documents[1], documents[0]])
+  })
+
   it('should search API on select text input', () => {
     const listSpy = jest.spyOn(documentService, 'listFiltered')
     listSpy.mockImplementation(

--- a/src-ui/src/app/components/common/input/document-link/document-link.component.ts
+++ b/src-ui/src/app/components/common/input/document-link/document-link.component.ts
@@ -65,7 +65,9 @@ export class DocumentLinkComponent
         .pipe(takeUntil(this.unsubscribeNotifier))
         .subscribe((documentResults) => {
           this.loading = false
-          this.selectedDocuments = documentResults.results
+          this.selectedDocuments = documentIDs.map((id) =>
+            documentResults.results.find((d) => d.id === id)
+          )
           super.writeValue(documentIDs)
         })
     }

--- a/src-ui/src/app/services/rest/abstract-paperless-service.spec.ts
+++ b/src-ui/src/app/services/rest/abstract-paperless-service.spec.ts
@@ -100,13 +100,13 @@ export const commonAbstractPaperlessServiceTests = (endpoint, ServiceClass) => {
     test('should call appropriate api endpoint for get a few objects', () => {
       subscription = service.getFew([1, 2, 3]).subscribe()
       const req = httpTestingController.expectOne(
-        `${environment.apiBaseUrl}${endpoint}/?id__in=1,2,3`
+        `${environment.apiBaseUrl}${endpoint}/?id__in=1,2,3&ordering=-id`
       )
       expect(req.request.method).toEqual('GET')
       req.flush([])
       subscription = service.getFew([4, 5, 6], { foo: 'bar' }).subscribe()
       const req2 = httpTestingController.expectOne(
-        `${environment.apiBaseUrl}${endpoint}/?id__in=4,5,6&foo=bar`
+        `${environment.apiBaseUrl}${endpoint}/?id__in=4,5,6&ordering=-id&foo=bar`
       )
       expect(req2.request.method).toEqual('GET')
       req2.flush([])

--- a/src-ui/src/app/services/rest/abstract-paperless-service.ts
+++ b/src-ui/src/app/services/rest/abstract-paperless-service.ts
@@ -94,6 +94,7 @@ export abstract class AbstractPaperlessService<T extends ObjectWithId> {
   getFew(ids: number[], extraParams?): Observable<Results<T>> {
     let httpParams = new HttpParams()
     httpParams = httpParams.set('id__in', ids.join(','))
+    httpParams = httpParams.set('ordering', '-id')
     for (let extraParamKey in extraParams) {
       if (extraParams[extraParamKey] != null) {
         httpParams = httpParams.set(extraParamKey, extraParams[extraParamKey])


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Small thing, the `UnorderedObjectListWarning` warning seems to worry people. So even though it's of little consequence, I think this should silence it. I can repro the warning by loading e.g. `http://localhost:8000/api/documents/?id__in=243,378,376&fields=id,title` i.e. no ordering param (`ordering=-id`) for the first time after starting the backend (I think it gets silenced after the first time).

So this PR just updates the place(s) where the frontend might make a request like that (not 100% sure its all of them). The only catch is that we dont want to re-order the docs in a doc link field (actually at the moment they may not return in order consistently anyway).

Closes #(issue or discussion)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
