### PR TITLE
Fix: Revert masking the content field from auditlog

### DIFF
--- a/src/documents/models.py
+++ b/src/documents/models.py
@@ -929,7 +929,6 @@ if settings.AUDIT_LOG_ENABLED:
     auditlog.register(
         Document,
         m2m_fields={"tags"},
-        mask_fields=["content"],
         exclude_fields=["modified"],
     )
     auditlog.register(Correspondent)


### PR DESCRIPTION
Masking does not meaningfully improve privacy (the second half of the content is stored in full), it does not save space (the asterisks are stored as string in the database) and it breaks the expectation that the auditlog can actually be used to audit changes.

This partly reverts #6388 (05b1ff9738201cafd7dea2cba4d9e5395b1e33da)

Resolves #6961

## Proposed change

Disables masking for the `content` field, as discussed in #6961 

## Type of change

- [X] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

- [X] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [X] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [X] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [X] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [X] I have checked my modifications for any breaking changes.
