### PR TITLE
Enhancement: use request user as owner of split / merge docs

### DIFF
--- a/src/documents/tests/test_api_bulk_edit.py
+++ b/src/documents/tests/test_api_bulk_edit.py
@@ -20,6 +20,7 @@ class TestBulkEditAPI(DirectoriesMixin, APITestCase):
         super().setUp()
 
         user = User.objects.create_superuser(username="temp_admin")
+        self.user = user
         self.client.force_authenticate(user=user)
 
         patcher = mock.patch("documents.bulk_edit.bulk_update_documents.delay")
@@ -993,6 +994,7 @@ class TestBulkEditAPI(DirectoriesMixin, APITestCase):
         args, kwargs = m.call_args
         self.assertCountEqual(args[0], [self.doc2.id, self.doc3.id])
         self.assertEqual(kwargs["metadata_document_id"], self.doc3.id)
+        self.assertEqual(kwargs["user"], self.user)
 
     @mock.patch("documents.serialisers.bulk_edit.merge")
     def test_merge_and_delete_insufficient_permissions(self, m):
@@ -1092,6 +1094,7 @@ class TestBulkEditAPI(DirectoriesMixin, APITestCase):
         args, kwargs = m.call_args
         self.assertCountEqual(args[0], [self.doc2.id])
         self.assertEqual(kwargs["pages"], [[1], [2, 3, 4], [5, 6], [7]])
+        self.assertEqual(kwargs["user"], self.user)
 
     def test_split_invalid_params(self):
         response = self.client.post(

--- a/src/documents/tests/test_bulk_edit.py
+++ b/src/documents/tests/test_bulk_edit.py
@@ -422,8 +422,9 @@ class TestPDFActions(DirectoriesMixin, TestCase):
         """
         doc_ids = [self.doc1.id, self.doc2.id, self.doc3.id]
         metadata_document_id = self.doc1.id
+        user = User.objects.create(username="test_user")
 
-        result = bulk_edit.merge(doc_ids)
+        result = bulk_edit.merge(doc_ids, None, False, user)
 
         expected_filename = (
             f"{'_'.join([str(doc_id) for doc_id in doc_ids])[:100]}_merged.pdf"
@@ -525,7 +526,8 @@ class TestPDFActions(DirectoriesMixin, TestCase):
         """
         doc_ids = [self.doc2.id]
         pages = [[1, 2], [3]]
-        result = bulk_edit.split(doc_ids, pages)
+        user = User.objects.create(username="test_user")
+        result = bulk_edit.split(doc_ids, pages, False, user)
         self.assertEqual(mock_consume_file.call_count, 2)
         consume_file_args, _ = mock_consume_file.call_args
         self.assertEqual(consume_file_args[1].title, "B (split 2)")

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -959,6 +959,11 @@ class BulkEditView(PassUserMixin):
         method = serializer.validated_data.get("method")
         parameters = serializer.validated_data.get("parameters")
         documents = serializer.validated_data.get("documents")
+        if method in [
+            bulk_edit.split,
+            bulk_edit.merge,
+        ]:
+            parameters["user"] = user
 
         if not user.is_superuser:
             document_objs = Document.objects.select_related("owner").filter(


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

See related discussion, in the end I think this is basically the most "expected" solution. In the same way that uploading a doc defaults to the current user, the person who performs the split / merge will now be the owner of the new doc. Welcome to other thoughts, theres a bit more in the thread.

Closes #7024

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [x] Other. Please explain: change

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
