### PR TITLE
Fix: handle errors for trash actions and only show documents user can restore or delete

### DIFF
--- a/src-ui/messages.xlf
+++ b/src-ui/messages.xlf
@@ -1437,7 +1437,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/admin/trash/trash.component.ts</context>
-          <context context-type="linenumber">80</context>
+          <context context-type="linenumber">86</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/admin/users-groups/users-groups.component.html</context>
@@ -2153,7 +2153,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/admin/trash/trash.component.ts</context>
-          <context context-type="linenumber">74</context>
+          <context context-type="linenumber">80</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/manage/management-list/management-list.component.ts</context>
@@ -2179,7 +2179,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/admin/trash/trash.component.ts</context>
-          <context context-type="linenumber">78</context>
+          <context context-type="linenumber">84</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/admin/users-groups/users-groups.component.ts</context>
@@ -2214,42 +2214,74 @@
         <source>Document deleted</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/admin/trash/trash.component.ts</context>
-          <context context-type="linenumber">63</context>
+          <context context-type="linenumber">64</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7295637485862454066" datatype="html">
+        <source>Error deleting document</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/admin/trash/trash.component.ts</context>
+          <context context-type="linenumber">69</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/document-detail/document-detail.component.ts</context>
+          <context context-type="linenumber">799</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7266264608936522311" datatype="html">
         <source>This operation will permanently delete the selected documents.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/admin/trash/trash.component.ts</context>
-          <context context-type="linenumber">76</context>
+          <context context-type="linenumber">82</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6804051092296228130" datatype="html">
         <source>This operation will permanently delete all documents in the trash.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/admin/trash/trash.component.ts</context>
-          <context context-type="linenumber">77</context>
+          <context context-type="linenumber">83</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6996183233986182894" datatype="html">
         <source>Document(s) deleted</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/admin/trash/trash.component.ts</context>
-          <context context-type="linenumber">87</context>
+          <context context-type="linenumber">94</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6962724852893361467" datatype="html">
+        <source>Error deleting document(s)</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/admin/trash/trash.component.ts</context>
+          <context context-type="linenumber">101</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7534569062269274401" datatype="html">
         <source>Document restored</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/admin/trash/trash.component.ts</context>
-          <context context-type="linenumber">97</context>
+          <context context-type="linenumber">113</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="9136016619414048201" datatype="html">
+        <source>Error restoring document</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/admin/trash/trash.component.ts</context>
+          <context context-type="linenumber">117</context>
         </context-group>
       </trans-unit>
       <trans-unit id="960063472770266304" datatype="html">
         <source>Document(s) restored</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/admin/trash/trash.component.ts</context>
-          <context context-type="linenumber">106</context>
+          <context context-type="linenumber">127</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8405416976953346141" datatype="html">
+        <source>Error restoring document(s)</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/admin/trash/trash.component.ts</context>
+          <context context-type="linenumber">133</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8119815638230251386" datatype="html">
@@ -6071,13 +6103,6 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/document-list/bulk-editor/bulk-editor.component.ts</context>
           <context context-type="linenumber">716</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="7295637485862454066" datatype="html">
-        <source>Error deleting document</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/components/document-detail/document-detail.component.ts</context>
-          <context context-type="linenumber">799</context>
         </context-group>
       </trans-unit>
       <trans-unit id="619486176823357521" datatype="html">

--- a/src-ui/src/app/components/admin/trash/trash.component.ts
+++ b/src-ui/src/app/components/admin/trash/trash.component.ts
@@ -59,10 +59,16 @@ export class TrashComponent implements OnDestroy {
       .pipe(takeUntil(this.unsubscribeNotifier))
       .subscribe(() => {
         modal.componentInstance.buttonsEnabled = false
-        this.trashService.emptyTrash([document.id]).subscribe(() => {
-          this.toastService.showInfo($localize`Document deleted`)
-          modal.close()
-          this.reload()
+        this.trashService.emptyTrash([document.id]).subscribe({
+          next: () => {
+            this.toastService.showInfo($localize`Document deleted`)
+            modal.close()
+            this.reload()
+          },
+          error: (err) => {
+            this.toastService.showError($localize`Error deleting document`, err)
+            modal.close()
+          },
         })
       })
   }
@@ -83,29 +89,51 @@ export class TrashComponent implements OnDestroy {
       .subscribe(() => {
         this.trashService
           .emptyTrash(documents ? Array.from(documents) : null)
-          .subscribe(() => {
-            this.toastService.showInfo($localize`Document(s) deleted`)
-            this.allToggled = false
-            modal.close()
-            this.reload()
+          .subscribe({
+            next: () => {
+              this.toastService.showInfo($localize`Document(s) deleted`)
+              this.allToggled = false
+              modal.close()
+              this.reload()
+            },
+            error: (err) => {
+              this.toastService.showError(
+                $localize`Error deleting document(s)`,
+                err
+              )
+              modal.close()
+            },
           })
       })
   }
 
   restore(document: Document) {
-    this.trashService.restoreDocuments([document.id]).subscribe(() => {
-      this.toastService.showInfo($localize`Document restored`)
-      this.reload()
+    this.trashService.restoreDocuments([document.id]).subscribe({
+      next: () => {
+        this.toastService.showInfo($localize`Document restored`)
+        this.reload()
+      },
+      error: (err) => {
+        this.toastService.showError($localize`Error restoring document`, err)
+      },
     })
   }
 
   restoreAll(documents: Set<number> = null) {
     this.trashService
       .restoreDocuments(documents ? Array.from(documents) : null)
-      .subscribe(() => {
-        this.toastService.showInfo($localize`Document(s) restored`)
-        this.allToggled = false
-        this.reload()
+      .subscribe({
+        next: () => {
+          this.toastService.showInfo($localize`Document(s) restored`)
+          this.allToggled = false
+          this.reload()
+        },
+        error: (err) => {
+          this.toastService.showError(
+            $localize`Error restoring document(s)`,
+            err
+          )
+        },
       })
   }
 

--- a/src/documents/filters.py
+++ b/src/documents/filters.py
@@ -276,3 +276,15 @@ class ObjectOwnedOrGrantedPermissionsFilter(ObjectPermissionsFilter):
         objects_owned = queryset.filter(owner=request.user)
         objects_unowned = queryset.filter(owner__isnull=True)
         return objects_with_perms | objects_owned | objects_unowned
+
+
+class ObjectOwnedPermissionsFilter(ObjectPermissionsFilter):
+    """
+    A filter backend that limits results to those where the requesting user
+    owns the objects or objects without an owner (for backwards compat)
+    """
+
+    def filter_queryset(self, request, queryset, view):
+        objects_owned = queryset.filter(owner=request.user)
+        objects_unowned = queryset.filter(owner__isnull=True)
+        return objects_owned | objects_unowned

--- a/src/documents/filters.py
+++ b/src/documents/filters.py
@@ -285,6 +285,8 @@ class ObjectOwnedPermissionsFilter(ObjectPermissionsFilter):
     """
 
     def filter_queryset(self, request, queryset, view):
+        if request.user.is_superuser:
+            return queryset
         objects_owned = queryset.filter(owner=request.user)
         objects_unowned = queryset.filter(owner__isnull=True)
         return objects_owned | objects_unowned

--- a/src/documents/tests/test_api_trash.py
+++ b/src/documents/tests/test_api_trash.py
@@ -1,3 +1,4 @@
+from django.contrib.auth.models import Permission
 from django.contrib.auth.models import User
 from django.core.cache import cache
 from rest_framework import status
@@ -10,7 +11,8 @@ class TestTrashAPI(APITestCase):
     def setUp(self):
         super().setUp()
 
-        self.user = User.objects.create_superuser(username="temp_admin")
+        self.user = User.objects.create_user(username="temp_admin")
+        self.user.user_permissions.add(*Permission.objects.all())
         self.client.force_authenticate(user=self.user)
         cache.clear()
 
@@ -97,6 +99,56 @@ class TestTrashAPI(APITestCase):
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         self.assertEqual(Document.global_objects.count(), 0)
 
+    def test_api_trash_show_owned_only(self):
+        """
+        GIVEN:
+            - Existing documents in trash
+        WHEN:
+            - API request to show documents in trash for regular user
+            - API request to show documents in trash for superuser
+        THEN:
+            - Only owned documents are returned
+        """
+
+        document_u1 = Document.objects.create(
+            title="Title",
+            content="content",
+            checksum="checksum",
+            mime_type="application/pdf",
+            owner=self.user,
+        )
+        document_u1.delete()
+        document_not_owned = Document.objects.create(
+            title="Title2",
+            content="content2",
+            checksum="checksum2",
+            mime_type="application/pdf",
+        )
+        document_not_owned.delete()
+        user2 = User.objects.create_user(username="user2")
+        document_u2 = Document.objects.create(
+            title="Title3",
+            content="content3",
+            checksum="checksum3",
+            mime_type="application/pdf",
+            owner=user2,
+        )
+        document_u2.delete()
+
+        # user only sees their own documents or unowned documents
+        resp = self.client.get("/api/trash/")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.data["count"], 2)
+        self.assertEqual(resp.data["results"][0]["id"], document_not_owned.pk)
+        self.assertEqual(resp.data["results"][1]["id"], document_u1.pk)
+
+        # superuser sees all documents
+        superuser = User.objects.create_superuser(username="superuser")
+        self.client.force_authenticate(user=superuser)
+        resp = self.client.get("/api/trash/")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.data["count"], 3)
+
     def test_api_trash_insufficient_permissions(self):
         """
         GIVEN:
@@ -107,9 +159,6 @@ class TestTrashAPI(APITestCase):
             - 403 Forbidden
         """
 
-        user1 = User.objects.create_user(username="user1")
-        self.client.force_authenticate(user=user1)
-        self.client.force_login(user=user1)
         user2 = User.objects.create_user(username="user2")
         document = Document.objects.create(
             title="Title",

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -232,10 +232,11 @@ class PermissionsAwareDocumentCountMixin(PassUserMixin):
 
     def get_queryset(self):
         filter = (
-            None
+            Q(documents__deleted_at__isnull=True)
             if self.request.user is None or self.request.user.is_superuser
             else (
                 Q(
+                    documents__deleted_at__isnull=True,
                     documents__id__in=get_objects_for_user_owner_aware(
                         self.request.user,
                         "documents.view_document",


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

2 parts:

1. Show errors for actions from trash in the frontend.
2. Since we dont really support granting `delete` perms (technically you can do that in admin) just limit the trash to owned by the requesting user or unowned (i.e. no longer show docs the user has perms granted for because they wont be able to delete / restore them).

Closes #7118

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
