### PR TITLE
schedule a export to allow backing up to external storage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -286,6 +286,11 @@ VOLUME ["/usr/src/paperless/data", \
         "/usr/src/paperless/consume", \
         "/usr/src/paperless/export"]
 
+ENV  SUPERCRONIC=supercronic-linux-amd64
+ENV  VERSION=0.2.30
+RUN curl -fsSL -o "/usr/local/bin/supercronic" "https://github.com/aptible/supercronic/releases/download/v$VERSION/$SUPERCRONIC"
+RUN chmod a+x "/usr/local/bin/supercronic"
+
 ENTRYPOINT ["/sbin/docker-entrypoint.sh"]
 
 EXPOSE 8000

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -157,6 +157,11 @@ if [[ -n "$PAPERLESS_OCR_LANGUAGES" ]]; then
 	install_languages "$PAPERLESS_OCR_LANGUAGES"
 fi
 
+touch /etc/cron.d/export.cron
+if [[ -n "$PAPERLESS_EXPORT_CRON" ]]; then
+	echo "$PAPERLESS_EXPORT_CRON document_exporter /usr/src/paperless/export" > /etc/cron.d/export.cron
+fi
+
 initialize
 
 if [[ "$1" != "/"* ]]; then

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -17,6 +17,16 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 environment = HOME="/usr/src/paperless",USER="paperless"
 
+[program:export]
+command=/usr/local/bin/supercronic /etc/cron.d/export.cron
+user=paperless
+startsecs=0
+priority=2
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
 [program:consumer]
 command=python3 manage.py document_consumer
 user=paperless


### PR DESCRIPTION
This PR implements #7192

## Proposed change
Include https://github.com/aptible/supercronic to automatically schedule the export. In my implementation `document_exporter` is run without any additional arguments, but they could of course be added as environment variables. 

The supercronic dependency gets compiled into the image, but the export gets only scheduled if you set the environment variable PAPERLESS_EXPORT_CRON to a valid cron expression. 

If you want to already use this I published an image from my fork as ghcr.io/danielr1996/paperless-ngx:supercronic-2.10.2, it's completely drop in and you can enable it by setting PAPERLESS_EXPORT_CRON="0-30/30 * * * *" (runs at xx:00 and xx:30)

Closes #7192

## Type of change

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ x ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ x ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ x ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ x ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ x ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ x ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ x ] I have checked my modifications for any breaking changes.
- [ ] I have made corresponding changes to the documentation as needed. (Will do so if there is enough interest to implement the change )
