### PR TITLE
Adds USERMAP_NOPERM_CHANGE env

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -8,11 +8,20 @@ map_uidgid() {
 	local -r usermap_original_gid=$(id -g paperless)
 	local -r usermap_new_uid=${USERMAP_UID:-$usermap_original_uid}
 	local -r usermap_new_gid=${USERMAP_GID:-${usermap_original_gid:-$usermap_new_uid}}
-	if [[ ${usermap_new_uid} != "${usermap_original_uid}" || ${usermap_new_gid} != "${usermap_original_gid}" ]]; then
+  local -r usermap_noperm_change=${USERMAP_NOPERM_CHANGE:-false}
+	if [[  ${usermap_new_uid} != "${usermap_original_uid}" || ${usermap_new_gid} != "${usermap_original_gid}" ]]; then
 		echo "Mapping UID and GID for paperless:paperless to $usermap_new_uid:$usermap_new_gid"
+		# Avoids changing the default permissions for the root folder of paperless
+		if [[ ${usermap_noperm_change} == "true" ]]; then
+			chown root:root /usr/src/paperless
+ 		fi
 		usermod -o -u "${usermap_new_uid}" paperless
 		groupmod -o -g "${usermap_new_gid}" paperless
-	fi
+	  # Avoids changing the default permissions for the root folder of paperless
+		if [[ ${usermap_noperm_change} == "true" ]]; then
+			chown paperless:paperless /usr/src/paperless
+ 		fi
+  fi
 }
 
 map_folders() {


### PR DESCRIPTION

## Proposed change
Adds a new USERMAP_NOPERM_CHANGE to disable recursive permission change on the home folder of paperless. On some systems (where the user uses slow storage such as HDD) this operation takes quite a while. The default behavior is to enable the recursive permission change.  The default value is false. If this is true, the container avoids recursive permission change as documented here: https://github.com/paperless-ngx/paperless-ngx/discussions/5086 and in the man page.

## Type of change

- [ ] Bug fix: non-breaking change which fixes an issue.
- [X ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

- [X ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
