### PR TITLE
Fix: support multiple inbox tags from stats widget

### DIFF
--- a/src-ui/e2e/dashboard/dashboard.spec.ts
+++ b/src-ui/e2e/dashboard/dashboard.spec.ts
@@ -9,7 +9,7 @@ test('dashboard inbox link', async ({ page }) => {
   await page.routeFromHAR(REQUESTS_HAR1, { notFound: 'fallback' })
   await page.goto('/dashboard')
   await page.getByRole('link', { name: 'Documents in inbox' }).click()
-  await expect(page).toHaveURL(/tags__id__all=9/)
+  await expect(page).toHaveURL(/tags__id__in=9/)
   await expect(page.locator('pngx-document-list')).toHaveText(/8 documents/)
 })
 

--- a/src-ui/e2e/dashboard/requests/api-dashboard1.har
+++ b/src-ui/e2e/dashboard/requests/api-dashboard1.har
@@ -236,7 +236,7 @@
           "content": {
             "size": -1,
             "mimeType": "application/json",
-            "text": "{\"documents_total\":61,\"documents_inbox\":8,\"inbox_tag\":9,\"document_file_type_counts\":[{\"mime_type\":\"application/pdf\",\"mime_type_count\":57},{\"mime_type\":\"text/plain\",\"mime_type_count\":3},{\"mime_type\":\"text/csv\",\"mime_type_count\":1}],\"character_count\":2407053}"
+            "text": "{\"documents_total\":61,\"documents_inbox\":8,\"inbox_tags\":[9],\"document_file_type_counts\":[{\"mime_type\":\"application/pdf\",\"mime_type_count\":57},{\"mime_type\":\"text/plain\",\"mime_type_count\":3},{\"mime_type\":\"text/csv\",\"mime_type_count\":1}],\"character_count\":2407053}"
           },
           "headersSize": -1,
           "bodySize": -1,
@@ -250,7 +250,7 @@
         "time": 0.609,
         "request": {
           "method": "GET",
-          "url": "http://localhost:8000/api/documents/?page=1&page_size=10&ordering=-created&truncate_content=true&tags__id__all=9",
+          "url": "http://localhost:8000/api/documents/?page=1&page_size=10&ordering=-created&truncate_content=true&tags__id__in=9",
           "httpVersion": "HTTP/1.1",
           "cookies": [],
           "headers": [
@@ -284,7 +284,7 @@
               "value": "true"
             },
             {
-              "name": "tags__id__all",
+              "name": "tags__id__in",
               "value": "9"
             }
           ],
@@ -468,7 +468,7 @@
         "time": 0.951,
         "request": {
           "method": "GET",
-          "url": "http://localhost:8000/api/documents/?page=1&page_size=50&ordering=-created&truncate_content=true&tags__id__all=9",
+          "url": "http://localhost:8000/api/documents/?page=1&page_size=50&ordering=-created&truncate_content=true&tags__id__in=9",
           "httpVersion": "HTTP/1.1",
           "cookies": [],
           "headers": [
@@ -502,7 +502,7 @@
               "value": "true"
             },
             {
-              "name": "tags__id__all",
+              "name": "tags__id__in",
               "value": "9"
             }
           ],

--- a/src-ui/e2e/dashboard/requests/api-dashboard2.har
+++ b/src-ui/e2e/dashboard/requests/api-dashboard2.har
@@ -236,7 +236,7 @@
           "content": {
             "size": -1,
             "mimeType": "application/json",
-            "text": "{\"documents_total\":61,\"documents_inbox\":8,\"inbox_tag\":9,\"document_file_type_counts\":[{\"mime_type\":\"application/pdf\",\"mime_type_count\":57},{\"mime_type\":\"text/plain\",\"mime_type_count\":3},{\"mime_type\":\"text/csv\",\"mime_type_count\":1}],\"character_count\":2407053}"
+            "text": "{\"documents_total\":61,\"documents_inbox\":8,\"inbox_tags\":[9],\"document_file_type_counts\":[{\"mime_type\":\"application/pdf\",\"mime_type_count\":57},{\"mime_type\":\"text/plain\",\"mime_type_count\":3},{\"mime_type\":\"text/csv\",\"mime_type_count\":1}],\"character_count\":2407053}"
           },
           "headersSize": -1,
           "bodySize": -1,
@@ -250,7 +250,7 @@
         "time": 0.622,
         "request": {
           "method": "GET",
-          "url": "http://localhost:8000/api/documents/?page=1&page_size=10&ordering=-created&truncate_content=true&tags__id__all=9",
+          "url": "http://localhost:8000/api/documents/?page=1&page_size=10&ordering=-created&truncate_content=true&tags__id__in=9",
           "httpVersion": "HTTP/1.1",
           "cookies": [],
           "headers": [
@@ -284,7 +284,7 @@
               "value": "true"
             },
             {
-              "name": "tags__id__all",
+              "name": "tags__id__in",
               "value": "9"
             }
           ],

--- a/src-ui/e2e/dashboard/requests/api-dashboard3.har
+++ b/src-ui/e2e/dashboard/requests/api-dashboard3.har
@@ -236,7 +236,7 @@
           "content": {
             "size": -1,
             "mimeType": "application/json",
-            "text": "{\"documents_total\":61,\"documents_inbox\":8,\"inbox_tag\":9,\"document_file_type_counts\":[{\"mime_type\":\"application/pdf\",\"mime_type_count\":57},{\"mime_type\":\"text/plain\",\"mime_type_count\":3},{\"mime_type\":\"text/csv\",\"mime_type_count\":1}],\"character_count\":2407053}"
+            "text": "{\"documents_total\":61,\"documents_inbox\":8,\"inbox_tags\":[9],\"document_file_type_counts\":[{\"mime_type\":\"application/pdf\",\"mime_type_count\":57},{\"mime_type\":\"text/plain\",\"mime_type_count\":3},{\"mime_type\":\"text/csv\",\"mime_type_count\":1}],\"character_count\":2407053}"
           },
           "headersSize": -1,
           "bodySize": -1,

--- a/src-ui/e2e/dashboard/requests/api-dashboard4.har
+++ b/src-ui/e2e/dashboard/requests/api-dashboard4.har
@@ -236,7 +236,7 @@
           "content": {
             "size": -1,
             "mimeType": "application/json",
-            "text": "{\"documents_total\":61,\"documents_inbox\":8,\"inbox_tag\":9,\"document_file_type_counts\":[{\"mime_type\":\"application/pdf\",\"mime_type_count\":57},{\"mime_type\":\"text/plain\",\"mime_type_count\":3},{\"mime_type\":\"text/csv\",\"mime_type_count\":1}],\"character_count\":2407053}"
+            "text": "{\"documents_total\":61,\"documents_inbox\":8,\"inbox_tags\":[9],\"document_file_type_counts\":[{\"mime_type\":\"application/pdf\",\"mime_type_count\":57},{\"mime_type\":\"text/plain\",\"mime_type_count\":3},{\"mime_type\":\"text/csv\",\"mime_type_count\":1}],\"character_count\":2407053}"
           },
           "headersSize": -1,
           "bodySize": -1,

--- a/src-ui/src/app/components/dashboard/widgets/statistics-widget/statistics-widget.component.spec.ts
+++ b/src-ui/src/app/components/dashboard/widgets/statistics-widget/statistics-widget.component.spec.ts
@@ -75,7 +75,7 @@ describe('StatisticsWidgetComponent', () => {
     const mockStats = {
       documents_total: 200,
       documents_inbox: 18,
-      inbox_tag: 10,
+      inbox_tags: [10],
     }
 
     const req = httpTestingController.expectOne(
@@ -100,7 +100,7 @@ describe('StatisticsWidgetComponent', () => {
     const mockStats = {
       documents_total: 200,
       documents_inbox: 18,
-      inbox_tag: 10,
+      inbox_tags: [10],
       document_file_type_counts: [
         {
           mime_type: 'application/pdf',

--- a/src-ui/src/app/components/dashboard/widgets/statistics-widget/statistics-widget.component.ts
+++ b/src-ui/src/app/components/dashboard/widgets/statistics-widget/statistics-widget.component.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@angular/common/http'
 import { Component, OnDestroy, OnInit } from '@angular/core'
 import { Observable, Subscription } from 'rxjs'
-import { FILTER_HAS_TAGS_ALL } from 'src/app/data/filter-rule-type'
+import { FILTER_HAS_TAGS_ANY } from 'src/app/data/filter-rule-type'
 import { ConsumerStatusService } from 'src/app/services/consumer-status.service'
 import { DocumentListViewService } from 'src/app/services/document-list-view.service'
 import { environment } from 'src/environments/environment'
@@ -11,7 +11,7 @@ import { ComponentWithPermissions } from 'src/app/components/with-permissions/wi
 export interface Statistics {
   documents_total?: number
   documents_inbox?: number
-  inbox_tag?: number
+  inbox_tags?: number[]
   document_file_type_counts?: DocumentFileType[]
   character_count?: number
   tag_count?: number
@@ -110,8 +110,10 @@ export class StatisticsWidgetComponent
   goToInbox() {
     this.documentListViewService.quickFilter([
       {
-        rule_type: FILTER_HAS_TAGS_ALL,
-        value: this.statistics.inbox_tag.toString(),
+        rule_type: FILTER_HAS_TAGS_ANY,
+        value: this.statistics.inbox_tags
+          .map((tagID) => tagID.toString())
+          .join(','),
       },
     ])
   }

--- a/src/documents/tests/test_api_documents.py
+++ b/src/documents/tests/test_api_documents.py
@@ -954,7 +954,7 @@ class TestDocumentApi(DirectoriesMixin, DocumentConsumeDelayMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["documents_total"], 3)
         self.assertEqual(response.data["documents_inbox"], 1)
-        self.assertEqual(response.data["inbox_tag"], tag_inbox.pk)
+        self.assertEqual(response.data["inbox_tags"], [tag_inbox.pk])
         self.assertEqual(
             response.data["document_file_type_counts"][0]["mime_type_count"],
             2,
@@ -975,7 +975,7 @@ class TestDocumentApi(DirectoriesMixin, DocumentConsumeDelayMixin, APITestCase):
         response = self.client.get("/api/statistics/")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["documents_inbox"], None)
-        self.assertEqual(response.data["inbox_tag"], None)
+        self.assertEqual(response.data["inbox_tags"], None)
 
     def test_statistics_multiple_users(self):
         """

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -1418,13 +1418,11 @@ class StatisticsView(APIView):
 
         documents_total = documents.count()
 
-        inbox_tag = tags.filter(is_inbox_tag=True)
+        inbox_tags = tags.filter(is_inbox_tag=True)
 
         documents_inbox = (
-            documents.filter(tags__is_inbox_tag=True, tags__id__in=tags)
-            .distinct()
-            .count()
-            if inbox_tag.exists()
+            documents.filter(tags__id__in=inbox_tags).distinct().count()
+            if inbox_tags.exists()
             else None
         )
 
@@ -1454,7 +1452,12 @@ class StatisticsView(APIView):
             {
                 "documents_total": documents_total,
                 "documents_inbox": documents_inbox,
-                "inbox_tag": inbox_tag.first().pk if inbox_tag.exists() else None,
+                "inbox_tag": inbox_tags.first().pk
+                if inbox_tags.exists()
+                else None,  # backwards compatibility
+                "inbox_tags": [tag.pk for tag in inbox_tags]
+                if inbox_tags.exists()
+                else None,
                 "document_file_type_counts": document_file_type_counts,
                 "character_count": character_count,
                 "tag_count": len(tags),


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

I agree that multiple inbox tags is odd but I think there are potential use cases (e.g. one is a shared inbox, one isnt) and I'd be hesitant to change [that behavior](https://github.com/paperless-ngx/paperless-ngx/blob/18991a77538321b5a1d143e2977f7761ccea5589/src/documents/signals/handlers.py#L55-L56), so I think this is the least disruptive change for the frontend. The diff looks larger than it really is, essentially we just change the link (and thus the `/api/statistics/` endpoint) to include all of the (visible) inbox tags.

Welcome any feedback ofc, I wasnt 100% certain we need to retain `inbox_tag` instead of just replacing it with `inbox_tags` but I think removing it could be seen as a breaking API change (I dont know if other apps etc really use it) so I kept it.

Closes #(issue or discussion)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
