### PR TITLE
Fix: increase search input text contrast with light custom theme colors

### DIFF
--- a/src-ui/src/theme.scss
+++ b/src-ui/src/theme.scss
@@ -130,7 +130,7 @@ $form-check-radio-checked-bg-image-dark: url("data:image/svg+xml,<svg xmlns='htt
   .btn-outline-secondary {
     &:hover, &:focus, &.active, &:active {
       background-color: var(--pngx-bg-darker);
-      color: var(--bs-white) !important;
+      color: var(--pngx-body-color-accent) !important;
     }
   }
 

--- a/src-ui/src/theme.scss
+++ b/src-ui/src/theme.scss
@@ -130,7 +130,7 @@ $form-check-radio-checked-bg-image-dark: url("data:image/svg+xml,<svg xmlns='htt
   .btn-outline-secondary {
     &:hover, &:focus, &.active, &:active {
       background-color: var(--pngx-bg-darker);
-      color: var(--bs-primary);
+      color: var(--bs-white) !important;
     }
   }
 
@@ -143,8 +143,8 @@ $form-check-radio-checked-bg-image-dark: url("data:image/svg+xml,<svg xmlns='htt
   }
 
   .search-container {
-    input, input:focus {
-      color: var(--bs-body-color) !important;
+    input, input:focus, i-bs[name="search"] , ::placeholder {
+      color: var(--pngx-primary-text-contrast) !important;
     }
   }
 


### PR DESCRIPTION

## Improve dark mode theme readability

Currently when using dark mode with a colour theme such as #fff004 will cause various text elements to switch to a contrast colour to preserve readability but the search bar, button and icon don't. This causes a readability issue:
<img width="1899" alt="Screenshot 2024-07-24 at 00 41 57" src="https://github.com/user-attachments/assets/120fab4c-18ce-43cc-bbff-e498afbe29c1">

Additionally the search button does not correctly contrast.  
<img width="959" alt="Screenshot 2024-07-24 at 00 42 13" src="https://github.com/user-attachments/assets/3f360934-8a50-42fd-b323-ce4d6d029739">

This PR makes a minor theme adjustment to use the correct contrast theme elements as well as ensure the iconography in the search bar also adopts the same contrast colour.
<img width="587" alt="Screenshot 2024-07-24 at 00 51 54" src="https://github.com/user-attachments/assets/9f3aa0d1-201b-46c1-9652-145c29bf9d02">
<img width="556" alt="Screenshot 2024-07-24 at 00 52 11" src="https://github.com/user-attachments/assets/1a5de967-a1ef-4f6a-ae04-a2a0f08a0bfe">



## Type of change

- [X] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

- [X] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [X] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [X] I have checked my modifications for any breaking changes.
