### PR TITLE
ability to add permissions on signup via social providers #7307

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -568,6 +568,16 @@ system. See the corresponding
 
     Defaults to True
 
+#### [`SOCIALACCOUNT_DEFAULT_PERMISSIONS=<json>`](#SOCIALACCOUNT_DEFAULT_PERMISSIONS) {#SOCIALACCOUNT_DEFAULT_PERMISSIONS}
+
+: By default, paperless doesn't add any permissions to users signed up via social account providers.
+
+    This can be adjusted by configuring a custom json array with
+    codenames of permissions being added to users on the signup via social account providers.
+
+    Defaults to `["view_uisettings"]`.
+
+
 #### [`PAPERLESS_ACCOUNT_ALLOW_SIGNUPS=<bool>`](#PAPERLESS_ACCOUNT_ALLOW_SIGNUPS) {#PAPERLESS_ACCOUNT_ALLOW_SIGNUPS}
 
 : Allow users to signup for a new Paperless-ngx account.

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -459,6 +459,14 @@ SOCIALACCOUNT_AUTO_SIGNUP = __get_boolean("PAPERLESS_SOCIAL_AUTO_SIGNUP")
 SOCIALACCOUNT_PROVIDERS = json.loads(
     os.getenv("PAPERLESS_SOCIALACCOUNT_PROVIDERS", "{}"),
 )
+SOCIALACCOUNT_DEFAULT_PERMISSIONS = list(
+    json.loads(
+        os.getenv(
+            "PAPERLESS_SOCIALACCOUNT_DEFAULT_PERMISSIONS",
+            '["view_uisettings"]',
+        ),
+    ),
+)
 
 ACCOUNT_EMAIL_SUBJECT_PREFIX = "[Paperless-ngx] "
 


### PR DESCRIPTION
Currently users signed up via social providers doesn't have any permissions set.
I suggest the following logic to have permissions applied automatically at the signup.

Relative discussions #7032 and #7307


## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
