### PR TITLE
Documentation: correct nltk data path

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -540,8 +540,7 @@ are released, dependency support is confirmed, etc.
 15. Optional: If using the NLTK machine learning processing (see
     [`PAPERLESS_ENABLE_NLTK`](configuration.md#PAPERLESS_ENABLE_NLTK) for details),
     download the NLTK data for the Snowball
-    Stemmer, Stopwords and Punkt tokenizer to your
-    `PAPERLESS_DATA_DIR/nltk`. Refer to the [NLTK
+    Stemmer, Stopwords and Punkt tokenizer to `/usr/share/nltk_data`. Refer to the [NLTK
     instructions](https://www.nltk.org/data.html) for details on how to
     download the data.
 


### PR DESCRIPTION
## Proposed change

The nltk data path default was changed to `/usr/share/nltk_data`. I had problems setting up nltk as the setup.md told me to put nltk data in `PAPERLESS_DATA_DIR/nltk`. 
I discovered in the source code, that it no longer defaults to `PAPERLESS_DATA_DIR/nltk` but to `/usr/share/nltk_data`.
The configuration.md is telling the same.

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [X] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [X] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [X] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
