### PR TITLE
Fix broken celery beat schedule path setting

### DIFF
--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -823,7 +823,7 @@ CELERY_ACCEPT_CONTENT = ["application/json", "application/x-python-serialize"]
 CELERY_BEAT_SCHEDULE = _parse_beat_schedule()
 
 # https://docs.celeryq.dev/en/stable/userguide/configuration.html#beat-schedule-filename
-CELERY_BEAT_SCHEDULE_FILENAME = os.path.join(DATA_DIR, "celerybeat-schedule.db")
+CELERY_BEAT_SCHEDULE_FILENAME = os.path.join(DATA_DIR, "celerybeat-schedule")
 
 # django setting.
 CACHES = {


### PR DESCRIPTION
## Proposed change

Since celery appends a ".db" to the beat_schedule_filename since Python 3 (https://docs.celeryq.dev/en/stable/userguide/configuration.html#beat-schedule-filename), this lead to a bug with `CELERY_BEAT_SCHEDULE_FILENAME` in `settings.py`. Since the default file name was set to `celerybeat-schedule.db`, celery created a file named `celerybeat-schedule.db.db` during startup, leading to a nun-functioning scheduler. 

I noticed this when mails no longer were automatically processed and after digging through the mail.log files, I found multiple `_dbm.error: cannot add item to database` critical errors.

This is a very simple fix, tests are not affected. Works with personal setup as e2e test.

Closes #7430

## Type of change

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
