### PR TITLE
Enhancement: mail message preprocessor for gpg encrypted mails

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -275,6 +275,8 @@ RUN set -eux \
     && mkdir --parents --verbose /usr/src/paperless/media \
     && mkdir --parents --verbose /usr/src/paperless/consume \
     && mkdir --parents --verbose /usr/src/paperless/export \
+  && echo "Creating gnupg directory" \
+    && mkdir -m700 --verbose /usr/src/paperless/.gnupg \
   && echo "Adjusting all permissions" \
     && chown --from root:root --changes --recursive paperless:paperless /usr/src/paperless \
   && echo "Collecting static files" \

--- a/docs/advanced_usage.md
+++ b/docs/advanced_usage.md
@@ -728,6 +728,9 @@ webserver:
     - <path to gpg-agent.extra socket>:/usr/src/paperless/.gnupg/S.gpg-agent
 ```
 
+For a 'bare-metal' installation no further configuration is necessary. If you
+want to use a separate `GNUPG_HOME`, you can do so by configuring the [PAPERLESS_EMAIL_GNUPG_HOME environment variable](configuration.md#PAPERLESS_EMAIL_GNUPG_HOME).
+
 ### Troubleshooting
 
 - Make sure, that `gpg-agent` is running on your host machine

--- a/docs/advanced_usage.md
+++ b/docs/advanced_usage.md
@@ -691,7 +691,7 @@ More details about configuration option for various providers can be found in th
 Once external auth is set up, 'regular' login can be disabled with the [PAPERLESS_DISABLE_REGULAR_LOGIN](configuration.md#PAPERLESS_DISABLE_REGULAR_LOGIN) setting and / or users can be automatically
 redirected with the [PAPERLESS_REDIRECT_LOGIN_TO_SSO](configuration.md#PAPERLESS_REDIRECT_LOGIN_TO_SSO) setting.
 
-## Decryption of encrypted emails before consumption
+## Decryption of encrypted emails before consumption {#gpg-decryptor}
 
 Paperless-ngx can be configured to decrypt gpg encrypted emails before consumption.
 
@@ -706,15 +706,11 @@ gpg --encrypt --armor -r person@email.com name_of_file
 gpg --decrypt name_of_file.asc
 ```
 
-### Setting up docker-compose file
+### Setup
 
-Add the following variable to your `docker-compose.env` file:
+First, enable the [PAPERLESS_GPG_DECRYPTOR environment variable](configuration.md#PAPERLESS_GPG_DECRYPTOR).
 
-```conf.
-PAPERLESS_GPG_DECRYPTOR=True
-```
-
-Determine your local `gpg-agent.extra` socket by invoking
+Then determine your local `gpg-agent.extra` socket by invoking
 
 ```
 gpgconf --list-dir agent-extra-socket
@@ -723,7 +719,7 @@ gpgconf --list-dir agent-extra-socket
 on your host. A possible output is `~/.gnupg/S.gpg-agent.extra`.
 Also find the location of your public keyring.
 
-Add the following volume mounts to your `docker-compose.yml` file:
+If using docker, you'll need to add the following volume mounts to your `docker-compose.yml` file:
 
 ```yaml
 webserver:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1149,6 +1149,12 @@ within your documents.
     second, and year last order. Characters D, M, or Y can be shuffled
     to meet the required order.
 
+#### [`PAPERLESS_GPG_DECRYPTOR=<bool>`](#PAPERLESS_GPG_DECRYPTOR) {#PAPERLESS_GPG_DECRYPTOR}
+
+: Enable or disable the GPG decryptor for encrypted files. See [GPG Decryptor](advanced_usage.md#gpg-decryptor) for more information.
+
+    Defaults to false.
+
 ### Polling {#polling}
 
 #### [`PAPERLESS_CONSUMER_POLLING=<num>`](#PAPERLESS_CONSUMER_POLLING) {#PAPERLESS_CONSUMER_POLLING}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1151,9 +1151,15 @@ within your documents.
 
 #### [`PAPERLESS_GPG_DECRYPTOR=<bool>`](#PAPERLESS_GPG_DECRYPTOR) {#PAPERLESS_GPG_DECRYPTOR}
 
-: Enable or disable the GPG decryptor for encrypted files. See [GPG Decryptor](advanced_usage.md#gpg-decryptor) for more information.
+: Enable or disable the GPG decryptor for encrypted emails. See [GPG Decryptor](advanced_usage.md#gpg-decryptor) for more information.
 
     Defaults to false.
+
+#### [`PAPERLESS_EMAIL_GNUPG_HOME=<str>`](#PAPERLESS_EMAIL_GNUPG_HOME) {#PAPERLESS_EMAIL_GNUPG_HOME}
+
+: Optional, sets the `GNUPG_HOME` path to use with GPG decryptor for encrypted emails. See [GPG Decryptor](advanced_usage.md#gpg-decryptor) for more information. If not set, defaults to the default `GNUPG_HOME` path.
+
+    Defaults to <not set>.
 
 ### Polling {#polling}
 

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -1171,6 +1171,15 @@ if DEBUG:  # pragma: no cover
     EMAIL_BACKEND = "django.core.mail.backends.filebased.EmailBackend"
     EMAIL_FILE_PATH = BASE_DIR / "sent_emails"
 
+###############################################################################
+# Email Preprocessors                                                         #
+###############################################################################
+
+EMAIL_GNUPG_HOME: Final[Optional[str]] = os.getenv("PAPERLESS_EMAIL_GNUPG_HOME")
+EMAIL_ENABLE_GPG_DECRYPTOR: Final[bool] = __get_boolean(
+    "PAPERLESS_ENABLE_GPG_DECRYPTOR",
+)
+
 
 ###############################################################################
 # Soft Delete

--- a/src/paperless_mail/mail.py
+++ b/src/paperless_mail/mail.py
@@ -440,10 +440,18 @@ class MailAccountHandler(LoggingMixin):
     def _init_preprocessors(self):
         self._message_preprocessors: list[MailMessagePreprocessor] = []
         for preprocessor_type in self._message_preprocessor_types:
-            if preprocessor_type.able_to_run():
+            self._init_preprocessor(preprocessor_type)
+
+    def _init_preprocessor(self, preprocessor_type):
+        if preprocessor_type.able_to_run():
+            try:
                 self._message_preprocessors.append(preprocessor_type())
-            else:
-                self.log.debug(f"Skipping mail preprocessor {preprocessor_type.NAME}")
+            except Exception as e:
+                self.log.warning(
+                    f"Error while initializing preprocessor {preprocessor_type.NAME}: {e}",
+                )
+        else:
+            self.log.debug(f"Skipping mail preprocessor {preprocessor_type.NAME}")
 
     def _correspondent_from_name(self, name: str) -> Optional[Correspondent]:
         try:

--- a/src/paperless_mail/preprocessor.py
+++ b/src/paperless_mail/preprocessor.py
@@ -1,0 +1,67 @@
+from email import message_from_bytes
+from email import policy
+from email.message import Message
+
+from gnupg import GPG
+from imap_tools import MailMessage
+
+from documents.loggers import LoggingMixin
+
+
+class MailMessageDecryptor(LoggingMixin):
+    logging_name = "paperless_mail_message_decryptor"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__()
+        self.renew_logging_group()
+        self._gpg = GPG(*args, **kwargs)
+
+    def __call__(self, message: MailMessage) -> MailMessage:
+        if not hasattr(message, "obj"):
+            self.log.debug("Message does not have 'obj' attribute")
+            return message
+        if message.obj.get_content_type() != "multipart/encrypted":
+            self.log.debug("Message not encrypted. Keep unchanged")
+            return message
+
+        self.log.debug("Message is encrypted.")
+        email_message = self._to_email_message(message)
+        decrypted_raw_message = self._gpg.decrypt(email_message.as_string())
+
+        if not decrypted_raw_message.ok:
+            self.log.debug(
+                f"Message decryption failed with status message "
+                f"{decrypted_raw_message.status}",
+            )
+            raise Exception(
+                f"Decryption failed: {decrypted_raw_message.status}, {decrypted_raw_message.stderr}",
+            )
+        self.log.debug("Message decrypted successfully.")
+
+        decrypted_message = self._build_decrypted_message(
+            decrypted_raw_message,
+            email_message,
+        )
+
+        return MailMessage(
+            [(f"UID {message.uid}".encode(), decrypted_message.as_bytes())],
+        )
+
+    @staticmethod
+    def _to_email_message(message: MailMessage) -> Message:
+        email_message = message_from_bytes(
+            message.obj.as_bytes(),
+            policy=policy.default,
+        )
+        return email_message
+
+    @staticmethod
+    def _build_decrypted_message(decrypted_raw_message, email_message):
+        decrypted_message = message_from_bytes(
+            decrypted_raw_message.data,
+            policy=policy.default,
+        )
+        for header, value in email_message.items():
+            if not decrypted_message.get(header):
+                decrypted_message.add_header(header, value)
+        return decrypted_message

--- a/src/paperless_mail/preprocessor.py
+++ b/src/paperless_mail/preprocessor.py
@@ -1,4 +1,5 @@
 import abc
+import os
 from email import message_from_bytes
 from email import policy
 from email.message import Message
@@ -45,7 +46,11 @@ class MailMessageDecryptor(MailMessagePreprocessor, LoggingMixin):
 
     @staticmethod
     def able_to_run() -> bool:
-        return settings.EMAIL_ENABLE_GPG_DECRYPTOR
+        if not settings.EMAIL_ENABLE_GPG_DECRYPTOR:
+            return False
+        if settings.EMAIL_GNUPG_HOME is None:
+            return True
+        return os.path.isdir(settings.EMAIL_GNUPG_HOME)
 
     def run(self, message: MailMessage) -> MailMessage:
         if not hasattr(message, "obj"):

--- a/src/paperless_mail/tests/test_mail.py
+++ b/src/paperless_mail/tests/test_mail.py
@@ -1385,6 +1385,7 @@ class TestMail(
             subject="the message title",
             from_="Myself",
             attachments=2,
+            body="Test mail",
         )
 
         encrypted_message = self.messageEncryptor.encrypt(message)
@@ -1392,18 +1393,25 @@ class TestMail(
         account = MailAccount.objects.create()
         rule = MailRule(
             assign_title_from=MailRule.TitleSource.FROM_FILENAME,
+            consumption_scope=MailRule.ConsumptionScope.EVERYTHING,
             account=account,
         )
         rule.save()
 
         result = self.mail_account_handler._handle_message(encrypted_message, rule)
 
-        self.assertEqual(result, 2)
+        self.assertEqual(result, 3)
 
         self._queue_consumption_tasks_mock.assert_called()
 
         self.assert_queue_consumption_tasks_call_args(
             [
+                [
+                    {
+                        "override_title": message.subject,
+                        "override_filename": f"{message.subject}.eml",
+                    },
+                ],
                 [
                     {"override_title": "file_0", "override_filename": "file_0.pdf"},
                     {"override_title": "file_1", "override_filename": "file_1.pdf"},

--- a/src/paperless_mail/tests/test_mail.py
+++ b/src/paperless_mail/tests/test_mail.py
@@ -1,22 +1,17 @@
 import dataclasses
 import email.contentmanager
 import random
-import tempfile
 import uuid
 from collections import namedtuple
 from contextlib import AbstractContextManager
-from email.mime.application import MIMEApplication
-from email.mime.multipart import MIMEMultipart
 from typing import Optional
 from typing import Union
 from unittest import mock
 
-import gnupg
 import pytest
 from django.core.management import call_command
 from django.db import DatabaseError
 from django.test import TestCase
-from django.test import override_settings
 from imap_tools import NOT
 from imap_tools import EmailAddress
 from imap_tools import FolderInfo
@@ -35,7 +30,6 @@ from paperless_mail.mail import TagMailAction
 from paperless_mail.mail import apply_mail_action
 from paperless_mail.models import MailAccount
 from paperless_mail.models import MailRule
-from paperless_mail.preprocessor import MailMessageDecryptor
 
 
 @dataclasses.dataclass
@@ -199,58 +193,6 @@ def fake_magic_from_buffer(buffer, mime=False):
         return "Some verbose file description"
 
 
-class MessageEncryptor:
-    def __init__(self):
-        self.gpg_home = tempfile.mkdtemp()
-        self.gpg = gnupg.GPG(gnupghome=self.gpg_home)
-        self._testUser = "testuser@example.com"
-        # Generate a new key
-        input_data = self.gpg.gen_key_input(
-            name_email=self._testUser,
-            passphrase=None,
-            key_type="RSA",
-            key_length=2048,
-            expire_date=0,
-            no_protection=True,
-        )
-        self.gpg.gen_key(input_data)
-
-    def encrypt(self, message):
-        original_email: email.message.Message = message.obj
-        encrypted_data = self.gpg.encrypt(
-            original_email.as_bytes(),
-            self._testUser,
-            armor=True,
-        )
-        if not encrypted_data.ok:
-            raise Exception(f"Encryption failed: {encrypted_data.stderr}")
-        encrypted_email_content = encrypted_data.data
-
-        new_email = MIMEMultipart("encrypted", protocol="application/pgp-encrypted")
-        new_email["From"] = original_email["From"]
-        new_email["To"] = original_email["To"]
-        new_email["Subject"] = original_email["Subject"]
-
-        # Add the control part
-        control_part = MIMEApplication(_data=b"", _subtype="pgp-encrypted")
-        control_part.set_payload("Version: 1")
-        new_email.attach(control_part)
-
-        # Add the encrypted data part
-        encrypted_part = MIMEApplication(_data=b"", _subtype="octet-stream")
-        encrypted_part.set_payload(encrypted_email_content.decode("ascii"))
-        encrypted_part.add_header(
-            "Content-Disposition",
-            'attachment; filename="encrypted.asc"',
-        )
-        new_email.attach(encrypted_part)
-
-        encrypted_message = MailMessage(
-            [(f"UID {message.uid}".encode(), new_email.as_bytes())],
-        )
-        return encrypted_message
-
-
 @mock.patch("paperless_mail.mail.magic.from_buffer", fake_magic_from_buffer)
 class TestMail(
     DirectoriesMixin,
@@ -273,12 +215,7 @@ class TestMail(
 
         self.reset_bogus_mailbox()
 
-        self.messageEncryptor = MessageEncryptor()
-        with override_settings(
-            EMAIL_GNUPG_HOME=self.messageEncryptor.gpg_home,
-            EMAIL_ENABLE_GPG_DECRYPTOR=True,
-        ):
-            self.mail_account_handler = MailAccountHandler()
+        self.mail_account_handler = MailAccountHandler()
 
         super().setUp()
 
@@ -1346,83 +1283,6 @@ class TestMail(
         self.assertEqual(self._queue_consumption_tasks_mock.call_count, 2)
         self.assertEqual(len(self.bogus_mailbox.fetch("UNSEEN", False)), 0)
         self.assertEqual(len(self.bogus_mailbox.messages), 3)
-
-    def test_decrypt_encrypted_mail(self):
-        """
-        Creates a mail with attachments. Then encrypts it with a new key.
-        Verifies that this encrypted message can be decrypted with attachments intact.
-        """
-        message = self.create_message(
-            body="Test message with 2 attachments",
-            attachments=[
-                _AttachmentDef(
-                    filename="f1.pdf",
-                    disposition="inline",
-                ),
-                _AttachmentDef(filename="f2.pdf"),
-            ],
-        )
-        headers = message.headers
-        text = message.text
-        encrypted_message = self.messageEncryptor.encrypt(message)
-
-        self.assertEqual(len(encrypted_message.attachments), 1)
-        self.assertEqual(encrypted_message.attachments[0].filename, "encrypted.asc")
-        self.assertEqual(encrypted_message.text, "")
-
-        with override_settings(
-            EMAIL_ENABLE_GPG_DECRYPTOR=True,
-            EMAIL_GNUPG_HOME=self.messageEncryptor.gpg_home,
-        ):
-            message_decryptor = MailMessageDecryptor()
-            self.assertTrue(message_decryptor.able_to_run())
-            decrypted_message = message_decryptor.run(encrypted_message)
-
-        self.assertEqual(len(decrypted_message.attachments), 2)
-        self.assertEqual(decrypted_message.attachments[0].filename, "f1.pdf")
-        self.assertEqual(decrypted_message.attachments[1].filename, "f2.pdf")
-        self.assertEqual(decrypted_message.headers, headers)
-        self.assertEqual(decrypted_message.text, text)
-        self.assertEqual(decrypted_message.uid, message.uid)
-
-    def test_handle_encrypted_message(self):
-        message = self.create_message(
-            subject="the message title",
-            from_="Myself",
-            attachments=2,
-            body="Test mail",
-        )
-
-        encrypted_message = self.messageEncryptor.encrypt(message)
-
-        account = MailAccount.objects.create()
-        rule = MailRule(
-            assign_title_from=MailRule.TitleSource.FROM_FILENAME,
-            consumption_scope=MailRule.ConsumptionScope.EVERYTHING,
-            account=account,
-        )
-        rule.save()
-
-        result = self.mail_account_handler._handle_message(encrypted_message, rule)
-
-        self.assertEqual(result, 3)
-
-        self._queue_consumption_tasks_mock.assert_called()
-
-        self.assert_queue_consumption_tasks_call_args(
-            [
-                [
-                    {
-                        "override_title": message.subject,
-                        "override_filename": f"{message.subject}.eml",
-                    },
-                ],
-                [
-                    {"override_title": "file_0", "override_filename": "file_0.pdf"},
-                    {"override_title": "file_1", "override_filename": "file_1.pdf"},
-                ],
-            ],
-        )
 
     def assert_queue_consumption_tasks_call_args(
         self,

--- a/src/paperless_mail/tests/test_preprocessor.py
+++ b/src/paperless_mail/tests/test_preprocessor.py
@@ -1,0 +1,333 @@
+import email.contentmanager
+import random
+import tempfile
+import uuid
+from collections import namedtuple
+from email.mime.application import MIMEApplication
+from email.mime.multipart import MIMEMultipart
+from typing import Optional
+from typing import Union
+from unittest import mock
+
+import gnupg
+from django.test import override_settings
+from imap_tools import EmailAddress
+from imap_tools import MailMessage
+
+from documents.models import Correspondent
+from paperless_mail.mail import MailAccountHandler
+from paperless_mail.models import MailAccount
+from paperless_mail.models import MailRule
+from paperless_mail.preprocessor import MailMessageDecryptor
+from paperless_mail.tests.test_mail import BogusMailBox
+from paperless_mail.tests.test_mail import _AttachmentDef
+
+
+class MessageEncryptor:
+    def __init__(self):
+        self.gpg_home = tempfile.mkdtemp()
+        self.gpg = gnupg.GPG(gnupghome=self.gpg_home)
+        self._testUser = "testuser@example.com"
+        # Generate a new key
+        input_data = self.gpg.gen_key_input(
+            name_email=self._testUser,
+            passphrase=None,
+            key_type="RSA",
+            key_length=2048,
+            expire_date=0,
+            no_protection=True,
+        )
+        self.gpg.gen_key(input_data)
+
+    def encrypt(self, message):
+        original_email: email.message.Message = message.obj
+        encrypted_data = self.gpg.encrypt(
+            original_email.as_bytes(),
+            self._testUser,
+            armor=True,
+        )
+        if not encrypted_data.ok:
+            raise Exception(f"Encryption failed: {encrypted_data.stderr}")
+        encrypted_email_content = encrypted_data.data
+
+        new_email = MIMEMultipart("encrypted", protocol="application/pgp-encrypted")
+        new_email["From"] = original_email["From"]
+        new_email["To"] = original_email["To"]
+        new_email["Subject"] = original_email["Subject"]
+
+        # Add the control part
+        control_part = MIMEApplication(_data=b"", _subtype="pgp-encrypted")
+        control_part.set_payload("Version: 1")
+        new_email.attach(control_part)
+
+        # Add the encrypted data part
+        encrypted_part = MIMEApplication(_data=b"", _subtype="octet-stream")
+        encrypted_part.set_payload(encrypted_email_content.decode("ascii"))
+        encrypted_part.add_header(
+            "Content-Disposition",
+            'attachment; filename="encrypted.asc"',
+        )
+        new_email.attach(encrypted_part)
+
+        encrypted_message = MailMessage(
+            [(f"UID {message.uid}".encode(), new_email.as_bytes())],
+        )
+        return encrypted_message
+
+
+class TestPreprocessor:
+    def setUp(self):
+        self.bogus_mailbox = BogusMailBox()
+
+        patcher = mock.patch("paperless_mail.mail.MailBox")
+        m = patcher.start()
+        m.return_value = self.bogus_mailbox
+        self.addCleanup(patcher.stop)
+
+        patcher = mock.patch("paperless_mail.mail.queue_consumption_tasks")
+        self._queue_consumption_tasks_mock = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        self.reset_bogus_mailbox()
+
+        self.messageEncryptor = MessageEncryptor()
+        with override_settings(
+            EMAIL_GNUPG_HOME=self.messageEncryptor.gpg_home,
+            EMAIL_ENABLE_GPG_DECRYPTOR=True,
+        ):
+            self.mail_account_handler = MailAccountHandler()
+
+        super().setUp()
+
+    def create_message(
+        self,
+        attachments: Union[int, list[_AttachmentDef]] = 1,
+        body: str = "",
+        subject: str = "the subject",
+        from_: str = "no_one@mail.com",
+        to: Optional[list[str]] = None,
+        seen: bool = False,
+        flagged: bool = False,
+        processed: bool = False,
+    ) -> MailMessage:
+        if to is None:
+            to = ["tosomeone@somewhere.com"]
+
+        email_msg = email.message.EmailMessage()
+        # TODO: This does NOT set the UID
+        email_msg["Message-ID"] = str(uuid.uuid4())
+        email_msg["Subject"] = subject
+        email_msg["From"] = from_
+        email_msg["To"] = str(" ,".join(to))
+        email_msg.set_content(body)
+
+        # Either add some default number of attachments
+        # or the provided attachments
+        if isinstance(attachments, int):
+            for i in range(attachments):
+                attachment = _AttachmentDef(filename=f"file_{i}.pdf")
+                email_msg.add_attachment(
+                    attachment.content,
+                    maintype=attachment.maintype,
+                    subtype=attachment.subtype,
+                    disposition=attachment.disposition,
+                    filename=attachment.filename,
+                )
+        else:
+            for attachment in attachments:
+                email_msg.add_attachment(
+                    attachment.content,
+                    maintype=attachment.maintype,
+                    subtype=attachment.subtype,
+                    disposition=attachment.disposition,
+                    filename=attachment.filename,
+                )
+
+        # Convert the EmailMessage to an imap_tools MailMessage
+        imap_msg = MailMessage.from_bytes(email_msg.as_bytes())
+
+        # TODO: Unsure how to add a uid to the actual EmailMessage. This hacks it in,
+        #  based on how imap_tools uses regex to extract it.
+        #  This should be a large enough pool
+        uid = random.randint(1, 10000)
+        while uid in self._used_uids:
+            uid = random.randint(1, 10000)
+        self._used_uids.add(uid)
+
+        imap_msg._raw_uid_data = f"UID {uid}".encode()
+
+        imap_msg.seen = seen
+        imap_msg.flagged = flagged
+        if processed:
+            imap_msg._raw_flag_data.append(b"+FLAGS (processed)")
+            MailMessage.flags.fget.cache_clear()
+
+        return imap_msg
+
+    def reset_bogus_mailbox(self):
+        self.bogus_mailbox.messages = []
+        self.bogus_mailbox.messages_spam = []
+        self.bogus_mailbox.messages.append(
+            self.create_message(
+                subject="Invoice 1",
+                from_="amazon@amazon.de",
+                to=["me@myselfandi.com", "helpdesk@mydomain.com"],
+                body="cables",
+                seen=True,
+                flagged=False,
+                processed=False,
+            ),
+        )
+        self.bogus_mailbox.messages.append(
+            self.create_message(
+                subject="Invoice 2",
+                body="from my favorite electronic store",
+                to=["invoices@mycompany.com"],
+                seen=False,
+                flagged=True,
+                processed=True,
+            ),
+        )
+        self.bogus_mailbox.messages.append(
+            self.create_message(
+                subject="Claim your $10M price now!",
+                from_="amazon@amazon-some-indian-site.org",
+                to="special@me.me",
+                seen=False,
+            ),
+        )
+        self.bogus_mailbox.updateClient()
+
+    def test_get_correspondent(self):
+        message = namedtuple("MailMessage", [])
+        message.from_ = "someone@somewhere.com"
+        message.from_values = EmailAddress(
+            "Someone!",
+            "someone@somewhere.com",
+        )
+
+        message2 = namedtuple("MailMessage", [])
+        message2.from_ = "me@localhost.com"
+        message2.from_values = EmailAddress(
+            "",
+            "fake@localhost.com",
+        )
+
+        me_localhost = Correspondent.objects.create(name=message2.from_)
+        someone_else = Correspondent.objects.create(name="someone else")
+
+        handler = MailAccountHandler()
+
+        rule = MailRule(
+            name="a",
+            assign_correspondent_from=MailRule.CorrespondentSource.FROM_NOTHING,
+        )
+        self.assertIsNone(handler._get_correspondent(message, rule))
+
+        rule = MailRule(
+            name="b",
+            assign_correspondent_from=MailRule.CorrespondentSource.FROM_EMAIL,
+        )
+        c = handler._get_correspondent(message, rule)
+        self.assertIsNotNone(c)
+        self.assertEqual(c.name, "someone@somewhere.com")
+        c = handler._get_correspondent(message2, rule)
+        self.assertIsNotNone(c)
+        self.assertEqual(c.name, "me@localhost.com")
+        self.assertEqual(c.id, me_localhost.id)
+
+        rule = MailRule(
+            name="c",
+            assign_correspondent_from=MailRule.CorrespondentSource.FROM_NAME,
+        )
+        c = handler._get_correspondent(message, rule)
+        self.assertIsNotNone(c)
+        self.assertEqual(c.name, "Someone!")
+        c = handler._get_correspondent(message2, rule)
+        self.assertIsNotNone(c)
+        self.assertEqual(c.id, me_localhost.id)
+
+        rule = MailRule(
+            name="d",
+            assign_correspondent_from=MailRule.CorrespondentSource.FROM_CUSTOM,
+            assign_correspondent=someone_else,
+        )
+        c = handler._get_correspondent(message, rule)
+        self.assertEqual(c, someone_else)
+
+    def test_decrypt_encrypted_mail(self):
+        """
+        Creates a mail with attachments. Then encrypts it with a new key.
+        Verifies that this encrypted message can be decrypted with attachments intact.
+        """
+        message = self.create_message(
+            body="Test message with 2 attachments",
+            attachments=[
+                _AttachmentDef(
+                    filename="f1.pdf",
+                    disposition="inline",
+                ),
+                _AttachmentDef(filename="f2.pdf"),
+            ],
+        )
+        headers = message.headers
+        text = message.text
+        encrypted_message = self.messageEncryptor.encrypt(message)
+
+        self.assertEqual(len(encrypted_message.attachments), 1)
+        self.assertEqual(encrypted_message.attachments[0].filename, "encrypted.asc")
+        self.assertEqual(encrypted_message.text, "")
+
+        with override_settings(
+            EMAIL_ENABLE_GPG_DECRYPTOR=True,
+            EMAIL_GNUPG_HOME=self.messageEncryptor.gpg_home,
+        ):
+            message_decryptor = MailMessageDecryptor()
+            self.assertTrue(message_decryptor.able_to_run())
+            decrypted_message = message_decryptor.run(encrypted_message)
+
+        self.assertEqual(len(decrypted_message.attachments), 2)
+        self.assertEqual(decrypted_message.attachments[0].filename, "f1.pdf")
+        self.assertEqual(decrypted_message.attachments[1].filename, "f2.pdf")
+        self.assertEqual(decrypted_message.headers, headers)
+        self.assertEqual(decrypted_message.text, text)
+        self.assertEqual(decrypted_message.uid, message.uid)
+
+    def test_handle_encrypted_message(self):
+        message = self.create_message(
+            subject="the message title",
+            from_="Myself",
+            attachments=2,
+            body="Test mail",
+        )
+
+        encrypted_message = self.messageEncryptor.encrypt(message)
+
+        account = MailAccount.objects.create()
+        rule = MailRule(
+            assign_title_from=MailRule.TitleSource.FROM_FILENAME,
+            consumption_scope=MailRule.ConsumptionScope.EVERYTHING,
+            account=account,
+        )
+        rule.save()
+
+        result = self.mail_account_handler._handle_message(encrypted_message, rule)
+
+        self.assertEqual(result, 3)
+
+        self._queue_consumption_tasks_mock.assert_called()
+
+        self.assert_queue_consumption_tasks_call_args(
+            [
+                [
+                    {
+                        "override_title": message.subject,
+                        "override_filename": f"{message.subject}.eml",
+                    },
+                ],
+                [
+                    {"override_title": "file_0", "override_filename": "file_0.pdf"},
+                    {"override_title": "file_1", "override_filename": "file_1.pdf"},
+                ],
+            ],
+        )

--- a/src/paperless_mail/tests/test_preprocessor.py
+++ b/src/paperless_mail/tests/test_preprocessor.py
@@ -1,26 +1,22 @@
-import email.contentmanager
-import random
 import tempfile
-import uuid
-from collections import namedtuple
 from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
-from typing import Optional
-from typing import Union
-from unittest import mock
+from typing import TYPE_CHECKING
 
 import gnupg
+from django.test import TestCase
 from django.test import override_settings
-from imap_tools import EmailAddress
 from imap_tools import MailMessage
 
-from documents.models import Correspondent
 from paperless_mail.mail import MailAccountHandler
 from paperless_mail.models import MailAccount
 from paperless_mail.models import MailRule
 from paperless_mail.preprocessor import MailMessageDecryptor
-from paperless_mail.tests.test_mail import BogusMailBox
+from paperless_mail.tests.test_mail import MailMocker
 from paperless_mail.tests.test_mail import _AttachmentDef
+
+if TYPE_CHECKING:
+    import email.contentmanager
 
 
 class MessageEncryptor:
@@ -75,20 +71,10 @@ class MessageEncryptor:
         return encrypted_message
 
 
-class TestPreprocessor:
+class TestPreprocessor(TestCase):
     def setUp(self):
-        self.bogus_mailbox = BogusMailBox()
-
-        patcher = mock.patch("paperless_mail.mail.MailBox")
-        m = patcher.start()
-        m.return_value = self.bogus_mailbox
-        self.addCleanup(patcher.stop)
-
-        patcher = mock.patch("paperless_mail.mail.queue_consumption_tasks")
-        self._queue_consumption_tasks_mock = patcher.start()
-        self.addCleanup(patcher.stop)
-
-        self.reset_bogus_mailbox()
+        self.mailMocker = MailMocker()
+        self.mailMocker.setUp()
 
         self.messageEncryptor = MessageEncryptor()
         with override_settings(
@@ -99,168 +85,12 @@ class TestPreprocessor:
 
         super().setUp()
 
-    def create_message(
-        self,
-        attachments: Union[int, list[_AttachmentDef]] = 1,
-        body: str = "",
-        subject: str = "the subject",
-        from_: str = "no_one@mail.com",
-        to: Optional[list[str]] = None,
-        seen: bool = False,
-        flagged: bool = False,
-        processed: bool = False,
-    ) -> MailMessage:
-        if to is None:
-            to = ["tosomeone@somewhere.com"]
-
-        email_msg = email.message.EmailMessage()
-        # TODO: This does NOT set the UID
-        email_msg["Message-ID"] = str(uuid.uuid4())
-        email_msg["Subject"] = subject
-        email_msg["From"] = from_
-        email_msg["To"] = str(" ,".join(to))
-        email_msg.set_content(body)
-
-        # Either add some default number of attachments
-        # or the provided attachments
-        if isinstance(attachments, int):
-            for i in range(attachments):
-                attachment = _AttachmentDef(filename=f"file_{i}.pdf")
-                email_msg.add_attachment(
-                    attachment.content,
-                    maintype=attachment.maintype,
-                    subtype=attachment.subtype,
-                    disposition=attachment.disposition,
-                    filename=attachment.filename,
-                )
-        else:
-            for attachment in attachments:
-                email_msg.add_attachment(
-                    attachment.content,
-                    maintype=attachment.maintype,
-                    subtype=attachment.subtype,
-                    disposition=attachment.disposition,
-                    filename=attachment.filename,
-                )
-
-        # Convert the EmailMessage to an imap_tools MailMessage
-        imap_msg = MailMessage.from_bytes(email_msg.as_bytes())
-
-        # TODO: Unsure how to add a uid to the actual EmailMessage. This hacks it in,
-        #  based on how imap_tools uses regex to extract it.
-        #  This should be a large enough pool
-        uid = random.randint(1, 10000)
-        while uid in self._used_uids:
-            uid = random.randint(1, 10000)
-        self._used_uids.add(uid)
-
-        imap_msg._raw_uid_data = f"UID {uid}".encode()
-
-        imap_msg.seen = seen
-        imap_msg.flagged = flagged
-        if processed:
-            imap_msg._raw_flag_data.append(b"+FLAGS (processed)")
-            MailMessage.flags.fget.cache_clear()
-
-        return imap_msg
-
-    def reset_bogus_mailbox(self):
-        self.bogus_mailbox.messages = []
-        self.bogus_mailbox.messages_spam = []
-        self.bogus_mailbox.messages.append(
-            self.create_message(
-                subject="Invoice 1",
-                from_="amazon@amazon.de",
-                to=["me@myselfandi.com", "helpdesk@mydomain.com"],
-                body="cables",
-                seen=True,
-                flagged=False,
-                processed=False,
-            ),
-        )
-        self.bogus_mailbox.messages.append(
-            self.create_message(
-                subject="Invoice 2",
-                body="from my favorite electronic store",
-                to=["invoices@mycompany.com"],
-                seen=False,
-                flagged=True,
-                processed=True,
-            ),
-        )
-        self.bogus_mailbox.messages.append(
-            self.create_message(
-                subject="Claim your $10M price now!",
-                from_="amazon@amazon-some-indian-site.org",
-                to="special@me.me",
-                seen=False,
-            ),
-        )
-        self.bogus_mailbox.updateClient()
-
-    def test_get_correspondent(self):
-        message = namedtuple("MailMessage", [])
-        message.from_ = "someone@somewhere.com"
-        message.from_values = EmailAddress(
-            "Someone!",
-            "someone@somewhere.com",
-        )
-
-        message2 = namedtuple("MailMessage", [])
-        message2.from_ = "me@localhost.com"
-        message2.from_values = EmailAddress(
-            "",
-            "fake@localhost.com",
-        )
-
-        me_localhost = Correspondent.objects.create(name=message2.from_)
-        someone_else = Correspondent.objects.create(name="someone else")
-
-        handler = MailAccountHandler()
-
-        rule = MailRule(
-            name="a",
-            assign_correspondent_from=MailRule.CorrespondentSource.FROM_NOTHING,
-        )
-        self.assertIsNone(handler._get_correspondent(message, rule))
-
-        rule = MailRule(
-            name="b",
-            assign_correspondent_from=MailRule.CorrespondentSource.FROM_EMAIL,
-        )
-        c = handler._get_correspondent(message, rule)
-        self.assertIsNotNone(c)
-        self.assertEqual(c.name, "someone@somewhere.com")
-        c = handler._get_correspondent(message2, rule)
-        self.assertIsNotNone(c)
-        self.assertEqual(c.name, "me@localhost.com")
-        self.assertEqual(c.id, me_localhost.id)
-
-        rule = MailRule(
-            name="c",
-            assign_correspondent_from=MailRule.CorrespondentSource.FROM_NAME,
-        )
-        c = handler._get_correspondent(message, rule)
-        self.assertIsNotNone(c)
-        self.assertEqual(c.name, "Someone!")
-        c = handler._get_correspondent(message2, rule)
-        self.assertIsNotNone(c)
-        self.assertEqual(c.id, me_localhost.id)
-
-        rule = MailRule(
-            name="d",
-            assign_correspondent_from=MailRule.CorrespondentSource.FROM_CUSTOM,
-            assign_correspondent=someone_else,
-        )
-        c = handler._get_correspondent(message, rule)
-        self.assertEqual(c, someone_else)
-
     def test_decrypt_encrypted_mail(self):
         """
         Creates a mail with attachments. Then encrypts it with a new key.
         Verifies that this encrypted message can be decrypted with attachments intact.
         """
-        message = self.create_message(
+        message = self.mailMocker.messageBuilder.create_message(
             body="Test message with 2 attachments",
             attachments=[
                 _AttachmentDef(
@@ -294,7 +124,7 @@ class TestPreprocessor:
         self.assertEqual(decrypted_message.uid, message.uid)
 
     def test_handle_encrypted_message(self):
-        message = self.create_message(
+        message = self.mailMocker.messageBuilder.create_message(
             subject="the message title",
             from_="Myself",
             attachments=2,
@@ -315,9 +145,9 @@ class TestPreprocessor:
 
         self.assertEqual(result, 3)
 
-        self._queue_consumption_tasks_mock.assert_called()
+        self.mailMocker._queue_consumption_tasks_mock.assert_called()
 
-        self.assert_queue_consumption_tasks_call_args(
+        self.mailMocker.assert_queue_consumption_tasks_call_args(
             [
                 [
                     {

--- a/src/paperless_mail/tests/test_preprocessor.py
+++ b/src/paperless_mail/tests/test_preprocessor.py
@@ -1,22 +1,19 @@
+import email
+import email.contentmanager
 import tempfile
+from email.message import Message
 from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
-from typing import TYPE_CHECKING
 
 import gnupg
-from django.test import TestCase
 from django.test import override_settings
 from imap_tools import MailMessage
 
-from paperless_mail.mail import MailAccountHandler
 from paperless_mail.models import MailAccount
 from paperless_mail.models import MailRule
 from paperless_mail.preprocessor import MailMessageDecryptor
-from paperless_mail.tests.test_mail import MailMocker
+from paperless_mail.tests.test_mail import TestMail
 from paperless_mail.tests.test_mail import _AttachmentDef
-
-if TYPE_CHECKING:
-    import email.contentmanager
 
 
 class MessageEncryptor:
@@ -35,10 +32,24 @@ class MessageEncryptor:
         )
         self.gpg.gen_key(input_data)
 
+    @staticmethod
+    def get_email_body_without_headers(email_message: Message) -> bytes:
+        """
+        Filters some relevant headers from an EmailMessage and returns just the body.
+        """
+        message_copy = email.message_from_bytes(email_message.as_bytes())
+
+        message_copy._headers = [
+            header
+            for header in message_copy._headers
+            if header[0].lower() not in ("from", "to", "subject")
+        ]
+        return message_copy.as_bytes()
+
     def encrypt(self, message):
         original_email: email.message.Message = message.obj
         encrypted_data = self.gpg.encrypt(
-            original_email.as_bytes(),
+            self.get_email_body_without_headers(original_email),
             self._testUser,
             armor=True,
         )
@@ -65,44 +76,66 @@ class MessageEncryptor:
         )
         new_email.attach(encrypted_part)
 
-        encrypted_message = MailMessage(
+        encrypted_message: MailMessage = MailMessage(
             [(f"UID {message.uid}".encode(), new_email.as_bytes())],
         )
         return encrypted_message
 
 
-class TestPreprocessor(TestCase):
+class TestMailMessageGpgDecryptor(TestMail):
     def setUp(self):
-        self.mailMocker = MailMocker()
-        self.mailMocker.setUp()
-
         self.messageEncryptor = MessageEncryptor()
         with override_settings(
             EMAIL_GNUPG_HOME=self.messageEncryptor.gpg_home,
             EMAIL_ENABLE_GPG_DECRYPTOR=True,
         ):
-            self.mail_account_handler = MailAccountHandler()
+            super().setUp()
 
-        super().setUp()
+    def test_preprocessor_is_able_to_run(self):
+        with override_settings(
+            EMAIL_GNUPG_HOME=self.messageEncryptor.gpg_home,
+            EMAIL_ENABLE_GPG_DECRYPTOR=True,
+        ):
+            self.assertTrue(MailMessageDecryptor.able_to_run())
+
+    def test_preprocessor_is_able_to_run2(self):
+        with override_settings(
+            EMAIL_GNUPG_HOME=None,
+            EMAIL_ENABLE_GPG_DECRYPTOR=True,
+        ):
+            self.assertTrue(MailMessageDecryptor.able_to_run())
+
+    def test_is_not_able_to_run_disabled(self):
+        with override_settings(
+            EMAIL_ENABLE_GPG_DECRYPTOR=False,
+        ):
+            self.assertFalse(MailMessageDecryptor.able_to_run())
+
+    def test_is_not_able_to_run_bogus_path(self):
+        with override_settings(
+            EMAIL_ENABLE_GPG_DECRYPTOR=True,
+            EMAIL_GNUPG_HOME="_)@# notapath &%#$",
+        ):
+            self.assertFalse(MailMessageDecryptor.able_to_run())
+
+    def test_decrypt_fails(self):
+        encrypted_message, _ = self.create_encrypted_unencrypted_message_pair()
+        empty_gpg_home = tempfile.mkdtemp()
+        with override_settings(
+            EMAIL_ENABLE_GPG_DECRYPTOR=True,
+            EMAIL_GNUPG_HOME=empty_gpg_home,
+        ):
+            message_decryptor = MailMessageDecryptor()
+            self.assertRaises(Exception, message_decryptor.run, encrypted_message)
 
     def test_decrypt_encrypted_mail(self):
         """
         Creates a mail with attachments. Then encrypts it with a new key.
         Verifies that this encrypted message can be decrypted with attachments intact.
         """
-        message = self.mailMocker.messageBuilder.create_message(
-            body="Test message with 2 attachments",
-            attachments=[
-                _AttachmentDef(
-                    filename="f1.pdf",
-                    disposition="inline",
-                ),
-                _AttachmentDef(filename="f2.pdf"),
-            ],
-        )
+        encrypted_message, message = self.create_encrypted_unencrypted_message_pair()
         headers = message.headers
         text = message.text
-        encrypted_message = self.messageEncryptor.encrypt(message)
 
         self.assertEqual(len(encrypted_message.attachments), 1)
         self.assertEqual(encrypted_message.attachments[0].filename, "encrypted.asc")
@@ -122,6 +155,20 @@ class TestPreprocessor(TestCase):
         self.assertEqual(decrypted_message.headers, headers)
         self.assertEqual(decrypted_message.text, text)
         self.assertEqual(decrypted_message.uid, message.uid)
+
+    def create_encrypted_unencrypted_message_pair(self):
+        message = self.mailMocker.messageBuilder.create_message(
+            body="Test message with 2 attachments",
+            attachments=[
+                _AttachmentDef(
+                    filename="f1.pdf",
+                    disposition="inline",
+                ),
+                _AttachmentDef(filename="f2.pdf"),
+            ],
+        )
+        encrypted_message = self.messageEncryptor.encrypt(message)
+        return encrypted_message, message
 
     def test_handle_encrypted_message(self):
         message = self.mailMocker.messageBuilder.create_message(


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change
Some mails come in encrypted, in particular certain mail providers allow to encrypt all incoming emails with a gpg key.

This change allows to decrypt encrypted messages with gpg before emails are handled and further processed as usual.

To test on a real setup, I built the docker image locally and used the following docker-compose file to pass through my keyring and my running gpg-agent such that no password input is required to decrypt the mails inside of paperless.

```yml
  webserver:
    #image: ghcr.io/paperless-ngx/paperless-ngx:latest
    image: docker.io/library/paperless:local
    restart: unless-stopped
    depends_on:
      - db
      - broker
    ports:
      - "8000:8000"
    volumes:
      - data:/usr/src/paperless/data
      - media:/usr/src/paperless/media
      - ./export:/usr/src/paperless/export
      - ./consume:/usr/src/paperless/consume
      - /home/daniel/.gnupg:/usr/src/paperless/.gnupg
      - /run/user/1000/gnupg/S.gpg-agent:/usr/src/paperless/.gnupg/S.gpg-agent
    env_file: docker-compose.env
    environment:
      PAPERLESS_REDIS: redis://broker:6379
      PAPERLESS_DBHOST: db
      GPG_AGENT_INFO: /root/.gnupg/S.gpg-agent:0:1
```

Targets #2644 and maybe useful for #7405.


<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

<!--
⚠️ Important: Pull requests that implement a new feature or enhancement *should almost always target an existing feature request* with evidence of community interest and discussion. This is in order to balance the work of implementing and maintaining new features / enhancements. If that is not currently the case, please open a feature request instead of this PR to gather feedback from both users and the project maintainers.
-->

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [x] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
