### PR TITLE
Documentation: move 'mime-support' requirement to RPi in bare-metal docs

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -269,14 +269,13 @@ are released, dependency support is confirmed, etc.
     - `libpq-dev` for PostgreSQL
     - `libmagic-dev` for mime type detection
     - `mariadb-client` for MariaDB compile time
-    - `mime-support` for mime type detection
     - `libzbar0` for barcode detection
     - `poppler-utils` for barcode detection
 
     Use this list for your preferred package management:
 
     ```
-    python3 python3-pip python3-dev imagemagick fonts-liberation gnupg libpq-dev default-libmysqlclient-dev pkg-config libmagic-dev mime-support libzbar0 poppler-utils
+    python3 python3-pip python3-dev imagemagick fonts-liberation gnupg libpq-dev default-libmysqlclient-dev pkg-config libmagic-dev libzbar0 poppler-utils
     ```
 
     These dependencies are required for OCRmyPDF, which is used for text

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -303,6 +303,7 @@ are released, dependency support is confirmed, etc.
 
     - `libatlas-base-dev`
     - `libxslt1-dev`
+    - `mime-support`
 
     You will also need these for installing some of the python dependencies:
 


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Was added in: https://github.com/paperless-ngx/paperless-ngx/commit/f5be2ac4bb2579a8e7203df39aa35f4bba804da3

I confirmed this in 24.04 (assuming we don't need in prior either):

```sh
shamoon:~$ cat /etc/os-release
PRETTY_NAME="Ubuntu 24.04.1 LTS"
NAME="Ubuntu"
VERSION_ID="24.04"
VERSION="24.04.1 LTS (Noble Numbat)"
VERSION_CODENAME=noble
ID=ubuntu
ID_LIKE=debian
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
UBUNTU_CODENAME=noble
LOGO=ubuntu-logo
```

```sh
shamoon:~$ sudo apt-get install libmagic-dev
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
0 upgraded, 1 newly installed, 0 to remove and 36 not upgraded.
Need to get 105 kB of archives.
After this operation, 373 kB of additional disk space will be used.
Get:1 http://us.archive.ubuntu.com/ubuntu noble/main amd64 libmagic-dev amd64 1:5.45-3build1 [105 kB]
Fetched 105 kB in 1s (167 kB/s)
Selecting previously unselected package libmagic-dev:amd64.
(Reading database ... 268532 files and directories currently installed.)
Preparing to unpack .../libmagic-dev_1%3a5.45-3build1_amd64.deb ...
Unpacking libmagic-dev:amd64 (1:5.45-3build1) ...
Setting up libmagic-dev:amd64 (1:5.45-3build1) ...
Processing triggers for man-db (2.12.0-4build2) ...
```

```sh
shamoon:~$ sudo apt install python3-magic
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
modules-extra-6.2.0-33-generic mailcap
Use 'sudo apt autoremove' to remove them.
The following NEW packages will be installed:
  python3-magic
0 upgraded, 1 newly installed, 0 to remove and 36 not upgraded.
Need to get 13.4 kB of archives.
After this operation, 55.3 kB of additional disk space will be used.
Get:1 http://us.archive.ubuntu.com/ubuntu noble/main amd64 python3-magic all 2:0.4.27-3 [13.4 kB]
Fetched 13.4 kB in 4s (3,225 B/s)
Selecting previously unselected package python3-magic.
(Reading database ... 268542 files and directories currently installed.)
Preparing to unpack .../python3-magic_2%3a0.4.27-3_all.deb ...
Unpacking python3-magic (2:0.4.27-3) ...
Setting up python3-magic (2:0.4.27-3) ...
```

```sh
shamoon:~$ python3
Python 3.12.3 (main, Jul 31 2024, 17:43:48) [GCC 13.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import magic
>>> print(magic.from_file('/home/docker/paperless/media/documents/originals/2024/example.pdf'))
PDF document, version 1.3
```

Closes #7684

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [x] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
