### PR TITLE
Chore: switch src/documents/bulk*.py from os.path to pathlib.Path

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -31,17 +31,61 @@ extend-select = [
   "PLE",   # https://docs.astral.sh/ruff/rules/#pylint-pl
   "RUF",   # https://docs.astral.sh/ruff/rules/#ruff-specific-rules-ruf
   "FLY",   # https://docs.astral.sh/ruff/rules/#flynt-fly
+  "PTH",   # https://docs.astral.sh/ruff/rules/#flake8-use-pathlib-pth
 ]
-# TODO PTH https://docs.astral.sh/ruff/rules/#flake8-use-pathlib-pth
 ignore = ["DJ001", "SIM105", "RUF012"]
 
 [lint.per-file-ignores]
 ".github/scripts/*.py" = ["E501", "INP001", "SIM117"]
 "docker/wait-for-redis.py" = ["INP001", "T201"]
+"src/documents/barcodes.py" = ["PTH"]  # TODO Enable & remove
+"src/documents/classifier.py" = ["PTH"]  # TODO Enable & remove
+"src/documents/consumer.py" = ["PTH"]  # TODO Enable & remove
+"src/documents/file_handling.py" = ["PTH"]  # TODO Enable & remove
+"src/documents/index.py" = ["PTH"]  # TODO Enable & remove
+"src/documents/management/commands/decrypt_documents.py" = ["PTH"]  # TODO Enable & remove
+"src/documents/management/commands/document_consumer.py" = ["PTH"]  # TODO Enable & remove
+"src/documents/management/commands/document_exporter.py" = ["PTH"]  # TODO Enable & remove
+"src/documents/management/commands/document_importer.py" = ["PTH"]  # TODO Enable & remove
+"src/documents/migrations/0012_auto_20160305_0040.py" = ["PTH"]  # TODO Enable & remove
+"src/documents/migrations/0014_document_checksum.py" = ["PTH"]  # TODO Enable & remove
+"src/documents/migrations/1003_mime_types.py" = ["PTH"]  # TODO Enable & remove
+"src/documents/migrations/1012_fix_archive_files.py" = ["PTH"]  # TODO Enable & remove
+"src/documents/migrations/1037_webp_encrypted_thumbnail_conversion.py" = ["PTH"]  # TODO Enable & remove
+"src/documents/models.py" = ["SIM115", "PTH"]  # TODO PTH Enable & remove
+"src/documents/parsers.py" = ["PTH"]  # TODO Enable & remove
+"src/documents/signals/handlers.py" = ["PTH"]  # TODO Enable & remove
+"src/documents/tasks.py" = ["PTH"]  # TODO Enable & remove
+"src/documents/tests/test_api_app_config.py" = ["PTH"]  # TODO Enable & remove
+"src/documents/tests/test_api_bulk_download.py" = ["PTH"]  # TODO Enable & remove
+"src/documents/tests/test_api_documents.py" = ["PTH"]  # TODO Enable & remove
+"src/documents/tests/test_classifier.py" = ["PTH"]  # TODO Enable & remove
+"src/documents/tests/test_consumer.py" = ["PTH"]  # TODO Enable & remove
+"src/documents/tests/test_file_handling.py" = ["PTH"]  # TODO Enable & remove
+"src/documents/tests/test_management.py" = ["PTH"]  # TODO Enable & remove
+"src/documents/tests/test_management_consumer.py" = ["PTH"]  # TODO Enable & remove
+"src/documents/tests/test_management_exporter.py" = ["PTH"]  # TODO Enable & remove
+"src/documents/tests/test_management_thumbnails.py" = ["PTH"]  # TODO Enable & remove
+"src/documents/tests/test_migration_archive_files.py" = ["PTH"]  # TODO Enable & remove
+"src/documents/tests/test_migration_document_pages_count.py" = ["PTH"]  # TODO Enable & remove
+"src/documents/tests/test_migration_mime_type.py" = ["PTH"]  # TODO Enable & remove
+"src/documents/tests/test_sanity_check.py" = ["PTH"]  # TODO Enable & remove
+"src/documents/tests/test_tasks.py" = ["PTH"]  # TODO Enable & remove
+"src/documents/tests/test_views.py" = ["PTH"]  # TODO Enable & remove
+"src/documents/views.py" = ["PTH"]  # TODO Enable & remove
+"src/paperless/checks.py" = ["PTH"]  # TODO Enable & remove
+"src/paperless/settings.py" = ["PTH"]  # TODO Enable & remove
+"src/paperless/tests/test_checks.py" = ["PTH"]  # TODO Enable & remove
+"src/paperless/urls.py" = ["PTH"]  # TODO Enable & remove
+"src/paperless/views.py" = ["PTH"]  # TODO Enable & remove
+"src/paperless_mail/mail.py" = ["PTH"]  # TODO Enable & remove
+"src/paperless_mail/preprocessor.py" = ["PTH"]  # TODO Enable & remove
+"src/paperless_tesseract/parsers.py" = ["PTH"]  # TODO Enable & remove
+"src/paperless_tesseract/tests/test_parser.py" = ["RUF001", "PTH"]  # TODO PTH Enable & remove
+"src/paperless_tika/tests/test_live_tika.py" = ["PTH"]  # TODO Enable & remove
+"src/paperless_tika/tests/test_tika_parser.py" = ["PTH"]  # TODO Enable & remove
 "*/tests/*.py" = ["E501", "SIM117"]
 "*/migrations/*.py" = ["E501", "SIM", "T201"]
-"src/paperless_tesseract/tests/test_parser.py" = ["RUF001"]
-"src/documents/models.py" = ["SIM115"]
 
 [lint.isort]
 force-single-line = true

--- a/src/documents/bulk_download.py
+++ b/src/documents/bulk_download.py
@@ -1,14 +1,21 @@
-import os
+from pathlib import Path
+from typing import TYPE_CHECKING
+from typing import NoReturn
 from zipfile import ZipFile
 
 from documents.models import Document
 
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
 
 class BulkArchiveStrategy:
-    def __init__(self, zipf: ZipFile, follow_formatting: bool = False):
-        self.zipf = zipf
+    def __init__(self, zipf: ZipFile, follow_formatting: bool = False) -> None:
+        self.zipf: ZipFile = zipf
         if follow_formatting:
-            self.make_unique_filename = self._formatted_filepath
+            self.make_unique_filename: Callable[..., Path | str] = (
+                self._formatted_filepath
+            )
         else:
             self.make_unique_filename = self._filename_only
 
@@ -17,7 +24,7 @@ class BulkArchiveStrategy:
         doc: Document,
         archive: bool = False,
         folder: str = "",
-    ):
+    ) -> str:
         """
         Constructs a unique name for the given document to be used inside the
         zip file.
@@ -26,7 +33,7 @@ class BulkArchiveStrategy:
         """
         counter = 0
         while True:
-            filename = folder + doc.get_public_filename(archive, counter)
+            filename: str = folder + doc.get_public_filename(archive, counter)
             if filename in self.zipf.namelist():
                 counter += 1
             else:
@@ -37,7 +44,7 @@ class BulkArchiveStrategy:
         doc: Document,
         archive: bool = False,
         folder: str = "",
-    ):
+    ) -> Path:
         """
         Constructs a full file path for the given document to be used inside
         the zipfile.
@@ -45,24 +52,30 @@ class BulkArchiveStrategy:
         The path is already unique, as handled when a document is consumed or updated
         """
         if archive and doc.has_archive_version:
-            in_archive_path = os.path.join(folder, doc.archive_filename)
+            if TYPE_CHECKING:
+                assert doc.archive_filename is not None
+            in_archive_path: Path = Path(folder) / doc.archive_filename
         else:
-            in_archive_path = os.path.join(folder, doc.filename)
+            if TYPE_CHECKING:
+                assert doc.filename is not None
+            in_archive_path = Path(folder) / doc.filename
 
         return in_archive_path
 
-    def add_document(self, doc: Document):
+    def add_document(self, doc: Document) -> NoReturn:
         raise NotImplementedError  # pragma: no cover
 
 
 class OriginalsOnlyStrategy(BulkArchiveStrategy):
-    def add_document(self, doc: Document):
+    def add_document(self, doc: Document) -> None:
         self.zipf.write(doc.source_path, self.make_unique_filename(doc))
 
 
 class ArchiveOnlyStrategy(BulkArchiveStrategy):
-    def add_document(self, doc: Document):
+    def add_document(self, doc: Document) -> None:
         if doc.has_archive_version:
+            if TYPE_CHECKING:
+                assert doc.archive_path is not None
             self.zipf.write(
                 doc.archive_path,
                 self.make_unique_filename(doc, archive=True),
@@ -72,8 +85,10 @@ class ArchiveOnlyStrategy(BulkArchiveStrategy):
 
 
 class OriginalAndArchiveStrategy(BulkArchiveStrategy):
-    def add_document(self, doc: Document):
+    def add_document(self, doc: Document) -> None:
         if doc.has_archive_version:
+            if TYPE_CHECKING:
+                assert doc.archive_path is not None
             self.zipf.write(
                 doc.archive_path,
                 self.make_unique_filename(doc, archive=True, folder="archive/"),


### PR DESCRIPTION
## Proposed change

Switch `src/documents/bulk*.py` from `os.path` to `pathlib.Path`.

This commit strictly preserves the return types.

Related to https://github.com/paperless-ngx/paperless-ngx/discussions/7861

## Type of change

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [x] Other. Please explain: Switch `src/documents/bulk*.py` from `os.path` to `pathlib.Path`.

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
