### PR TITLE
Fix: v2.13.0 RC1 - trigger move and rename after CustomFieldInstance saved

### DIFF
--- a/src/documents/signals/handlers.py
+++ b/src/documents/signals/handlers.py
@@ -364,9 +364,17 @@ class CannotMoveFilesException(Exception):
     pass
 
 
+@receiver(models.signals.post_save, sender=CustomFieldInstance)
 @receiver(models.signals.m2m_changed, sender=Document.tags.through)
 @receiver(models.signals.post_save, sender=Document)
-def update_filename_and_move_files(sender, instance: Document, **kwargs):
+def update_filename_and_move_files(
+    sender,
+    instance: Document | CustomFieldInstance,
+    **kwargs,
+):
+    if isinstance(instance, CustomFieldInstance):
+        instance = instance.document
+
     def validate_move(instance, old_path, new_path):
         if not os.path.isfile(old_path):
             # Can't do anything if the old file does not exist anymore.


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Went through a few iterations on this, but basically `DocumentSerializer.update` triggers the `post_save` signal before the custom fields have been updated (by `CustomFieldInstanceSerializer`).

Again, there's more than one approach here I think but this seemed cleanest to me.


https://github.com/user-attachments/assets/f026ce49-531a-4a71-9707-84e8d328a39b



Closes #7926

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
