### PR TITLE
Fix: v2.13.0 RC1 - Handling of Nones when using custom fields in filepath templating

### DIFF
--- a/src/documents/templating/filepath.py
+++ b/src/documents/templating/filepath.py
@@ -235,8 +235,10 @@ def get_custom_fields_context(
             field_instance.field.data_type,
             replacement_text="-",
         )
+        if field_instance.value is None:
+            value = None
         # String types need to be sanitized
-        if field_instance.field.data_type in {
+        elif field_instance.field.data_type in {
             CustomField.FieldDataType.MONETARY,
             CustomField.FieldDataType.STRING,
             CustomField.FieldDataType.URL,

--- a/src/documents/templating/filepath.py
+++ b/src/documents/templating/filepath.py
@@ -82,7 +82,7 @@ def get_cf_value(
     name: str,
     default: str | None = None,
 ) -> str | None:
-    if name in custom_field_data:
+    if name in custom_field_data and custom_field_data[name]["value"] is not None:
         return custom_field_data[name]["value"]
     elif default is not None:
         return default

--- a/src/documents/tests/test_file_handling.py
+++ b/src/documents/tests/test_file_handling.py
@@ -1322,7 +1322,7 @@ class TestFilenameGeneration(DirectoriesMixin, TestCase):
             extra_data={"select_options": ["ChoiceOne", "ChoiceTwo"]},
         )
 
-        CustomFieldInstance.objects.create(
+        cfi1 = CustomFieldInstance.objects.create(
             document=doc_a,
             field=cf2,
             value_select=0,
@@ -1351,7 +1351,7 @@ class TestFilenameGeneration(DirectoriesMixin, TestCase):
         with override_settings(
             FILENAME_FORMAT="""
                  {% if "Select Field" in custom_fields %}
-                   {{ title }}_{{ custom_fields | get_cf_value('Select Field') }}
+                   {{ title }}_{{ custom_fields | get_cf_value('Select Field', 'Default Value') }}
                  {% else %}
                    {{ title }}
                  {% endif %}
@@ -1360,6 +1360,15 @@ class TestFilenameGeneration(DirectoriesMixin, TestCase):
             self.assertEqual(
                 generate_filename(doc_a),
                 "Some Title_ChoiceOne.pdf",
+            )
+
+            # Check for handling Nones well
+            cfi1.value_select = None
+            cfi1.save()
+
+            self.assertEqual(
+                generate_filename(doc_a),
+                "Some Title_Default Value.pdf",
             )
 
         cf.name = "Invoice Number"


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

<!--
⚠️ Important: Pull requests that implement a new feature or enhancement *should almost always target an existing feature request* with evidence of community interest and discussion. This is in order to balance the work of implementing and maintaining new features / enhancements. If that is not currently the case, please open a feature request instead of this PR to gather feedback from both users and the project maintainers.
-->

When a field is added, but no value is yet selected, the value can be None.  So don't try to convert that to anything or sanitize it.  In parallel, using the custom filter, don't return a None, so we can hit the default if provided, then None if really nothing matches.

Closes #7925 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
