### PR TITLE
Fix: remove auth tokens from export

### DIFF
--- a/docs/administration.md
+++ b/docs/administration.md
@@ -19,6 +19,8 @@ Options available to any installation of paperless:
     export. Therefore, incremental backups with `rsync` are entirely
     possible.
 
+    The exporter does not include API tokens and they will need to be re-generated after importing.
+
 !!! caution
 
     You cannot import the export generated with one version of paperless in

--- a/src/documents/management/commands/document_exporter.py
+++ b/src/documents/management/commands/document_exporter.py
@@ -24,7 +24,6 @@ from django.utils import timezone
 from filelock import FileLock
 from guardian.models import GroupObjectPermission
 from guardian.models import UserObjectPermission
-from rest_framework.authtoken.models import Token
 
 if TYPE_CHECKING:
     from django.db.models import QuerySet
@@ -284,20 +283,6 @@ class Command(CryptMixin, BaseCommand):
                 manifest_dict[key] = json.loads(
                     serializers.serialize("json", manifest_key_to_object_query[key]),
                 )
-
-            # Add the auth tokens to the manifest, serialized manually
-            manifest_dict["auth_tokens"] = [
-                {
-                    "model": "authtoken.token",
-                    "pk": t.pk,
-                    "fields": {
-                        "key": t.key,
-                        "user": t.user_id,
-                        "created": t.created.isoformat(),
-                    },
-                }
-                for t in Token.objects.all()
-            ]
 
             self.encrypt_secret_fields(manifest_dict)
 
@@ -583,11 +568,7 @@ class Command(CryptMixin, BaseCommand):
                                 value=manifest_record["fields"][field],
                             )
 
-        elif (
-            MailAccount.objects.count() > 0
-            or SocialToken.objects.count() > 0
-            or Token.objects.count() > 0
-        ):
+        elif MailAccount.objects.count() > 0 or SocialToken.objects.count() > 0:
             self.stdout.write(
                 self.style.NOTICE(
                     "No passphrase was given, sensitive fields will be in plaintext",

--- a/src/documents/management/commands/document_exporter.py
+++ b/src/documents/management/commands/document_exporter.py
@@ -271,7 +271,6 @@ class Command(CryptMixin, BaseCommand):
             "social_accounts": SocialAccount.objects.all(),
             "social_apps": SocialApp.objects.all(),
             "social_tokens": SocialToken.objects.all(),
-            "auth_tokens": Token.objects.all(),
         }
 
         if settings.AUDIT_LOG_ENABLED:
@@ -285,6 +284,20 @@ class Command(CryptMixin, BaseCommand):
                 manifest_dict[key] = json.loads(
                     serializers.serialize("json", manifest_key_to_object_query[key]),
                 )
+
+            # Add the auth tokens to the manifest, serialized manually
+            manifest_dict["auth_tokens"] = [
+                {
+                    "model": "authtoken.token",
+                    "pk": t.pk,
+                    "fields": {
+                        "key": t.key,
+                        "user": t.user_id,
+                        "created": t.created.isoformat(),
+                    },
+                }
+                for t in Token.objects.all()
+            ]
 
             self.encrypt_secret_fields(manifest_dict)
 

--- a/src/documents/management/commands/mixins.py
+++ b/src/documents/management/commands/mixins.py
@@ -108,13 +108,6 @@ class CryptMixin:
                 "token_secret",
             ],
         },
-        {
-            "exporter_key": "auth_tokens",
-            "model_name": "authtoken.token",
-            "fields": [
-                "key",
-            ],
-        },
     ]
 
     def get_crypt_params(self) -> dict[str, dict[str, str | int]]:

--- a/src/documents/tests/test_management_exporter.py
+++ b/src/documents/tests/test_management_exporter.py
@@ -23,7 +23,6 @@ from django.utils import timezone
 from guardian.models import GroupObjectPermission
 from guardian.models import UserObjectPermission
 from guardian.shortcuts import assign_perm
-from rest_framework.authtoken.models import Token
 
 from documents.management.commands import document_exporter
 from documents.models import Correspondent
@@ -878,8 +877,6 @@ class TestCryptExportImport(
             password="mypassword",
         )
 
-        Token.objects.create(user=User.objects.first())
-
         app = SocialApp.objects.create(
             provider="test",
             name="test",
@@ -934,9 +931,6 @@ class TestCryptExportImport(
 
         self.assertIsNotNone(account)
         self.assertEqual(account.password, "mypassword")
-
-        token = Token.objects.first()
-        self.assertIsNotNone(token)
 
         social_token = SocialToken.objects.first()
         self.assertIsNotNone(social_token)

--- a/src/documents/tests/test_management_exporter.py
+++ b/src/documents/tests/test_management_exporter.py
@@ -8,6 +8,9 @@ from pathlib import Path
 from unittest import mock
 from zipfile import ZipFile
 
+from allauth.socialaccount.models import SocialAccount
+from allauth.socialaccount.models import SocialApp
+from allauth.socialaccount.models import SocialToken
 from django.contrib.auth.models import Group
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
@@ -877,6 +880,23 @@ class TestCryptExportImport(
 
         Token.objects.create(user=User.objects.first())
 
+        app = SocialApp.objects.create(
+            provider="test",
+            name="test",
+            client_id="test",
+        )
+        account = SocialAccount.objects.create(
+            user=User.objects.first(),
+            provider="test",
+            uid="test",
+        )
+        SocialToken.objects.create(
+            app=app,
+            account=account,
+            token="test",
+            token_secret="test",
+        )
+
         call_command(
             "document_exporter",
             "--no-progress-bar",
@@ -916,8 +936,10 @@ class TestCryptExportImport(
         self.assertEqual(account.password, "mypassword")
 
         token = Token.objects.first()
-
         self.assertIsNotNone(token)
+
+        social_token = SocialToken.objects.first()
+        self.assertIsNotNone(social_token)
 
     def test_import_crypt_no_passphrase(self):
         """

--- a/src/documents/tests/test_management_exporter.py
+++ b/src/documents/tests/test_management_exporter.py
@@ -20,6 +20,7 @@ from django.utils import timezone
 from guardian.models import GroupObjectPermission
 from guardian.models import UserObjectPermission
 from guardian.shortcuts import assign_perm
+from rest_framework.authtoken.models import Token
 
 from documents.management.commands import document_exporter
 from documents.models import Correspondent
@@ -874,6 +875,8 @@ class TestCryptExportImport(
             password="mypassword",
         )
 
+        Token.objects.create(user=User.objects.first())
+
         call_command(
             "document_exporter",
             "--no-progress-bar",
@@ -911,6 +914,10 @@ class TestCryptExportImport(
 
         self.assertIsNotNone(account)
         self.assertEqual(account.password, "mypassword")
+
+        token = Token.objects.first()
+
+        self.assertIsNotNone(token)
 
     def test_import_crypt_no_passphrase(self):
         """


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

~~For some reason `serialize` doesn't work as expected for auth tokens. Options here are this PR or I can change it to just use "pk" as the crypt field key because that's what it serializes to (weird). Or we can just remove auth tokens from the export.~~

~~LMK~~

~~Currently `auth_tokens` looks like `{'model': 'authtoken.token', 'pk': '4310a8ef9e6bbce7146ef995b7dec33e0be7da02', 'fields': {'user': 3, 'created': '2023-03-10T06:22:38.138Z'}}`~~

Edit: lets just remove them

Closes #8098

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
