### PR TITLE
Fix: use static object for activedisplayfields to prevent changes

### DIFF
--- a/src-ui/src/app/services/document-list-view.service.spec.ts
+++ b/src-ui/src/app/services/document-list-view.service.spec.ts
@@ -599,14 +599,17 @@ describe('DocumentListViewService', () => {
   it('should not filter out custom fields if settings not initialized', () => {
     const customFields = ['custom_field_1', 'custom_field_2']
     documentListViewService.displayFields = customFields as any
-    settingsService.displayFieldsInitialized = false
     expect(documentListViewService.displayFields).toEqual(customFields)
     jest.spyOn(settingsService, 'allDisplayFields', 'get').mockReturnValue([
       { id: DisplayField.ADDED, name: 'Added' },
       { id: DisplayField.TITLE, name: 'Title' },
       { id: 'custom_field_1', name: 'Custom Field 1' },
     ] as any)
-    settingsService.displayFieldsInitialized = true
+    settingsService.displayFieldsInit.emit(true)
+    expect(documentListViewService.displayFields).toEqual(['custom_field_1'])
+
+    // will now filter on set
+    documentListViewService.displayFields = customFields as any
     expect(documentListViewService.displayFields).toEqual(['custom_field_1'])
   })
 })

--- a/src-ui/src/app/services/settings.service.ts
+++ b/src-ui/src/app/services/settings.service.ts
@@ -274,7 +274,7 @@ export class SettingsService {
   public get allDisplayFields(): Array<{ id: DisplayField; name: string }> {
     return this._allDisplayFields
   }
-  public displayFieldsInitialized: boolean = false
+  public displayFieldsInit: EventEmitter<boolean> = new EventEmitter()
 
   constructor(
     rendererFactory: RendererFactory2,
@@ -382,10 +382,10 @@ export class SettingsService {
             }
           })
         )
-        this.displayFieldsInitialized = true
+        this.displayFieldsInit.emit(true)
       })
     } else {
-      this.displayFieldsInitialized = true
+      this.displayFieldsInit.emit(true)
     }
   }
 


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

This is essentially a bug / inefficiency I noticed while working on something else. I've made the same mistake many times before, using a dynamic object for a `get` which causes Angular change detection to run numerous time, unnecessarily.

There is no functional change here (I sincerely hope) as demonstrated by no changes to the tests.

Closes #(issue or discussion)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
