### PR TITLE
Fix: dont use filters for inverted thumbnails in Safari

### DIFF
--- a/src-ui/src/app/components/document-list/document-card-large/document-card-large.component.html
+++ b/src-ui/src/app/components/document-list/document-card-large/document-card-large.component.html
@@ -1,6 +1,6 @@
 <div class="card mb-3 shadow-sm bg-light" [class.card-selected]="selected" [class.document-card]="selectable" [class.popover-hidden]="popoverHidden" (mouseleave)="mouseLeaveCard()">
   <div class="row g-0">
-    <div class="col-md-2 doc-img-background rounded-start" [class.doc-img-background-selected]="selected" (click)="this.toggleSelected.emit($event)" (dblclick)="dblClickDocument.emit()">
+    <div class="col-md-2 doc-img-container rounded-start" (click)="this.toggleSelected.emit($event)" (dblclick)="dblClickDocument.emit()">
       <img [src]="getThumbUrl()" class="card-img doc-img border-end rounded-start" [class.inverted]="getIsThumbInverted()">
 
       <div class="border-end border-bottom bg-light document-card-check">

--- a/src-ui/src/app/components/document-list/document-card-large/document-card-large.component.scss
+++ b/src-ui/src/app/components/document-list/document-card-large/document-card-large.component.scss
@@ -2,7 +2,7 @@
   overflow-wrap: anywhere;
 }
 
-.doc-img-background {
+.doc-img-container {
   position: relative;
 }
 
@@ -47,18 +47,6 @@
 
 .document-card:hover .document-card-check {
   display: block;
-}
-
-.card-selected {
-  border-color: var(--bs-primary);
-
-  .document-card-check {
-    display: block;
-  }
-}
-
-.doc-img-background-selected {
-  background-color: var(--pngx-primary-faded);
 }
 
 .card-info {

--- a/src-ui/src/app/components/document-list/document-card-small/document-card-small.component.html
+++ b/src-ui/src/app/components/document-list/document-card-small/document-card-small.component.html
@@ -1,7 +1,7 @@
 <div class="col p-2 h-100">
   <div class="card h-100 shadow-sm document-card" [class.card-selected]="selected" [class.popover-hidden]="popoverHidden" (mouseleave)="mouseLeaveCard()">
-    <div class="border-bottom doc-img-container" [class.doc-img-background-selected]="selected" (click)="this.toggleSelected.emit($event)" (dblclick)="dblClickDocument.emit(this)">
-      <img class="card-img doc-img rounded-top" [class.inverted]="getIsThumbInverted()" [src]="getThumbUrl()">
+    <div class="border-bottom doc-img-container" (click)="this.toggleSelected.emit($event)" (dblclick)="dblClickDocument.emit(this)">
+      <img class="card-img doc-img" [class.inverted]="getIsThumbInverted()" [src]="getThumbUrl()">
 
       <div class="border-end border-bottom bg-light py-1 px-2 document-card-check">
         <div class="form-check">

--- a/src-ui/src/app/components/document-list/document-card-small/document-card-small.component.scss
+++ b/src-ui/src/app/components/document-list/document-card-small/document-card-small.component.scss
@@ -40,18 +40,6 @@
   top: 142px;
 }
 
-.card-selected {
-  border-color:var(--bs-primary);
-
-  .document-card-check {
-    display: block;
-  }
-}
-
-.doc-img-background-selected {
-  background-color: var(--pngx-primary-faded);
-}
-
 .card-info {
   line-height: 1;
 

--- a/src-ui/src/styles.scss
+++ b/src-ui/src/styles.scss
@@ -490,9 +490,23 @@ ul.pagination {
 
 .doc-img-container {
   border: none !important;
-  border-top-left-radius: .25rem;
-  border-top-right-radius: .25rem;
   overflow: hidden;
+
+  .doc-img {
+    overflow: visible;
+  }
+}
+
+.card-selected {
+  border-color:var(--bs-primary);
+
+  .document-card-check {
+    display: block;
+  }
+
+  .doc-img-container {
+    background-color: var(--pngx-primary-faded);
+  }
 }
 
 table.table {
@@ -705,6 +719,10 @@ i-bs svg {
   vertical-align: text-bottom;
 }
 
-.document-card .card-footer i-bs svg {
-  vertical-align: middle;
+.document-card {
+  overflow: hidden;
+
+  .card-footer i-bs svg {
+    vertical-align: middle;
+  }
 }

--- a/src-ui/src/theme.scss
+++ b/src-ui/src/theme.scss
@@ -183,7 +183,7 @@ $form-check-radio-checked-bg-image-dark: url("data:image/svg+xml,<svg xmlns='htt
   }
 
   .doc-img {
-    mix-blend-mode: normal !important;
+    mix-blend-mode: normal;
     border-radius: 0;
     border-color: var(--bs-border-color);
     filter: invert(10%);
@@ -199,6 +199,24 @@ $form-check-radio-checked-bg-image-dark: url("data:image/svg+xml,<svg xmlns='htt
 
   .card-selected .doc-img {
     mix-blend-mode: luminosity;
+  }
+
+  @supports (hanging-punctuation: first) and (font: -apple-system-body) and (-webkit-appearance: none) {
+    // Safari does not like the filters on the image, see https://github.com/paperless-ngx/paperless-ngx/pull/8121
+    .doc-img-container {
+      background-color: #ffffff;
+    }
+
+    .doc-img {
+      filter: none !important;
+      box-shadow: inset 0px 0px 0px 10px rgba(0,0,0,1);
+    }
+
+    .doc-img.inverted {
+      filter: none !important;
+      mix-blend-mode: difference;
+      opacity: 0.95;
+    }
   }
 
   .paperless-input-select .ng-select .ng-dropdown-panel .ng-dropdown-panel-items .ng-option:not(.ng-option-selected):hover,


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Ok this shouldn't be too controversial, but to summarize:

- Safari has some kind of rendering bug by which every doc card is re-rendered with any mouseover. This severely affects the responsiveness of the UI, worse with more cards visible. I have little hopes of how to 'solve' / 'prevent' it.
- The part that is 'costly' are the CSS filters we use to invert the thumbnail images (for people that use that) and changing them to use CSS blend-modes almost entirely relieves the issue.
- The _catch_ is that the filters do a better job of preserving colors.

So this PR changes the inversion for Safari-only to use blend-modes and no filters.

Closes #(issue or discussion)

For the curious, after:

https://github.com/user-attachments/assets/b2e1a895-e8bd-42df-b2c5-87c6ec768491

vs before (notice the lag of the checkbox):


https://github.com/user-attachments/assets/55993db0-b639-49fc-a49d-ef3d4bd4ac25



## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
