### PR TITLE
Fix: fix auto-clean PDFs, create parent dir for storing unmodified original

### DIFF
--- a/src/documents/consumer.py
+++ b/src/documents/consumer.py
@@ -411,6 +411,7 @@ class ConsumerPlugin(
                     self.unmodified_original = (
                         Path(tempdir.name) / Path("uo") / Path(self.filename)
                     )
+                    self.unmodified_original.parent.mkdir(exist_ok=True)
                     copy_file_with_basic_stats(
                         self.input_doc.original_file,
                         self.unmodified_original,


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

I guess something about using tempdir the current way isn't supported.

<img width="496" alt="Screenshot 2024-11-02 at 4 25 00 PM" src="https://github.com/user-attachments/assets/bb1f8b37-e0e8-4cf6-bcdd-a4abe4abd034">


```
[2024-11-02 16:24:53,938] [INFO] [paperless.consumer] Consuming invalid_pdf.pdf
[2024-11-02 16:24:53,941] [DEBUG] [paperless.consumer] Detected mime type: application/octet-stream
[2024-11-02 16:24:53,941] [DEBUG] [paperless.consumer] Detected possible PDF with wrong mime type, trying to clean with qpdf
[2024-11-02 16:24:53,961] [INFO] [paperless.consumer] qpdf exited 0
[2024-11-02 16:24:53,962] [DEBUG] [paperless.consumer] Detected mime type after qpdf: application/pdf
[2024-11-02 16:24:53,966] [DEBUG] [paperless.consumer] Parser: RasterisedDocumentParser
[2024-11-02 16:24:53,969] [DEBUG] [paperless.consumer] Parsing invalid_pdf.pdf...
[2024-11-02 16:24:53,980] [INFO] [paperless.parsing.tesseract] pdftotext exited 0
[2024-11-02 16:24:54,071] [DEBUG] [paperless.parsing.tesseract] Calling OCRmyPDF with args: {'input_file': PosixPath('/tmp/paperless/paperless-ngxrm_t7x5u/invalid_pdf.pdf'), 'output_file': PosixPath('/tmp/paperless/paperless-tirn12es/archive.pdf'), 'use_threads': True, 'jobs': 12, 'language': 'eng', 'output_type': 'pdfa', 'progress_bar': False, 'color_conversion_strategy': 'RGB', 'skip_text': True, 'clean': True, 'rotate_pages': True, 'rotate_pages_threshold': 12.0, 'sidecar': PosixPath('/tmp/paperless/paperless-tirn12es/sidecar.txt'), 'invalidate_digital_signatures': True}
[2024-11-02 16:24:54,205] [WARNING] [ocrmypdf._pipeline] This PDF is marked as a Tagged PDF. This often indicates that the PDF was generated from an office document and does not need OCR. PDF pages processed by OCRmyPDF may not be tagged correctly.
[2024-11-02 16:24:54,205] [INFO] [ocrmypdf._pipelines.ocr] Start processing 2 pages concurrently
[2024-11-02 16:24:54,207] [INFO] [ocrmypdf._pipeline] skipping all processing on this page
[2024-11-02 16:24:54,207] [INFO] [ocrmypdf._pipeline] skipping all processing on this page
[2024-11-02 16:24:54,233] [INFO] [ocrmypdf._pipelines.ocr] Postprocessing...
[2024-11-02 16:24:54,341] [WARNING] [ocrmypdf._metadata] Some input metadata could not be copied because it is not permitted in PDF/A. You may wish to examine the output PDF's XMP metadata.
[2024-11-02 16:24:54,363] [INFO] [ocrmypdf._pipeline] Image optimization ratio: 1.01 savings: 0.6%
[2024-11-02 16:24:54,364] [INFO] [ocrmypdf._pipeline] Total file size ratio: 2.11 savings: 52.5%
[2024-11-02 16:24:54,368] [INFO] [ocrmypdf._pipelines._common] Output file is a PDF/A-2B (as expected)
[2024-11-02 16:24:54,379] [DEBUG] [paperless.parsing.tesseract] Incomplete sidecar file: discarding.
[2024-11-02 16:24:54,415] [INFO] [paperless.parsing.tesseract] pdftotext exited 0
[2024-11-02 16:24:54,429] [DEBUG] [paperless.consumer] Generating thumbnail for invalid_pdf.pdf...
[2024-11-02 16:24:54,431] [DEBUG] [paperless.parsing] Execute: convert -density 300 -scale 500x5000> -alpha remove -strip -auto-orient -define pdf:use-cropbox=true /tmp/paperless/paperless-tirn12es/archive.pdf[0] /tmp/paperless/paperless-tirn12es/convert.webp
[2024-11-02 16:24:55,084] [INFO] [paperless.parsing] convert exited 0
[2024-11-02 16:24:56,059] [DEBUG] [paperless.consumer] Saving record to database
[2024-11-02 16:24:56,060] [DEBUG] [paperless.consumer] Creation date from parse_date: 2024-08-31 00:00:00-07:00
[2024-11-02 16:24:56,431] [INFO] [paperless.handlers] Tagging "2024-08-31 invalid_pdf" with "Third Tag"
[2024-11-02 16:24:56,468] [DEBUG] [paperless.consumer] Deleting file /tmp/paperless/paperless-ngxrm_t7x5u/invalid_pdf.pdf
[2024-11-02 16:24:56,474] [DEBUG] [paperless.parsing.tesseract] Deleting directory /tmp/paperless/paperless-tirn12es
[2024-11-02 16:24:56,475] [INFO] [paperless.consumer] Document 2024-08-31 invalid_pdf consumption finished
[2024-11-02 16:24:56,477] [INFO] [paperless.tasks] ConsumeTaskPlugin completed with: Success. New document id 236 created
```

Closes #8156 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
