### PR TITLE
Chore: cleanup urls, use actions for some views

### DIFF
--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -1546,6 +1546,12 @@ class StoragePathViewSet(ModelViewSet, PermissionsAwareDocumentCountMixin):
     filterset_class = StoragePathFilterSet
     ordering_fields = ("name", "path", "matching_algorithm", "match", "document_count")
 
+    def get_permissions(self):
+        if self.action == "test":
+            # Test action does not require object level permissions
+            self.permission_classes = (IsAuthenticated,)
+        return super().get_permissions()
+
     def destroy(self, request, *args, **kwargs):
         """
         When a storage path is deleted, see if documents
@@ -1562,17 +1568,12 @@ class StoragePathViewSet(ModelViewSet, PermissionsAwareDocumentCountMixin):
 
         return response
 
-
-class StoragePathTestView(GenericAPIView):
-    """
-    Test storage path against a document
-    """
-
-    permission_classes = [IsAuthenticated]
-    serializer_class = StoragePathTestSerializer
-
-    def post(self, request, *args, **kwargs):
-        serializer = self.get_serializer(data=request.data)
+    @action(methods=["post"], detail=False)
+    def test(self, request):
+        """
+        Test storage path against a document
+        """
+        serializer = StoragePathTestSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
         document = serializer.validated_data.get("document")

--- a/src/paperless/urls.py
+++ b/src/paperless/urls.py
@@ -11,7 +11,6 @@ from django.contrib.auth.decorators import login_required
 from django.urls import path
 from django.urls import re_path
 from django.utils.translation import gettext_lazy as _
-from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.generic import RedirectView
 from django.views.static import serve
@@ -35,7 +34,6 @@ from documents.views import SelectionDataView
 from documents.views import SharedLinkView
 from documents.views import ShareLinkViewSet
 from documents.views import StatisticsView
-from documents.views import StoragePathTestView
 from documents.views import StoragePathViewSet
 from documents.views import SystemStatusView
 from documents.views import TagViewSet
@@ -56,7 +54,6 @@ from paperless.views import ProfileView
 from paperless.views import SocialAccountProvidersView
 from paperless.views import TOTPView
 from paperless.views import UserViewSet
-from paperless_mail.views import MailAccountTestView
 from paperless_mail.views import MailAccountViewSet
 from paperless_mail.views import MailRuleViewSet
 from paperless_mail.views import OauthCallbackView
@@ -95,57 +92,82 @@ urlpatterns = [
                     ),
                 ),
                 re_path(
-                    "^search/autocomplete/",
-                    SearchAutoCompleteView.as_view(),
-                    name="autocomplete",
-                ),
-                re_path(
                     "^search/",
-                    GlobalSearchView.as_view(),
-                    name="global_search",
-                ),
-                re_path("^statistics/", StatisticsView.as_view(), name="statistics"),
-                re_path(
-                    "^documents/post_document/",
-                    PostDocumentView.as_view(),
-                    name="post_document",
-                ),
-                re_path(
-                    "^documents/bulk_edit/",
-                    BulkEditView.as_view(),
-                    name="bulk_edit",
-                ),
-                re_path(
-                    "^documents/selection_data/",
-                    SelectionDataView.as_view(),
-                    name="selection_data",
+                    include(
+                        [
+                            re_path(
+                                "^$",
+                                GlobalSearchView.as_view(),
+                                name="global_search",
+                            ),
+                            re_path(
+                                "^autocomplete/",
+                                SearchAutoCompleteView.as_view(),
+                                name="autocomplete",
+                            ),
+                        ],
+                    ),
                 ),
                 re_path(
-                    "^documents/bulk_download/",
-                    BulkDownloadView.as_view(),
-                    name="bulk_download",
+                    "^statistics/",
+                    StatisticsView.as_view(),
+                    name="statistics",
                 ),
                 re_path(
-                    "^remote_version/",
-                    RemoteVersionView.as_view(),
-                    name="remoteversion",
+                    "^documents/",
+                    include(
+                        [
+                            re_path(
+                                "^post_document/",
+                                PostDocumentView.as_view(),
+                                name="post_document",
+                            ),
+                            re_path(
+                                "^bulk_edit/",
+                                BulkEditView.as_view(),
+                                name="bulk_edit",
+                            ),
+                            re_path(
+                                "^bulk_download/",
+                                BulkDownloadView.as_view(),
+                                name="bulk_download",
+                            ),
+                            re_path(
+                                "^selection_data/",
+                                SelectionDataView.as_view(),
+                                name="selection_data",
+                            ),
+                        ],
+                    ),
                 ),
-                re_path("^ui_settings/", UiSettingsView.as_view(), name="ui_settings"),
-                re_path(
-                    "^mail_accounts/test/",
-                    MailAccountTestView.as_view(),
-                    name="mail_accounts_test",
-                ),
-                path("token/", views.obtain_auth_token),
                 re_path(
                     "^bulk_edit_objects/",
                     BulkEditObjectsView.as_view(),
                     name="bulk_edit_objects",
                 ),
                 re_path(
+                    "^remote_version/",
+                    RemoteVersionView.as_view(),
+                    name="remoteversion",
+                ),
+                re_path(
+                    "^ui_settings/",
+                    UiSettingsView.as_view(),
+                    name="ui_settings",
+                ),
+                path(
+                    "token/",
+                    views.obtain_auth_token,
+                ),
+                re_path(
                     "^profile/",
                     include(
                         [
+                            re_path(
+                                "^$",
+                                ProfileView.as_view(),
+                                name="profile_view",
+                            ),
                             path(
                                 "generate_auth_token/",
                                 GenerateAuthTokenView.as_view(),
@@ -157,11 +179,6 @@ urlpatterns = [
                             path(
                                 "social_account_providers/",
                                 SocialAccountProvidersView.as_view(),
-                            ),
-                            re_path(
-                                "^$",
-                                ProfileView.as_view(),
-                                name="profile_view",
                             ),
                             path(
                                 "totp/",
@@ -180,11 +197,6 @@ urlpatterns = [
                     "^trash/",
                     TrashView.as_view(),
                     name="trash",
-                ),
-                re_path(
-                    "^storage_paths/test/",
-                    StoragePathTestView.as_view(),
-                    name="storage_paths_test",
                 ),
                 re_path(
                     r"^oauth/callback/",
@@ -221,14 +233,6 @@ urlpatterns = [
                     ),
                 ),
             ],
-        ),
-    ),
-    re_path(
-        r"^push$",
-        csrf_exempt(
-            RedirectView.as_view(
-                url=settings.BASE_URL + "api/documents/post_document/",
-            ),
         ),
     ),
     # Frontend assets TODO: this is pretty bad, but it works.


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Github seems confused about the diff but just some cleanup, absolutely no functional changes here:

- Use `action` decorator for storage path & mail account test views, so no longer needed in urls.py
- Move some urls under a 'top-level' path to make more readable
- Change order and formatting to make more readable
- Remove outdated `push` endpoint

Will merge so as not to bother anyone.

Closes #(issue or discussion)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [x] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
