### PR TITLE
Documentation: correct socket info for gpg decryption of emails

### DIFF
--- a/docs/advanced_usage.md
+++ b/docs/advanced_usage.md
@@ -811,13 +811,13 @@ gpg --decrypt name_of_file.asc
 
 First, enable the [PAPERLESS_ENABLE_GPG_DECRYPTOR environment variable](configuration.md#PAPERLESS_ENABLE_GPG_DECRYPTOR).
 
-Then determine your local `gpg-agent.extra` socket by invoking
+Then determine your local `gpg-agent` socket by invoking
 
 ```
-gpgconf --list-dir agent-extra-socket
+gpgconf --list-dir agent-socket
 ```
 
-on your host. A possible output is `~/.gnupg/S.gpg-agent.extra`.
+on your host. A possible output is `~/.gnupg/S.gpg-agent`.
 Also find the location of your public keyring.
 
 If using docker, you'll need to add the following volume mounts to your `docker-compose.yml` file:
@@ -826,7 +826,7 @@ If using docker, you'll need to add the following volume mounts to your `docker-
 webserver:
     volumes:
         - /home/user/.gnupg/pubring.gpg:/usr/src/paperless/.gnupg/pubring.gpg
-        - <path to gpg-agent.extra socket>:/usr/src/paperless/.gnupg/S.gpg-agent
+        - <path to gpg-agent socket>:/usr/src/paperless/.gnupg/S.gpg-agent
 ```
 
 For a 'bare-metal' installation no further configuration is necessary. If you


### PR DESCRIPTION
## Proposed change

This fixes the socket used for the gpg decryption of emails. As discussed with @dbankmann (who introduced this functionality) in #8447 this only works when using the normal socket.

Closes #8447 

## Type of change

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [x] Documentation only.
- [ ] Other. Please explain:

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.

Also sorry for my mess with the previous 2 PRs, was a bit confused about the branches :)