### PR TITLE
Enhancement: custom field sorting

### DIFF
--- a/src-ui/messages.xlf
+++ b/src-ui/messages.xlf
@@ -5942,7 +5942,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/document-list/document-list.component.html</context>
-          <context context-type="linenumber">289</context>
+          <context context-type="linenumber">294</context>
         </context-group>
       </trans-unit>
       <trans-unit id="78870852467682010" datatype="html">
@@ -5957,7 +5957,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/document-list/document-list.component.html</context>
-          <context context-type="linenumber">329</context>
+          <context context-type="linenumber">334</context>
         </context-group>
       </trans-unit>
       <trans-unit id="157572966557284263" datatype="html">
@@ -5972,7 +5972,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/document-list/document-list.component.html</context>
-          <context context-type="linenumber">336</context>
+          <context context-type="linenumber">341</context>
         </context-group>
       </trans-unit>
       <trans-unit id="872092479747931526" datatype="html">
@@ -7209,7 +7209,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/document-list/document-list.component.html</context>
-          <context context-type="linenumber">305</context>
+          <context context-type="linenumber">310</context>
         </context-group>
       </trans-unit>
       <trans-unit id="106713086593101376" datatype="html">
@@ -7573,25 +7573,32 @@
           <context context-type="linenumber">261,263</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="5083658411133224968" datatype="html">
+        <source>Sort by <x id="INTERPOLATION" equiv-text="{{getDisplayCustomFieldTitle(field_id)}}"/></source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/document-list/document-list.component.html</context>
+          <context context-type="linenumber">268,269</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="2179847500064178686" datatype="html">
         <source>Edit document</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/document-list/document-list.component.html</context>
-          <context context-type="linenumber">297</context>
+          <context context-type="linenumber">302</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3420321797707163677" datatype="html">
         <source>Preview document</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/document-list/document-list.component.html</context>
-          <context context-type="linenumber">298</context>
+          <context context-type="linenumber">303</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2807800733729323332" datatype="html">
         <source>Yes</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/document-list/document-list.component.html</context>
-          <context context-type="linenumber">357</context>
+          <context context-type="linenumber">362</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pipes/yes-no.pipe.ts</context>
@@ -7602,7 +7609,7 @@
         <source>No</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/document-list/document-list.component.html</context>
-          <context context-type="linenumber">357</context>
+          <context context-type="linenumber">362</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pipes/yes-no.pipe.ts</context>

--- a/src-ui/src/app/components/document-list/document-list.component.html
+++ b/src-ui/src/app/components/document-list/document-list.component.html
@@ -262,9 +262,14 @@
                   Shared
                 </th>
               }
-              @for (field of activeDisplayCustomFields; track field) {
-                <th>
-                  {{getDisplayCustomFieldTitle(field)}}
+              @for (field_id of activeDisplayCustomFields; track field_id) {
+                <th class="cursor-pointer"
+                  pngxSortable="{{field_id}}"
+                  title="Sort by {{getDisplayCustomFieldTitle(field_id)}}" i18n-title
+                  [currentSortField]="list.sortField"
+                  [currentSortReverse]="list.sortReverse"
+                  (sort)="onSort($event)">
+                  {{getDisplayCustomFieldTitle(field_id)}}
                 </th>
               }
             </tr>

--- a/src-ui/src/app/components/manage/saved-views/saved-views.component.spec.ts
+++ b/src-ui/src/app/components/manage/saved-views/saved-views.component.spec.ts
@@ -11,6 +11,7 @@ import { SavedView } from 'src/app/data/saved-view'
 import { IfPermissionsDirective } from 'src/app/directives/if-permissions.directive'
 import { PermissionsGuard } from 'src/app/guards/permissions.guard'
 import { PermissionsService } from 'src/app/services/permissions.service'
+import { CustomFieldsService } from 'src/app/services/rest/custom-fields.service'
 import { SavedViewService } from 'src/app/services/rest/saved-view.service'
 import { ToastService } from 'src/app/services/toast.service'
 import { ConfirmButtonComponent } from '../../common/confirm-button/confirm-button.component'
@@ -58,6 +59,17 @@ describe('SavedViewsComponent', () => {
           provide: PermissionsService,
           useValue: {
             currentUserCan: () => true,
+          },
+        },
+        {
+          provide: CustomFieldsService,
+          useValue: {
+            listAll: () =>
+              of({
+                all: [],
+                count: 0,
+                results: [],
+              }),
           },
         },
         PermissionsGuard,

--- a/src-ui/src/app/services/document-list-view.service.ts
+++ b/src-ui/src/app/services/document-list-view.service.ts
@@ -307,18 +307,23 @@ export class DocumentListViewService {
             activeListViewState.currentPage = 1
             this.reload()
           } else {
+            console.log(error)
+
             this.selectionData = null
             let errorMessage
             if (
-              typeof error.error !== 'string' &&
+              typeof error.error === 'object' &&
               Object.keys(error.error).length > 0
             ) {
               // e.g. { archive_serial_number: Array<string> }
               errorMessage = Object.keys(error.error)
                 .map((fieldName) => {
+                  const fieldNameBase = fieldName.split('__')[0]
                   const fieldError: Array<string> = error.error[fieldName]
                   return `${
-                    this.sortFields.find((f) => f.field == fieldName)?.name
+                    this.sortFields.find(
+                      (f) => f.field?.split('__')[0] == fieldNameBase
+                    )?.name ?? fieldNameBase
                   }: ${fieldError[0]}`
                 })
                 .join(', ')

--- a/src-ui/src/app/services/rest/document.service.spec.ts
+++ b/src-ui/src/app/services/rest/document.service.spec.ts
@@ -4,7 +4,8 @@ import {
   provideHttpClientTesting,
 } from '@angular/common/http/testing'
 import { TestBed } from '@angular/core/testing'
-import { Subscription } from 'rxjs'
+import { of, Subscription } from 'rxjs'
+import { CustomFieldDataType } from 'src/app/data/custom-field'
 import {
   DOCUMENT_SORT_FIELDS,
   DOCUMENT_SORT_FIELDS_FULLTEXT,
@@ -14,12 +15,15 @@ import { SETTINGS_KEYS } from 'src/app/data/ui-settings'
 import { environment } from 'src/environments/environment'
 import { PermissionsService } from '../permissions.service'
 import { SettingsService } from '../settings.service'
+import { CustomFieldsService } from './custom-fields.service'
 import { DocumentService } from './document.service'
 
 let httpTestingController: HttpTestingController
 let service: DocumentService
 let subscription: Subscription
 let settingsService: SettingsService
+let permissionsService: PermissionsService
+let customFieldsService: CustomFieldsService
 
 const endpoint = 'documents'
 const documents = [
@@ -55,8 +59,29 @@ beforeEach(() => {
   })
 
   httpTestingController = TestBed.inject(HttpTestingController)
-  service = TestBed.inject(DocumentService)
   settingsService = TestBed.inject(SettingsService)
+  customFieldsService = TestBed.inject(CustomFieldsService)
+  permissionsService = TestBed.inject(PermissionsService)
+  jest.spyOn(permissionsService, 'currentUserCan').mockReturnValue(true)
+  jest.spyOn(customFieldsService, 'listAll').mockReturnValue(
+    of({
+      all: [1, 2, 3],
+      count: 3,
+      results: [
+        {
+          id: 1,
+          name: 'Custom Field 1',
+          data_type: CustomFieldDataType.String,
+        },
+        {
+          id: 2,
+          name: 'Custom Field 2',
+          data_type: CustomFieldDataType.Integer,
+        },
+      ],
+    })
+  )
+  service = TestBed.inject(DocumentService)
 })
 
 describe(`DocumentService`, () => {
@@ -289,18 +314,25 @@ describe(`DocumentService`, () => {
 it('should construct sort fields respecting permissions', () => {
   expect(
     service.sortFields.find((f) => f.field === 'correspondent__name')
-  ).toBeUndefined()
+  ).not.toBeUndefined()
   expect(
     service.sortFields.find((f) => f.field === 'document_type__name')
-  ).toBeUndefined()
+  ).not.toBeUndefined()
+  expect(
+    service.sortFields.find((f) => f.field === 'owner')
+  ).not.toBeUndefined()
 
-  const permissionsService: PermissionsService =
-    TestBed.inject(PermissionsService)
-  jest.spyOn(permissionsService, 'currentUserCan').mockReturnValue(true)
+  jest.spyOn(permissionsService, 'currentUserCan').mockReturnValue(false)
   service['setupSortFields']()
-  expect(service.sortFields).toEqual(DOCUMENT_SORT_FIELDS)
+  const fields = DOCUMENT_SORT_FIELDS.filter(
+    (f) =>
+      ['correspondent__name', 'document_type__name', 'owner'].indexOf(
+        f.field
+      ) === -1
+  )
+  expect(service.sortFields).toEqual(fields)
   expect(service.sortFieldsFullText).toEqual([
-    ...DOCUMENT_SORT_FIELDS,
+    ...fields,
     ...DOCUMENT_SORT_FIELDS_FULLTEXT,
   ])
 
@@ -309,6 +341,38 @@ it('should construct sort fields respecting permissions', () => {
   expect(
     service.sortFields.find((f) => f.field === 'num_notes')
   ).toBeUndefined()
+})
+
+it('should include custom fields in sort fields if user has permission', () => {
+  const permissionsService: PermissionsService =
+    TestBed.inject(PermissionsService)
+  jest.spyOn(permissionsService, 'currentUserCan').mockReturnValue(true)
+
+  service['customFields'] = [
+    {
+      id: 1,
+      name: 'Custom Field 1',
+      data_type: CustomFieldDataType.String,
+    },
+    {
+      id: 2,
+      name: 'Custom Field 2',
+      data_type: CustomFieldDataType.Integer,
+    },
+  ]
+
+  service['setupSortFields']()
+  expect(service.sortFields).toEqual([
+    ...DOCUMENT_SORT_FIELDS,
+    {
+      field: 'custom_field_1',
+      name: 'Custom Field 1',
+    },
+    {
+      field: 'custom_field_2',
+      name: 'Custom Field 2',
+    },
+  ])
 })
 
 afterEach(() => {

--- a/src-ui/src/app/services/rest/document.service.ts
+++ b/src-ui/src/app/services/rest/document.service.ts
@@ -3,6 +3,7 @@ import { Injectable } from '@angular/core'
 import { Observable } from 'rxjs'
 import { map, tap } from 'rxjs/operators'
 import { AuditLogEntry } from 'src/app/data/auditlog-entry'
+import { CustomField } from 'src/app/data/custom-field'
 import {
   DOCUMENT_SORT_FIELDS,
   DOCUMENT_SORT_FIELDS_FULLTEXT,
@@ -22,6 +23,7 @@ import {
 import { SettingsService } from '../settings.service'
 import { AbstractPaperlessService } from './abstract-paperless-service'
 import { CorrespondentService } from './correspondent.service'
+import { CustomFieldsService } from './custom-fields.service'
 import { DocumentTypeService } from './document-type.service'
 import { StoragePathService } from './storage-path.service'
 import { TagService } from './tag.service'
@@ -55,6 +57,8 @@ export class DocumentService extends AbstractPaperlessService<Document> {
     return this._sortFieldsFullText
   }
 
+  private customFields: CustomField[] = []
+
   constructor(
     http: HttpClient,
     private correspondentService: CorrespondentService,
@@ -62,14 +66,40 @@ export class DocumentService extends AbstractPaperlessService<Document> {
     private tagService: TagService,
     private storagePathService: StoragePathService,
     private permissionsService: PermissionsService,
-    private settingsService: SettingsService
+    private settingsService: SettingsService,
+    private customFieldService: CustomFieldsService
   ) {
     super(http, 'documents')
+    if (
+      this.permissionsService.currentUserCan(
+        PermissionAction.View,
+        PermissionType.CustomField
+      )
+    ) {
+      this.customFieldService.listAll().subscribe((fields) => {
+        this.customFields = fields.results
+        this.setupSortFields()
+      })
+    }
+
     this.setupSortFields()
   }
 
   private setupSortFields() {
     this._sortFields = [...DOCUMENT_SORT_FIELDS]
+    if (
+      this.permissionsService.currentUserCan(
+        PermissionAction.View,
+        PermissionType.CustomField
+      )
+    ) {
+      this.customFields.forEach((field) => {
+        this._sortFields.push({
+          field: `custom_field_${field.id}`,
+          name: field.name,
+        })
+      })
+    }
     let excludes = []
     if (
       !this.permissionsService.currentUserCan(

--- a/src/documents/filters.py
+++ b/src/documents/filters.py
@@ -781,7 +781,9 @@ class DocumentsOrderingFilter(OrderingFilter):
             try:
                 field = CustomField.objects.get(pk=custom_field_id)
             except CustomField.DoesNotExist:
-                raise ValueError("Custom field not found")
+                raise serializers.ValidationError(
+                    {self.prefix + str(custom_field_id): [_("Custom field not found")]},
+                )
 
             annotation = None
             match field.data_type:

--- a/src/documents/filters.py
+++ b/src/documents/filters.py
@@ -10,6 +10,7 @@ from django.db.models import Case
 from django.db.models import CharField
 from django.db.models import Count
 from django.db.models import DateTimeField
+from django.db.models import Exists
 from django.db.models import FloatField
 from django.db.models import IntegerField
 from django.db.models import OuterRef
@@ -914,13 +915,11 @@ class DocumentsOrderingFilter(OrderingFilter):
                 # We need to annotate the queryset with the custom field value
                 custom_field_value=annotation,
                 # We also need to annotate the queryset with a boolean for sorting whether the field exists
-                has_field=Case(
-                    When(
-                        custom_fields__field_id=custom_field_id,
-                        then=Value(1),
+                has_field=Exists(
+                    CustomFieldInstance.objects.filter(
+                        document_id=OuterRef("id"),
+                        field_id=custom_field_id,
                     ),
-                    default=Value(0),
-                    output_field=IntegerField(),
                 ),
             )
 

--- a/src/documents/filters.py
+++ b/src/documents/filters.py
@@ -778,8 +778,9 @@ class DocumentsOrderingFilter(OrderingFilter):
         param = request.query_params.get("ordering")
         if param and self.prefix in param:
             custom_field_id = int(param.split(self.prefix)[1])
-            field = CustomField.objects.get(pk=custom_field_id)
-            if not field:
+            try:
+                field = CustomField.objects.get(pk=custom_field_id)
+            except CustomField.DoesNotExist:
                 raise ValueError("Custom field not found")
 
             annotation = None
@@ -877,6 +878,7 @@ class DocumentsOrderingFilter(OrderingFilter):
                     )
 
             if not annotation:
+                # Only happens if a new data type is added and not handled here
                 raise ValueError("Invalid custom field data type")
 
             queryset = (

--- a/src/documents/filters.py
+++ b/src/documents/filters.py
@@ -773,9 +773,6 @@ class DocumentsOrderingFilter(OrderingFilter):
     field_name = "ordering"
     prefix = "custom_field_"
 
-    def __init__(self, *args, **kwargs):
-        super().__init__()
-
     def filter_queryset(self, request, queryset, view):
         param = request.query_params.get("ordering")
         if param and self.prefix in param:
@@ -927,7 +924,7 @@ class DocumentsOrderingFilter(OrderingFilter):
                 ),
             )
 
-            return queryset.order_by(
+            queryset = queryset.order_by(
                 "-has_field",
                 param.replace(
                     self.prefix + str(custom_field_id),

--- a/src/documents/tests/test_api_documents.py
+++ b/src/documents/tests/test_api_documents.py
@@ -2909,3 +2909,40 @@ class TestDocumentApiCustomFieldsSorting(DirectoriesMixin, APITestCase):
                     [results[0]["id"], results[1]["id"], results[2]["id"]],
                     [self.doc1.id, self.doc3.id, self.doc2.id],
                 )
+
+    def test_document_custom_fields_sorting_invalid(self):
+        """
+        GIVEN:
+            - Documents with custom fields
+        WHEN:
+            - API request for document filtering with invalid custom field sorting
+        THEN:
+            - 400 is returned
+        """
+
+        with self.assertRaises(ValueError):
+            response = self.client.get(
+                "/api/documents/?ordering=custom_field_999",
+            )
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_document_custom_fields_sorting_invalid_data_type(self):
+        """
+        GIVEN:
+            - Documents with custom fields
+        WHEN:
+            - API request for document filtering with a custom field sorting with a new (unhandled) data type
+        THEN:
+            - 400 is returned
+        """
+
+        custom_field = CustomField.objects.create(
+            name="custom field",
+            data_type="foo",
+        )
+
+        with self.assertRaises(ValueError):
+            response = self.client.get(
+                f"/api/documents/?ordering=custom_field_{custom_field.pk}",
+            )
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/src/documents/tests/test_api_documents.py
+++ b/src/documents/tests/test_api_documents.py
@@ -2920,11 +2920,10 @@ class TestDocumentApiCustomFieldsSorting(DirectoriesMixin, APITestCase):
             - 400 is returned
         """
 
-        with self.assertRaises(ValueError):
-            response = self.client.get(
-                "/api/documents/?ordering=custom_field_999",
-            )
-            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        response = self.client.get(
+            "/api/documents/?ordering=custom_field_999",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_document_custom_fields_sorting_invalid_data_type(self):
         """
@@ -2933,7 +2932,7 @@ class TestDocumentApiCustomFieldsSorting(DirectoriesMixin, APITestCase):
         WHEN:
             - API request for document filtering with a custom field sorting with a new (unhandled) data type
         THEN:
-            - 400 is returned
+            - Error is raised
         """
 
         custom_field = CustomField.objects.create(
@@ -2942,7 +2941,6 @@ class TestDocumentApiCustomFieldsSorting(DirectoriesMixin, APITestCase):
         )
 
         with self.assertRaises(ValueError):
-            response = self.client.get(
+            self.client.get(
                 f"/api/documents/?ordering=custom_field_{custom_field.pk}",
             )
-            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -96,6 +96,7 @@ from documents.data_models import DocumentSource
 from documents.filters import CorrespondentFilterSet
 from documents.filters import CustomFieldFilterSet
 from documents.filters import DocumentFilterSet
+from documents.filters import DocumentsOrderingFilter
 from documents.filters import DocumentTypeFilterSet
 from documents.filters import ObjectOwnedOrGrantedPermissionsFilter
 from documents.filters import ObjectOwnedPermissionsFilter
@@ -350,7 +351,7 @@ class DocumentViewSet(
     filter_backends = (
         DjangoFilterBackend,
         SearchFilter,
-        OrderingFilter,
+        DocumentsOrderingFilter,
         ObjectOwnedOrGrantedPermissionsFilter,
     )
     filterset_class = DocumentFilterSet
@@ -367,6 +368,7 @@ class DocumentViewSet(
         "num_notes",
         "owner",
         "page_count",
+        "custom_field_",
     )
 
     def get_queryset(self):


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

(This is last thing from me for the next release, wanted to get a bunch of these improvements to custom fields in together) 

This was actually pretty tough for me to figure out (the backend part), appreciate any thoughts about the approach. I spent a bunch of time digging into Django Queryset stuff. I think this works in the end but there may be a smarter way, or of course maybe Im missing something. I left the commit history so you can see what I tried (aka all the fumbling around I did 😅)

<img width="229" alt="Screenshot 2024-12-15 at 3 42 35 PM" src="https://github.com/user-attachments/assets/cc52db77-434d-4e8c-9d63-fe749606b141" />
<img width="2030" alt="Screenshot 2024-12-15 at 3 43 25 PM" src="https://github.com/user-attachments/assets/d8484de0-c5ae-497f-ae4f-3e780b26645a" />
<img width="2030" alt="Screenshot 2024-12-15 at 3 43 13 PM" src="https://github.com/user-attachments/assets/90662510-b276-4bf7-b387-80b0ddf3591c" />
<img width="2030" alt="Screenshot 2024-12-15 at 3 42 04 PM" src="https://github.com/user-attachments/assets/3757527a-3311-4e97-80a6-5ef454ab2025" />


Closes #5434

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [x] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
