### PR TITLE
Fix: Fix too lengthy string representation of documents during logging

### DIFF
--- a/src/documents/signals/handlers.py
+++ b/src/documents/signals/handlers.py
@@ -547,7 +547,7 @@ def set_log_entry(sender, document: Document, logging_group=None, **kwargs):
         content_type=ct,
         object_id=document.pk,
         user=user,
-        object_repr=document.__str__(),
+        object_repr=document.__str__()[:200],
     )
 
 


### PR DESCRIPTION
## Proposed change

I ran into an edge case during mail consumption lately. It failed with the following error message:

```
value too long for type character varying(200)
```

<details>
<summary>Full stack trace</summary>

```
[2024-12-22 04:30:08,182] [ERROR] [paperless.consumer] The following error occurred while storing document Rechnung6014567.pdf after parsing: value too long for type character varying(200)

Traceback (most recent call last):

  File "/usr/local/lib/python3.12/site-packages/django/db/backends/utils.py", line 105, in _execute

    return self.cursor.execute(sql, params)

           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/usr/local/lib/python3.12/site-packages/psycopg/cursor.py", line 97, in execute

    raise ex.with_traceback(None)

psycopg.errors.StringDataRightTruncation: value too long for type character varying(200)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):

  File "/usr/local/lib/python3.12/site-packages/asgiref/sync.py", line 327, in main_wrap

    raise exc_info[1]

  File "/usr/src/paperless/src/documents/consumer.py", line 555, in run

    document_consumption_finished.send(

  File "/usr/local/lib/python3.12/site-packages/django/dispatch/dispatcher.py", line 189, in send

    response = receiver(signal=self, sender=sender, **named)

               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/usr/src/paperless/src/documents/signals/handlers.py", line 527, in set_log_entry

    LogEntry.objects.create(

  File "/usr/local/lib/python3.12/site-packages/django/db/models/manager.py", line 87, in manager_method

    return getattr(self.get_queryset(), name)(*args, **kwargs)

           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/usr/local/lib/python3.12/site-packages/django/db/models/query.py", line 679, in create

    obj.save(force_insert=True, using=self.db)

  File "/usr/local/lib/python3.12/site-packages/django/db/models/base.py", line 891, in save

    self.save_base(

  File "/usr/local/lib/python3.12/site-packages/django/db/models/base.py", line 997, in save_base

    updated = self._save_table(

              ^^^^^^^^^^^^^^^^^

  File "/usr/local/lib/python3.12/site-packages/django/db/models/base.py", line 1160, in _save_table

    results = self._do_insert(

              ^^^^^^^^^^^^^^^^

  File "/usr/local/lib/python3.12/site-packages/django/db/models/base.py", line 1201, in _do_insert

    return manager._insert(

           ^^^^^^^^^^^^^^^^

  File "/usr/local/lib/python3.12/site-packages/django/db/models/manager.py", line 87, in manager_method

    return getattr(self.get_queryset(), name)(*args, **kwargs)

           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/usr/local/lib/python3.12/site-packages/django/db/models/query.py", line 1847, in _insert

    return query.get_compiler(using=using).execute_sql(returning_fields)

           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/usr/local/lib/python3.12/site-packages/django/db/models/sql/compiler.py", line 1836, in execute_sql

    cursor.execute(sql, params)

  File "/usr/local/lib/python3.12/site-packages/django/db/backends/utils.py", line 79, in execute

    return self._execute_with_wrappers(

           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/usr/local/lib/python3.12/site-packages/django/db/backends/utils.py", line 92, in _execute_with_wrappers

    return executor(sql, params, many, context)

           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/usr/local/lib/python3.12/site-packages/django/db/backends/utils.py", line 100, in _execute

    with self.db.wrap_database_errors:

         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/usr/local/lib/python3.12/site-packages/django/db/utils.py", line 91, in __exit__

    raise dj_exc_value.with_traceback(traceback) from exc_value

  File "/usr/local/lib/python3.12/site-packages/django/db/backends/utils.py", line 105, in _execute

    return self.cursor.execute(sql, params)

           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/usr/local/lib/python3.12/site-packages/psycopg/cursor.py", line 97, in execute

    raise ex.with_traceback(None)

django.db.utils.DataError: value too long for type character varying(200)

[2024-12-22 04:30:08,297] [DEBUG] [paperless.parsing.tesseract] Deleting directory /tmp/paperless/paperless-zmnyghbn

[2024-12-22 04:30:08,298] [ERROR] [paperless.tasks] ConsumeTaskPlugin failed: Rechnung6014567.pdf: The following error occurred while storing document Rechnung6014567.pdf after parsing: value too long for type character varying(200)

Traceback (most recent call last):

  File "/usr/local/lib/python3.12/site-packages/django/db/backends/utils.py", line 105, in _execute

    return self.cursor.execute(sql, params)

           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/usr/local/lib/python3.12/site-packages/psycopg/cursor.py", line 97, in execute

    raise ex.with_traceback(None)

psycopg.errors.StringDataRightTruncation: value too long for type character varying(200)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):

  File "/usr/local/lib/python3.12/site-packages/asgiref/sync.py", line 327, in main_wrap

    raise exc_info[1]

  File "/usr/src/paperless/src/documents/consumer.py", line 555, in run

    document_consumption_finished.send(

  File "/usr/local/lib/python3.12/site-packages/django/dispatch/dispatcher.py", line 189, in send

    response = receiver(signal=self, sender=sender, **named)

               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/usr/src/paperless/src/documents/signals/handlers.py", line 527, in set_log_entry

    LogEntry.objects.create(

  File "/usr/local/lib/python3.12/site-packages/django/db/models/manager.py", line 87, in manager_method

    return getattr(self.get_queryset(), name)(*args, **kwargs)

           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/usr/local/lib/python3.12/site-packages/django/db/models/query.py", line 679, in create

    obj.save(force_insert=True, using=self.db)

  File "/usr/local/lib/python3.12/site-packages/django/db/models/base.py", line 891, in save

    self.save_base(

  File "/usr/local/lib/python3.12/site-packages/django/db/models/base.py", line 997, in save_base

    updated = self._save_table(

              ^^^^^^^^^^^^^^^^^

  File "/usr/local/lib/python3.12/site-packages/django/db/models/base.py", line 1160, in _save_table

    results = self._do_insert(

              ^^^^^^^^^^^^^^^^

  File "/usr/local/lib/python3.12/site-packages/django/db/models/base.py", line 1201, in _do_insert

    return manager._insert(

           ^^^^^^^^^^^^^^^^

  File "/usr/local/lib/python3.12/site-packages/django/db/models/manager.py", line 87, in manager_method

    return getattr(self.get_queryset(), name)(*args, **kwargs)

           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/usr/local/lib/python3.12/site-packages/django/db/models/query.py", line 1847, in _insert

    return query.get_compiler(using=using).execute_sql(returning_fields)

           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/usr/local/lib/python3.12/site-packages/django/db/models/sql/compiler.py", line 1836, in execute_sql

    cursor.execute(sql, params)

  File "/usr/local/lib/python3.12/site-packages/django/db/backends/utils.py", line 79, in execute

    return self._execute_with_wrappers(

           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/usr/local/lib/python3.12/site-packages/django/db/backends/utils.py", line 92, in _execute_with_wrappers

    return executor(sql, params, many, context)

           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/usr/local/lib/python3.12/site-packages/django/db/backends/utils.py", line 100, in _execute

    with self.db.wrap_database_errors:

         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/usr/local/lib/python3.12/site-packages/django/db/utils.py", line 91, in __exit__

    raise dj_exc_value.with_traceback(traceback) from exc_value

  File "/usr/local/lib/python3.12/site-packages/django/db/backends/utils.py", line 105, in _execute

    return self.cursor.execute(sql, params)

           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/usr/local/lib/python3.12/site-packages/psycopg/cursor.py", line 97, in execute

    raise ex.with_traceback(None)

django.db.utils.DataError: value too long for type character varying(200)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):

  File "/usr/src/paperless/src/documents/tasks.py", line 148, in consume_file

    msg = plugin.run()

          ^^^^^^^^^^^^

  File "/usr/src/paperless/src/documents/consumer.py", line 622, in run

    self._fail(

  File "/usr/src/paperless/src/documents/consumer.py", line 151, in _fail

    raise ConsumerError(f"{self.filename}: {log_message or message}") from exception

documents.consumer.ConsumerError: Rechnung6014567.pdf: The following error occurred while storing document Rechnung6014567.pdf after parsing: value too long for type character varying(200)
```

</details>

After some research, I found that the issue occurs during an insert statement into the `django_admin_log` data table:

```
2024-12-30 13:09:05.539 CET [580] LOG:  statement: INSERT INTO "django_admin_log" ("action_time", "user_id", "content_type_id", "object_id", "object_repr", "action_flag", "change_message") VALUES ('2024-12-30 12:09:05.538474+00:00'::timestamptz, 1, 6, '1854', '2024-07-19 Gemeinschaftspraxis für Kinder- und Jugendmedizin Dr. Vomstein / Dr. Oesterle Rechnung für Artikel Dell Monitor 24 Zoll (60,96cm) U2421E "2206274" (Gebraucht)( Artikelnummer: 395533830185 )...', 1, '') RETURNING "django_admin_log"."id"
2024-12-30 13:09:05.539 CET [580] ERROR:  value too long for type character varying(200)
2024-12-30 13:09:05.539 CET [580] STATEMENT:  INSERT INTO "django_admin_log" ("action_time", "user_id", "content_type_id", "object_id", "object_repr", "action_flag", "change_message") VALUES ('2024-12-30 12:09:05.538474+00:00'::timestamptz, 1, 6, '1854', '2024-07-19 Gemeinschaftspraxis für Kinder- und Jugendmedizin Dr. Vomstein / Dr. Oesterle Rechnung für Artikel Dell Monitor 24 Zoll (60,96cm) U2421E "2206274" (Gebraucht)( Artikelnummer: 395533830185 )...', 1, '') RETURNING "django_admin_log"."id"
2024-12-30 13:09:05.539 CET [580] LOG:  statement: ROLLBACK
```

The [corresponding code](https://github.com/django/django/blob/8d9901c961bf9d5cfa6bddddbbcebfbf487a5125/django/contrib/admin/models.py#L125) revealed a max length of 200 characters for the object_repr field, which is exceeded in my case.

This pull request limits the string representation of the document to the first 200 characters during logging.

## Type of change

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.