### PR TITLE
Documentation:  Error in storage paths example in advanced_usage.md

### DIFF
--- a/docs/advanced_usage.md
+++ b/docs/advanced_usage.md
@@ -476,7 +476,7 @@ a document with an ASN of 355 would be placed in `somepath/asn-201-400/asn-3xx/T
 /{{ title }}
 ```
 
-For a PDF document, it would result in `pdfs/Title.pdf`, but for a PNG document, the path would be `pngs/Title.pdf`.
+For a PDF document, it would result in `pdfs/Title.pdf`, but for a PNG document, the path would be `pngs/Title.png`.
 
 To use custom fields:
 


### PR DESCRIPTION
Fix file extension in storage path example for sorting by mime type. A file with extension .pdf can't be sorted into the PNGs directory

<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

The [`File name handling`](https://github.com/paperless-ngx/paperless-ngx/blob/dev/docs/advanced_usage.md#file-name-handling-file-name-handling) section states "Paperless adds the correct file extension e.g. .pdf, .jpg automatically."
Thus, in the [sort by mime type example below](https://github.com/paperless-ngx/paperless-ngx/blob/dev/docs/advanced_usage.md#examples), a PDF cannot be put into the directory for mime type "image/png". So fix the file name in the example to end in ".png".


## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [x] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
