### PR TITLE
Change: restrict altering and creation of superusers to superusers only

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -252,7 +252,7 @@ permissions can be granted to limit access to certain parts of the UI (and corre
 
 #### Superusers
 
-Superusers can access all parts of the front and backend application as well as any and all objects.
+Superusers can access all parts of the front and backend application as well as any and all objects. Superuser status can only be granted by another superuser.
 
 #### Admin Status
 

--- a/src-ui/src/app/components/common/edit-dialog/user-edit-dialog/user-edit-dialog.component.spec.ts
+++ b/src-ui/src/app/components/common/edit-dialog/user-edit-dialog/user-edit-dialog.component.spec.ts
@@ -160,4 +160,23 @@ describe('UserEditDialogComponent', () => {
     })
     expect(component.currentUserIsSuperUser).toBeTruthy()
   })
+
+  it('should disable superuser option if current user is not superuser', () => {
+    const control: AbstractControl = component.objectForm.get('is_superuser')
+    permissionsService.initialize([], {
+      id: 99,
+      username: 'user99',
+      is_superuser: false,
+    })
+    component.ngOnInit()
+    expect(control.disabled).toBeTruthy()
+
+    permissionsService.initialize([], {
+      id: 99,
+      username: 'user99',
+      is_superuser: true,
+    })
+    component.ngOnInit()
+    expect(control.disabled).toBeFalsy()
+  })
 })

--- a/src-ui/src/app/components/common/edit-dialog/user-edit-dialog/user-edit-dialog.component.ts
+++ b/src-ui/src/app/components/common/edit-dialog/user-edit-dialog/user-edit-dialog.component.ts
@@ -60,6 +60,11 @@ export class UserEditDialogComponent
   ngOnInit(): void {
     super.ngOnInit()
     this.onToggleSuperUser()
+    if (!this.currentUserIsSuperUser) {
+      this.objectForm.get('is_superuser').disable()
+    } else {
+      this.objectForm.get('is_superuser').enable()
+    }
   }
 
   getCreateTitle() {

--- a/src/paperless/admin.py
+++ b/src/paperless/admin.py
@@ -5,6 +5,11 @@ from django.contrib.auth.models import User
 
 
 class PaperlessUserForm(forms.ModelForm):
+    """
+    Custom form for the User model that adds validation to prevent non-superusers
+    from changing the superuser status of a user.
+    """
+
     class Meta:
         model = User
         fields = [

--- a/src/paperless/admin.py
+++ b/src/paperless/admin.py
@@ -1,0 +1,48 @@
+from django import forms
+from django.contrib import admin
+from django.contrib.auth.admin import UserAdmin
+from django.contrib.auth.models import User
+
+
+class PaperlessUserForm(forms.ModelForm):
+    class Meta:
+        model = User
+        fields = [
+            "username",
+            "first_name",
+            "last_name",
+            "email",
+            "is_staff",
+            "is_active",
+            "is_superuser",
+            "groups",
+            "user_permissions",
+        ]
+
+    def clean(self):
+        cleaned_data = super().clean()
+        user_being_edited = self.instance
+        is_superuser = cleaned_data.get("is_superuser")
+
+        if (
+            not self.request.user.is_superuser
+            and is_superuser != user_being_edited.is_superuser
+        ):
+            raise forms.ValidationError(
+                "Superuser status can only be changed by a superuser",
+            )
+
+        return cleaned_data
+
+
+class PaperlessUserAdmin(UserAdmin):
+    form = PaperlessUserForm
+
+    def get_form(self, request, obj=None, **kwargs):
+        form = super().get_form(request, obj, **kwargs)
+        form.request = request
+        return form
+
+
+admin.site.unregister(User)
+admin.site.register(User, PaperlessUserAdmin)

--- a/src/paperless/views.py
+++ b/src/paperless/views.py
@@ -109,6 +109,25 @@ class UserViewSet(ModelViewSet):
     filterset_class = UserFilterSet
     ordering_fields = ("username",)
 
+    def create(self, request, *args, **kwargs):
+        if not request.user.is_superuser and request.data.get("is_superuser") is True:
+            return HttpResponseForbidden(
+                "Superuser status can only be granted by a superuser",
+            )
+        return super().create(request, *args, **kwargs)
+
+    def update(self, request, *args, **kwargs):
+        user_to_update: User = self.get_object()
+        if (
+            not request.user.is_superuser
+            and request.data.get("is_superuser") is not None
+            and request.data.get("is_superuser") != user_to_update.is_superuser
+        ):
+            return HttpResponseForbidden(
+                "Superuser status can only be changed by a superuser",
+            )
+        return super().update(request, *args, **kwargs)
+
     @action(detail=True, methods=["post"])
     def deactivate_totp(self, request, pk=None):
         request_user = request.user


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

I think this is a reasonable change without having more granular permissions for now. I do find it slightly surprising that Django doesn't even have this restriction out of the box.

Closes #(issue or discussion)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [x] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
