### PR TITLE
Change: Revert dropdown sorting by doc count

### DIFF
--- a/src-ui/messages.xlf
+++ b/src-ui/messages.xlf
@@ -4974,7 +4974,7 @@
         <source>Not assigned</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/common/filterable-dropdown/filterable-dropdown.component.ts</context>
-          <context context-type="linenumber">390</context>
+          <context context-type="linenumber">380</context>
         </context-group>
         <note priority="1" from="description">Filter drop down element to filter for documents with no correspondent/type/tag assigned</note>
       </trans-unit>
@@ -4982,7 +4982,7 @@
         <source>Open <x id="PH" equiv-text="this.title"/> filter</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/common/filterable-dropdown/filterable-dropdown.component.ts</context>
-          <context context-type="linenumber">511</context>
+          <context context-type="linenumber">501</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7005745151564974365" datatype="html">

--- a/src-ui/src/app/components/common/filterable-dropdown/filterable-dropdown.component.spec.ts
+++ b/src-ui/src/app/components/common/filterable-dropdown/filterable-dropdown.component.spec.ts
@@ -490,37 +490,6 @@ describe('FilterableDropdownComponent & FilterableDropdownSelectionModel', () =>
     ])
   })
 
-  it('selection model should sort items by state and document counts, if set', () => {
-    component.items = items.concat([{ id: 4, name: 'Item D' }])
-    component.selectionModel = selectionModel
-    component.documentCounts = [
-      { id: 1, document_count: 0 }, // Tag1
-      { id: 2, document_count: 1 }, // Tag2
-      { id: 4, document_count: 2 },
-    ]
-    component.selectionModel.apply()
-    expect(selectionModel.items).toEqual([
-      nullItem,
-      { id: 4, name: 'Item D' },
-      items[1], // Tag2
-      items[0], // Tag1
-    ])
-
-    selectionModel.toggle(items[1].id)
-    component.documentCounts = [
-      { id: 1, document_count: 0 },
-      { id: 2, document_count: 1 },
-      { id: 4, document_count: 0 },
-    ]
-    selectionModel.apply()
-    expect(selectionModel.items).toEqual([
-      nullItem,
-      items[1], // Tag2
-      { id: 4, name: 'Item D' },
-      items[0], // Tag1
-    ])
-  })
-
   it('should set support create, keep open model and call createRef method', fakeAsync(() => {
     component.items = items
     component.icon = 'tag-fill'

--- a/src-ui/src/app/components/common/filterable-dropdown/filterable-dropdown.component.ts
+++ b/src-ui/src/app/components/common/filterable-dropdown/filterable-dropdown.component.ts
@@ -81,16 +81,6 @@ export class FilterableDropdownSelectionModel {
         this.getNonTemporary(b.id) == ToggleableItemState.NotSelected
       ) {
         return -1
-      } else if (
-        this._documentCounts.length &&
-        this.getDocumentCount(a.id) > this.getDocumentCount(b.id)
-      ) {
-        return -1
-      } else if (
-        this._documentCounts.length &&
-        this.getDocumentCount(a.id) < this.getDocumentCount(b.id)
-      ) {
-        return 1
       } else {
         return a.name.localeCompare(b.name)
       }


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

I'll take a cue from GitHub's UI designers here (and not the incredibly obnoxious comments), this change seems to be more of a net negative than positive. Will retain the opacity thing which seems useful and less disruptive. 

Partially reverts #8386

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
