### PR TITLE
Fix: use newest version as default API version

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -573,3 +573,8 @@ Initial API version.
 #### Version 6
 
 -   Moved acknowledge tasks endpoint to be under `/api/tasks/acknowledge/`.
+
+#### Version 7
+
+-   The format of select type custom fields has changed to return the options
+    as an array of objects with `id` and `label` fields.

--- a/docs/api.md
+++ b/docs/api.md
@@ -577,4 +577,7 @@ Initial API version.
 #### Version 7
 
 -   The format of select type custom fields has changed to return the options
-    as an array of objects with `id` and `label` fields.
+    as an array of objects with `id` and `label` fields. When creating or
+    updating a custom field value of a document for a select type custom field,
+    the value should be the `id` of the option whereas previously was the index
+    of the option.

--- a/docs/api.md
+++ b/docs/api.md
@@ -577,7 +577,7 @@ Initial API version.
 #### Version 7
 
 -   The format of select type custom fields has changed to return the options
-    as an array of objects with `id` and `label` fields. When creating or
-    updating a custom field value of a document for a select type custom field,
-    the value should be the `id` of the option whereas previously was the index
-    of the option.
+    as an array of objects with `id` and `label` fields as opposed to a simple
+    list of strings. When creating or updating a custom field value of a
+    document for a select type custom field, the value should be the `id` of
+    the option whereas previously was the index of the option.

--- a/src-ui/src/environments/environment.prod.ts
+++ b/src-ui/src/environments/environment.prod.ts
@@ -3,7 +3,7 @@ const base_url = new URL(document.baseURI)
 export const environment = {
   production: true,
   apiBaseUrl: document.baseURI + 'api/',
-  apiVersion: '6',
+  apiVersion: '7',
   appTitle: 'Paperless-ngx',
   version: '2.14.5',
   webSocketHost: window.location.host,

--- a/src-ui/src/environments/environment.ts
+++ b/src-ui/src/environments/environment.ts
@@ -5,7 +5,7 @@
 export const environment = {
   production: false,
   apiBaseUrl: 'http://localhost:8000/api/',
-  apiVersion: '6',
+  apiVersion: '7',
   appTitle: 'Paperless-ngx',
   version: 'DEVELOPMENT',
   webSocketHost: 'localhost:8000',

--- a/src/documents/serialisers.py
+++ b/src/documents/serialisers.py
@@ -511,8 +511,11 @@ class ReadWriteSerializerMethodField(serializers.SerializerMethodField):
 
 class CustomFieldSerializer(serializers.ModelSerializer):
     def __init__(self, *args, **kwargs):
+        context = kwargs.get("context")
         self.api_version = int(
-            kwargs.pop("api_version", settings.REST_FRAMEWORK["ALLOWED_VERSIONS"][-1]),
+            context.get("request").version
+            if context.get("request")
+            else settings.REST_FRAMEWORK["ALLOWED_VERSIONS"][-1],
         )
         super().__init__(*args, **kwargs)
 

--- a/src/documents/serialisers.py
+++ b/src/documents/serialisers.py
@@ -515,7 +515,7 @@ class CustomFieldSerializer(serializers.ModelSerializer):
         self.api_version = int(
             context.get("request").version
             if context.get("request")
-            else settings.REST_FRAMEWORK["ALLOWED_VERSIONS"][-1],
+            else settings.REST_FRAMEWORK["DEFAULT_VERSION"],
         )
         super().__init__(*args, **kwargs)
 
@@ -628,8 +628,7 @@ class CustomFieldSerializer(serializers.ModelSerializer):
             extra_data["select_options"] = [
                 option["label"] for option in extra_data["select_options"]
             ]
-        field = serializers.JSONField()
-        return field.to_representation(extra_data)
+        return serializers.JSONField().to_representation(extra_data)
 
 
 class CustomFieldInstanceSerializer(serializers.ModelSerializer):
@@ -649,7 +648,7 @@ class CustomFieldInstanceSerializer(serializers.ModelSerializer):
         api_version = int(
             self.context.get("request").version
             if self.context.get("request")
-            else settings.REST_FRAMEWORK["ALLOWED_VERSIONS"][-1],
+            else settings.REST_FRAMEWORK["DEFAULT_VERSION"],
         )
 
         if custom_field.data_type == CustomField.FieldDataType.DOCUMENTLINK:
@@ -679,7 +678,7 @@ class CustomFieldInstanceSerializer(serializers.ModelSerializer):
         api_version = int(
             self.context.get("request").version
             if self.context.get("request")
-            else settings.REST_FRAMEWORK["ALLOWED_VERSIONS"][-1],
+            else settings.REST_FRAMEWORK["DEFAULT_VERSION"],
         )
         if api_version < 7 and obj.field.data_type == CustomField.FieldDataType.SELECT:
             # return the index of the option in the field.extra_data["select_options"] list
@@ -988,12 +987,6 @@ class DocumentSerializer(
             or context.get("request").method == "PUT"
         ):
             kwargs["full_perms"] = True
-
-        self.api_version = int(
-            context.get("request").version
-            if context.get("request")
-            else settings.REST_FRAMEWORK["ALLOWED_VERSIONS"][-1],
-        )
 
         super().__init__(*args, **kwargs)
 

--- a/src/documents/tests/test_api_custom_fields.py
+++ b/src/documents/tests/test_api_custom_fields.py
@@ -280,11 +280,12 @@ class TestCustomFieldsAPI(DirectoriesMixin, APITestCase):
     def test_custom_field_select_old_version(self):
         """
         GIVEN:
-            - Select custom field exists with old version of select options
+            - Nothing
         WHEN:
             - API post request is made for custom fields with api version header < 7
             - API get request is made for custom fields with api version header < 7
         THEN:
+            - The select options are created with unique ids
             - The select options are returned in the old format
         """
         resp = self.client.post(

--- a/src/documents/tests/test_api_custom_fields.py
+++ b/src/documents/tests/test_api_custom_fields.py
@@ -151,7 +151,6 @@ class TestCustomFieldsAPI(DirectoriesMixin, APITestCase):
     def test_custom_field_select_unique_ids(self):
         """
         GIVEN:
-            - Nothing
             - Existing custom field
         WHEN:
             - API request to create custom field with select options without id
@@ -172,6 +171,7 @@ class TestCustomFieldsAPI(DirectoriesMixin, APITestCase):
                     },
                 },
             ),
+            headers={"Accept": "application/json; version=7"},
             content_type="application/json",
         )
         self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
@@ -197,6 +197,7 @@ class TestCustomFieldsAPI(DirectoriesMixin, APITestCase):
                     },
                 },
             ),
+            headers={"Accept": "application/json; version=7"},
             content_type="application/json",
         )
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
@@ -560,6 +561,7 @@ class TestCustomFieldsAPI(DirectoriesMixin, APITestCase):
                     },
                 ],
             },
+            headers={"Accept": "application/json; version=7"},
             format="json",
         )
 

--- a/src/documents/tests/test_api_custom_fields.py
+++ b/src/documents/tests/test_api_custom_fields.py
@@ -171,7 +171,6 @@ class TestCustomFieldsAPI(DirectoriesMixin, APITestCase):
                     },
                 },
             ),
-            headers={"Accept": "application/json; version=7"},
             content_type="application/json",
         )
         self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
@@ -197,7 +196,6 @@ class TestCustomFieldsAPI(DirectoriesMixin, APITestCase):
                     },
                 },
             ),
-            headers={"Accept": "application/json; version=7"},
             content_type="application/json",
         )
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
@@ -249,7 +247,6 @@ class TestCustomFieldsAPI(DirectoriesMixin, APITestCase):
 
         resp = self.client.patch(
             f"{self.ENDPOINT}{custom_field_select.id}/",
-            headers={"Accept": "application/json; version=7"},
             data=json.dumps(
                 {
                     "extra_data": {
@@ -562,7 +559,6 @@ class TestCustomFieldsAPI(DirectoriesMixin, APITestCase):
                     },
                 ],
             },
-            headers={"Accept": "application/json; version=7"},
             format="json",
         )
 
@@ -981,7 +977,6 @@ class TestCustomFieldsAPI(DirectoriesMixin, APITestCase):
 
         resp = self.client.patch(
             f"/api/documents/{doc.id}/",
-            headers={"Accept": "application/json; version=7"},
             data={
                 "custom_fields": [
                     {"field": custom_field_select.id, "value": "not an option"},

--- a/src/documents/tests/test_api_custom_fields.py
+++ b/src/documents/tests/test_api_custom_fields.py
@@ -249,7 +249,8 @@ class TestCustomFieldsAPI(DirectoriesMixin, APITestCase):
 
         resp = self.client.patch(
             f"{self.ENDPOINT}{custom_field_select.id}/",
-            json.dumps(
+            headers={"Accept": "application/json; version=7"},
+            data=json.dumps(
                 {
                     "extra_data": {
                         "select_options": [

--- a/src/documents/tests/test_api_documents.py
+++ b/src/documents/tests/test_api_documents.py
@@ -2029,31 +2029,37 @@ class TestDocumentApi(DirectoriesMixin, DocumentConsumeDelayMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(Tag.objects.get(id=response.data["id"]).color, "#a6cee3")
         self.assertEqual(
-            self.client.get(f"/api/tags/{response.data['id']}/", format="json").data[
-                "colour"
-            ],
+            self.client.get(
+                f"/api/tags/{response.data['id']}/",
+                headers={"Accept": "application/json; version=1"},
+                format="json",
+            ).data["colour"],
             1,
         )
 
     def test_tag_color(self):
         response = self.client.post(
             "/api/tags/",
-            {"name": "tag", "colour": 3},
+            data={"name": "tag", "colour": 3},
+            headers={"Accept": "application/json; version=1"},
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(Tag.objects.get(id=response.data["id"]).color, "#b2df8a")
         self.assertEqual(
-            self.client.get(f"/api/tags/{response.data['id']}/", format="json").data[
-                "colour"
-            ],
+            self.client.get(
+                f"/api/tags/{response.data['id']}/",
+                headers={"Accept": "application/json; version=1"},
+                format="json",
+            ).data["colour"],
             3,
         )
 
     def test_tag_color_invalid(self):
         response = self.client.post(
             "/api/tags/",
-            {"name": "tag", "colour": 34},
+            data={"name": "tag", "colour": 34},
+            headers={"Accept": "application/json; version=1"},
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -2061,7 +2067,11 @@ class TestDocumentApi(DirectoriesMixin, DocumentConsumeDelayMixin, APITestCase):
     def test_tag_color_custom(self):
         tag = Tag.objects.create(name="test", color="#abcdef")
         self.assertEqual(
-            self.client.get(f"/api/tags/{tag.id}/", format="json").data["colour"],
+            self.client.get(
+                f"/api/tags/{tag.id}/",
+                headers={"Accept": "application/json; version=1"},
+                format="json",
+            ).data["colour"],
             1,
         )
 

--- a/src/documents/tests/test_api_filter_by_custom_fields.py
+++ b/src/documents/tests/test_api_filter_by_custom_fields.py
@@ -1,7 +1,7 @@
 import json
+import types
 from collections.abc import Callable
 from datetime import date
-from unittest.mock import Mock
 from urllib.parse import quote
 
 from django.contrib.auth.models import User
@@ -149,7 +149,12 @@ class TestCustomFieldsSearch(DirectoriesMixin, APITestCase):
             document,
             data=data,
             partial=True,
-            context={"request": Mock()},
+            context={
+                "request": types.SimpleNamespace(
+                    method="GET",
+                    version="7",
+                ),
+            },
         )
         serializer.is_valid(raise_exception=True)
         serializer.save()

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -2065,6 +2065,10 @@ class CustomFieldViewSet(ModelViewSet):
             )
         )
 
+    def get_serializer(self, *args, **kwargs):
+        kwargs.setdefault("api_version", self.request.version)
+        return super().get_serializer(*args, **kwargs)
+
 
 class SystemStatusView(PassUserMixin):
     permission_classes = (IsAuthenticated,)

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -2065,10 +2065,6 @@ class CustomFieldViewSet(ModelViewSet):
             )
         )
 
-    def get_serializer(self, *args, **kwargs):
-        kwargs.setdefault("context", self.get_serializer_context())
-        return super().get_serializer(*args, **kwargs)
-
 
 class SystemStatusView(PassUserMixin):
     permission_classes = (IsAuthenticated,)

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -2066,7 +2066,7 @@ class CustomFieldViewSet(ModelViewSet):
         )
 
     def get_serializer(self, *args, **kwargs):
-        kwargs.setdefault("api_version", self.request.version)
+        kwargs.setdefault("context", self.get_serializer_context())
         return super().get_serializer(*args, **kwargs)
 
 

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -341,10 +341,10 @@ REST_FRAMEWORK = {
         "rest_framework.authentication.SessionAuthentication",
     ],
     "DEFAULT_VERSIONING_CLASS": "rest_framework.versioning.AcceptHeaderVersioning",
-    "DEFAULT_VERSION": "1",
+    "DEFAULT_VERSION": "7",
     # Make sure these are ordered and that the most recent version appears
     # last
-    "ALLOWED_VERSIONS": ["1", "2", "3", "4", "5", "6"],
+    "ALLOWED_VERSIONS": ["1", "2", "3", "4", "5", "6", "7"],
 }
 
 if DEBUG:

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -341,7 +341,7 @@ REST_FRAMEWORK = {
         "rest_framework.authentication.SessionAuthentication",
     ],
     "DEFAULT_VERSIONING_CLASS": "rest_framework.versioning.AcceptHeaderVersioning",
-    "DEFAULT_VERSION": "1",
+    "DEFAULT_VERSION": "7",
     # Make sure these are ordered and that the most recent version appears
     # last
     "ALLOWED_VERSIONS": ["1", "2", "3", "4", "5", "6", "7"],

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -341,7 +341,7 @@ REST_FRAMEWORK = {
         "rest_framework.authentication.SessionAuthentication",
     ],
     "DEFAULT_VERSIONING_CLASS": "rest_framework.versioning.AcceptHeaderVersioning",
-    "DEFAULT_VERSION": "7",
+    "DEFAULT_VERSION": "1",
     # Make sure these are ordered and that the most recent version appears
     # last
     "ALLOWED_VERSIONS": ["1", "2", "3", "4", "5", "6", "7"],


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

As mentioned in #8912 I think this makes sense. Only thing I could think of would be extremely old clients that are designed to work with OG paperless or aren't sending the version at all.

I'll re-based this pending #8912

Closes #(issue or discussion)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
