### PR TITLE
Enhancement: Return to original destination after editing documents (#8879)

### DIFF
--- a/src-ui/src/app/components/admin/tasks/tasks.component.ts
+++ b/src-ui/src/app/components/admin/tasks/tasks.component.ts
@@ -169,7 +169,9 @@ export class TasksComponent
 
   dismissAndGo(task: PaperlessTask) {
     this.dismissTask(task)
-    this.router.navigate(['documents', task.related_document])
+    this.router.navigate(['documents', task.related_document, 'details'], {
+      state: { previousUrl: this.router.url },
+    })
   }
 
   expandTask(task: PaperlessTask) {

--- a/src-ui/src/app/components/document-detail/document-detail.component.ts
+++ b/src-ui/src/app/components/document-detail/document-detail.component.ts
@@ -254,6 +254,7 @@ export class DocumentDetailComponent
 
   DocumentDetailNavIDs = DocumentDetailNavIDs
   activeNavID: number
+  previousUrl: string
 
   constructor(
     private documentsService: DocumentService,
@@ -275,6 +276,9 @@ export class DocumentDetailComponent
     private hotKeyService: HotKeyService
   ) {
     super()
+
+    let previousUrl = router.getCurrentNavigation()?.extras?.state?.previousUrl
+    this.previousUrl = previousUrl ? previousUrl : '/'
   }
 
   titleKeyUp(event) {
@@ -889,7 +893,7 @@ export class DocumentDetailComponent
             this.documentListViewService.activeSavedViewId,
           ])
         } else {
-          this.router.navigate(['documents'])
+          this.router.navigateByUrl(this.previousUrl)
         }
       })
   }

--- a/src-ui/src/app/components/document-list/document-card-small/document-card-small.component.html
+++ b/src-ui/src/app/components/document-list/document-card-small/document-card-small.component.html
@@ -140,7 +140,7 @@
       <div class="d-flex justify-content-between align-items-center">
         <div class="btn-group w-100">
           @if (document) {
-            <a routerLink="/documents/{{document.id}}" class="btn btn-sm btn-outline-secondary" title="Open" i18n-title *pngxIfPermissions="{ action: PermissionAction.Change, type: PermissionType.Document }" i18n-title>
+            <a (click)="openDocumentDetail(document.id)"  class="btn btn-sm btn-outline-secondary" title="Open" i18n-title *pngxIfPermissions="{ action: PermissionAction.Change, type: PermissionType.Document }" i18n-title>
               <i-bs name="file-earmark-richtext"></i-bs>
             </a>
             <pngx-preview-popup [document]="document" #popupPreview>

--- a/src-ui/src/app/components/document-list/document-card-small/document-card-small.component.ts
+++ b/src-ui/src/app/components/document-list/document-card-small/document-card-small.component.ts
@@ -7,7 +7,7 @@ import {
   Output,
   ViewChild,
 } from '@angular/core'
-import { RouterModule } from '@angular/router'
+import { Router, RouterModule } from '@angular/router'
 import {
   NgbProgressbarModule,
   NgbTooltipModule,
@@ -67,7 +67,8 @@ export class DocumentCardSmallComponent
 
   constructor(
     private documentService: DocumentService,
-    public settingsService: SettingsService
+    public settingsService: SettingsService,
+    private router: Router
   ) {
     super()
   }
@@ -121,6 +122,12 @@ export class DocumentCardSmallComponent
 
   getDownloadUrl() {
     return this.documentService.getDownloadUrl(this.document.id)
+  }
+
+  openDocumentDetail(documentId) {
+    this.router.navigate(['/documents', documentId, 'details'], {
+      state: { previousUrl: this.router.url },
+    })
   }
 
   get tagIDs() {


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

This PR adds a feature that will redirect the user to the previous view after editing / viewing a document. Currently you will either be redirected to a view or to `documents`

Therefore I looked into different options.

One option to use the `location.back` function from the Angular provided `Location` instance. The problem with this approach is that the way the ui is implemented switching to tabs e.g. (Details, Content etc.) would result in a change in the location history rendering the `back` function useless.

Therefore the approach I chose is to pass the location info to the detail view by using navigation extras. 

One downside of this approach is, that you have to pass this information explicitly every time you want to navigate to the document detail view andI did not expect this to happen at so many places. Should I pass these extras in every component or would you rather want me to centralize this within a service? 

Two more considerations:

* I saw many places where there is a navigate to `documents/<DOCID>/` which always ends in a redirect to `documents/<DOCID>/details` . Is there a special reason for that? Because I did change the navigation to directly navigate to the detail view.
* Within the if statement `activeSavedViewId` is evaluated. If true, it will always redirect to the view. Is this intentional? 

This is my first contribution. Please tell me if I should add / change anything.

<!--
⚠️ Important: Pull requests that implement a new feature or enhancement *should almost always target an existing feature request* with evidence of community interest and discussion. This is in order to balance the work of implementing and maintaining new features / enhancements. If that is not currently the case, please open a feature request instead of this PR to gather feedback from both users and the project maintainers.
-->

Closes #8879

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [X] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [X] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [X] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [X] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [X] I have checked my modifications for any breaking changes.
