### PR TITLE
Feature: Allow custom redirect_uri for OIDC

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -581,6 +581,12 @@ system. See the corresponding
 
     Defaults to 'https'
 
+#### [`PAPERLESS_OIDC_REDIRECT_URI=<string>`](#PAPERLESS_OIDC_REDIRECT_URI) {#PAPERLESS_OIDC_REDIRECT_URI}
+
+: The redirect URI which will be passed to the OAuth callback.
+
+    : Defaults to ''.
+
 #### [`PAPERLESS_ACCOUNT_EMAIL_VERIFICATION=<string>`](#PAPERLESS_ACCOUNT_EMAIL_VERIFICATION) {#PAPERLESS_ACCOUNT_EMAIL_VERIFICATION}
 
 : Determines whether email addresses are verified during signup (as performed by Django allauth). See the relevant

--- a/src/paperless/adapter.py
+++ b/src/paperless/adapter.py
@@ -77,8 +77,7 @@ class CustomSocialAccountAdapter(DefaultSocialAccountAdapter):
         Returns the default URL to redirect to after successfully
         connecting a social account.
         """
-        url = reverse("base")
-        return url
+        return getattr(settings, 'OIDC_REDIRECT_URI', '') or reverse("base")
 
     def populate_user(self, request, sociallogin, data):
         """

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -457,6 +457,8 @@ ACCOUNT_DEFAULT_HTTP_PROTOCOL = os.getenv(
     "https",
 )
 
+OIDC_REDIRECT_URI: Final[str] = os.getenv("PAPERLESS_OIDC_REDIRECT_URI", "")
+
 ACCOUNT_ADAPTER = "paperless.adapter.CustomAccountAdapter"
 ACCOUNT_ALLOW_SIGNUPS = __get_boolean("PAPERLESS_ACCOUNT_ALLOW_SIGNUPS")
 


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change
Allow user to specify env var: `PAPERLESS_OIDC_REDIRECT_URI` to override current host mapping when it won't be correct.

<!--
⚠️ Important: Pull requests that implement a new feature or enhancement *should almost always target an existing feature request* with evidence of community interest and discussion. This is in order to balance the work of implementing and maintaining new features / enhancements. If that is not currently the case, please open a feature request instead of this PR to gather feedback from both users and the project maintainers.
-->

Closes #8942

## Type of change
- [ ] Bug fix: non-breaking change which fixes an issue.
- [x] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:
- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
