### PR TITLE
Fix: also ensure symmetric doc link removal on bulk edit

### DIFF
--- a/src/documents/bulk_edit.py
+++ b/src/documents/bulk_edit.py
@@ -183,21 +183,20 @@ def modify_custom_fields(
                 reflect_doclinks(doc, custom_field, value)
 
     # For doc link fields that are being removed, remove symmetrical links
-    for doclink_field in CustomField.objects.filter(
-        id__in=remove_custom_fields,
-        data_type=CustomField.FieldDataType.DOCUMENTLINK,
-    ).distinct():
-        for target_doc_instance in CustomFieldInstance.objects.filter(
-            document_id__in=affected_docs,
-            field=doclink_field,
-            value_document_ids__isnull=False,
-        ):
-            for target_doc_id in target_doc_instance.value:
-                remove_doclink(
-                    document=Document.objects.get(id=target_doc_instance.document.id),
-                    field=doclink_field,
-                    target_doc_id=target_doc_id,
-                )
+    for doclink_being_removed_instance in CustomFieldInstance.objects.filter(
+        document_id__in=affected_docs,
+        field__id__in=remove_custom_fields,
+        field__data_type=CustomField.FieldDataType.DOCUMENTLINK,
+        value_document_ids__isnull=False,
+    ):
+        for target_doc_id in doclink_being_removed_instance.value:
+            remove_doclink(
+                document=Document.objects.get(
+                    id=doclink_being_removed_instance.document.id,
+                ),
+                field=doclink_being_removed_instance.field,
+                target_doc_id=target_doc_id,
+            )
 
     # Finally, remove the custom fields
     CustomFieldInstance.objects.filter(

--- a/src/documents/bulk_edit.py
+++ b/src/documents/bulk_edit.py
@@ -181,22 +181,25 @@ def modify_custom_fields(
             if custom_field.data_type == CustomField.FieldDataType.DOCUMENTLINK:
                 doc = Document.objects.get(id=doc_id)
                 reflect_doclinks(doc, custom_field, value)
-    remove_fields = CustomField.objects.filter(id__in=remove_custom_fields).distinct()
-    for remove_field in remove_fields:
-        if remove_field.data_type == CustomField.FieldDataType.DOCUMENTLINK:
-            # Remove symmetrical links from target documents
-            for doc_id in affected_docs:
-                target_doc_instance = CustomFieldInstance.objects.filter(
-                    document_id=doc_id,
-                    field=remove_field,
-                ).first()
-                if target_doc_instance and target_doc_instance.value:
-                    for target_doc_id in target_doc_instance.value:
-                        remove_doclink(
-                            document=Document.objects.get(id=doc_id),
-                            field=remove_field,
-                            target_doc_id=target_doc_id,
-                        )
+
+    # For doc link fields that are being removed, remove symmetrical links
+    for doclink_field in CustomField.objects.filter(
+        id__in=remove_custom_fields,
+        data_type=CustomField.FieldDataType.DOCUMENTLINK,
+    ).distinct():
+        for target_doc_instance in CustomFieldInstance.objects.filter(
+            document_id__in=affected_docs,
+            field=doclink_field,
+            value_document_ids__isnull=False,
+        ):
+            for target_doc_id in target_doc_instance.value:
+                remove_doclink(
+                    document=Document.objects.get(id=target_doc_instance.document.id),
+                    field=doclink_field,
+                    target_doc_id=target_doc_id,
+                )
+
+    # Finally, remove the custom fields
     CustomFieldInstance.objects.filter(
         document_id__in=affected_docs,
         field_id__in=remove_custom_fields,

--- a/src/documents/tests/test_bulk_edit.py
+++ b/src/documents/tests/test_bulk_edit.py
@@ -282,14 +282,9 @@ class TestBulkEdit(DirectoriesMixin, TestCase):
             document=self.doc2,
             field=cf3,
         )
-        doc3: Document = Document.objects.create(
-            title="doc3",
-            content="content",
-            checksum="D3",
-        )
         bulk_edit.modify_custom_fields(
             [self.doc1.id, self.doc2.id],
-            add_custom_fields={cf2.id: None, cf3.id: [doc3.id]},
+            add_custom_fields={cf2.id: None, cf3.id: [self.doc3.id]},
             remove_custom_fields=[cf.id],
         )
 
@@ -306,7 +301,7 @@ class TestBulkEdit(DirectoriesMixin, TestCase):
         )
         self.assertEqual(
             self.doc1.custom_fields.get(field=cf3).value,
-            [doc3.id],
+            [self.doc3.id],
         )
         self.assertEqual(
             self.doc2.custom_fields.count(),
@@ -314,18 +309,34 @@ class TestBulkEdit(DirectoriesMixin, TestCase):
         )
         self.assertEqual(
             self.doc2.custom_fields.get(field=cf3).value,
-            [doc3.id],
+            [self.doc3.id],
         )
         # assert reflect document link
-        doc3.refresh_from_db()
+        self.doc3.refresh_from_db()
         self.assertEqual(
-            doc3.custom_fields.first().value,
+            self.doc3.custom_fields.first().value,
             [self.doc2.id, self.doc1.id],
         )
 
         self.async_task.assert_called_once()
         args, kwargs = self.async_task.call_args
         self.assertCountEqual(kwargs["document_ids"], [self.doc1.id, self.doc2.id])
+
+        # removal of document link cf, should also remove symmetric link
+        bulk_edit.modify_custom_fields(
+            [self.doc3.id],
+            add_custom_fields={},
+            remove_custom_fields=[cf3.id],
+        )
+        self.doc1.refresh_from_db()
+        self.assertNotIn(
+            self.doc3.id,
+            self.doc1.custom_fields.filter(field=cf3).first().value,
+        )
+        self.assertNotIn(
+            self.doc3.id,
+            self.doc2.custom_fields.filter(field=cf3).first().value,
+        )
 
     def test_delete(self):
         self.assertEqual(Document.objects.count(), 5)

--- a/src/documents/tests/test_bulk_edit.py
+++ b/src/documents/tests/test_bulk_edit.py
@@ -312,7 +312,6 @@ class TestBulkEdit(DirectoriesMixin, TestCase):
             [self.doc3.id],
         )
         # assert reflect document link
-        self.doc3.refresh_from_db()
         self.assertEqual(
             self.doc3.custom_fields.first().value,
             [self.doc2.id, self.doc1.id],
@@ -328,7 +327,6 @@ class TestBulkEdit(DirectoriesMixin, TestCase):
             add_custom_fields={},
             remove_custom_fields=[cf3.id],
         )
-        self.doc1.refresh_from_db()
         self.assertNotIn(
             self.doc3.id,
             self.doc1.custom_fields.filter(field=cf3).first().value,


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

> Realized I may need to handle the reverse (remove), should be straightforward

_Originally posted by @shamoon in https://github.com/paperless-ngx/paperless-ngx/issues/8962#issuecomment-2625396684_
   
Lol, famous last words. Not _that_ bad but this stuff is definitely a little confusing.

Should have been in #8962
Fully closes #8960

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
