### PR TITLE
Tweak: more accurate classifier last trained time

### DIFF
--- a/src/documents/classifier.py
+++ b/src/documents/classifier.py
@@ -1,6 +1,8 @@
 import logging
+import os
 import pickle
 import re
+import time
 import warnings
 from collections.abc import Iterator
 from hashlib import sha256
@@ -229,6 +231,9 @@ class DocumentClassifier:
             and self.last_doc_change_time >= latest_doc_change
         ) and self.last_auto_type_hash == hasher.digest():
             logger.info("No updates since last training")
+            # Update the modification time of the file to mark it as fresh
+            new_mtime = time.time()
+            os.utime(settings.MODEL_FILE, (new_mtime, new_mtime))
             # Set the classifier information into the cache
             # Caching for 50 minutes, so slightly less than the normal retrain time
             cache.set(

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -15,7 +15,6 @@ from urllib.parse import quote
 from urllib.parse import urlparse
 
 import pathvalidate
-from django.apps import apps
 from django.conf import settings
 from django.contrib.auth.models import Group
 from django.contrib.auth.models import User
@@ -2174,32 +2173,12 @@ class SystemStatusView(PassUserMixin):
                     classifier_status = "WARNING"
                     raise FileNotFoundError(classifier_error)
             classifier_status = "OK"
-            task_result_model = apps.get_model("django_celery_results", "taskresult")
-            result = (
-                task_result_model.objects.filter(
-                    task_name="documents.tasks.train_classifier",
-                    status="SUCCESS",
-                )
-                .order_by(
-                    "-date_done",
-                )
-                .first()
-            )
-            classifier_last_auto_trained = result.date_done if result else None
-            classifier_last_modified = (
+            classifier_last_trained = (
                 make_aware(
                     datetime.fromtimestamp(settings.MODEL_FILE.stat().st_mtime),
                 )
                 if settings.MODEL_FILE.exists()
                 else None
-            )
-            classifier_last_trained = (
-                max(
-                    classifier_last_auto_trained,
-                    classifier_last_modified,
-                )
-                if classifier_last_auto_trained and classifier_last_modified
-                else classifier_last_auto_trained or classifier_last_modified
             )
         except Exception as e:
             if classifier_status is None:

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -2175,9 +2175,10 @@ class SystemStatusView(PassUserMixin):
             classifier_status = "OK"
             classifier_last_trained = (
                 make_aware(
-                    datetime.fromtimestamp(settings.MODEL_FILE.stat().st_mtime),
+                    datetime.fromtimestamp(classifier.get_last_checked()),
                 )
                 if settings.MODEL_FILE.exists()
+                and classifier.get_last_checked() is not None
                 else None
             )
         except Exception as e:

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -2185,7 +2185,22 @@ class SystemStatusView(PassUserMixin):
                 )
                 .first()
             )
-            classifier_last_trained = result.date_done if result else None
+            classifier_last_auto_trained = result.date_done if result else None
+            classifier_last_modified = (
+                make_aware(
+                    datetime.fromtimestamp(settings.MODEL_FILE.stat().st_mtime),
+                )
+                if settings.MODEL_FILE.exists()
+                else None
+            )
+            classifier_last_trained = (
+                max(
+                    classifier_last_auto_trained,
+                    classifier_last_modified,
+                )
+                if classifier_last_auto_trained and classifier_last_modified
+                else classifier_last_auto_trained or classifier_last_modified
+            )
         except Exception as e:
             if classifier_status is None:
                 classifier_status = "ERROR"


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Small thing but I think can be improved. Basically at the moment we check the last celery result but thats not always accurate (e.g. if training manually some other way).

Went through a couple iterations here, Im sure you'll have thoughts.

1. First commit was to check the model file mtime and compare it to the last celery result  but that still doesnt really say if the model is fresh, it could have just not changed in a while but have been checked. 
2. Second commit updated the mtime of the file as a way to mark it checked, but maybe thats bad form, and it broke the test that checks mtime (I guess because its bad form).
3. Third (current) idea is to put the checked timestamp into a file next to the model file.

If you dont like this I have other ideas (more complicated, like creating a PaperlessTask entry every time it checks) but I dont see a big downside to this—feel free to correct me or suggest a better way!

Closes #8485

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [x] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
