### PR TITLE
Add an optional flag to the PostDocument endpoint to skip auto tagging

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -192,6 +192,8 @@ The endpoint supports the following optional form fields:
 -   `tags`: Similar to correspondent. Specify this multiple times to
     have multiple tags added to the document.
 -   `archive_serial_number`: An optional archive serial number to set.
+-   `skip_auto_tags`: Boolean to indicate that the classifier should not
+    attempt to determine and add tags to the document.
 -   `custom_fields`: An array of custom field ids to assign (with an empty
     value) to the document.
 

--- a/src/documents/consumer.py
+++ b/src/documents/consumer.py
@@ -577,6 +577,7 @@ class ConsumerPlugin(
                     original_file=self.unmodified_original
                     if self.unmodified_original
                     else self.working_copy,
+                    skip_auto_tagging=self.metadata.skip_auto_tagging,
                 )
 
                 # After everything is in the database, copy the files into

--- a/src/documents/data_models.py
+++ b/src/documents/data_models.py
@@ -30,6 +30,7 @@ class DocumentMetadataOverrides:
     change_users: list[int] | None = None
     change_groups: list[int] | None = None
     custom_field_ids: list[int] | None = None
+    skip_auto_tagging: bool | None = None
 
     def update(self, other: "DocumentMetadataOverrides") -> "DocumentMetadataOverrides":
         """
@@ -49,6 +50,8 @@ class DocumentMetadataOverrides:
             self.storage_path_id = other.storage_path_id
         if other.owner_id is not None:
             self.owner_id = other.owner_id
+        if other.skip_auto_tagging is not None:
+            self.skip_auto_tagging = other.skip_auto_tagging
 
         # merge
         if self.tag_ids is None:

--- a/src/documents/serialisers.py
+++ b/src/documents/serialisers.py
@@ -1536,6 +1536,13 @@ class PostDocumentSerializer(serializers.Serializer):
         required=False,
     )
 
+    skip_auto_tagging = serializers.BooleanField(
+        label="Skip auto tagging",
+        default=False,
+        write_only=True,
+        required=False,
+    )
+
     def validate_document(self, document):
         document_data = document.file.read()
         mime_type = magic.from_buffer(document_data, mime=True)

--- a/src/documents/signals/handlers.py
+++ b/src/documents/signals/handlers.py
@@ -206,8 +206,12 @@ def set_tags(
     base_url=None,
     stdout=None,
     style_func=None,
+    skip_auto_tagging=False,
     **kwargs,
 ):
+    if skip_auto_tagging:
+        return
+
     if replace:
         Document.tags.through.objects.filter(document=document).exclude(
             Q(tag__is_inbox_tag=True),

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -1385,6 +1385,7 @@ class PostDocumentView(GenericAPIView):
         created = serializer.validated_data.get("created")
         archive_serial_number = serializer.validated_data.get("archive_serial_number")
         custom_field_ids = serializer.validated_data.get("custom_fields")
+        skip_auto_tagging = serializer.validated_data.get("skip_auto_tagging")
 
         t = int(mktime(datetime.now().timetuple()))
 
@@ -1413,6 +1414,7 @@ class PostDocumentView(GenericAPIView):
             asn=archive_serial_number,
             owner_id=request.user.id,
             custom_field_ids=custom_field_ids,
+            skip_auto_tagging=skip_auto_tagging,
         )
 
         async_task = consume_file.delay(


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

Add an optional flag to the PostDocument endpoint to skip auto tagging.

When uploading documents with the API, it can be inconvenient to check every document for wrongly added tags. This PR adds a flag to the endpoint that instructs the consumer to not run the classifier on those documents.

I've used the DocumentMetadataOverrides dataclass to pass the flag to the signal handler.

<!--
⚠️ Important: Pull requests that implement a new feature or enhancement *should almost always target an existing feature request* with evidence of community interest and discussion. This is in order to balance the work of implementing and maintaining new features / enhancements. If that is not currently the case, please open a feature request instead of this PR to gather feedback from both users and the project maintainers.
-->

Also opened discussion in #9101.

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [X] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [X] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [X] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [X] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [X] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [X] I have made corresponding changes to the documentation as needed.
- [X] I have checked my modifications for any breaking changes.
