### PR TITLE
Enhancement: Add slugify filter in templating

### DIFF
--- a/docs/advanced_usage.md
+++ b/docs/advanced_usage.md
@@ -509,6 +509,12 @@ Invoice_{{ custom_fields|get_cf_value("Select Field") }}_{{ custom_fields|get_cf
 
 This will create a path like `invoices/2022/01/01/Invoice_OptionTwo_20220101.pdf` if the custom field "Date Field" is set to January 1, 2022 and "Select Field" is set to `OptionTwo`.
 
+You can also use a custom `slugify` filter to slufigy text:
+
+```jinja
+{{ title | slugify }}
+```
+
 ## Automatic recovery of invalid PDFs {#pdf-recovery}
 
 Paperless will attempt to "clean" certain invalid PDFs with `qpdf` before processing if, for example, the mime_type

--- a/src/documents/templating/filepath.py
+++ b/src/documents/templating/filepath.py
@@ -8,6 +8,7 @@ from pathlib import PurePath
 import pathvalidate
 from django.utils import timezone
 from django.utils.dateparse import parse_date
+from django.utils.text import slugify as django_slugify
 from jinja2 import StrictUndefined
 from jinja2 import Template
 from jinja2 import TemplateSyntaxError
@@ -99,6 +100,8 @@ def format_datetime(value: str | datetime, format: str) -> str:
 
 
 _template_environment.filters["datetime"] = format_datetime
+
+_template_environment.filters["slugify"] = django_slugify
 
 
 def create_dummy_document():


### PR DESCRIPTION
## Proposed change

Adds a new filter usable in templating.
`slugify` is quite useful for people who prefer not having spaces or special characters in their filenames.

Closes #(issue or discussion)
#9266 

## Type of change

- [ ] Bug fix: non-breaking change which fixes an issue.
- [x] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
