### PR TITLE
Fix: Ensure export filenames fit within 143-character limit

### DIFF
--- a/docs/administration.md
+++ b/docs/administration.md
@@ -324,9 +324,11 @@ must be provided to import. If this value is lost, the export cannot be imported
 
 !!! warning
 
-    If exporting with the file name format, there may be errors due to
-    your operating system's maximum path lengths.  Try adjusting the export
-    target or consider not using the filename format.
+    Some operating systems, particularly those using encrypted filesystems
+    (e.g., some Synology and QNAP NAS devices), impose strict limits
+    on file name lengths (143 characters).
+    To ensure compatibility, file names may be truncated to fit within this limit,
+    meaning the configured filename format may not be fully respected.
 
 ### Document importer {#importer}
 

--- a/src/documents/file_handling.py
+++ b/src/documents/file_handling.py
@@ -96,7 +96,13 @@ def generate_filename(
     counter=0,
     append_gpg=True,
     archive_filename=False,
+    basename_max_length=None,
 ):
+    if basename_max_length and basename_max_length < 20:
+        raise ValueError(
+            f"The base name length limit ({basename_max_length}) should be at least 20 characters",
+        )
+
     path = ""
 
     def format_filename(document: Document, template_str: str) -> str | None:
@@ -135,6 +141,8 @@ def generate_filename(
     # If we have one, render it
     if filename_format is not None:
         path = format_filename(doc, filename_format)
+        if basename_max_length:
+            path = path[:basename_max_length]
 
     counter_str = f"_{counter:02}" if counter else ""
     filetype_str = ".pdf" if archive_filename else doc.file_type

--- a/src/documents/management/commands/document_exporter.py
+++ b/src/documents/management/commands/document_exporter.py
@@ -427,9 +427,13 @@ class Command(CryptMixin, BaseCommand):
                     document,
                     counter=filename_counter,
                     append_gpg=False,
+                    basename_max_length=120,
                 )
             else:
-                base_name = document.get_public_filename(counter=filename_counter)
+                base_name = document.get_public_filename(
+                    counter=filename_counter,
+                    basename_max_length=120,
+                )
 
             if base_name not in self.exported_files:
                 self.exported_files.add(base_name)

--- a/src/documents/models.py
+++ b/src/documents/models.py
@@ -332,11 +332,26 @@ class Document(SoftDeleteModel, ModelWithOwner):
     def archive_file(self):
         return Path(self.archive_path).open("rb")
 
-    def get_public_filename(self, *, archive=False, counter=0, suffix=None) -> str:
+    def get_public_filename(
+        self,
+        *,
+        archive=False,
+        counter=0,
+        suffix=None,
+        basename_max_length=None,
+    ) -> str:
         """
         Returns a sanitized filename for the document, not including any paths.
         """
+        if basename_max_length and basename_max_length < 20:
+            raise ValueError(
+                f"The base name length limit ({basename_max_length}) should be at least 20 characters",
+            )
+
         result = str(self)
+
+        if basename_max_length:
+            result = result[:basename_max_length]
 
         if counter:
             result += f"_{counter:02}"


### PR DESCRIPTION
Hi,

I found that the backup and restore won't work if at least one file exceeds the filesystem filename length constraints, which happens with systems using eCryptfs (eg: encrypted folders on Synology or QNAP NAS devices).

Solution: limiting the filename length, but only for document exporting. In other use cases, I believe this error is handled correctly.

I consider this as a breaking change as it does change some filenames and might impact some specific scenarios (?).

I've tested an attempt to backup & restore successfully with a document that exceeded this limitation before.

<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

<!--
⚠️ Important: Pull requests that implement a new feature or enhancement *should almost always target an existing feature request* with evidence of community interest and discussion. This is in order to balance the work of implementing and maintaining new features / enhancements. If that is not currently the case, please open a feature request instead of this PR to gather feedback from both users and the project maintainers.
-->

Implements #9324

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [x] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
