### PR TITLE
Fix: correct all results with whoosh queries

### DIFF
--- a/src/paperless/views.py
+++ b/src/paperless/views.py
@@ -70,9 +70,11 @@ class StandardPagination(PageNumberPagination):
         if hasattr(self.page.paginator.object_list, "saved_results"):
             results_page = self.page.paginator.object_list.saved_results[0]
             if results_page is not None:
-                for i in range(len(results_page.results.docs())):
+                for doc_num in results_page.results.docs():
                     try:
-                        fields = results_page.results.fields(i)
+                        fields = results_page.results.searcher.ixreader.stored_fields(
+                            doc_num,
+                        )
                         if "id" in fields:
                             ids.append(fields["id"])
                     except Exception:


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<img width="968" alt="Screenshot 2025-03-07 at 9 28 46 AM" src="https://github.com/user-attachments/assets/f25aea5f-5a97-4b10-b429-4e7976af0406" />


Only applies to whoosh queries so I suspect this got messed up by https://github.com/paperless-ngx/paperless-ngx/pull/7507 (maybe #7505)? Anyway, fix seems to be go back up to the searcher, even though `results_page.results.docs()` has all of the docs (with whoosh doc num, not the db pk), `results_page.results.fields(i)` doesn't return anything for docs beyond the `page_size`

Closes #9330

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
