### PR TITLE
Change: better handle permissions in patch requests

### DIFF
--- a/src/documents/serialisers.py
+++ b/src/documents/serialisers.py
@@ -226,7 +226,11 @@ class SerializerWithPerms(serializers.Serializer):
     },
 )
 class SetPermissionsSerializer(serializers.DictField):
-    pass
+    def validate_empty_values(self, data: dict | None):
+        if data is fields.empty or (data is not None and len(data) == 0):
+            # allow empty but skip the field to prevent overwriting permissions
+            raise fields.SkipField
+        return super().validate_empty_values(data)
 
 
 class OwnedObjectSerializer(

--- a/src/documents/serialisers.py
+++ b/src/documents/serialisers.py
@@ -160,24 +160,24 @@ class SetPermissionsMixin:
 
     def validate_set_permissions(self, set_permissions=None):
         permissions_dict = {
-            "view": {
-                "users": User.objects.none(),
-                "groups": Group.objects.none(),
-            },
-            "change": {
-                "users": User.objects.none(),
-                "groups": Group.objects.none(),
-            },
+            "view": {},
+            "change": {},
         }
         if set_permissions is not None:
-            for action, _ in permissions_dict.items():
+            for action in ["view", "change"]:
                 if action in set_permissions:
-                    users = set_permissions[action]["users"]
-                    permissions_dict[action]["users"] = self._validate_user_ids(users)
-                    groups = set_permissions[action]["groups"]
-                    permissions_dict[action]["groups"] = self._validate_group_ids(
-                        groups,
-                    )
+                    if "users" in set_permissions[action]:
+                        users = set_permissions[action]["users"]
+                        permissions_dict[action]["users"] = self._validate_user_ids(
+                            users,
+                        )
+                    if "groups" in set_permissions[action]:
+                        groups = set_permissions[action]["groups"]
+                        permissions_dict[action]["groups"] = self._validate_group_ids(
+                            groups,
+                        )
+                else:
+                    del permissions_dict[action]
         return permissions_dict
 
     def _set_permissions(self, permissions, object):
@@ -226,11 +226,7 @@ class SerializerWithPerms(serializers.Serializer):
     },
 )
 class SetPermissionsSerializer(serializers.DictField):
-    def validate_empty_values(self, data: dict | None):
-        if data is fields.empty or (data is not None and len(data) == 0):
-            # allow empty but skip the field to prevent overwriting permissions
-            raise fields.SkipField
-        return super().validate_empty_values(data)
+    pass
 
 
 class OwnedObjectSerializer(


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Ok, got to the bottom of this. Basically the `set_permissions` dict is being initialized as empty (we cant just set `allow_empty = False`) which then gets turned into a dict like `{ "view": { "users": None...` essentially overriding existing perms. Im not clear why this _doesnt_ happen with JSON requests, presumably it gets initialized somehow differently, but the point is the added test here fails without a change.

Anyway, two solutions, I think I prefer the second commit which also supports passing partial `set_permissions` objects (non-breaking), but of course I also would be fine with the first one.

Closes #(issue or discussion)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
