### PR TITLE
Documentation: correct static url description

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -404,7 +404,7 @@ set this value to /paperless. No trailing slash!
 #### [`PAPERLESS_STATIC_URL=<path>`](#PAPERLESS_STATIC_URL) {#PAPERLESS_STATIC_URL}
 
 : Override the STATIC_URL here. Unless you're hosting Paperless off a
-subdomain like /paperless/, you probably don't need to change this.
+specific path like /paperless/, you probably don't need to change this.
 If you do change it, be sure to include the trailing slash.
 
     Defaults to "/static/".


### PR DESCRIPTION
## Proposed change

This PR updates the documentation for the `STATIC_URL` configuration. The docs previously referred to this configuration as being for a subdomain (e.g. `/paperless/`), but in reality it specifies a URL path.

The change clarifies the purpose of the setting and should help prevent confusion for users configuring their deployments.

Closes #(issue or discussion)

## Type of change

- [x] Documentation only.

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
