### PR TITLE
Fix: ensure only matched scheduled workflows are applied

### DIFF
--- a/src/documents/matching.py
+++ b/src/documents/matching.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 import logging
 import re
+from datetime import timedelta
 from fnmatch import fnmatch
 from typing import TYPE_CHECKING
+
+from django.utils import timezone
 
 from documents.data_models import ConsumableDocument
 from documents.data_models import DocumentSource
@@ -386,6 +389,14 @@ def existing_document_matches_workflow(
         )
         trigger_matched = False
 
+    # Scheduled trigger
+    if (
+        trigger.type == WorkflowTrigger.WorkflowTriggerType.SCHEDULED
+        and not document_matches_scheduled_workflow(document, trigger)
+    ):
+        reason = (f"Document {document} does not match scheduled trigger {trigger}",)
+        trigger_matched = False
+
     return (trigger_matched, reason)
 
 
@@ -433,3 +444,35 @@ def document_matches_workflow(
                 logger.debug(reason)
 
     return trigger_matched
+
+
+def document_matches_scheduled_workflow(
+    document: Document,
+    trigger: WorkflowTrigger,
+) -> bool:
+    """
+    Returns True if the Document matches a scheduled workflow
+    """
+
+    offset_td = timedelta(days=trigger.schedule_offset_days)
+    logger.debug(
+        f"Checking trigger {trigger} with offset {offset_td} against field: {trigger.schedule_date_field}",
+    )
+    matches = False
+    match trigger.schedule_date_field:
+        case WorkflowTrigger.ScheduleDateField.ADDED:
+            matches = document.added < timezone.now() - offset_td
+        case WorkflowTrigger.ScheduleDateField.CREATED:
+            matches = document.created < timezone.now() - offset_td
+        case WorkflowTrigger.ScheduleDateField.MODIFIED:
+            matches = document.modified < timezone.now() - offset_td
+        case WorkflowTrigger.ScheduleDateField.CUSTOM_FIELD:
+            cf_instance = document.custom_field_instances.filter(
+                field=trigger.schedule_date_custom_field,
+            ).first()
+            if cf_instance:
+                matches = cf_instance.value_date < timezone.now() - offset_td
+            else:
+                matches = False
+
+    return matches

--- a/src/documents/tasks.py
+++ b/src/documents/tasks.py
@@ -461,6 +461,7 @@ def check_scheduled_workflows():
                             )
                             continue
                         run_workflows(
-                            WorkflowTrigger.WorkflowTriggerType.SCHEDULED,
-                            document,
+                            trigger_type=WorkflowTrigger.WorkflowTriggerType.SCHEDULED,
+                            workflow_to_run=workflow,
+                            document=document,
                         )


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

In retrospect, I think I had meant to add something to `existing_document_matches_workflow`, which is the first commit here (then reverted) just for curiosity, but I think this is an easier solution as we've already done the logic to check the scheduled ones. Only other note is we could make `run_workflows` first param be e.g. `trigger_type_or_workflow` but this seemed clearer to me.

Happy to go either way.

Closes #9577

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
