### PR TITLE
Fix: Adds a warning to the user if their secret file includes a trailing newline

### DIFF
--- a/docker/rootfs/etc/s6-overlay/s6-rc.d/init-env-file/run
+++ b/docker/rootfs/etc/s6-overlay/s6-rc.d/init-env-file/run
@@ -17,6 +17,9 @@ if find /run/s6/container_environment/*"_FILE" -maxdepth 1 > /dev/null 2>&1; the
 			if [[ -f ${SECRETFILE} ]]; then
 				# Trim off trailing _FILE
 				FILESTRIP=${FILENAME//_FILE/}
+				if [[ $(tail -n1 "${SECRETFILE}" | wc -l) != 0 ]]; then
+					echo "${log_prefix} Your secret: ${FILENAME##*/} contains a trailing newline and may not work as expected"
+				fi
 				# Set environment variable
 				cat "${SECRETFILE}" > "${FILESTRIP}"
 				echo "${log_prefix} ${FILESTRIP##*/} set from ${FILENAME##*/}"


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

<!--
⚠️ Important: Pull requests that implement a new feature or enhancement *should almost always target an existing feature request* with evidence of community interest and discussion. This is in order to balance the work of implementing and maintaining new features / enhancements. If that is not currently the case, please open a feature request instead of this PR to gather feedback from both users and the project maintainers.
-->

I still strongly suspect this is the cause of #9582.  LSIO also does this, so we borrow from them again:

https://github.com/linuxserver/docker-baseimage-ubuntu/blob/e522840e4f275bf8b6cb4fe4c66e904131b03380/root/etc/s6-overlay/s6-rc.d/init-envfile/run#L9-L12

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
