### PR TITLE
Fix: Run migration lock as the correct user

### DIFF
--- a/docker/rootfs/etc/s6-overlay/s6-rc.d/init-migrations/migrate.sh
+++ b/docker/rootfs/etc/s6-overlay/s6-rc.d/init-migrations/migrate.sh
@@ -1,0 +1,11 @@
+#!/command/with-contenv /usr/bin/bash
+# shellcheck shell=bash
+declare -r data_dir="${PAPERLESS_DATA_DIR:-/usr/src/paperless/data}"
+
+# Use file locking to prevent simultaneous migrations
+(
+	flock 200
+	# shellcheck disable=SC2164
+	cd "${PAPERLESS_SRC_DIR}"
+	python3 manage.py migrate --skip-checks --no-input
+) 200>"${data_dir}/migration_lock"

--- a/docker/rootfs/etc/s6-overlay/s6-rc.d/init-migrations/migrate.sh
+++ b/docker/rootfs/etc/s6-overlay/s6-rc.d/init-migrations/migrate.sh
@@ -2,10 +2,6 @@
 # shellcheck shell=bash
 declare -r data_dir="${PAPERLESS_DATA_DIR:-/usr/src/paperless/data}"
 
-# Use file locking to prevent simultaneous migrations
-(
-	flock 200
-	# shellcheck disable=SC2164
-	cd "${PAPERLESS_SRC_DIR}"
-	python3 manage.py migrate --skip-checks --no-input
-) 200>"${data_dir}/migration_lock"
+# shellcheck disable=SC2164
+cd "${PAPERLESS_SRC_DIR}"
+exec s6-setlock -n "${data_dir}/migration_lock" python3 manage.py migrate --skip-checks --no-input

--- a/docker/rootfs/etc/s6-overlay/s6-rc.d/init-migrations/run
+++ b/docker/rootfs/etc/s6-overlay/s6-rc.d/init-migrations/run
@@ -1,20 +1,12 @@
 #!/command/with-contenv /usr/bin/bash
 # shellcheck shell=bash
 declare -r log_prefix="[init-migrations]"
-declare -r data_dir="${PAPERLESS_DATA_DIR:-/usr/src/paperless/data}"
 
-(
-	# flock is in place to prevent multiple containers from doing migrations
-	# simultaneously. This also ensures that the db is ready when the command
-	# of the current container starts.
-	flock 200
-	echo "${log_prefix} Apply database migrations..."
-	cd "${PAPERLESS_SRC_DIR}"
+echo "${log_prefix} Apply database migrations..."
 
-	if [[ -n "${USER_IS_NON_ROOT}" ]]; then
-		exec python3 manage.py migrate --skip-checks --no-input
-	else
-		exec s6-setuidgid paperless python3 manage.py migrate --skip-checks --no-input
-	fi
-
-) 200>"${data_dir}/migration_lock"
+# The whole migrate, with flock, needs to run as the right user
+if [[ -n "${USER_IS_NON_ROOT}" ]]; then
+	exec /etc/s6-overlay/s6-rc.d/init-migrations/migrate.sh
+else
+	exec s6-setuidgid paperless /etc/s6-overlay/s6-rc.d/init-migrations/migrate.sh
+fi


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

<!--
⚠️ Important: Pull requests that implement a new feature or enhancement *should almost always target an existing feature request* with evidence of community interest and discussion. This is in order to balance the work of implementing and maintaining new features / enhancements. If that is not currently the case, please open a feature request instead of this PR to gather feedback from both users and the project maintainers.
-->

Essentially, the lock was running as the incorrect user.  So we move that portion to a new script and run the whole script as the correct user.

That's more in line with the original, where the whole prepare script ran as the `paperless` user:
https://github.com/paperless-ngx/paperless-ngx/blob/49b658a9447e82326c4dfc9ec4983495533b1ea4/docker/docker-entrypoint.sh#L109

Closes #9603 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
