### PR TITLE
Fix: Adds better handling during folder checking/creation/permissions for non-root

### DIFF
--- a/docker/rootfs/etc/s6-overlay/s6-rc.d/init-folders/run
+++ b/docker/rootfs/etc/s6-overlay/s6-rc.d/init-folders/run
@@ -9,25 +9,57 @@ declare -r media_root_dir="${PAPERLESS_MEDIA_ROOT:-/usr/src/paperless/media}"
 declare -r consume_dir="${PAPERLESS_CONSUMPTION_DIR:-/usr/src/paperless/consume}"
 declare -r tmp_dir="${PAPERLESS_SCRATCH_DIR:=/tmp/paperless}"
 
-echo "${log_prefix} Checking for folder existence"
+declare -r main_dirs=(
+	"${export_dir}"
+	"${data_dir}"
+	"${media_root_dir}"
+	"${consume_dir}"
+	"${tmp_dir}"
+)
 
-for dir in \
-	"${export_dir}" \
-	"${data_dir}" "${data_dir}/index" \
-	"${media_root_dir}" "${media_root_dir}/documents" "${media_root_dir}/documents/originals" "${media_root_dir}/documents/thumbnails" \
-	"${consume_dir}" \
-	"${tmp_dir}"; do
-	if [[ ! -d "${dir}" ]]; then
-		mkdir --parents --verbose "${dir}"
-	fi
-done
+declare -r extra_dirs=(
+	"${main_dirs[@]}"
+	"${data_dir}/index"
+	"${media_root_dir}/documents"
+	"${media_root_dir}/documents/originals"
+	"${media_root_dir}/documents/thumbnails"
+)
 
-echo "${log_prefix} Adjusting file and folder permissions"
-for dir in \
-	"${export_dir}" \
-	"${data_dir}" \
-	"${media_root_dir}" \
-	"${consume_dir}" \
-	"${tmp_dir}"; do
-	find "${dir}" -not \( -user paperless -and -group paperless \) -exec chown --changes paperless:paperless {} +
-done
+if [[ -n "${USER_IS_NON_ROOT}" ]]; then
+	# Non-root mode: Create directories as current user, warn about permission issues
+	echo "${log_prefix} Running in non-root mode, checking directories"
+	current_uid=$(id -u)
+	current_gid=$(id -g)
+
+	for dir in "${extra_dirs[@]}"; do
+		if [[ ! -d "${dir}" ]]; then
+			mkdir --parents --verbose "${dir}" || echo "${log_prefix} WARNING: Could not create ${dir} - permission denied"
+		fi
+		# Check permissions on existing directories too
+		if [[ -d "${dir}" && ! -w "${dir}" ]]; then
+			echo "${log_prefix} WARNING: No write permission to ${dir}"
+		fi
+	done
+
+	# Warn about ownership issues
+	for dir in "${main_dirs[@]}"; do
+		if [[ -d "${dir}" ]]; then
+			find "${dir}" -not \( -user ${current_uid} -and -group ${current_gid} \) -exec echo "${log_prefix} WARNING: Permission issue on {}: not owned by current user (${current_uid}:${current_gid})" \; 2>/dev/null || echo "${log_prefix} WARNING: Cannot check permissions on ${dir}"
+		fi
+	done
+else
+	# Root mode: Create and fix permissions as needed
+	echo "${log_prefix} Running with root privileges, adjusting directories and permissions"
+
+	# First create directories
+	for dir in "${extra_dirs[@]}"; do
+		if [[ ! -d "${dir}" ]]; then
+			mkdir --parents --verbose "${dir}"
+		fi
+	done
+
+	# Then fix permissions on all directories
+	for dir in "${main_dirs[@]}"; do
+		find "${dir}" -not \( -user paperless -and -group paperless \) -exec chown --changes paperless:paperless {} +
+	done
+fi

--- a/docker/rootfs/etc/s6-overlay/s6-rc.d/init-folders/run
+++ b/docker/rootfs/etc/s6-overlay/s6-rc.d/init-folders/run
@@ -28,8 +28,8 @@ declare -r extra_dirs=(
 if [[ -n "${USER_IS_NON_ROOT}" ]]; then
 	# Non-root mode: Create directories as current user, warn about permission issues
 	echo "${log_prefix} Running in non-root mode, checking directories"
-	current_uid=$(id -u)
-	current_gid=$(id -g)
+	current_uid=$(id --user)
+	current_gid=$(id --group)
 
 	for dir in "${extra_dirs[@]}"; do
 		if [[ ! -d "${dir}" ]]; then

--- a/docker/rootfs/etc/s6-overlay/s6-rc.d/init-start/run
+++ b/docker/rootfs/etc/s6-overlay/s6-rc.d/init-start/run
@@ -11,9 +11,9 @@ printf "/usr/src/paperless/src" > /var/run/s6/container_environment/PAPERLESS_SR
 echo $(date +%s) > /var/run/s6/container_environment/PAPERLESS_START_TIME_S
 
 # Check if we're starting as a non-root user
-if [ $(id -u) == $(id -u paperless) ]; then
+if [ "$(id -u)" != "0" ]; then
 	printf "true" > /var/run/s6/container_environment/USER_IS_NON_ROOT
-	echo "${log_prefix}  paperless-ngx docker container running under a user"
+	echo "${log_prefix}  paperless-ngx docker container running under a user ($(id -u):$(id -g))"
 else
 	printf "/usr/src/paperless" > /var/run/s6/container_environment/HOME
 	echo "${log_prefix}  paperless-ngx docker container starting init as root"

--- a/docker/rootfs/etc/s6-overlay/s6-rc.d/init-start/run
+++ b/docker/rootfs/etc/s6-overlay/s6-rc.d/init-start/run
@@ -11,9 +11,9 @@ printf "/usr/src/paperless/src" > /var/run/s6/container_environment/PAPERLESS_SR
 echo $(date +%s) > /var/run/s6/container_environment/PAPERLESS_START_TIME_S
 
 # Check if we're starting as a non-root user
-if [ "$(id -u)" != "0" ]; then
+if [ "$(id --user)" != "0" ]; then
 	printf "true" > /var/run/s6/container_environment/USER_IS_NON_ROOT
-	echo "${log_prefix}  paperless-ngx docker container running under a user ($(id -u):$(id -g))"
+	echo "${log_prefix}  paperless-ngx docker container running under a user ($(id --user):$(id --group))"
 else
 	printf "/usr/src/paperless" > /var/run/s6/container_environment/HOME
 	echo "${log_prefix}  paperless-ngx docker container starting init as root"


### PR DESCRIPTION

<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

<!--
⚠️ Important: Pull requests that implement a new feature or enhancement *should almost always target an existing feature request* with evidence of community interest and discussion. This is in order to balance the work of implementing and maintaining new features / enhancements. If that is not currently the case, please open a feature request instead of this PR to gather feedback from both users and the project maintainers.
-->

Just noticed while looking at the Kubnetres thing.  Do double check this logic makes sense.

First thing, I don't think the check for non-root was right: https://github.com/paperless-ngx/paperless-ngx/blob/49b658a9447e82326c4dfc9ec4983495533b1ea4/docker/docker-entrypoint.sh#L162-L164

From my understanding, if the user sets `user: ` or `--user` in Docker, then the processes are all started by that user.  So this only would have worked if `user: 1000:1000` was set, right?

Next, improve the folder creation/permissions step.

1. If the current user is non-root:
    1. If a directory doesn't exist, attempt to create it (this is run as the current user).  If that fails, output a warning
    2. if the directory does but is not writable, also output a warning
    3. Recursively look in the directories for files/folders that are not owned by the current uid/gid and warn about them
1. Else:
    1. Create the directories as needed (the current user will be root, so this will work)
    2. Fix all permissions to the `paperless:paperless:

I think this is basically as it should be.  If not running as root, the folders need to be somewhere the user can create other folders and files.  Otherwise, for initial root running, the folders can be created (because root) and adjusted before we drop privileges.

Testing is pretty easy, play around with `user: ` in service.  With current `:dev` image, setting something like `user: 999:999` will fail with permission issues, even if the directories are owned by the user and group.  With this image, folders are created without issue.

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
