### PR TITLE
Fix: preserve non-ASCII filenames in document downloads

### DIFF
--- a/src-ui/src/app/components/document-detail/document-detail.component.ts
+++ b/src-ui/src/app/components/document-detail/document-detail.component.ts
@@ -77,6 +77,7 @@ import { StoragePathService } from 'src/app/services/rest/storage-path.service'
 import { UserService } from 'src/app/services/rest/user.service'
 import { SettingsService } from 'src/app/services/settings.service'
 import { ToastService } from 'src/app/services/toast.service'
+import { getFilenameFromContentDisposition } from 'src/app/utils/http'
 import { ISODateAdapter } from 'src/app/utils/ngb-iso-date-adapter'
 import * as UTIF from 'utif'
 import { ConfirmDialogComponent } from '../common/confirm-dialog/confirm-dialog.component'
@@ -999,12 +1000,10 @@ export class DocumentDetailComponent
       .get(downloadUrl, { observe: 'response', responseType: 'blob' })
       .subscribe({
         next: (response: HttpResponse<Blob>) => {
-          const filename = response.headers
-            .get('Content-Disposition')
-            ?.split(';')
-            ?.find((part) => part.trim().startsWith('filename='))
-            ?.split('=')[1]
-            ?.replace(/['"]/g, '')
+          const contentDisposition = response.headers.get('Content-Disposition')
+          const filename =
+            getFilenameFromContentDisposition(contentDisposition) ||
+            this.document.title
           const blob = new Blob([response.body], {
             type: response.body.type,
           })

--- a/src-ui/src/app/utils/http.spec.ts
+++ b/src-ui/src/app/utils/http.spec.ts
@@ -1,0 +1,31 @@
+import { getFilenameFromContentDisposition } from './http'
+
+describe('getFilenameFromContentDisposition', () => {
+  it('should extract filename from Content-Disposition header with filename*', () => {
+    const header = "attachment; filename*=UTF-8''example%20file.txt"
+    expect(getFilenameFromContentDisposition(header)).toBe('example file.txt')
+  })
+
+  it('should extract filename from Content-Disposition header with filename=', () => {
+    const header = 'attachment; filename="example-file.txt"'
+    expect(getFilenameFromContentDisposition(header)).toBe('example-file.txt')
+  })
+
+  it('should prioritize filename* over filename if both are present', () => {
+    const header =
+      'attachment; filename="fallback.txt"; filename*=UTF-8\'\'preferred%20file.txt'
+    const result = getFilenameFromContentDisposition(header)
+    expect(result).toBe('preferred file.txt')
+  })
+
+  it('should gracefully fall back to null', () => {
+    // invalid UTF-8 sequence
+    expect(
+      getFilenameFromContentDisposition("attachment; filename*=UTF-8''%E0%A4%A")
+    ).toBeNull()
+    // missing filename
+    expect(getFilenameFromContentDisposition('attachment;')).toBeNull()
+    // empty header
+    expect(getFilenameFromContentDisposition(null)).toBeNull()
+  })
+})

--- a/src-ui/src/app/utils/http.ts
+++ b/src-ui/src/app/utils/http.ts
@@ -1,0 +1,23 @@
+export function getFilenameFromContentDisposition(header: string): string {
+  if (!header) {
+    return null
+  }
+
+  // Try filename* (RFC 5987)
+  const filenameStar = header.match(/filename\*=(?:UTF-\d['']*)?([^;]+)/i)
+  if (filenameStar?.[1]) {
+    try {
+      return decodeURIComponent(filenameStar[1])
+    } catch (e) {
+      // Ignore decoding errors and fall through
+    }
+  }
+
+  // Fallback to filename=
+  const filenameMatch = header.match(/filename="?([^"]+)"?/)
+  if (filenameMatch?.[1]) {
+    return filenameMatch[1]
+  }
+
+  return null
+}


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

A little trickier than I thought but decided to extract this into a helper function to isolate the logic. To be clear, this used to be handled by the browser.

<img width="911" alt="Screenshot 2025-04-17 at 10 22 27 PM" src="https://github.com/user-attachments/assets/6f665c85-0e2f-4e28-90e5-32fd4347efb1" />

Closes #9688

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
