### PR TITLE
Fixhancement: check more permissions for status consumer messages

### DIFF
--- a/src-ui/src/app/data/websocket-progress-message.ts
+++ b/src-ui/src/app/data/websocket-progress-message.ts
@@ -7,4 +7,6 @@ export interface WebsocketProgressMessage {
   message?: string
   document_id: number
   owner_id?: number
+  users_can_view?: number[]
+  groups_can_view?: number[]
 }

--- a/src-ui/src/app/services/websocket-status.service.spec.ts
+++ b/src-ui/src/app/services/websocket-status.service.spec.ts
@@ -355,6 +355,50 @@ describe('ConsumerStatusService', () => {
     )
   })
 
+  it('should notify user if user can view or is in group', () => {
+    settingsService.currentUser = {
+      id: 1,
+      username: 'testuser',
+      is_superuser: false,
+      groups: [1],
+    }
+    websocketStatusService.connect()
+    server.send({
+      type: WebsocketStatusType.STATUS_UPDATE,
+      data: {
+        task_id: '1234',
+        filename: 'file1.pdf',
+        current_progress: 50,
+        max_progress: 100,
+        docuement_id: 12,
+        owner_id: 2,
+        status: 'WORKING',
+        users_can_view: [1],
+        groups_can_view: [],
+      },
+    })
+    expect(websocketStatusService.getConsumerStatusNotCompleted()).toHaveLength(
+      1
+    )
+    server.send({
+      type: WebsocketStatusType.STATUS_UPDATE,
+      data: {
+        task_id: '5678',
+        filename: 'file2.pdf',
+        current_progress: 50,
+        max_progress: 100,
+        docuement_id: 13,
+        owner_id: 2,
+        status: 'WORKING',
+        users_can_view: [],
+        groups_can_view: [1],
+      },
+    })
+    expect(websocketStatusService.getConsumerStatusNotCompleted()).toHaveLength(
+      2
+    )
+  })
+
   it('should trigger deleted subject on document deleted', () => {
     let deleted = false
     websocketStatusService.onDocumentDeleted().subscribe(() => {

--- a/src-ui/src/app/services/websocket-status.service.ts
+++ b/src-ui/src/app/services/websocket-status.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core'
 import { Subject } from 'rxjs'
 import { environment } from 'src/environments/environment'
+import { User } from '../data/user'
 import { WebsocketDocumentsDeletedMessage } from '../data/websocket-documents-deleted-message'
 import { WebsocketProgressMessage } from '../data/websocket-progress-message'
 import { SettingsService } from './settings.service'
@@ -173,13 +174,25 @@ export class WebsocketStatusService {
     }
   }
 
+  private canViewMessage(messageData: WebsocketProgressMessage): boolean {
+    // see paperless.consumers.StatusConsumer._can_view
+    const user: User = this.settingsService.currentUser
+    return (
+      !messageData.owner_id ||
+      user.is_superuser ||
+      (messageData.owner_id && messageData.owner_id === user.id) ||
+      (messageData.users_can_view &&
+        messageData.users_can_view.includes(user.id)) ||
+      (messageData.groups_can_view &&
+        messageData.groups_can_view.some((groupId) =>
+          user.groups?.includes(groupId)
+        ))
+    )
+  }
+
   handleProgressUpdate(messageData: WebsocketProgressMessage) {
     // fallback if backend didn't restrict message
-    if (
-      messageData.owner_id &&
-      messageData.owner_id !== this.settingsService.currentUser?.id &&
-      !this.settingsService.currentUser?.is_superuser
-    ) {
+    if (!this.canViewMessage(messageData)) {
       return
     }
 

--- a/src/documents/consumer.py
+++ b/src/documents/consumer.py
@@ -137,6 +137,10 @@ class ConsumerPlugin(
             extra_args={
                 "document_id": document_id,
                 "owner_id": self.metadata.owner_id if self.metadata.owner_id else None,
+                "users_can_view": (self.metadata.view_users or [])
+                + (self.metadata.change_users or []),
+                "groups_can_view": (self.metadata.view_groups or [])
+                + (self.metadata.change_groups or []),
             },
         )
 


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Seems a bit edge-case-y, but anyway...

Closes #9801

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
