### PR TITLE
Fix: always update classifier task result

### DIFF
--- a/src/documents/tasks.py
+++ b/src/documents/tasks.py
@@ -123,13 +123,14 @@ def train_classifier(*, scheduled=True):
             task.result = "Training data unchanged"
 
         task.status = states.SUCCESS
-        task.date_done = timezone.now()
-        task.save(update_fields=["status", "result", "date_done"])
 
     except Exception as e:
         logger.warning("Classifier error: " + str(e))
         task.status = states.FAILURE
         task.result = str(e)
+
+    task.date_done = timezone.now()
+    task.save(update_fields=["status", "result", "date_done"])
 
 
 @shared_task(bind=True)


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Took me a second to see it, we're not updating the task if it fails, which it (correctly) will when there are 0 non-deleted non-inbox-tagged docs like in the video the user posted. (I also have a theory that https://github.com/paperless-ngx/paperless-ngx/blob/3f3b64fdb45a21c351780faafa17469ca5ba1f47/src/documents/views.py#L2733-L2737 will return tasks with null date_done in non-sqlite databases).

<img width="304" alt="Screenshot 2025-04-27 at 11 54 27 PM" src="https://github.com/user-attachments/assets/1400d9fd-bc27-4c86-8200-2e84fd6e1b0d" />


Closes #9813 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
