### PR TITLE
Chore: switch from os.path to pathlib.Path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,22 +221,12 @@ lint.per-file-ignores."src/documents/parsers.py" = [
 lint.per-file-ignores."src/documents/signals/handlers.py" = [
   "PTH",
 ] # TODO Enable & remove
-lint.per-file-ignores."src/documents/views.py" = [
-  "PTH",
-] # TODO Enable & remove
-lint.per-file-ignores."src/paperless/checks.py" = [
-  "PTH",
-] # TODO Enable & remove
 lint.per-file-ignores."src/paperless/settings.py" = [
   "PTH",
 ] # TODO Enable & remove
-lint.per-file-ignores."src/paperless_mail/mail.py" = [
-  "PTH",
-] # TODO Enable & remove
 lint.per-file-ignores."src/paperless_tesseract/tests/test_parser.py" = [
-  "PTH",
   "RUF001",
-] # TODO PTH Enable & remove
+]
 lint.isort.force-single-line = true
 
 [tool.pytest.ini_options]

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -1221,7 +1221,7 @@ class LogViewSet(ViewSet):
         "celery": "celery.log",
     }
 
-    def get_log_filename(self, log_key: str) -> Path:
+    def get_log_file(self, log_key: str) -> Path:
         return Path(settings.LOGGING_DIR) / self.ALLOWED_LOG_FILES[log_key]
 
     def retrieve(self, request, *args, **kwargs):
@@ -1229,12 +1229,12 @@ class LogViewSet(ViewSet):
         if log_key not in self.ALLOWED_LOG_FILES:
             raise Http404
 
-        filename = self.get_log_filename(log_key)
+        log_file = self.get_log_file(log_key)
 
-        if not filename.is_file():
+        if not log_file.is_file():
             raise Http404
 
-        with filename.open() as f:
+        with log_file.open() as f:
             lines = [line.rstrip() for line in f.readlines()]
 
         return Response(lines)
@@ -1243,7 +1243,7 @@ class LogViewSet(ViewSet):
         existing_logs = [
             log_key
             for log_key in self.ALLOWED_LOG_FILES
-            if self.get_log_filename(log_key).is_file()
+            if self.get_log_file(log_key).is_file()
         ]
         return Response(existing_logs)
 

--- a/src/paperless/tests/test_checks.py
+++ b/src/paperless/tests/test_checks.py
@@ -27,9 +27,9 @@ class TestChecks(DirectoriesMixin, TestCase):
         self.assertEqual(paths_check(None), [])
 
     @override_settings(
-        MEDIA_ROOT="uuh",
-        DATA_DIR="whatever",
-        CONSUMPTION_DIR="idontcare",
+        MEDIA_ROOT=Path("uuh"),
+        DATA_DIR=Path("whatever"),
+        CONSUMPTION_DIR=Path("idontcare"),
     )
     def test_paths_check_dont_exist(self):
         msgs = paths_check(None)

--- a/src/paperless_mail/mail.py
+++ b/src/paperless_mail/mail.py
@@ -1,7 +1,6 @@
 import datetime
 import itertools
 import logging
-import os
 import ssl
 import tempfile
 import traceback
@@ -484,7 +483,7 @@ class MailAccountHandler(LoggingMixin):
             return message.subject
 
         elif rule.assign_title_from == MailRule.TitleSource.FROM_FILENAME:
-            return os.path.splitext(os.path.basename(att.filename))[0]
+            return Path(att.filename).stem
 
         elif rule.assign_title_from == MailRule.TitleSource.NONE:
             return None
@@ -908,7 +907,7 @@ class MailAccountHandler(LoggingMixin):
             dir=settings.SCRATCH_DIR,
             suffix=".eml",
         )
-        with open(temp_filename, "wb") as f:
+        with Path(temp_filename).open("wb") as f:
             # Move "From"-header to beginning of file
             # TODO: This ugly workaround is needed because the parser is
             #   chosen only by the mime_type detected via magic

--- a/src/paperless_tesseract/tests/test_parser.py
+++ b/src/paperless_tesseract/tests/test_parser.py
@@ -1,4 +1,3 @@
-import os
 import shutil
 import tempfile
 import uuid
@@ -70,13 +69,13 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
         """
         parser = RasterisedDocumentParser(uuid.uuid4())
         page_count = parser.get_page_count(
-            os.path.join(self.SAMPLE_FILES, "simple-digital.pdf"),
+            (self.SAMPLE_FILES / "simple-digital.pdf").as_posix(),
             "application/pdf",
         )
         self.assertEqual(page_count, 1)
 
         page_count = parser.get_page_count(
-            os.path.join(self.SAMPLE_FILES, "multi-page-mixed.pdf"),
+            (self.SAMPLE_FILES / "multi-page-mixed.pdf").as_posix(),
             "application/pdf",
         )
         self.assertEqual(page_count, 6)
@@ -93,7 +92,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
         parser = RasterisedDocumentParser(uuid.uuid4())
         with self.assertLogs("paperless.parsing.tesseract", level="WARNING") as cm:
             page_count = parser.get_page_count(
-                os.path.join(self.SAMPLE_FILES, "password-protected.pdf"),
+                (self.SAMPLE_FILES / "password-protected.pdf").as_posix(),
                 "application/pdf",
             )
             self.assertEqual(page_count, None)
@@ -102,7 +101,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
     def test_thumbnail(self):
         parser = RasterisedDocumentParser(uuid.uuid4())
         thumb = parser.get_thumbnail(
-            os.path.join(self.SAMPLE_FILES, "simple-digital.pdf"),
+            (self.SAMPLE_FILES / "simple-digital.pdf").as_posix(),
             "application/pdf",
         )
         self.assertIsFile(thumb)
@@ -119,7 +118,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
 
         parser = RasterisedDocumentParser(uuid.uuid4())
         thumb = parser.get_thumbnail(
-            os.path.join(self.SAMPLE_FILES, "simple-digital.pdf"),
+            (self.SAMPLE_FILES / "simple-digital.pdf").as_posix(),
             "application/pdf",
         )
         self.assertIsFile(thumb)
@@ -127,7 +126,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
     def test_thumbnail_encrypted(self):
         parser = RasterisedDocumentParser(uuid.uuid4())
         thumb = parser.get_thumbnail(
-            os.path.join(self.SAMPLE_FILES, "encrypted.pdf"),
+            (self.SAMPLE_FILES / "encrypted.pdf").as_posix(),
             "application/pdf",
         )
         self.assertIsFile(thumb)
@@ -135,17 +134,17 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
     def test_get_dpi(self):
         parser = RasterisedDocumentParser(None)
 
-        dpi = parser.get_dpi(os.path.join(self.SAMPLE_FILES, "simple-no-dpi.png"))
+        dpi = parser.get_dpi((self.SAMPLE_FILES / "simple-no-dpi.png").as_posix())
         self.assertEqual(dpi, None)
 
-        dpi = parser.get_dpi(os.path.join(self.SAMPLE_FILES, "simple.png"))
+        dpi = parser.get_dpi((self.SAMPLE_FILES / "simple.png").as_posix())
         self.assertEqual(dpi, 72)
 
     def test_simple_digital(self):
         parser = RasterisedDocumentParser(None)
 
         parser.parse(
-            os.path.join(self.SAMPLE_FILES, "simple-digital.pdf"),
+            (self.SAMPLE_FILES / "simple-digital.pdf").as_posix(),
             "application/pdf",
         )
 
@@ -157,7 +156,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
         parser = RasterisedDocumentParser(None)
 
         parser.parse(
-            os.path.join(self.SAMPLE_FILES, "with-form.pdf"),
+            (self.SAMPLE_FILES / "with-form.pdf").as_posix(),
             "application/pdf",
         )
 
@@ -173,7 +172,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
         parser = RasterisedDocumentParser(None)
 
         parser.parse(
-            os.path.join(self.SAMPLE_FILES, "with-form.pdf"),
+            (self.SAMPLE_FILES / "with-form.pdf").as_posix(),
             "application/pdf",
         )
 
@@ -187,7 +186,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
     def test_signed(self):
         parser = RasterisedDocumentParser(None)
 
-        parser.parse(os.path.join(self.SAMPLE_FILES, "signed.pdf"), "application/pdf")
+        parser.parse((self.SAMPLE_FILES / "signed.pdf").as_posix(), "application/pdf")
 
         self.assertIsNone(parser.archive_path)
         self.assertContainsStrings(
@@ -203,7 +202,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
         parser = RasterisedDocumentParser(None)
 
         parser.parse(
-            os.path.join(self.SAMPLE_FILES, "encrypted.pdf"),
+            (self.SAMPLE_FILES / "encrypted.pdf").as_posix(),
             "application/pdf",
         )
 
@@ -214,7 +213,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
     def test_with_form_error_notext(self):
         parser = RasterisedDocumentParser(None)
         parser.parse(
-            os.path.join(self.SAMPLE_FILES, "with-form.pdf"),
+            (self.SAMPLE_FILES / "with-form.pdf").as_posix(),
             "application/pdf",
         )
 
@@ -228,7 +227,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
         parser = RasterisedDocumentParser(None)
 
         parser.parse(
-            os.path.join(self.SAMPLE_FILES, "with-form.pdf"),
+            (self.SAMPLE_FILES / "with-form.pdf").as_posix(),
             "application/pdf",
         )
 
@@ -240,7 +239,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
     def test_image_simple(self):
         parser = RasterisedDocumentParser(None)
 
-        parser.parse(os.path.join(self.SAMPLE_FILES, "simple.png"), "image/png")
+        parser.parse((self.SAMPLE_FILES / "simple.png").as_posix(), "image/png")
 
         self.assertIsFile(parser.archive_path)
 
@@ -252,11 +251,11 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
         with tempfile.TemporaryDirectory() as tempdir:
             # Copy sample file to temp directory, as the parsing changes the file
             # and this makes it modified to Git
-            sample_file = os.path.join(self.SAMPLE_FILES, "simple-alpha.png")
-            dest_file = os.path.join(tempdir, "simple-alpha.png")
+            sample_file = self.SAMPLE_FILES / "simple-alpha.png"
+            dest_file = Path(tempdir) / "simple-alpha.png"
             shutil.copy(sample_file, dest_file)
 
-            parser.parse(dest_file, "image/png")
+            parser.parse(dest_file.as_posix(), "image/png")
 
             self.assertIsFile(parser.archive_path)
 
@@ -266,7 +265,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
         parser = RasterisedDocumentParser(None)
 
         dpi = parser.calculate_a4_dpi(
-            os.path.join(self.SAMPLE_FILES, "simple-no-dpi.png"),
+            (self.SAMPLE_FILES / "simple-no-dpi.png").as_posix(),
         )
 
         self.assertEqual(dpi, 62)
@@ -278,7 +277,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
 
         def f():
             parser.parse(
-                os.path.join(self.SAMPLE_FILES, "simple-no-dpi.png"),
+                (self.SAMPLE_FILES / "simple-no-dpi.png").as_posix(),
                 "image/png",
             )
 
@@ -288,7 +287,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
     def test_image_no_dpi_default(self):
         parser = RasterisedDocumentParser(None)
 
-        parser.parse(os.path.join(self.SAMPLE_FILES, "simple-no-dpi.png"), "image/png")
+        parser.parse((self.SAMPLE_FILES / "simple-no-dpi.png").as_posix(), "image/png")
 
         self.assertIsFile(parser.archive_path)
 
@@ -300,7 +299,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
     def test_multi_page(self):
         parser = RasterisedDocumentParser(None)
         parser.parse(
-            os.path.join(self.SAMPLE_FILES, "multi-page-digital.pdf"),
+            (self.SAMPLE_FILES / "multi-page-digital.pdf").as_posix(),
             "application/pdf",
         )
         self.assertIsFile(parser.archive_path)
@@ -313,7 +312,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
     def test_multi_page_pages_skip(self):
         parser = RasterisedDocumentParser(None)
         parser.parse(
-            os.path.join(self.SAMPLE_FILES, "multi-page-digital.pdf"),
+            (self.SAMPLE_FILES / "multi-page-digital.pdf").as_posix(),
             "application/pdf",
         )
         self.assertIsFile(parser.archive_path)
@@ -326,7 +325,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
     def test_multi_page_pages_redo(self):
         parser = RasterisedDocumentParser(None)
         parser.parse(
-            os.path.join(self.SAMPLE_FILES, "multi-page-digital.pdf"),
+            (self.SAMPLE_FILES / "multi-page-digital.pdf").as_posix(),
             "application/pdf",
         )
         self.assertIsFile(parser.archive_path)
@@ -339,7 +338,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
     def test_multi_page_pages_force(self):
         parser = RasterisedDocumentParser(None)
         parser.parse(
-            os.path.join(self.SAMPLE_FILES, "multi-page-digital.pdf"),
+            (self.SAMPLE_FILES / "multi-page-digital.pdf").as_posix(),
             "application/pdf",
         )
         self.assertIsFile(parser.archive_path)
@@ -352,7 +351,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
     def test_multi_page_analog_pages_skip(self):
         parser = RasterisedDocumentParser(None)
         parser.parse(
-            os.path.join(self.SAMPLE_FILES, "multi-page-images.pdf"),
+            (self.SAMPLE_FILES / "multi-page-images.pdf").as_posix(),
             "application/pdf",
         )
         self.assertIsFile(parser.archive_path)
@@ -376,7 +375,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
         """
         parser = RasterisedDocumentParser(None)
         parser.parse(
-            os.path.join(self.SAMPLE_FILES, "multi-page-images.pdf"),
+            (self.SAMPLE_FILES / "multi-page-images.pdf").as_posix(),
             "application/pdf",
         )
         self.assertIsFile(parser.archive_path)
@@ -398,7 +397,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
         """
         parser = RasterisedDocumentParser(None)
         parser.parse(
-            os.path.join(self.SAMPLE_FILES, "multi-page-images.pdf"),
+            (self.SAMPLE_FILES / "multi-page-images.pdf").as_posix(),
             "application/pdf",
         )
         self.assertIsFile(parser.archive_path)
@@ -420,7 +419,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
         """
         parser = RasterisedDocumentParser(None)
         parser.parse(
-            os.path.join(self.SAMPLE_FILES, "multi-page-digital.pdf"),
+            (self.SAMPLE_FILES / "multi-page-digital.pdf").as_posix(),
             "application/pdf",
         )
         self.assertIsNone(parser.archive_path)
@@ -443,7 +442,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
         """
         parser = RasterisedDocumentParser(None)
         parser.parse(
-            os.path.join(self.SAMPLE_FILES, "multi-page-images.pdf"),
+            (self.SAMPLE_FILES / "multi-page-images.pdf").as_posix(),
             "application/pdf",
         )
 
@@ -468,7 +467,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
         """
         parser = RasterisedDocumentParser(None)
         parser.parse(
-            os.path.join(self.SAMPLE_FILES, "multi-page-digital.pdf"),
+            (self.SAMPLE_FILES / "multi-page-digital.pdf").as_posix(),
             "application/pdf",
         )
         self.assertIsNotNone(parser.archive_path)
@@ -491,7 +490,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
         """
         parser = RasterisedDocumentParser(None)
         parser.parse(
-            os.path.join(self.SAMPLE_FILES, "multi-page-images.pdf"),
+            (self.SAMPLE_FILES / "multi-page-images.pdf").as_posix(),
             "application/pdf",
         )
         self.assertIsNotNone(parser.archive_path)
@@ -514,7 +513,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
         """
         parser = RasterisedDocumentParser(None)
         parser.parse(
-            os.path.join(self.SAMPLE_FILES, "multi-page-digital.pdf"),
+            (self.SAMPLE_FILES / "multi-page-digital.pdf").as_posix(),
             "application/pdf",
         )
         self.assertIsNone(parser.archive_path)
@@ -537,7 +536,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
         """
         parser = RasterisedDocumentParser(None)
         parser.parse(
-            os.path.join(self.SAMPLE_FILES, "multi-page-images.pdf"),
+            (self.SAMPLE_FILES / "multi-page-images.pdf").as_posix(),
             "application/pdf",
         )
         self.assertIsNotNone(parser.archive_path)
@@ -560,7 +559,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
         """
         parser = RasterisedDocumentParser(None)
         parser.parse(
-            os.path.join(self.SAMPLE_FILES, "multi-page-digital.pdf"),
+            (self.SAMPLE_FILES / "multi-page-digital.pdf").as_posix(),
             "application/pdf",
         )
         self.assertIsNone(parser.archive_path)
@@ -583,7 +582,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
         """
         parser = RasterisedDocumentParser(None)
         parser.parse(
-            os.path.join(self.SAMPLE_FILES, "multi-page-images.pdf"),
+            (self.SAMPLE_FILES / "multi-page-images.pdf").as_posix(),
             "application/pdf",
         )
         self.assertIsNone(parser.archive_path)
@@ -606,7 +605,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
         """
         parser = RasterisedDocumentParser(None)
         parser.parse(
-            os.path.join(self.SAMPLE_FILES, "multi-page-mixed.pdf"),
+            (self.SAMPLE_FILES / "multi-page-mixed.pdf").as_posix(),
             "application/pdf",
         )
         self.assertIsNotNone(parser.archive_path)
@@ -616,7 +615,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
             ["page 1", "page 2", "page 3", "page 4", "page 5", "page 6"],
         )
 
-        with open(os.path.join(parser.tempdir, "sidecar.txt")) as f:
+        with (parser.tempdir / "sidecar.txt").open() as f:
             sidecar = f.read()
 
         self.assertIn("[OCR skipped on page(s) 4-6]", sidecar)
@@ -637,7 +636,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
         """
         parser = RasterisedDocumentParser(None)
         parser.parse(
-            os.path.join(self.SAMPLE_FILES, "single-page-mixed.pdf"),
+            (self.SAMPLE_FILES / "single-page-mixed.pdf").as_posix(),
             "application/pdf",
         )
         self.assertIsNotNone(parser.archive_path)
@@ -651,7 +650,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
             ],
         )
 
-        with open(os.path.join(parser.tempdir, "sidecar.txt")) as f:
+        with (parser.tempdir / "sidecar.txt").open() as f:
             sidecar = f.read().lower()
 
         self.assertIn("this is some text, but in an image, also on page 1.", sidecar)
@@ -674,7 +673,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
         """
         parser = RasterisedDocumentParser(None)
         parser.parse(
-            os.path.join(self.SAMPLE_FILES, "multi-page-mixed.pdf"),
+            (self.SAMPLE_FILES / "multi-page-mixed.pdf").as_posix(),
             "application/pdf",
         )
         self.assertIsNone(parser.archive_path)
@@ -686,7 +685,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
     @override_settings(OCR_MODE="skip", OCR_ROTATE_PAGES=True)
     def test_rotate(self):
         parser = RasterisedDocumentParser(None)
-        parser.parse(os.path.join(self.SAMPLE_FILES, "rotated.pdf"), "application/pdf")
+        parser.parse((self.SAMPLE_FILES / "rotated.pdf").as_posix(), "application/pdf")
         self.assertContainsStrings(
             parser.get_text(),
             [
@@ -708,7 +707,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
         """
         parser = RasterisedDocumentParser(None)
         parser.parse(
-            os.path.join(self.SAMPLE_FILES, "multi-page-images.tiff"),
+            (self.SAMPLE_FILES / "multi-page-images.tiff").as_posix(),
             "image/tiff",
         )
         self.assertIsFile(parser.archive_path)
@@ -728,7 +727,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
             - Text from all pages extracted
         """
         parser = RasterisedDocumentParser(None)
-        sample_file = os.path.join(self.SAMPLE_FILES, "multi-page-images-alpha.tiff")
+        sample_file = self.SAMPLE_FILES / "multi-page-images-alpha.tiff"
         with tempfile.NamedTemporaryFile() as tmp_file:
             shutil.copy(sample_file, tmp_file.name)
             parser.parse(
@@ -753,10 +752,9 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
             - Text from all pages extracted
         """
         parser = RasterisedDocumentParser(None)
-        sample_file = os.path.join(
-            self.SAMPLE_FILES,
-            "multi-page-images-alpha-rgb.tiff",
-        )
+        sample_file = (
+            self.SAMPLE_FILES / "multi-page-images-alpha-rgb.tiff"
+        ).as_posix()
         with tempfile.NamedTemporaryFile() as tmp_file:
             shutil.copy(sample_file, tmp_file.name)
             parser.parse(
@@ -845,7 +843,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
         parser = RasterisedDocumentParser(None)
 
         parser.parse(
-            os.path.join(self.SAMPLE_FILES, "rtl-test.pdf"),
+            (self.SAMPLE_FILES / "rtl-test.pdf").as_posix(),
             "application/pdf",
         )
 
@@ -860,49 +858,52 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
         self.assertRaises(
             ParseError,
             parser.parse,
-            os.path.join(self.SAMPLE_FILES, "simple-digital.pdf"),
+            (self.SAMPLE_FILES / "simple-digital.pdf").as_posix(),
             "application/pdf",
         )
 
 
 class TestParserFileTypes(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
-    SAMPLE_FILES = os.path.join(os.path.dirname(__file__), "samples")
+    SAMPLE_FILES = Path(__file__).parent / "samples"
 
     def test_bmp(self):
         parser = RasterisedDocumentParser(None)
-        parser.parse(os.path.join(self.SAMPLE_FILES, "simple.bmp"), "image/bmp")
+        parser.parse((self.SAMPLE_FILES / "simple.bmp").as_posix(), "image/bmp")
         self.assertIsFile(parser.archive_path)
         self.assertIn("this is a test document", parser.get_text().lower())
 
     def test_jpg(self):
         parser = RasterisedDocumentParser(None)
-        parser.parse(os.path.join(self.SAMPLE_FILES, "simple.jpg"), "image/jpeg")
+        parser.parse((self.SAMPLE_FILES / "simple.jpg").as_posix(), "image/jpeg")
         self.assertIsFile(parser.archive_path)
         self.assertIn("this is a test document", parser.get_text().lower())
 
     def test_heic(self):
         parser = RasterisedDocumentParser(None)
-        parser.parse(os.path.join(self.SAMPLE_FILES, "simple.heic"), "image/heic")
+        parser.parse((self.SAMPLE_FILES / "simple.heic").as_posix(), "image/heic")
         self.assertIsFile(parser.archive_path)
         self.assertIn("pizza", parser.get_text().lower())
 
     @override_settings(OCR_IMAGE_DPI=200)
     def test_gif(self):
         parser = RasterisedDocumentParser(None)
-        parser.parse(os.path.join(self.SAMPLE_FILES, "simple.gif"), "image/gif")
+        parser.parse((self.SAMPLE_FILES / "simple.gif").as_posix(), "image/gif")
         self.assertIsFile(parser.archive_path)
         self.assertIn("this is a test document", parser.get_text().lower())
 
     def test_tiff(self):
         parser = RasterisedDocumentParser(None)
-        parser.parse(os.path.join(self.SAMPLE_FILES, "simple.tif"), "image/tiff")
+        parser.parse((self.SAMPLE_FILES / "simple.tif").as_posix(), "image/tiff")
         self.assertIsFile(parser.archive_path)
         self.assertIn("this is a test document", parser.get_text().lower())
 
     @override_settings(OCR_IMAGE_DPI=72)
     def test_webp(self):
         parser = RasterisedDocumentParser(None)
-        parser.parse(os.path.join(self.SAMPLE_FILES, "document.webp"), "image/webp")
+        parser.parse(
+            (self.SAMPLE_FILES / "document.webp").as_posix(),
+            "image/webp",
+        )
         self.assertIsFile(parser.archive_path)
         # Older tesseracts consistently mangle the space between "a webp",
         # tesseract 5.3.0 seems to do a better job, so we're accepting both


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

<!--
⚠️ Important: Pull requests that implement a new feature or enhancement *should almost always target an existing feature request* with evidence of community interest and discussion. This is in order to balance the work of implementing and maintaining new features / enhancements. If that is not currently the case, please open a feature request instead of this PR to gather feedback from both users and the project maintainers.
-->

Switch some more python files from os.path to pathlib.Path.

Related to https://github.com/paperless-ngx/paperless-ngx/discussions/7861

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [x] Other. Please explain: Switch some more python files from `os.path` to `pathlib.Path`.

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [X] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.