### PR TITLE
Chore: warn users about removal of postgres v13 support

### DIFF
--- a/src/paperless/checks.py
+++ b/src/paperless/checks.py
@@ -212,3 +212,31 @@ def audit_log_check(app_configs, **kwargs):
         )
 
     return result
+
+
+@register()
+def check_postgres_version(app_configs, **kwargs):
+    """
+    Django 5.2 deprecated PostgreSQL 13 support, and it will be removed in
+    a future Paperless-ngx version. This can be removed eventually.
+    See https://docs.djangoproject.com/en/5.2/releases/5.2/#dropped-support-for-postgresql-13
+    """
+    db_conn = connections["default"]
+    result = []
+    if db_conn.vendor == "postgresql":
+        try:
+            with db_conn.cursor() as cursor:
+                cursor.execute("SHOW server_version;")
+                version = cursor.fetchone()[0]
+                if version.startswith("13"):
+                    return [
+                        Warning(
+                            "PostgreSQL 13 is deprecated in Django 5.2 and will not be supported in a future Paperless-ngx release.",
+                            hint="Upgrade to PostgreSQL 14 or newer.",
+                        ),
+                    ]
+        except Exception:  # pragma: no cover
+            # Don't block checks on version query failure
+            pass
+
+    return result

--- a/src/paperless/checks.py
+++ b/src/paperless/checks.py
@@ -217,8 +217,8 @@ def audit_log_check(app_configs, **kwargs):
 @register()
 def check_postgres_version(app_configs, **kwargs):
     """
-    Django 5.2 deprecated PostgreSQL 13 support, and it will be removed in
-    a future Paperless-ngx version. This can be removed eventually.
+    Django 5.2 removed PostgreSQL 13 support and thus it will be removed in
+    a future Paperless-ngx version. This check can be removed eventually.
     See https://docs.djangoproject.com/en/5.2/releases/5.2/#dropped-support-for-postgresql-13
     """
     db_conn = connections["default"]
@@ -231,7 +231,7 @@ def check_postgres_version(app_configs, **kwargs):
                 if version.startswith("13"):
                     return [
                         Warning(
-                            "PostgreSQL 13 is deprecated in Django 5.2 and will not be supported in a future Paperless-ngx release.",
+                            "PostgreSQL 13 is deprecated and will not be supported in a future Paperless-ngx release.",
                             hint="Upgrade to PostgreSQL 14 or newer.",
                         ),
                     ]

--- a/src/paperless/tests/test_checks.py
+++ b/src/paperless/tests/test_checks.py
@@ -9,6 +9,7 @@ from documents.tests.utils import DirectoriesMixin
 from documents.tests.utils import FileSystemAssertsMixin
 from paperless.checks import audit_log_check
 from paperless.checks import binaries_check
+from paperless.checks import check_postgres_version
 from paperless.checks import debug_mode_check
 from paperless.checks import paths_check
 from paperless.checks import settings_values_check
@@ -262,3 +263,39 @@ class TestAuditLogChecks(TestCase):
                     ("auditlog table was found but audit log is disabled."),
                     msg.msg,
                 )
+
+
+class TestPostgresVersionCheck(TestCase):
+    @mock.patch("paperless.checks.connections")
+    def test_postgres_13_warns(self, mock_connections):
+        mock_connection = mock.MagicMock()
+        mock_connection.vendor = "postgresql"
+        mock_cursor = mock.MagicMock()
+        mock_cursor.__enter__.return_value.fetchone.return_value = ["13.11"]
+        mock_connection.cursor.return_value = mock_cursor
+        mock_connections.__getitem__.return_value = mock_connection
+
+        warnings = check_postgres_version(None)
+        self.assertEqual(len(warnings), 1)
+        self.assertIn("PostgreSQL 13 is deprecated", warnings[0].msg)
+
+    @mock.patch("paperless.checks.connections")
+    def test_postgres_14_passes(self, mock_connections):
+        mock_connection = mock.MagicMock()
+        mock_connection.vendor = "postgresql"
+        mock_cursor = mock.MagicMock()
+        mock_cursor.__enter__.return_value.fetchone.return_value = ["14.10"]
+        mock_connection.cursor.return_value = mock_cursor
+        mock_connections.__getitem__.return_value = mock_connection
+
+        warnings = check_postgres_version(None)
+        self.assertEqual(warnings, [])
+
+    @mock.patch("paperless.checks.connections")
+    def test_non_postgres_skipped(self, mock_connections):
+        mock_connection = mock.MagicMock()
+        mock_connection.vendor = "sqlite"
+        mock_connections.__getitem__.return_value = mock_connection
+
+        warnings = check_postgres_version(None)
+        self.assertEqual(warnings, [])


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Django 5.2 removed PostgreSQL 13 support, so it will be removed in a future Paperless-ngx version when we upgrade Django. I think we need to at least warn users and wait until the next major pngx version?

Presumably this check can be removed eventually.

See https://docs.djangoproject.com/en/5.2/releases/5.2/#dropped-support-for-postgresql-13

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [x] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
