### PR TITLE
Performance: pre-filter document list in scheduled workflow checks

### DIFF
--- a/src/documents/tasks.py
+++ b/src/documents/tasks.py
@@ -33,6 +33,7 @@ from documents.data_models import DocumentMetadataOverrides
 from documents.double_sided import CollatePlugin
 from documents.file_handling import create_source_path_directory
 from documents.file_handling import generate_unique_filename
+from documents.matching import filter_documents_by_workflowtrigger_criteria
 from documents.models import Correspondent
 from documents.models import CustomFieldInstance
 from documents.models import Document
@@ -472,6 +473,13 @@ def check_scheduled_workflows():
                         ]
 
                         documents = Document.objects.filter(id__in=matched_ids)
+
+                # Workflows initially matched against one document at a time, so speed things up
+                # by filtering documents by the trigger criteria
+                documents = filter_documents_by_workflowtrigger_criteria(
+                    documents,
+                    trigger,
+                )
 
                 if documents.count() > 0:
                     logger.debug(

--- a/src/documents/tasks.py
+++ b/src/documents/tasks.py
@@ -33,7 +33,7 @@ from documents.data_models import DocumentMetadataOverrides
 from documents.double_sided import CollatePlugin
 from documents.file_handling import create_source_path_directory
 from documents.file_handling import generate_unique_filename
-from documents.matching import filter_documents_by_workflowtrigger_criteria
+from documents.matching import prefilter_documents_by_workflowtrigger
 from documents.models import Correspondent
 from documents.models import CustomFieldInstance
 from documents.models import Document
@@ -474,12 +474,11 @@ def check_scheduled_workflows():
 
                         documents = Document.objects.filter(id__in=matched_ids)
 
-                # Workflows initially matched against one document at a time, so speed things up
-                # by filtering documents by the trigger criteria
-                documents = filter_documents_by_workflowtrigger_criteria(
-                    documents,
-                    trigger,
-                )
+                if documents.count() > 0:
+                    documents = prefilter_documents_by_workflowtrigger(
+                        documents,
+                        trigger,
+                    )
 
                 if documents.count() > 0:
                     logger.debug(

--- a/src/documents/tests/test_workflows.py
+++ b/src/documents/tests/test_workflows.py
@@ -25,6 +25,7 @@ from documents import tasks
 from documents.data_models import ConsumableDocument
 from documents.data_models import DocumentSource
 from documents.matching import document_matches_workflow
+from documents.matching import prefilter_documents_by_workflowtrigger
 from documents.models import Correspondent
 from documents.models import CustomField
 from documents.models import CustomFieldInstance
@@ -1710,6 +1711,55 @@ class TestWorkflows(
         self.assertEqual(doc.owner, self.user2)
         doc2.refresh_from_db()
         self.assertIsNone(doc2.owner)  # has not triggered yet
+
+    def test_workflow_scheduled_filters_queryset(self):
+        """
+        GIVEN:
+            - Existing workflow with scheduled trigger
+        WHEN:
+            - Workflows run and matching documents are found
+        THEN:
+            - prefilter_documents_by_workflowtrigger appropriately filters
+        """
+        trigger = WorkflowTrigger.objects.create(
+            type=WorkflowTrigger.WorkflowTriggerType.SCHEDULED,
+            schedule_offset_days=-7,
+            schedule_date_field=WorkflowTrigger.ScheduleDateField.CREATED,
+            filter_filename="*sample*",
+            filter_has_document_type=self.dt,
+            filter_has_correspondent=self.c,
+        )
+        trigger.filter_has_tags.set([self.t1])
+        trigger.save()
+        action = WorkflowAction.objects.create(
+            assign_owner=self.user2,
+        )
+        w = Workflow.objects.create(
+            name="Workflow 1",
+            order=0,
+        )
+        w.triggers.add(trigger)
+        w.actions.add(action)
+        w.save()
+
+        # create 10 docs with half having the document type
+        for i in range(10):
+            doc = Document.objects.create(
+                title=f"sample test {i}",
+                checksum=f"checksum{i}",
+                correspondent=self.c,
+                original_filename=f"sample_{i}.pdf",
+                document_type=self.dt if i % 2 == 0 else None,
+            )
+            doc.tags.set([self.t1])
+            doc.save()
+
+        documents = Document.objects.all()
+        filtered_docs = prefilter_documents_by_workflowtrigger(
+            documents,
+            trigger,
+        )
+        self.assertEqual(filtered_docs.count(), 5)
 
     def test_workflow_enabled_disabled(self):
         trigger = WorkflowTrigger.objects.create(


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Currently, scheduled workflow checks will check _every_ document that passes the date filter with `document_matches_workflow`. This works, but of course can be very slow, see the linked thread. Instead, we can try to 'pre-filter' the documents to reduce the number that we fully check. The only 'downside' of this is some redundancy, but theres also an advantage I think because this is just kind of a 'first swipe' but the later `document_matches_workflow` check will still run.

In particular the filename check which later runs with `fnmatch` is simplified to a regex, worst case is no regex in sqlite and it would silently fail but the later check would still run.

Hopefully didnt miss anything here, welcome feedback of course.

See #10012 (8k docs, initially > 30 min --> ~10 seconds)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
