### PR TITLE
Fix: Add exception to `utime` in `copy_basic_file_stats`

### DIFF
--- a/src/documents/utils.py
+++ b/src/documents/utils.py
@@ -29,6 +29,7 @@ def copy_basic_file_stats(source: Path | str, dest: Path | str) -> None:
     """
     source, dest = _coerce_to_path(source, dest)
     src_stat = source.stat()
+
     try:
         utime(dest, ns=(src_stat.st_atime_ns, src_stat.st_mtime_ns))
     except PermissionError:

--- a/src/documents/utils.py
+++ b/src/documents/utils.py
@@ -23,11 +23,16 @@ def copy_basic_file_stats(source: Path | str, dest: Path | str) -> None:
 
     The extended attribute copy does weird things with SELinux and files
     copied from temporary directories and copystat doesn't allow disabling
-    these copies
+    these copies.
+
+    If there is a PermissionError, skip copying file stats.
     """
     source, dest = _coerce_to_path(source, dest)
     src_stat = source.stat()
-    utime(dest, ns=(src_stat.st_atime_ns, src_stat.st_mtime_ns))
+    try:
+        utime(dest, ns=(src_stat.st_atime_ns, src_stat.st_mtime_ns))
+    except PermissionError:
+        pass
 
 
 def copy_file_with_basic_stats(


### PR DESCRIPTION
## Proposed change

Add an exception to `utime` in `copy_basic_file_stats`:
```
[2025-05-28 03:01:02,966] [ERROR] [paperless.tasks] ConsumeTaskPlugin failed: [Errno 1] Operation not permitted

Traceback (most recent call last):
  File "/usr/src/paperless/src/documents/tasks.py", line 180, in consume_file
    msg = plugin.run()
          ^^^^^^^^^^^^
  File "/usr/src/paperless/src/documents/consumer.py", line 390, in run
    copy_file_with_basic_stats(self.input_doc.original_file, self.working_copy)
  File "/usr/src/paperless/src/documents/utils.py", line 54, in copy_file_with_basic_stats
    copy_basic_file_stats(source, dest)
  File "/usr/src/paperless/src/documents/utils.py", line 30, in copy_basic_file_stats
    utime(dest, ns=(src_stat.st_atime_ns, src_stat.st_mtime_ns))
PermissionError: [Errno 1] Operation not permitted
```

This error occurs, when mounting the consume directory (network share) in Docker. It does not happen under default configuration. With this exception, the consumption runs without errors.

## Type of change

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
