### PR TITLE
Fix: handle whoosh query correction errors

### DIFF
--- a/src/documents/index.py
+++ b/src/documents/index.py
@@ -396,7 +396,7 @@ class DelayedMoreLikeThisQuery(DelayedQuery):
         )
         mask: set = {docnum}
 
-        return q, mask
+        return q, mask, None
 
 
 def autocomplete(

--- a/src/documents/index.py
+++ b/src/documents/index.py
@@ -362,9 +362,16 @@ class DelayedFullTextQuery(DelayedQuery):
         )
         q = qp.parse(q_str)
 
-        corrected = self.searcher.correct_query(q, q_str)
-        if corrected.query != q:
-            corrected.query = corrected.string
+        try:
+            corrected = self.searcher.correct_query(q, q_str)
+            if corrected.query != q:
+                corrected.query = corrected.string
+        except Exception as e:
+            logger.info(
+                "Error while correcting query %s: %s",
+                f"{q_str!r}",
+                e,
+            )
 
         return q, None
 

--- a/src/documents/tests/test_api_search.py
+++ b/src/documents/tests/test_api_search.py
@@ -2,7 +2,6 @@ import datetime
 from datetime import timedelta
 from unittest import mock
 
-import pytest
 from dateutil.relativedelta import relativedelta
 from django.contrib.auth.models import Group
 from django.contrib.auth.models import Permission
@@ -623,8 +622,7 @@ class TestDocumentSearchApi(DirectoriesMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data[0], b"auto")
 
-    @pytest.mark.skip(reason="Not implemented yet")
-    def test_search_spelling_correction(self):
+    def test_search_spelling_suggestion(self):
         with AsyncWriter(index.open_index()) as writer:
             for i in range(55):
                 doc = Document.objects.create(
@@ -635,12 +633,12 @@ class TestDocumentSearchApi(DirectoriesMixin, APITestCase):
                 )
                 index.update_document(writer, doc)
 
-        response = self.client.get("/api/search/?query=thing")
+        response = self.client.get("/api/documents/?query=thing")
         correction = response.data["corrected_query"]
 
         self.assertEqual(correction, "things")
 
-        response = self.client.get("/api/search/?query=things")
+        response = self.client.get("/api/documents/?query=things")
         correction = response.data["corrected_query"]
 
         self.assertEqual(correction, None)


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

I was able to get a more useful traceback:

```
Internal Server Error: /api/search/
Traceback (most recent call last):
  File "paperless-ngx/.venv/lib/python3.10/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
  File "paperless-ngx/.venv/lib/python3.10/site-packages/django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "paperless-ngx/.venv/lib/python3.10/site-packages/django/views/decorators/csrf.py", line 65, in _view_wrapper
    return view_func(request, *args, **kwargs)
  File "paperless-ngx/.venv/lib/python3.10/site-packages/django/views/generic/base.py", line 104, in view
    return self.dispatch(request, *args, **kwargs)
  File "paperless-ngx/.venv/lib/python3.10/site-packages/rest_framework/views.py", line 515, in dispatch
    response = self.handle_exception(exc)
  File "paperless-ngx/.venv/lib/python3.10/site-packages/rest_framework/views.py", line 475, in handle_exception
    self.raise_uncaught_exception(exc)
  File "paperless-ngx/.venv/lib/python3.10/site-packages/rest_framework/views.py", line 486, in raise_uncaught_exception
    raise exc
  File "paperless-ngx/.venv/lib/python3.10/site-packages/rest_framework/views.py", line 512, in dispatch
    response = handler(request, *args, **kwargs)
  File "paperless-ngx/src/documents/views.py", line 1725, in get
    results = fts_query[0:1]
  File "paperless-ngx/src/documents/index.py", line 293, in __getitem__
    q, mask = self._get_query()
  File "paperless-ngx/src/documents/index.py", line 365, in _get_query
    corrected = self.searcher.correct_query(q, q_str)
  File "paperless-ngx/.venv/lib/python3.10/site-packages/whoosh/searching.py", line 977, in correct_query
    return sqc.correct_query(q, qstring)
  File "paperless-ngx/.venv/lib/python3.10/site-packages/whoosh/spelling.py", line 345, in correct_query
    return Correction(q, qstring, corrected_q, corrected_tokens)
  File "paperless-ngx/.venv/lib/python3.10/site-packages/whoosh/spelling.py", line 216, in __init__
    self.string = self.format_string(highlight.NullFormatter())
  File "paperless-ngx/.venv/lib/python3.10/site-packages/whoosh/spelling.py", line 238, in format_string
    out = formatter.format_fragment(fragment, replace=True)
  File "paperless-ngx/.venv/lib/python3.10/site-packages/whoosh/highlight.py", line 721, in format_fragment
    for t in sorted(
  File "paperless-ngx/.venv/lib/python3.10/site-packages/whoosh/highlight.py", line 723, in <lambda>
    key=lambda token: (token.startchar, -(token.endchar - token.startchar)),
TypeError: unsupported operand type(s) for -: 'NoneType' and 'NoneType'
```

Closes #10119

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
