### PR TITLE
Documentation: correct Gotenberg API timeout value

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -130,7 +130,7 @@ command:
     - 'gotenberg'
     - '--chromium-disable-javascript=true'
     - '--chromium-allow-list=file:///tmp/.*'
-    - '--api-timeout=60'
+    - '--api-timeout=60s'
 ```
 
 ## Permission denied errors in the consumption directory


### PR DESCRIPTION
## Proposed change

Fix of documentation to add unit onto the end of Gotenberg timeout value (https://gotenberg.dev/docs/configuration)

## Type of change

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [x] Documentation only.
- [ ] Other. Please explain:

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
