### PR TITLE
Fix: remove duplicate base path in websocket urls

### DIFF
--- a/src/paperless/urls.py
+++ b/src/paperless/urls.py
@@ -363,7 +363,7 @@ urlpatterns = [
 
 
 websocket_urlpatterns = [
-    path(settings.BASE_URL.lstrip("/") + "ws/status/", StatusConsumer.as_asgi()),
+    path("ws/status/", StatusConsumer.as_asgi()),
 ]
 
 # Text in each page's <h1> (and above login form).


### PR DESCRIPTION
Fixes #10193, see there for details.