### PR TITLE
Fix: restore expected pre-2.16 scheduled workflow offset behavior

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -408,7 +408,7 @@ Currently, there are three events that correspond to workflow trigger 'types':
    tags, doc type, or correspondent.
 4. **Scheduled**: a scheduled trigger that can be used to run workflows at a specific time. The date used can be either the document
    added, created, updated date or you can specify a (date) custom field. You can also specify a day offset from the date (positive
-   offsets will trigger before the date, negative offsets will trigger after).
+   offsets will trigger after the date, negative offsets will trigger before).
 
 The following flow diagram illustrates the three document trigger types:
 

--- a/src-ui/src/app/components/common/edit-dialog/workflow-edit-dialog/workflow-edit-dialog.component.html
+++ b/src-ui/src/app/components/common/edit-dialog/workflow-edit-dialog/workflow-edit-dialog.component.html
@@ -129,7 +129,7 @@
             formControlName="schedule_offset_days"
             [showAdd]="false"
             [error]="error?.schedule_offset_days"
-            hint="Positive values will trigger the workflow before the date, negative values after."
+            hint="Positive values will trigger after the date, negative values before."
             i18n-hint
           ></pngx-input-number>
         </div>

--- a/src/documents/tasks.py
+++ b/src/documents/tasks.py
@@ -420,7 +420,7 @@ def check_scheduled_workflows():
             trigger: WorkflowTrigger
             for trigger in schedule_triggers:
                 documents = Document.objects.none()
-                offset_td = datetime.timedelta(days=-trigger.schedule_offset_days)
+                offset_td = datetime.timedelta(days=trigger.schedule_offset_days)
                 threshold = now - offset_td
                 logger.debug(
                     f"Trigger {trigger.id}: checking if (date + {offset_td}) <= now ({now})",

--- a/src/documents/tests/test_workflows.py
+++ b/src/documents/tests/test_workflows.py
@@ -1614,13 +1614,14 @@ class TestWorkflows(
     def test_workflow_scheduled_trigger_negative_offset_customfield(self):
         """
         GIVEN:
-            - Existing workflow with SCHEDULED trigger and negative offset of -7 days (so 7 days after date)
-            - Custom field date initially set to 5 days ago → trigger time = 2 days in future
-            - Then updated to 8 days ago → trigger time = 1 day ago
+            - Workflow with offset -7 (i.e., 7 days *before* the date)
+            - doc1: value_date = 5 days ago → trigger time = 12 days ago → triggers
+            - doc2: value_date = 9 days in future → trigger time = 2 days in future → does NOT trigger
         WHEN:
-            - Scheduled workflows are checked for document with custom field date 8 days in the past
+            - Scheduled workflows are checked
         THEN:
-            - Workflow runs and document owner is updated
+            - doc1 has owner assigned
+            - doc2 remains untouched
         """
         trigger = WorkflowTrigger.objects.create(
             type=WorkflowTrigger.WorkflowTriggerType.SCHEDULED,
@@ -1640,38 +1641,49 @@ class TestWorkflows(
         w.actions.add(action)
         w.save()
 
-        doc = Document.objects.create(
-            title="sample test",
+        doc1 = Document.objects.create(
+            title="doc1",
             correspondent=self.c,
-            original_filename="sample.pdf",
+            original_filename="doc1.pdf",
+            checksum="doc1-checksum",
         )
-        cfi = CustomFieldInstance.objects.create(
-            document=doc,
+        CustomFieldInstance.objects.create(
+            document=doc1,
             field=self.cf1,
-            value_date=timezone.now() - timedelta(days=5),
+            value_date=timezone.now().date() - timedelta(days=5),
+        )
+
+        doc2 = Document.objects.create(
+            title="doc2",
+            correspondent=self.c,
+            original_filename="doc2.pdf",
+            checksum="doc2-checksum",
+        )
+        CustomFieldInstance.objects.create(
+            document=doc2,
+            field=self.cf1,
+            value_date=timezone.now().date() + timedelta(days=9),
         )
 
         tasks.check_scheduled_workflows()
 
-        doc.refresh_from_db()
-        self.assertIsNone(doc.owner)  # has not triggered yet
+        doc1.refresh_from_db()
+        self.assertEqual(doc1.owner, self.user2)
 
-        cfi.value_date = timezone.now() - timedelta(days=8)
-        cfi.save()
-
-        tasks.check_scheduled_workflows()
-        doc.refresh_from_db()
-        self.assertEqual(doc.owner, self.user2)
+        doc2.refresh_from_db()
+        self.assertIsNone(doc2.owner)
 
     def test_workflow_scheduled_trigger_negative_offset_created(self):
         """
         GIVEN:
-            - Existing workflow with SCHEDULED trigger and negative offset of -7 days (so 7 days after date)
-            - Created date set to 8 days ago → trigger time = 1 day ago and 5 days ago
+            - Existing workflow with SCHEDULED trigger and negative offset of -7 days (so 7 days before date)
+            - doc created 8 days ago → trigger time = 15 days ago → triggers
+            - doc2 created 8 days *in the future* → trigger time = 1 day in future → does NOT trigger
         WHEN:
             - Scheduled workflows are checked for document
         THEN:
-            - Workflow runs and document owner is updated for the first document, not the second
+            - doc is matched and owner updated
+            - doc2 is untouched
         """
         trigger = WorkflowTrigger.objects.create(
             type=WorkflowTrigger.WorkflowTriggerType.SCHEDULED,
@@ -1703,7 +1715,7 @@ class TestWorkflows(
             correspondent=self.c,
             original_filename="sample2.pdf",
             checksum="2",
-            created=timezone.now().date() - timedelta(days=5),
+            created=timezone.now().date() + timedelta(days=8),
         )
 
         tasks.check_scheduled_workflows()
@@ -1711,6 +1723,40 @@ class TestWorkflows(
         self.assertEqual(doc.owner, self.user2)
         doc2.refresh_from_db()
         self.assertIsNone(doc2.owner)  # has not triggered yet
+
+    def test_offset_positive_means_after(self):
+        """
+        GIVEN:
+            - Document created 30 days ago
+            - Workflow with offset +10
+        EXPECT:
+            - It triggers now, because created + 10 = 20 days ago < now
+        """
+        doc = Document.objects.create(
+            title="Test doc",
+            created=timezone.now() - timedelta(days=30),
+            correspondent=self.c,
+            original_filename="test.pdf",
+        )
+        trigger = WorkflowTrigger.objects.create(
+            type=WorkflowTrigger.WorkflowTriggerType.SCHEDULED,
+            schedule_date_field=WorkflowTrigger.ScheduleDateField.CREATED,
+            schedule_offset_days=10,
+        )
+        action = WorkflowAction.objects.create(
+            assign_title="Doc assign owner",
+            assign_owner=self.user2,
+        )
+        w = Workflow.objects.create(
+            name="Workflow 1",
+            order=0,
+        )
+        w.triggers.add(trigger)
+        w.actions.add(action)
+        w.save()
+        tasks.check_scheduled_workflows()
+        doc.refresh_from_db()
+        self.assertEqual(doc.owner, self.user2)
 
     def test_workflow_scheduled_filters_queryset(self):
         """


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Perhaps this is the best approach: make the logic more expected and restore it to 2.15 behavior, release this as a breaking change so users can at least check.

Closes #10216

Here's the release message:

> ### ⚠️ Breaking Change: Scheduled Workflow Offset
> 
> In versions v2.16.0–v2.16.3, the interpretation of offset days for scheduled workflows was inverted. This has now been **corrected** to restore the intuitive, pre-v2.16 behavior:
> 
> - **Positive offsets now trigger workflows *after* the date**
> - **Negative offsets trigger workflows *before* the date**
> 
> If you configured scheduled workflows in v2.16.x with inverted offsets (or adjusted a trigger created in 2.15.x), you must now **adjust the offset sign** to match this corrected logic.
> 
> If you did not alter your workflow triggers after upgrading from v2.15, no changes are required.
> 
> We apologize for the confusion — this fix restores consistency and better matches user expectations.

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
