### PR TITLE
Fix: prevent duplicate cachalot app in Django settings

### DIFF
--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -918,7 +918,6 @@ CELERY_BEAT_SCHEDULE_FILENAME = str(DATA_DIR / "celerybeat-schedule.db")
 
 # Cachalot: Database read cache.
 def _parse_cachalot_settings():
-    global INSTALLED_APPS
     ttl = __get_int("PAPERLESS_READ_CACHE_TTL", 3600)
     ttl = min(ttl, 31536000) if ttl > 0 else 3600
     _, redis_url = _parse_redis_url(
@@ -936,12 +935,12 @@ def _parse_cachalot_settings():
         "CACHALOT_REDIS_URL": redis_url,
         "CACHALOT_TIMEOUT": ttl,
     }
-    if result["CACHALOT_ENABLED"]:
-        INSTALLED_APPS.append("cachalot")
     return result
 
 
 cachalot_settings = _parse_cachalot_settings()
+if cachalot_settings["CACHALOT_ENABLED"]:
+    INSTALLED_APPS.append("cachalot")
 CACHALOT_ENABLED = cachalot_settings["CACHALOT_ENABLED"]
 CACHALOT_CACHE = cachalot_settings["CACHALOT_CACHE"]
 CACHALOT_TIMEOUT = cachalot_settings["CACHALOT_TIMEOUT"]

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -936,7 +936,7 @@ def _parse_cachalot_settings():
         "CACHALOT_REDIS_URL": redis_url,
         "CACHALOT_TIMEOUT": ttl,
     }
-    if result["CACHALOT_ENABLED"] and "cachalot" not in INSTALLED_APPS:
+    if result["CACHALOT_ENABLED"]:
         INSTALLED_APPS.append("cachalot")
     return result
 

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -941,13 +941,13 @@ def _parse_cachalot_settings():
     return result
 
 
-_cachalot_settings = _parse_cachalot_settings()
-CACHALOT_ENABLED = _cachalot_settings["CACHALOT_ENABLED"]
-CACHALOT_CACHE = _cachalot_settings["CACHALOT_CACHE"]
-CACHALOT_TIMEOUT = _cachalot_settings["CACHALOT_TIMEOUT"]
-CACHALOT_QUERY_KEYGEN = _cachalot_settings["CACHALOT_QUERY_KEYGEN"]
-CACHALOT_TABLE_KEYGEN = _cachalot_settings["CACHALOT_TABLE_KEYGEN"]
-CACHALOT_FINAL_SQL_CHECK = _cachalot_settings["CACHALOT_FINAL_SQL_CHECK"]
+cachalot_settings = _parse_cachalot_settings()
+CACHALOT_ENABLED = cachalot_settings["CACHALOT_ENABLED"]
+CACHALOT_CACHE = cachalot_settings["CACHALOT_CACHE"]
+CACHALOT_TIMEOUT = cachalot_settings["CACHALOT_TIMEOUT"]
+CACHALOT_QUERY_KEYGEN = cachalot_settings["CACHALOT_QUERY_KEYGEN"]
+CACHALOT_TABLE_KEYGEN = cachalot_settings["CACHALOT_TABLE_KEYGEN"]
+CACHALOT_FINAL_SQL_CHECK = cachalot_settings["CACHALOT_FINAL_SQL_CHECK"]
 
 
 # Django default & Cachalot cache configuration
@@ -968,16 +968,13 @@ def _parse_caches():
         },
         "read-cache": {
             "BACKEND": _CACHE_BACKEND,
-            "LOCATION": _parse_cachalot_settings()["CACHALOT_REDIS_URL"],
+            "LOCATION": cachalot_settings["CACHALOT_REDIS_URL"],
             "KEY_PREFIX": _REDIS_KEY_PREFIX,
         },
     }
 
 
 CACHES = _parse_caches()
-
-
-del _cachalot_settings
 
 
 def default_threads_per_worker(task_workers) -> int:

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -936,7 +936,7 @@ def _parse_cachalot_settings():
         "CACHALOT_REDIS_URL": redis_url,
         "CACHALOT_TIMEOUT": ttl,
     }
-    if result["CACHALOT_ENABLED"]:
+    if result["CACHALOT_ENABLED"] and "cachalot" not in INSTALLED_APPS:
         INSTALLED_APPS.append("cachalot")
     return result
 

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -939,9 +939,9 @@ def _parse_cachalot_settings():
 
 
 cachalot_settings = _parse_cachalot_settings()
-if cachalot_settings["CACHALOT_ENABLED"]:
-    INSTALLED_APPS.append("cachalot")
 CACHALOT_ENABLED = cachalot_settings["CACHALOT_ENABLED"]
+if CACHALOT_ENABLED:
+    INSTALLED_APPS.append("cachalot")
 CACHALOT_CACHE = cachalot_settings["CACHALOT_CACHE"]
 CACHALOT_TIMEOUT = cachalot_settings["CACHALOT_TIMEOUT"]
 CACHALOT_QUERY_KEYGEN = cachalot_settings["CACHALOT_QUERY_KEYGEN"]

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -940,7 +940,7 @@ def _parse_cachalot_settings():
 
 cachalot_settings = _parse_cachalot_settings()
 CACHALOT_ENABLED = cachalot_settings["CACHALOT_ENABLED"]
-if CACHALOT_ENABLED:
+if CACHALOT_ENABLED:  # pragma: no cover
     INSTALLED_APPS.append("cachalot")
 CACHALOT_CACHE = cachalot_settings["CACHALOT_CACHE"]
 CACHALOT_TIMEOUT = cachalot_settings["CACHALOT_TIMEOUT"]

--- a/src/paperless/tests/test_db_cache.py
+++ b/src/paperless/tests/test_db_cache.py
@@ -63,26 +63,20 @@ class TestDbCacheSettings:
         },
     )
     def test_cachalot_custom_settings(self):
-        cachalot_settings = _parse_cachalot_settings()
-        assert "cachalot" in settings.INSTALLED_APPS
-        caches = _parse_caches()
+        settings = _parse_cachalot_settings()
 
-        # Modifiable settings
-        assert cachalot_settings["CACHALOT_ENABLED"]
-        assert cachalot_settings["CACHALOT_TIMEOUT"] == 7200
-        assert caches["read-cache"]["LOCATION"] == "redis://localhost:6380/7"
-
-        # Fixed settings
-        assert cachalot_settings["CACHALOT_CACHE"] == "read-cache"
+        assert settings["CACHALOT_ENABLED"]
+        assert settings["CACHALOT_TIMEOUT"] == 7200
+        assert settings["CACHALOT_CACHE"] == "read-cache"
         assert (
-            cachalot_settings["CACHALOT_QUERY_KEYGEN"]
+            settings["CACHALOT_QUERY_KEYGEN"]
             == "paperless.db_cache.custom_get_query_cache_key"
         )
         assert (
-            cachalot_settings["CACHALOT_TABLE_KEYGEN"]
+            settings["CACHALOT_TABLE_KEYGEN"]
             == "paperless.db_cache.custom_get_table_cache_key"
         )
-        assert cachalot_settings["CACHALOT_FINAL_SQL_CHECK"] is True
+        assert settings["CACHALOT_FINAL_SQL_CHECK"] is True
 
     @pytest.mark.parametrize(
         ("env_var_ttl", "expected_cachalot_timeout"),


### PR DESCRIPTION
Fix a bug introduced by #9784.
Enabling database caching would add "cachalot" multiple times in the Django applications, causing the app to crash immediately:
```
django.core.exceptions.ImproperlyConfigured: Application labels aren't unique, duplicates: cachalot
```

<!--
⚠️ Important: Pull requests that implement a new feature or enhancement *should almost always target an existing feature request* with evidence of community interest and discussion. This is in order to balance the work of implementing and maintaining new features / enhancements. If that is not currently the case, please open a feature request instead of this PR to gather feedback from both users and the project maintainers.
-->

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
