### PR TITLE
Update PDF editor to support updating documents

### DIFF
--- a/src-ui/src/app/components/common/pdf-editor/pdf-editor.component.html
+++ b/src-ui/src/app/components/common/pdf-editor/pdf-editor.component.html
@@ -68,11 +68,21 @@
     }
   </div>
 </div>
-<div class="modal-footer">
-  <div class="form-check form-switch me-auto">
-    <input class="form-check-input" type="checkbox" id="deleteSwitch" [(ngModel)]="deleteOriginal">
-    <label class="form-check-label" for="deleteSwitch" i18n>Delete original after edit</label>
+<div class="modal-footer flex-column">
+  <div class="form-check">
+    <input class="form-check-input" type="radio" id="modeUpdate" name="editmode" [(ngModel)]="updateDocument" [ngValue]="true">
+    <label class="form-check-label" for="modeUpdate" i18n>Update this document</label>
   </div>
-  <button type="button" class="btn" [class]="cancelBtnClass" (click)="cancel()" [disabled]="!buttonsEnabled">{{ cancelBtnCaption }}</button>
-  <button type="button" class="btn" [class]="btnClass" (click)="confirm()" [disabled]="pages.length === 0">{{ btnCaption }}</button>
+  <div class="form-check mb-2">
+    <input class="form-check-input" type="radio" id="modeCreate" name="editmode" [(ngModel)]="updateDocument" [ngValue]="false">
+    <label class="form-check-label" for="modeCreate" i18n>Create a new document</label>
+  </div>
+  <div class="form-check ms-3 mb-2" *ngIf="!updateDocument">
+    <input class="form-check-input" type="checkbox" id="copyMeta" [(ngModel)]="includeMetadata">
+    <label class="form-check-label" for="copyMeta" i18n>Copy metadata from existing document</label>
+  </div>
+  <div class="d-flex w-100 justify-content-end">
+    <button type="button" class="btn me-2" [class]="cancelBtnClass" (click)="cancel()" [disabled]="!buttonsEnabled">{{ cancelBtnCaption }}</button>
+    <button type="button" class="btn" [class]="btnClass" (click)="confirm()" [disabled]="pages.length === 0">{{ btnCaption }}</button>
+  </div>
 </div>

--- a/src-ui/src/app/components/common/pdf-editor/pdf-editor.component.ts
+++ b/src-ui/src/app/components/common/pdf-editor/pdf-editor.component.ts
@@ -39,7 +39,8 @@ export class PDFEditorComponent extends ConfirmDialogComponent {
   documentID: number
   pages: PageOperation[] = []
   totalPages = 0
-  deleteOriginal = false
+  updateDocument = false
+  includeMetadata = true
 
   get pdfSrc(): string {
     return this.documentService.getPreviewUrl(this.documentID)

--- a/src-ui/src/app/components/document-detail/document-detail.component.spec.ts
+++ b/src-ui/src/app/components/document-detail/document-detail.component.spec.ts
@@ -1159,7 +1159,8 @@ describe('DocumentDetailComponent', () => {
       method: 'edit_pdf',
       parameters: {
         operations: [{ page: 1, rotate: 0, doc: 0 }],
-        delete_original: false,
+        update_document: false,
+        include_metadata: true,
       },
     })
     req.flush(true)

--- a/src-ui/src/app/components/document-detail/document-detail.component.ts
+++ b/src-ui/src/app/components/document-detail/document-detail.component.ts
@@ -1350,7 +1350,8 @@ export class DocumentDetailComponent
         this.documentsService
           .bulkEdit([this.document.id], 'edit_pdf', {
             operations: modal.componentInstance.getOperations(),
-            delete_original: modal.componentInstance.deleteOriginal,
+            update_document: modal.componentInstance.updateDocument,
+            include_metadata: modal.componentInstance.includeMetadata,
           })
           .pipe(first(), takeUntil(this.unsubscribeNotifier))
           .subscribe({

--- a/src/documents/serialisers.py
+++ b/src/documents/serialisers.py
@@ -1537,11 +1537,23 @@ class BulkEditSerializer(
                 raise serializers.ValidationError("rotate must be an integer")
             if "doc" in op and not isinstance(op["doc"], int):
                 raise serializers.ValidationError("doc must be an integer")
-        if "delete_original" in parameters:
-            if not isinstance(parameters["delete_original"], bool):
-                raise serializers.ValidationError("delete_original must be a boolean")
+        if "update_document" in parameters:
+            if not isinstance(parameters["update_document"], bool):
+                raise serializers.ValidationError("update_document must be a boolean")
         else:
-            parameters["delete_original"] = False
+            parameters["update_document"] = False
+        if "include_metadata" in parameters:
+            if not isinstance(parameters["include_metadata"], bool):
+                raise serializers.ValidationError("include_metadata must be a boolean")
+        else:
+            parameters["include_metadata"] = True
+
+        if parameters["update_document"]:
+            max_idx = max(op.get("doc", 0) for op in parameters["operations"])
+            if max_idx > 0:
+                raise serializers.ValidationError(
+                    "update_document only allowed with a single output document",
+                )
 
     def validate(self, attrs):
         method = attrs["method"]

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -1368,17 +1368,21 @@ class BulkEditView(PassUserMixin):
                     method in [bulk_edit.merge, bulk_edit.split]
                     and parameters["delete_originals"]
                 )
-                or (method == bulk_edit.edit_pdf and parameters["delete_original"])
+                or (method == bulk_edit.edit_pdf and parameters["update_document"])
             ):
                 has_perms = user_is_owner_of_all_documents
 
             # check global add permissions for methods that create documents
             if (
                 has_perms
-                and method in [bulk_edit.split, bulk_edit.merge, bulk_edit.edit_pdf]
-                and not user.has_perm(
-                    "documents.add_document",
+                and (
+                    method in [bulk_edit.split, bulk_edit.merge]
+                    or (
+                        method == bulk_edit.edit_pdf
+                        and not parameters["update_document"]
+                    )
                 )
+                and not user.has_perm("documents.add_document")
             ):
                 has_perms = False
 
@@ -1391,7 +1395,6 @@ class BulkEditView(PassUserMixin):
                         method in [bulk_edit.merge, bulk_edit.split]
                         and parameters["delete_originals"]
                     )
-                    or (method == bulk_edit.edit_pdf and parameters["delete_original"])
                 )
                 and not user.has_perm("documents.delete_document")
             ):


### PR DESCRIPTION
## Summary
- allow `edit_pdf` to update existing document or create a new one
- support optional metadata copy when creating a new document
- adjust PDF editor UI for update/create choices
- wire new options through document detail view
- update serializer validation and view permission logic

## Testing
- `pre-commit run --files src/documents/bulk_edit.py src/documents/serialisers.py src/documents/views.py src-ui/src/app/components/common/pdf-editor/pdf-editor.component.ts src-ui/src/app/components/common/pdf-editor/pdf-editor.component.html src-ui/src/app/components/document-detail/document-detail.component.ts src-ui/src/app/components/document-detail/document-detail.component.spec.ts`
- `pytest -k "edit_pdf"` *(fails: ModuleNotFoundError: No module named 'django')*

