### PR TITLE
Documentation: Fix URL for PAPERLESS_OCR_LANGUAGE example in docker-compose.env

### DIFF
--- a/docker/compose/docker-compose.env
+++ b/docker/compose/docker-compose.env
@@ -32,6 +32,6 @@
 # Note that this is different from PAPERLESS_OCR_LANGUAGE (default=eng), which defines
 # the language used for OCR.
 # The container installs English, German, Italian, Spanish and French by default.
-# See https://packages.debian.org/search?keywords=tesseract-ocr-&searchon=names&suite=buster
+# See https://packages.debian.org/search?keywords=tesseract-ocr-&searchon=names
 # for available languages.
 #PAPERLESS_OCR_LANGUAGES=tur ces


### PR DESCRIPTION
## Proposed change

For possible values of PAPERLESS_OCR_LANGUAGES, the original comment provides a link to packages.debian.org but with an old suite=buster parameter, which is now invalid due to being outdated. This comment removes this parameter in the URL to make the link future-proof and working again.

* `https://packages.debian.org/search?keywords=tesseract-ocr-&searchon=names&suite=buster`: unavailable
* `https://packages.debian.org/search?keywords=tesseract-ocr-&searchon=names`: working

## Type of change

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [X] Documentation only.
- [ ] Other. Please explain:

## Checklist:

- [X] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [X] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [X] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [X] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [X] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [X] I have made corresponding changes to the documentation as needed.
- [X] I have checked my modifications for any breaking changes.
