### PR TITLE
Feature/add regex search replace for placeholders

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -51,6 +51,21 @@ as the Python linting and formatting tool `ruff`, will format failing
 files, so all you need to do is `git add` those files again
 and retry your commit.
 
+!!! tip "Running pre-commit manually"
+
+    You can run pre-commit hooks manually on all files or specific files:
+
+    ```bash
+    # Run on all files
+    $ pre-commit run --all-files
+
+    # Run on specific files
+    $ pre-commit run --files src/documents/models.py
+
+    # Run specific hook
+    $ pre-commit run ruff --all-files
+    ```
+
 ## General setup
 
 After you forked and cloned the code from GitHub you need to perform a
@@ -59,6 +74,15 @@ first-time setup.
 !!! note
 
       Every command is executed directly from the root folder of the project unless specified otherwise.
+
+!!! warning "Prerequisites"
+
+      Make sure you have the following installed before proceeding:
+      
+      - Python 3.10 or higher
+      - Node.js 14.15+ and `pnpm` (for frontend development)
+      - Redis server (or Docker to run Redis in a container)
+      - Git for version control
 
 1.  Install prerequisites + [uv](https://github.com/astral-sh/uv) as mentioned in
     [Bare metal route](setup.md#bare_metal).
@@ -77,6 +101,16 @@ first-time setup.
     ```bash
     $ uv sync --group dev
     ```
+
+    !!! note "Alternative without uv"
+
+        If `uv` is not available on your system or you prefer using pip, you can install dependencies manually:
+
+        ```bash
+        $ pip install --user -e .[dev]
+        ```
+
+        However, note that `uv` is the recommended package manager for this project and provides better dependency resolution and faster installations.
 
 5.  Install pre-commit hooks:
 
@@ -151,6 +185,24 @@ $ ng build --configuration production
     is loaded as well. However, the tests rely on the default
     configuration. This is not ideal. But for now, make sure no settings
     except for DEBUG are overridden when testing.
+
+-   To run specific test categories:
+    ```bash
+    # Run only unit tests
+    $ pytest -m "not slow"
+    
+    # Run integration tests
+    $ pytest tests/test_
+    
+    # Run with coverage report
+    $ pytest --cov=paperless --cov-report=html
+    ```
+
+-   For faster test iterations during development, consider running tests for
+    specific modules you're working on:
+    ```bash
+    $ pytest src/documents/tests/test_parsers.py::TestSpecificParser
+    ```
 
 !!! note
 
@@ -476,3 +528,52 @@ To get started:
 
 4. The project is ready for debugging, start either run the fullstack debug or individual debug
    processes. Yo spin up the project without debugging run the task **Project Start: Run all Services**
+
+## Common Development Issues
+
+### Database Issues
+
+If you encounter database-related errors:
+
+```bash
+# Reset the database (WARNING: This will delete all data)
+$ rm -f src/db.sqlite3
+$ cd src && python manage.py migrate
+$ python manage.py createsuperuser
+```
+
+### Redis Connection Issues
+
+If Redis is not running or accessible:
+
+```bash
+# Start Redis with Docker
+$ docker run -d -p 6379:6379 --restart unless-stopped redis:latest
+
+# Or check if Redis is running locally
+$ redis-cli ping
+```
+
+### Frontend Build Issues
+
+If the frontend fails to build:
+
+```bash
+# Clear npm/pnpm cache and reinstall
+$ cd src-ui
+$ rm -rf node_modules pnpm-lock.yaml
+$ pnpm install
+```
+
+### Permission Issues
+
+If you encounter permission issues with file operations:
+
+```bash
+# Ensure proper ownership of the project directory
+$ sudo chown -R $(whoami):$(whoami) /path/to/paperless-ngx
+
+# Create required directories with proper permissions
+$ mkdir -p consume media export
+$ chmod 755 consume media export
+```

--- a/docs/development.md
+++ b/docs/development.md
@@ -51,21 +51,6 @@ as the Python linting and formatting tool `ruff`, will format failing
 files, so all you need to do is `git add` those files again
 and retry your commit.
 
-!!! tip "Running pre-commit manually"
-
-    You can run pre-commit hooks manually on all files or specific files:
-
-    ```bash
-    # Run on all files
-    $ pre-commit run --all-files
-
-    # Run on specific files
-    $ pre-commit run --files src/documents/models.py
-
-    # Run specific hook
-    $ pre-commit run ruff --all-files
-    ```
-
 ## General setup
 
 After you forked and cloned the code from GitHub you need to perform a
@@ -74,15 +59,6 @@ first-time setup.
 !!! note
 
       Every command is executed directly from the root folder of the project unless specified otherwise.
-
-!!! warning "Prerequisites"
-
-      Make sure you have the following installed before proceeding:
-      
-      - Python 3.10 or higher
-      - Node.js 14.15+ and `pnpm` (for frontend development)
-      - Redis server (or Docker to run Redis in a container)
-      - Git for version control
 
 1.  Install prerequisites + [uv](https://github.com/astral-sh/uv) as mentioned in
     [Bare metal route](setup.md#bare_metal).
@@ -101,16 +77,6 @@ first-time setup.
     ```bash
     $ uv sync --group dev
     ```
-
-    !!! note "Alternative without uv"
-
-        If `uv` is not available on your system or you prefer using pip, you can install dependencies manually:
-
-        ```bash
-        $ pip install --user -e .[dev]
-        ```
-
-        However, note that `uv` is the recommended package manager for this project and provides better dependency resolution and faster installations.
 
 5.  Install pre-commit hooks:
 
@@ -185,24 +151,6 @@ $ ng build --configuration production
     is loaded as well. However, the tests rely on the default
     configuration. This is not ideal. But for now, make sure no settings
     except for DEBUG are overridden when testing.
-
--   To run specific test categories:
-    ```bash
-    # Run only unit tests
-    $ pytest -m "not slow"
-    
-    # Run integration tests
-    $ pytest tests/test_
-    
-    # Run with coverage report
-    $ pytest --cov=paperless --cov-report=html
-    ```
-
--   For faster test iterations during development, consider running tests for
-    specific modules you're working on:
-    ```bash
-    $ pytest src/documents/tests/test_parsers.py::TestSpecificParser
-    ```
 
 !!! note
 
@@ -528,52 +476,3 @@ To get started:
 
 4. The project is ready for debugging, start either run the fullstack debug or individual debug
    processes. Yo spin up the project without debugging run the task **Project Start: Run all Services**
-
-## Common Development Issues
-
-### Database Issues
-
-If you encounter database-related errors:
-
-```bash
-# Reset the database (WARNING: This will delete all data)
-$ rm -f src/db.sqlite3
-$ cd src && python manage.py migrate
-$ python manage.py createsuperuser
-```
-
-### Redis Connection Issues
-
-If Redis is not running or accessible:
-
-```bash
-# Start Redis with Docker
-$ docker run -d -p 6379:6379 --restart unless-stopped redis:latest
-
-# Or check if Redis is running locally
-$ redis-cli ping
-```
-
-### Frontend Build Issues
-
-If the frontend fails to build:
-
-```bash
-# Clear npm/pnpm cache and reinstall
-$ cd src-ui
-$ rm -rf node_modules pnpm-lock.yaml
-$ pnpm install
-```
-
-### Permission Issues
-
-If you encounter permission issues with file operations:
-
-```bash
-# Ensure proper ownership of the project directory
-$ sudo chown -R $(whoami):$(whoami) /path/to/paperless-ngx
-
-# Create required directories with proper permissions
-$ mkdir -p consume media export
-$ chmod 755 consume media export
-```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -528,6 +528,49 @@ The following placeholders are only available for "added" or "updated" triggers
 -   `{created_time}`: created time in HH:MM format
 -   `{doc_url}`: URL to the document in the web UI. Requires the `PAPERLESS_URL` setting to be set.
 
+##### Enhanced placeholder transformations
+
+Workflow placeholders support advanced regex-based transformations to modify placeholder values. This allows you to extract specific parts of text, perform substitutions, or reformat values using regular expressions.
+
+**Syntax:**
+-   `{field_name}` - Simple field replacement (standard behavior)
+-   `{field_name:s/pattern/replacement/}` - Regex substitution
+-   `{field_name:s/pattern/replacement/flags}` - Regex substitution with flags
+
+**Supported flags:**
+-   `i` - Case insensitive matching
+-   `s` - Dot matches newlines (dotall mode)
+
+**Examples:**
+
+Replace text in the original filename:
+```
+{original_filename:s/Invoice_/Bill_/}
+```
+If `original_filename` is "Invoice_2024_March", this becomes "Bill_2024_March".
+
+Extract parts using capture groups:
+```
+{original_filename:s/(\d{4})_(\w+)/Statement $2 $1/}
+```
+If `original_filename` is "2024_March_Report", this becomes "Statement March 2024".
+
+Case insensitive replacement:
+```
+{correspondent:s/bank/BANK/i}
+```
+Replaces "bank", "Bank", "BANK", etc. with "BANK".
+
+Combine multiple transformations in workflow text:
+```
+Document from {correspondent:s/\s+/_/} - {original_filename:s/^.*_(\d{4}).*/$1/}
+```
+This replaces spaces in correspondent name with underscores and extracts a year from the filename.
+
+!!! note
+    
+    Regex transformations use Python's `re.sub()` function. Invalid regex patterns will fall back to the original placeholder value. Capture groups use `$1`, `$2`, etc. syntax for replacements.
+
 ### Workflow permissions
 
 All users who have application permissions for editing workflows can see the same set

--- a/src/documents/consumer.py
+++ b/src/documents/consumer.py
@@ -609,6 +609,7 @@ class ConsumerPlugin(
             local_added,
             self.filename,
             self.filename,
+            content=None,
         )
 
     def _store(

--- a/src/documents/signals/handlers.py
+++ b/src/documents/signals/handlers.py
@@ -769,6 +769,7 @@ def run_workflows(
                         document.original_filename or "",
                         document.filename or "",
                         document.created,
+                        content=document.content,
                     )
                 except Exception:
                     logger.exception(
@@ -1092,6 +1093,7 @@ def run_workflows(
                 created,
                 title,
                 doc_url,
+                content=document.content,
             )
             if action.email.subject
             else ""
@@ -1108,6 +1110,7 @@ def run_workflows(
                 created,
                 title,
                 doc_url,
+                content=document.content,
             )
             if action.email.body
             else ""
@@ -1185,6 +1188,7 @@ def run_workflows(
                                 created,
                                 title,
                                 doc_url,
+                                content=document.content,
                             )
                     except Exception as e:
                         logger.error(
@@ -1203,6 +1207,7 @@ def run_workflows(
                     created,
                     title,
                     doc_url,
+                    content=document.content,
                 )
             headers = {}
             if action.webhook.headers:

--- a/src/documents/templating/workflows.py
+++ b/src/documents/templating/workflows.py
@@ -1,90 +1,7 @@
-import logging
 import re
 from datetime import date
 from datetime import datetime
 from pathlib import Path
-
-logger = logging.getLogger("paperless.templating.workflows")
-
-
-def _parse_enhanced_placeholder(placeholder_content: str, formatting: dict) -> str:
-    """
-    Parse enhanced placeholder syntax with regex transformations.
-    
-    Supports:
-    - {field_name} - simple field replacement (backward compatible)
-    - {field_name:s/pattern/replacement/} - regex replacement
-    - {field_name:s/pattern/replacement/flags} - regex replacement with flags
-    
-    Args:
-        placeholder_content: The content inside the {} placeholder
-        formatting: Dictionary of available field values
-        
-    Returns:
-        The transformed value or original field value if transformation fails
-    """
-    # Check if this is a regex transformation placeholder
-    if ':s/' in placeholder_content:
-        parts = placeholder_content.split(':s/', 1)
-        if len(parts) == 2:
-            field_name = parts[0]
-            regex_part = parts[1]
-            
-            # Parse the regex pattern: s/pattern/replacement/flags
-            if regex_part.count('/') >= 2:
-                # Split by '/' but handle the case where there might be more than expected
-                pattern_parts = regex_part.split('/')
-                if len(pattern_parts) >= 3:
-                    pattern = pattern_parts[0]
-                    replacement = pattern_parts[1]
-                    flags_str = pattern_parts[2] if len(pattern_parts) > 2 else ''
-                    
-                    # Convert flags string to re flags
-                    flags = 0
-                    if 'i' in flags_str:
-                        flags |= re.IGNORECASE
-                    if 'm' in flags_str:
-                        flags |= re.MULTILINE
-                    if 's' in flags_str:
-                        flags |= re.DOTALL
-                    
-                    # Get the original value
-                    original_value = formatting.get(field_name, '')
-                    if isinstance(original_value, str):
-                        try:
-                            # Convert sed-style backreferences ($1, $2) to Python style (\1, \2)
-                            python_replacement = replacement
-                            # Handle $1, $2, etc. -> \1, \2, etc.
-                            import re as regex_re
-                            python_replacement = regex_re.sub(r'\$(\d+)', r'\\\1', replacement)
-                            
-                            # Perform regex substitution
-                            return re.sub(pattern, python_replacement, original_value, flags=flags)
-                        except re.error as e:
-                            # Log error and return original value
-                            logger.warning(
-                                f"Regex error in placeholder '{{{placeholder_content}}}': {e}. "
-                                f"Falling back to original value."
-                            )
-                            return original_value
-                        except Exception as e:
-                            # Catch any other unexpected errors
-                            logger.warning(
-                                f"Unexpected error in placeholder '{{{placeholder_content}}}': {e}. "
-                                f"Falling back to original value."
-                            )
-                            return original_value
-                    else:
-                        # Non-string values can't be regex processed
-                        logger.warning(
-                            f"Cannot apply regex transformation to non-string field '{field_name}' "
-                            f"in placeholder '{{{placeholder_content}}}'. Falling back to original value."
-                        )
-                        return str(original_value) if original_value is not None else ''
-    
-    # Fallback to original field value (backward compatibility)
-    field_name = placeholder_content.split(':')[0]
-    return formatting.get(field_name, '')
 
 
 def parse_w_workflow_placeholders(
@@ -107,7 +24,7 @@ def parse_w_workflow_placeholders(
     Enhanced to support regex transformations with syntax:
     - {field_name} - simple field replacement (backward compatible)
     - {field_name:s/pattern/replacement/} - regex replacement
-    - {field_name:s/pattern/replacement/flags} - regex replacement with flags (i=case insensitive, m=multiline, s=dotall)
+    - {field_name:s/pattern/replacement/flags} - regex replacement with flags (i=case insensitive, s=dotall)
     """
     formatting = {
         "correspondent": correspondent_name,
@@ -122,6 +39,7 @@ def parse_w_workflow_placeholders(
         "added_time": local_added.strftime("%H:%M"),
         "owner_username": owner_username,
         "original_filename": Path(original_filename).stem,
+        "original_filename_full": original_filename,
         "filename": Path(filename).stem,
     }
     if created is not None:
@@ -143,18 +61,61 @@ def parse_w_workflow_placeholders(
         formatting.update({"doc_url": doc_url})
     
     # Handle enhanced placeholders by pre-processing the text
-    import re as regex_module
-    
     def replace_placeholder(match):
         """Replace a single placeholder match with its processed value."""
         placeholder_content = match.group(1)  # Content inside the braces
-        return str(_parse_enhanced_placeholder(placeholder_content, formatting))
+        
+        # Check if this is a regex transformation placeholder using proper regex
+        if re.search(r':\s*s/', placeholder_content):
+            parts = re.split(r':\s*s/', placeholder_content, 1)
+            if len(parts) == 2:
+                field_name = parts[0]
+                regex_part = parts[1]
+                
+                # Parse the regex pattern: s/pattern/replacement/flags or s/pattern/replacement
+                # Support both with and without trailing slash for convenience
+                if regex_part.count('/') >= 1:
+                    # Split by '/' but handle the case where there might be more than expected
+                    pattern_parts = regex_part.split('/')
+                    if len(pattern_parts) >= 2:
+                        pattern = pattern_parts[0]
+                        replacement = pattern_parts[1]
+                        flags_str = pattern_parts[2] if len(pattern_parts) > 2 else ''
+                        
+                        # Convert flags string to re flags
+                        flags = 0
+                        if 'i' in flags_str:
+                            flags |= re.IGNORECASE
+                        if 's' in flags_str:
+                            flags |= re.DOTALL
+                        
+                        # Get the original value
+                        original_value = formatting.get(field_name, '')
+                        if isinstance(original_value, str):
+                            try:
+                                # Convert sed-style backreferences ($1, $2) to Python style (\1, \2)
+                                python_replacement = re.sub(r'\$(\d+)', r'\\\1', replacement)
+                                
+                                # Perform regex substitution
+                                return re.sub(pattern, python_replacement, original_value, flags=flags)
+                            except re.error:
+                                # Fall back to original value for invalid regex
+                                return original_value
+                            except Exception:
+                                # Catch any other unexpected errors
+                                return original_value
+                        else:
+                            # Non-string values can't be regex processed
+                            return str(original_value) if original_value is not None else ''
+        
+        # Fallback to original field value (backward compatibility)
+        field_name = placeholder_content.split(':')[0]
+        return str(formatting.get(field_name, ''))
     
     try:
         # Find all placeholders and replace them
-        processed_text = regex_module.sub(r'\{([^}]+)\}', replace_placeholder, text)
+        processed_text = re.sub(r'\{([^}]+)\}', replace_placeholder, text)
         return processed_text.strip()
-    except Exception as e:
+    except Exception:
         # Fall back to original behavior for malformed placeholders
-        logger.warning(f"Error formatting text '{text}': {e}. Falling back to original text.")
         return text.strip()

--- a/src/documents/templating/workflows.py
+++ b/src/documents/templating/workflows.py
@@ -1,6 +1,90 @@
+import logging
+import re
 from datetime import date
 from datetime import datetime
 from pathlib import Path
+
+logger = logging.getLogger("paperless.templating.workflows")
+
+
+def _parse_enhanced_placeholder(placeholder_content: str, formatting: dict) -> str:
+    """
+    Parse enhanced placeholder syntax with regex transformations.
+    
+    Supports:
+    - {field_name} - simple field replacement (backward compatible)
+    - {field_name:s/pattern/replacement/} - regex replacement
+    - {field_name:s/pattern/replacement/flags} - regex replacement with flags
+    
+    Args:
+        placeholder_content: The content inside the {} placeholder
+        formatting: Dictionary of available field values
+        
+    Returns:
+        The transformed value or original field value if transformation fails
+    """
+    # Check if this is a regex transformation placeholder
+    if ':s/' in placeholder_content:
+        parts = placeholder_content.split(':s/', 1)
+        if len(parts) == 2:
+            field_name = parts[0]
+            regex_part = parts[1]
+            
+            # Parse the regex pattern: s/pattern/replacement/flags
+            if regex_part.count('/') >= 2:
+                # Split by '/' but handle the case where there might be more than expected
+                pattern_parts = regex_part.split('/')
+                if len(pattern_parts) >= 3:
+                    pattern = pattern_parts[0]
+                    replacement = pattern_parts[1]
+                    flags_str = pattern_parts[2] if len(pattern_parts) > 2 else ''
+                    
+                    # Convert flags string to re flags
+                    flags = 0
+                    if 'i' in flags_str:
+                        flags |= re.IGNORECASE
+                    if 'm' in flags_str:
+                        flags |= re.MULTILINE
+                    if 's' in flags_str:
+                        flags |= re.DOTALL
+                    
+                    # Get the original value
+                    original_value = formatting.get(field_name, '')
+                    if isinstance(original_value, str):
+                        try:
+                            # Convert sed-style backreferences ($1, $2) to Python style (\1, \2)
+                            python_replacement = replacement
+                            # Handle $1, $2, etc. -> \1, \2, etc.
+                            import re as regex_re
+                            python_replacement = regex_re.sub(r'\$(\d+)', r'\\\1', replacement)
+                            
+                            # Perform regex substitution
+                            return re.sub(pattern, python_replacement, original_value, flags=flags)
+                        except re.error as e:
+                            # Log error and return original value
+                            logger.warning(
+                                f"Regex error in placeholder '{{{placeholder_content}}}': {e}. "
+                                f"Falling back to original value."
+                            )
+                            return original_value
+                        except Exception as e:
+                            # Catch any other unexpected errors
+                            logger.warning(
+                                f"Unexpected error in placeholder '{{{placeholder_content}}}': {e}. "
+                                f"Falling back to original value."
+                            )
+                            return original_value
+                    else:
+                        # Non-string values can't be regex processed
+                        logger.warning(
+                            f"Cannot apply regex transformation to non-string field '{field_name}' "
+                            f"in placeholder '{{{placeholder_content}}}'. Falling back to original value."
+                        )
+                        return str(original_value) if original_value is not None else ''
+    
+    # Fallback to original field value (backward compatibility)
+    field_name = placeholder_content.split(':')[0]
+    return formatting.get(field_name, '')
 
 
 def parse_w_workflow_placeholders(
@@ -18,7 +102,12 @@ def parse_w_workflow_placeholders(
     """
     Available title placeholders for Workflows depend on what has already been assigned,
     e.g. for pre-consumption triggers created will not have been parsed yet, but it will
-    for added / updated triggers
+    for added / updated triggers.
+    
+    Enhanced to support regex transformations with syntax:
+    - {field_name} - simple field replacement (backward compatible)
+    - {field_name:s/pattern/replacement/} - regex replacement
+    - {field_name:s/pattern/replacement/flags} - regex replacement with flags (i=case insensitive, m=multiline, s=dotall)
     """
     formatting = {
         "correspondent": correspondent_name,
@@ -52,4 +141,20 @@ def parse_w_workflow_placeholders(
         formatting.update({"doc_title": doc_title})
     if doc_url is not None:
         formatting.update({"doc_url": doc_url})
-    return text.format(**formatting).strip()
+    
+    # Handle enhanced placeholders by pre-processing the text
+    import re as regex_module
+    
+    def replace_placeholder(match):
+        """Replace a single placeholder match with its processed value."""
+        placeholder_content = match.group(1)  # Content inside the braces
+        return str(_parse_enhanced_placeholder(placeholder_content, formatting))
+    
+    try:
+        # Find all placeholders and replace them
+        processed_text = regex_module.sub(r'\{([^}]+)\}', replace_placeholder, text)
+        return processed_text.strip()
+    except Exception as e:
+        # Fall back to original behavior for malformed placeholders
+        logger.warning(f"Error formatting text '{text}': {e}. Falling back to original text.")
+        return text.strip()

--- a/src/documents/templating/workflows.py
+++ b/src/documents/templating/workflows.py
@@ -40,7 +40,6 @@ def parse_w_workflow_placeholders(
         "added_time": local_added.strftime("%H:%M"),
         "owner_username": owner_username,
         "original_filename": Path(original_filename).stem,
-        "original_filename_full": original_filename,
         "filename": Path(filename).stem,
         "content": content or "",
     }

--- a/src/documents/templating/workflows.py
+++ b/src/documents/templating/workflows.py
@@ -70,10 +70,20 @@ def parse_w_workflow_placeholders(
         # - {field_name:s/pattern/replacement/flags}
         # - Supports escaped slashes in pattern/replacement
         # - Flags (optional): any characters, but only i and s are supported
-        regex_match = re.match(
-            r'^(?P<field_name>[^:]+):\s*s/(?P<pattern>(?:[^/\\]|\\.)*)/(?P<replacement>(?:[^/\\]|\\.)*)(?:/(?P<flags>[a-zA-Z]*))?/?$',
-            placeholder_content
+        # Define components of the regex pattern for readability
+        field_name_pattern = r'(?P<field_name>[^:]+)'  # Matches the field name before the colon
+        sed_command_pattern = r's'  # Matches the 's' command in sed-like syntax
+        pattern_group = r'(?P<pattern>(?:[^/\\]|\\.)*)'  # Matches the search pattern, allowing escaped slashes
+        replacement_group = r'(?P<replacement>(?:[^/\\]|\\.)*)'  # Matches the replacement string, allowing escaped slashes
+        flags_group = r'(?P<flags>[a-zA-Z]*)'  # Matches optional flags (e.g., 'i', 's')
+        
+        # Combine components into the final regex pattern
+        enhanced_placeholder_regex = (
+            rf'^{field_name_pattern}:\s*{sed_command_pattern}/{pattern_group}/{replacement_group}(?:/{flags_group})?/?$'
         )
+        
+        # Match the placeholder content against the regex
+        regex_match = re.match(enhanced_placeholder_regex, placeholder_content)
         
         if regex_match:
             field_name = regex_match.group("field_name")

--- a/src/documents/tests/test_regex_placeholders.py
+++ b/src/documents/tests/test_regex_placeholders.py
@@ -1,0 +1,349 @@
+"""
+Tests for regex-based placeholder transformations in workflows.
+"""
+import logging
+from datetime import datetime
+from unittest import mock
+
+from django.test import TestCase
+from django.utils import timezone
+
+from documents.templating.workflows import parse_w_workflow_placeholders
+
+
+class TestRegexPlaceholders(TestCase):
+    """Test regex-based placeholder transformations."""
+
+    def setUp(self):
+        """Set up test data."""
+        self.test_correspondent = "Sparkasse Bank"
+        self.test_doc_type = "Bank Statement"
+        self.test_owner = "testuser"
+        self.test_added = timezone.localtime(timezone.now())
+        self.test_original_filename = "Sparkasse_12_2023_statement.pdf"
+        self.test_filename = "processed_document.pdf"
+        self.test_created = self.test_added.date()
+        self.test_title = "Test Document"
+        self.test_url = "http://localhost/doc/123"
+
+    def test_backward_compatibility_simple_placeholders(self):
+        """Test that existing simple placeholders still work."""
+        template = "Doc from {correspondent} type {document_type}"
+        result = parse_w_workflow_placeholders(
+            template,
+            self.test_correspondent,
+            self.test_doc_type,
+            self.test_owner,
+            self.test_added,
+            self.test_original_filename,
+            self.test_filename,
+            self.test_created,
+            self.test_title,
+            self.test_url,
+        )
+        expected = f"Doc from {self.test_correspondent} type {self.test_doc_type}"
+        self.assertEqual(result, expected)
+
+    def test_regex_placeholder_basic_substitution(self):
+        """Test basic regex substitution functionality."""
+        template = r"{original_filename:s/Sparkasse_/Bank_/}"
+        result = parse_w_workflow_placeholders(
+            template,
+            self.test_correspondent,
+            self.test_doc_type,
+            self.test_owner,
+            self.test_added,
+            self.test_original_filename,
+            self.test_filename,
+        )
+        self.assertEqual(result, "Bank_12_2023_statement")
+
+    def test_regex_placeholder_with_capture_groups(self):
+        """Test regex substitution with capture groups."""
+        template = r"{original_filename:s/Sparkasse_(\d+)_(\d+)_/Statement $2-$1 /}"
+        result = parse_w_workflow_placeholders(
+            template,
+            self.test_correspondent,
+            self.test_doc_type,
+            self.test_owner,
+            self.test_added,
+            self.test_original_filename,
+            self.test_filename,
+        )
+        self.assertEqual(result, "Statement 2023-12 statement")
+
+    def test_regex_placeholder_case_insensitive_flag(self):
+        """Test regex substitution with case insensitive flag."""
+        template = r"{original_filename:s/sparkasse/Bank/i}"
+        result = parse_w_workflow_placeholders(
+            template,
+            self.test_correspondent,
+            self.test_doc_type,
+            self.test_owner,
+            self.test_added,
+            self.test_original_filename,
+            self.test_filename,
+        )
+        self.assertEqual(result, "Bank_12_2023_statement")
+
+    def test_regex_placeholder_multiline_flag(self):
+        """Test regex substitution with multiline flag."""
+        template = r"{doc_title:s/^Test/New/m}"
+        result = parse_w_workflow_placeholders(
+            template,
+            self.test_correspondent,
+            self.test_doc_type,
+            self.test_owner,
+            self.test_added,
+            self.test_original_filename,
+            self.test_filename,
+            self.test_created,
+            self.test_title,
+            self.test_url,
+        )
+        self.assertEqual(result, "New Document")
+
+    def test_regex_placeholder_dotall_flag(self):
+        """Test regex substitution with dotall flag."""
+        multiline_title = "Test\nDocument\nTitle"
+        template = r"{doc_title:s/Test.*Title/New Title/s}"
+        result = parse_w_workflow_placeholders(
+            template,
+            self.test_correspondent,
+            self.test_doc_type,
+            self.test_owner,
+            self.test_added,
+            self.test_original_filename,
+            self.test_filename,
+            self.test_created,
+            multiline_title,
+            self.test_url,
+        )
+        self.assertEqual(result, "New Title")
+
+    def test_regex_placeholder_combined_flags(self):
+        """Test regex substitution with multiple flags."""
+        template = r"{correspondent:s/sparkasse/Bank/im}"
+        result = parse_w_workflow_placeholders(
+            template,
+            self.test_correspondent,
+            self.test_doc_type,
+            self.test_owner,
+            self.test_added,
+            self.test_original_filename,
+            self.test_filename,
+        )
+        self.assertEqual(result, "Bank Bank")
+
+    def test_regex_placeholder_no_match(self):
+        """Test regex substitution when pattern doesn't match."""
+        template = r"{original_filename:s/NonExistent/Replacement/}"
+        result = parse_w_workflow_placeholders(
+            template,
+            self.test_correspondent,
+            self.test_doc_type,
+            self.test_owner,
+            self.test_added,
+            self.test_original_filename,
+            self.test_filename,
+        )
+        # Should return original value since pattern doesn't match
+        self.assertEqual(result, "Sparkasse_12_2023_statement")
+
+    def test_regex_placeholder_invalid_regex_pattern(self):
+        """Test handling of invalid regex patterns."""
+        template = r"{original_filename:s/[invalid(/Replacement/}"
+        with self.assertLogs("paperless.templating.workflows", level="WARNING") as cm:
+            result = parse_w_workflow_placeholders(
+                template,
+                self.test_correspondent,
+                self.test_doc_type,
+                self.test_owner,
+                self.test_added,
+                self.test_original_filename,
+                self.test_filename,
+            )
+            # Should fall back to original value
+            self.assertEqual(result, "Sparkasse_12_2023_statement")
+            self.assertIn("Regex error", cm.output[0])
+
+    def test_regex_placeholder_nonexistent_field(self):
+        """Test regex substitution on nonexistent field."""
+        template = r"{nonexistent_field:s/test/replacement/}"
+        result = parse_w_workflow_placeholders(
+            template,
+            self.test_correspondent,
+            self.test_doc_type,
+            self.test_owner,
+            self.test_added,
+            self.test_original_filename,
+            self.test_filename,
+        )
+        # Should return empty string for nonexistent field
+        self.assertEqual(result, "")
+
+    def test_regex_placeholder_empty_field(self):
+        """Test regex substitution on empty field."""
+        template = r"{correspondent:s/test/replacement/}"
+        result = parse_w_workflow_placeholders(
+            template,
+            "",  # Empty correspondent
+            self.test_doc_type,
+            self.test_owner,
+            self.test_added,
+            self.test_original_filename,
+            self.test_filename,
+        )
+        # Should handle empty string gracefully
+        self.assertEqual(result, "")
+
+    def test_regex_placeholder_malformed_syntax(self):
+        """Test handling of malformed regex syntax."""
+        # Missing closing slash
+        template = r"{original_filename:s/pattern/replacement}"
+        result = parse_w_workflow_placeholders(
+            template,
+            self.test_correspondent,
+            self.test_doc_type,
+            self.test_owner,
+            self.test_added,
+            self.test_original_filename,
+            self.test_filename,
+        )
+        # Should fall back to simple field replacement
+        self.assertEqual(result, "Sparkasse_12_2023_statement")
+
+    def test_regex_placeholder_mixed_with_simple_placeholders(self):
+        """Test mixing regex and simple placeholders in the same template."""
+        template = r"{correspondent} - {original_filename:s/Sparkasse_(\d+)/Statement $1/} - {document_type}"
+        result = parse_w_workflow_placeholders(
+            template,
+            self.test_correspondent,
+            self.test_doc_type,
+            self.test_owner,
+            self.test_added,
+            self.test_original_filename,
+            self.test_filename,
+        )
+        expected = f"{self.test_correspondent} - Statement 12_2023_statement - {self.test_doc_type}"
+        self.assertEqual(result, expected)
+
+    def test_regex_placeholder_complex_example_from_problem_statement(self):
+        """Test the specific example from the problem statement."""
+        # The example: {filename:s/^+?Sparkasse_(\d\d)$/Kontoauszug $1}
+        # Note: The original example has an error (^+?) - fixing to be a valid regex
+        template = r"{original_filename:s/^.*Sparkasse_(\d\d).*$/Kontoauszug $1/}"
+        result = parse_w_workflow_placeholders(
+            template,
+            self.test_correspondent,
+            self.test_doc_type,
+            self.test_owner,
+            self.test_added,
+            self.test_original_filename,
+            self.test_filename,
+        )
+        self.assertEqual(result, "Kontoauszug 12")
+
+    def test_regex_placeholder_non_string_field_handling(self):
+        """Test handling of non-string fields in regex transformations."""
+        # Mock a situation where a field might be non-string
+        template = "{created_year:s/2023/2024/}"
+        with mock.patch(
+            "documents.templating.workflows.Path"
+        ) as mock_path:
+            mock_path.return_value.stem = "test"
+            with self.assertLogs("paperless.templating.workflows", level="WARNING") as cm:
+                result = parse_w_workflow_placeholders(
+                    template,
+                    self.test_correspondent,
+                    self.test_doc_type,
+                    self.test_owner,
+                    self.test_added,
+                    self.test_original_filename,
+                    self.test_filename,
+                    self.test_created,
+                )
+                # Should convert to string and apply transformation
+                expected_year = self.test_created.strftime("%Y")
+                if expected_year == "2023":
+                    self.assertEqual(result, "2024")
+                else:
+                    self.assertEqual(result, expected_year)
+
+    def test_regex_placeholder_special_characters_in_replacement(self):
+        """Test regex substitution with special characters in replacement."""
+        template = r"{original_filename:s/Sparkasse/Bank & Trust/}"
+        result = parse_w_workflow_placeholders(
+            template,
+            self.test_correspondent,
+            self.test_doc_type,
+            self.test_owner,
+            self.test_added,
+            self.test_original_filename,
+            self.test_filename,
+        )
+        self.assertEqual(result, "Bank & Trust_12_2023_statement")
+
+    def test_regex_placeholder_escape_sequences(self):
+        """Test regex substitution with escape sequences."""
+        template = r"{original_filename:s/Sparkasse_(\d+)/Bank_$1/}"
+        result = parse_w_workflow_placeholders(
+            template,
+            self.test_correspondent,
+            self.test_doc_type,
+            self.test_owner,
+            self.test_added,
+            self.test_original_filename,
+            self.test_filename,
+        )
+        self.assertEqual(result, r"Bank_12_2023_statement")
+
+    def test_legacy_malformed_placeholder_handling(self):
+        """Test that malformed placeholders are handled gracefully (backward compatibility)."""
+        # This test ensures the existing error handling from the original code still works
+        template = "Doc {created_year]"  # Missing opening brace - from existing test
+        with self.assertLogs("paperless.templating.workflows", level="WARNING") as cm:
+            result = parse_w_workflow_placeholders(
+                template,
+                self.test_correspondent,
+                self.test_doc_type,
+                self.test_owner,
+                self.test_added,
+                self.test_original_filename,
+                self.test_filename,
+                self.test_created,
+            )
+            # Should fall back to original text
+            self.assertEqual(result, "Doc {created_year]")
+            self.assertIn("Error formatting text", cm.output[0])
+
+    def test_regex_placeholder_edge_case_empty_pattern(self):
+        """Test edge case with empty regex pattern."""
+        template = r"{original_filename:s//replacement/}"
+        result = parse_w_workflow_placeholders(
+            template,
+            self.test_correspondent,
+            self.test_doc_type,
+            self.test_owner,
+            self.test_added,
+            self.test_original_filename,
+            self.test_filename,
+        )
+        # Empty pattern should match everywhere and replace with replacement
+        # This might insert replacement between every character
+        self.assertIn("replacement", result)
+
+    def test_regex_placeholder_edge_case_empty_replacement(self):
+        """Test edge case with empty replacement string."""
+        template = r"{original_filename:s/Sparkasse_//}"
+        result = parse_w_workflow_placeholders(
+            template,
+            self.test_correspondent,
+            self.test_doc_type,
+            self.test_owner,
+            self.test_added,
+            self.test_original_filename,
+            self.test_filename,
+        )
+        # Should remove "Sparkasse_" from the filename
+        self.assertEqual(result, "12_2023_statement")

--- a/src/documents/tests/test_regex_placeholders.py
+++ b/src/documents/tests/test_regex_placeholders.py
@@ -341,7 +341,7 @@ class TestRegexPlaceholders(TestCase):
         self.assertEqual(result, "12_2023_statement")
 
     def test_original_filename_full_placeholder(self):
-        """Test the new original_filename_full placeholder with whole file content."""
+        """Test the new original_filename_full placeholder with whole filename including extension."""
         template = r"{original_filename_full}"
         result = parse_w_workflow_placeholders(
             template,
@@ -353,6 +353,38 @@ class TestRegexPlaceholders(TestCase):
             self.test_filename,
         )
         self.assertEqual(result, self.test_original_filename)
+
+    def test_content_placeholder(self):
+        """Test the new content placeholder with document content."""
+        test_content = "This is the extracted content of the PDF document."
+        template = r"{content}"
+        result = parse_w_workflow_placeholders(
+            template,
+            self.test_correspondent,
+            self.test_doc_type,
+            self.test_owner,
+            self.test_added,
+            self.test_original_filename,
+            self.test_filename,
+            content=test_content,
+        )
+        self.assertEqual(result, test_content)
+
+    def test_content_placeholder_with_regex(self):
+        """Test regex transformation on content placeholder."""
+        test_content = "Account Number: 123456789 Statement Date: 2023-12"
+        template = r"{content:s/Account Number: (\d+)/Konto $1/}"
+        result = parse_w_workflow_placeholders(
+            template,
+            self.test_correspondent,
+            self.test_doc_type,
+            self.test_owner,
+            self.test_added,
+            self.test_original_filename,
+            self.test_filename,
+            content=test_content,
+        )
+        self.assertEqual(result, "Konto 123456789 Statement Date: 2023-12")
 
     def test_original_filename_full_with_regex(self):
         """Test regex transformation on original_filename_full placeholder."""

--- a/src/documents/tests/test_regex_placeholders.py
+++ b/src/documents/tests/test_regex_placeholders.py
@@ -340,20 +340,6 @@ class TestRegexPlaceholders(TestCase):
         # Should remove "Sparkasse_" from the filename
         self.assertEqual(result, "12_2023_statement")
 
-    def test_original_filename_full_placeholder(self):
-        """Test the new original_filename_full placeholder with whole filename including extension."""
-        template = r"{original_filename_full}"
-        result = parse_w_workflow_placeholders(
-            template,
-            self.test_correspondent,
-            self.test_doc_type,
-            self.test_owner,
-            self.test_added,
-            self.test_original_filename,
-            self.test_filename,
-        )
-        self.assertEqual(result, self.test_original_filename)
-
     def test_content_placeholder(self):
         """Test the new content placeholder with document content."""
         test_content = "This is the extracted content of the PDF document."
@@ -385,17 +371,3 @@ class TestRegexPlaceholders(TestCase):
             content=test_content,
         )
         self.assertEqual(result, "Konto 123456789 Statement Date: 2023-12")
-
-    def test_original_filename_full_with_regex(self):
-        """Test regex transformation on original_filename_full placeholder."""
-        template = r"{original_filename_full:s/\.pdf$/\.backup/}"
-        result = parse_w_workflow_placeholders(
-            template,
-            self.test_correspondent,
-            self.test_doc_type,
-            self.test_owner,
-            self.test_added,
-            self.test_original_filename,
-            self.test_filename,
-        )
-        self.assertEqual(result, "Sparkasse_12_2023_statement.backup")

--- a/src/documents/tests/test_regex_placeholders.py
+++ b/src/documents/tests/test_regex_placeholders.py
@@ -225,7 +225,7 @@ class TestRegexPlaceholders(TestCase):
 
     def test_regex_placeholder_complex_example_from_problem_statement(self):
         """Test the specific example from the problem statement."""
-        # The example: {filename:s/^+?Sparkasse_(\d\d)$/Kontoauszug $1}
+        # The example: {original_filename:s/^+?Sparkasse_(\d\d)$/Kontoauszug $1}
         # Note: The original example has an error (^+?) - fixing to be a valid regex
         template = r"{original_filename:s/^.*Sparkasse_(\d\d).*$/Kontoauszug $1/}"
         result = parse_w_workflow_placeholders(
@@ -290,7 +290,7 @@ class TestRegexPlaceholders(TestCase):
             self.test_original_filename,
             self.test_filename,
         )
-        self.assertEqual(result, r"Bank_12_2023_statement")
+        self.assertEqual(result, "Bank_12_2023_statement")
 
     def test_legacy_malformed_placeholder_handling(self):
         """Test that malformed placeholders are handled gracefully (backward compatibility)."""
@@ -371,3 +371,18 @@ class TestRegexPlaceholders(TestCase):
             content=test_content,
         )
         self.assertEqual(result, "Konto 123456789 Statement Date: 2023-12")
+
+    def test_regex_placeholder_unsupported_flags(self):
+        """Test that unsupported flags are silently ignored."""
+        template = r"{original_filename:s/Sparkasse/Bank/ig}"  # 'g' flag is unsupported
+        result = parse_w_workflow_placeholders(
+            template,
+            self.test_correspondent,
+            self.test_doc_type,
+            self.test_owner,
+            self.test_added,
+            self.test_original_filename,
+            self.test_filename,
+        )
+        # Should still work with the 'i' flag, ignoring the unsupported 'g' flag
+        self.assertEqual(result, "Bank_12_2023_statement")


### PR DESCRIPTION
## Proposed change

This pull request introduces enhanced support for regex-based placeholder transformations in workflow templates. The update allows users to perform advanced text manipulations on placeholders using regular expressions, enabling extraction, substitution, and reformatting of values directly within workflow templates. The documentation has been updated to describe the new syntax, supported flags, and usage examples. Comprehensive tests have been added to ensure correct behavior and backward compatibility.

No additional dependencies are required for this change.

Testing can be performed by running the updated test suite, which now includes extensive coverage for the new placeholder transformation features.

Closes #10401 

## Type of change

- [ ] Bug fix: non-breaking change which fixes an issue.
- [x] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
