### PR TITLE
Performance: Faster document title & content search with full-text indexes

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -684,9 +684,7 @@ collection.
 
 The top search bar in the web UI performs a "global" search of the various
 objects Paperless-ngx uses, including documents, tags, workflows, etc. Only
-objects for which the user has appropriate permissions are returned. For
-documents, if there are < 3 results, "advanced" search results (which use
-the document index) will also be included. This can be disabled under settings.
+objects for which the user has appropriate permissions are returned.
 
 ### Document searches
 

--- a/src/documents/filters.py
+++ b/src/documents/filters.py
@@ -8,7 +8,6 @@ from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
 from django.contrib.contenttypes.models import ContentType
-from django.db import connection
 from django.db.models import Case
 from django.db.models import CharField
 from django.db.models import Count
@@ -20,7 +19,6 @@ from django.db.models import Subquery
 from django.db.models import Sum
 from django.db.models import Value
 from django.db.models import When
-from django.db.models.expressions import RawSQL
 from django.db.models.functions import Cast
 from django.utils.translation import gettext_lazy as _
 from django_filters import DateFilter
@@ -43,8 +41,6 @@ from documents.models import PaperlessTask
 from documents.models import ShareLink
 from documents.models import StoragePath
 from documents.models import Tag
-from documents.utils import FULLTEXT_MINIMAL_TOKEN_LENGTH
-from documents.utils import split_tokens
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -158,59 +154,10 @@ class InboxFilter(Filter):
 @extend_schema_field(serializers.CharField)
 class TitleContentFilter(Filter):
     def filter(self, qs, value):
-        if not value:
-            return qs
-        tokens = split_tokens(value)
-        fulltext_tokens = [t for t in tokens if len(t) >= FULLTEXT_MINIMAL_TOKEN_LENGTH]
-        limit = 1000  # Limit subquery results for performance reasons
-        vendor = connection.vendor
-        if vendor == "postgresql" and tokens:
-            ft_search_exp = " & ".join(tokens) + ":*"
-            # Django SearchQuery produces a "coalesce" SQL clause which doesn't use the fulltext index.
-            # so we use raw SQL instead. See issue: https://code.djangoproject.com/ticket/31304
-            id_query = RawSQL(
-                "SELECT id FROM documents_document WHERE to_tsvector('simple', title) @@ to_tsquery('simple', %s) OR to_tsvector('simple', content) @@ to_tsquery('simple', %s) limit %s",
-                params=(ft_search_exp, ft_search_exp, limit),
-            )
-            return qs.filter(id__in=(id_query))
-        elif vendor in {"mysql", "mariadb"} and fulltext_tokens:
-            ft_search_exp = "+" + " +".join(fulltext_tokens) + "*"
-            like_search_exp = "%" + "_%".join(tokens) + "%"
-            # MariaDB has limitations: it can use fulltext search only for at least 3-char long tokens.
-            # Do a fulltext prefiltering on title and content to use fulltext index,
-            # then apply the actual search query (LIKE "%A_%B%") to refine the results.
-            # Note: MariaDB Doesn't support the LIMIT clause in subqueries
-            # https://dba.stackexchange.com/questions/346009/why-is-limit-disallowed-in-in-subqueries-in-mysql
-            id_query = RawSQL(
-                "SELECT id FROM documents_document WHERE (MATCH(title) AGAINST(%s IN BOOLEAN MODE) OR MATCH(content) AGAINST(%s IN BOOLEAN MODE)) AND (title LIKE %s OR content LIKE %s)",
-                params=(
-                    ft_search_exp,
-                    ft_search_exp,
-                    like_search_exp,
-                    like_search_exp,
-                ),
-            )
-            return qs.filter(id__in=(id_query))
-        elif vendor == "sqlite" and tokens:
-            # SQLite fulltext works for any token size
-            ft_search_exp = "+".join(tokens) + "*"
-            id_query = (
-                Document.objects.filter(
-                    id__in=(
-                        RawSQL(
-                            "SELECT rowid FROM documents_document_fts WHERE title MATCH %s OR content MATCH %s LIMIT %s",
-                            params=(ft_search_exp, ft_search_exp, limit),
-                        )
-                    ),
-                )
-                .order_by()  # disables Django default ordering, we don't need it
-                .values_list("id", flat=True)
-            )
-            # In SQLite, finding IDs in a separate query first seems faster compared to in a subquery.
-            ids = [id for id in id_query.all()]
-            return qs.filter(id__in=ids)
+        if value:
+            return qs.filter(Q(title__ftcontains=value) | Q(content__ftcontains=value))
         else:
-            return qs.filter(Q(title__icontains=value) | Q(content__icontains=value))
+            return qs
 
 
 @extend_schema_field(serializers.BooleanField)

--- a/src/documents/filters.py
+++ b/src/documents/filters.py
@@ -155,7 +155,9 @@ class InboxFilter(Filter):
 class TitleContentFilter(Filter):
     def filter(self, qs, value):
         if value:
-            return qs.filter(Q(title__ftcontains=value) | Q(content__ftcontains=value))
+            return qs.filter(
+                Q(title__fticontains=value) | Q(content__fticontains=value),
+            )
         else:
             return qs
 

--- a/src/documents/migrations/1069_document_fulltext_index.py
+++ b/src/documents/migrations/1069_document_fulltext_index.py
@@ -1,0 +1,109 @@
+from django.db import connection
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("documents", "1068_alter_document_created"),
+    ]
+
+    operations = []
+
+    vendor = connection.vendor
+
+    if vendor == "postgresql":
+        operations += [
+            migrations.RunSQL(
+                """
+            CREATE INDEX IF NOT EXISTS document_title_fts
+            ON documents_document
+            USING GIN (to_tsvector('simple', title));
+            """,
+                reverse_sql="""
+            DROP INDEX IF EXISTS document_title_fts;
+            """,
+            ),
+            migrations.RunSQL(
+                """
+            CREATE INDEX IF NOT EXISTS document_content_fts
+            ON documents_document
+            USING GIN (to_tsvector('simple', content));
+            """,
+                reverse_sql="""
+            DROP INDEX IF EXISTS document_content_fts;
+            """,
+            ),
+        ]
+    elif vendor in {"mysql", "mariadb"}:
+        operations += [
+            migrations.RunSQL(
+                """
+            ALTER TABLE documents_document
+            ADD FULLTEXT INDEX document_title_fts (title);
+            """,
+                reverse_sql="""
+            ALTER TABLE documents_document
+            DROP INDEX document_title_fts;
+            """,
+            ),
+            migrations.RunSQL(
+                """
+            ALTER TABLE documents_document
+            ADD FULLTEXT INDEX document_content_fts (content);
+            """,
+                reverse_sql="""
+            ALTER TABLE documents_document
+            DROP INDEX document_content_fts;
+            """,
+            ),
+        ]
+    else:
+        operations += [
+            # SQLite indexes all words with prefix indexes to speed up wildcard searches.
+            # Prefix length (e.g., 3) helps queries like 'joh*' use the index efficiently.
+            # Shorter wildcards like 'jo*' without a 2-char prefix index require scanning all matching 3-char prefixes,
+            # which still uses the index but is slower.
+            # More prefix indexes increase DB size and slow writes, so balance is needed.
+            migrations.RunSQL(
+                """
+                CREATE VIRTUAL TABLE IF NOT EXISTS documents_document_fts
+                USING fts5(title, content, prefix='3,4,5,6,7');
+                """,
+                reverse_sql="DROP TABLE IF EXISTS documents_document_fts;",
+            ),
+            migrations.RunSQL(
+                """
+                INSERT INTO documents_document_fts(rowid, title, content)
+                SELECT id, title, content FROM documents_document;
+                """,
+                reverse_sql="DELETE FROM documents_document_fts;",
+            ),
+            migrations.RunSQL(
+                """
+                CREATE TRIGGER documents_document_ai AFTER INSERT ON documents_document BEGIN
+                INSERT INTO documents_document_fts(rowid, title, content)
+                VALUES (new.id, new.title, new.content);
+                END;
+                """,
+                reverse_sql="DROP TRIGGER IF EXISTS documents_document_ai;",
+            ),
+            migrations.RunSQL(
+                """
+                CREATE TRIGGER documents_document_au AFTER UPDATE ON documents_document BEGIN
+                UPDATE documents_document_fts SET
+                    title = new.title,
+                    content = new.content
+                WHERE rowid = new.id;
+                END;
+                """,
+                reverse_sql="DROP TRIGGER IF EXISTS documents_document_au;",
+            ),
+            migrations.RunSQL(
+                """
+                CREATE TRIGGER documents_document_ad AFTER DELETE ON documents_document BEGIN
+                DELETE FROM documents_document_fts WHERE rowid = old.id;
+                END;
+                """,
+                reverse_sql="DROP TRIGGER IF EXISTS documents_document_ad;",
+            ),
+        ]

--- a/src/documents/migrations/1069_document_fulltext_index.py
+++ b/src/documents/migrations/1069_document_fulltext_index.py
@@ -59,15 +59,12 @@ class Migration(migrations.Migration):
         ]
     else:
         operations += [
-            # SQLite indexes all words with prefix indexes to speed up wildcard searches.
-            # Prefix length (e.g., 3) helps queries like 'joh*' use the index efficiently.
-            # Shorter wildcards like 'jo*' without a 2-char prefix index require scanning all matching 3-char prefixes,
-            # which still uses the index but is slower.
-            # More prefix indexes increase DB size and slow writes, so balance is needed.
+            # Avoid prefixes in the SQLite FTS table to limit disk usage.
+            # Queries will work even without indexing the prefixes.
             migrations.RunSQL(
                 """
                 CREATE VIRTUAL TABLE IF NOT EXISTS documents_document_fts
-                USING fts5(title, content, prefix='3,4,5,6,7');
+                USING fts5(title, content, content='', contentless_delete=1);
                 """,
                 reverse_sql="DROP TABLE IF EXISTS documents_document_fts;",
             ),

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -1788,13 +1788,13 @@ class GlobalSearchView(PassUserMixin):
                 Document,
             )
             # First search by title
-            docs = all_docs.filter(Q(title__ftcontains=query))
+            docs = all_docs.filter(Q(title__fticontains=query))
 
             # If not enough results, search also by content
             if len(docs) < OBJECT_LIMIT:
                 doc_ids = docs.values_list("id", flat=True)
                 other_doc_ids = (
-                    all_docs.filter(content__ftcontains=query)
+                    all_docs.filter(content__fticontains=query)
                     .exclude(id__in=doc_ids)[: OBJECT_LIMIT - len(doc_ids)]
                     .values_list("id", flat=True)
                 )


### PR DESCRIPTION
## Proposed change

This PR basically adds a full-text index for Title & Content searches on all supported databases: PostgreSQL, MariaDB, and SQLite.  The goal is to have a "title & content search" that scales better with a high number of documents. The user can still choose between `Title & Content` or `Advanced Search`.

Full-text indexes are added for the `title` and `content` columns of the document table, as they may contain thousands or tens of thousands of rows. For tags, correspondents, etc., the current full scan (`icontains`) is simple and probably performant enough, except in some edge cases (hundreds of tags?).

I tried to keep the syntax as close as possible to the Django ORM, but behind the scenes, it behaves differently depending on the database backend.

The global search also benefits from this improvement.

I'm not a Django specialist nor a DB expert. I checked that the full text is correctly used with `EXPLAIN` SQL queries and manual benchmarking. There is no need to hurry for this PR; any feedback is very welcome!


Here are some discussions about search performance issues:
- [High RAM Usage, Slow Response Times On Search #4503](https://github.com/paperless-ngx/paperless-ngx/discussions/4503)
- [Suboptimal SQL queries makes UI hard to use with postgres and > 10 000 documents #4922](https://github.com/paperless-ngx/paperless-ngx/discussions/4922)
- [Very slow queries causing very slow search #5866](https://github.com/paperless-ngx/paperless-ngx/discussions/5866)
- [Search and documents way too slow #9649](https://github.com/paperless-ngx/paperless-ngx/discussions/9649)

## Limitations:
-  In PostgreSQL, due to how the stemming is done, fewer results will be found than with a true `ILIKE %A%` search. Especially partial email address may not be found. Example with  `john@gmail.com`: `john@gmai`, `john@gmail`, and `john@gmai.c` won't work, but `john`, `john@`, `john@gmai.co`, and `john@gmai.com` will.
- This implementation doesn't support CJK characters: in this case, it fallbacks to the non-indexed `icontains` search.


## Type of change


- [x] Bug fix: non-breaking change which fixes an issue.
- [x] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
