### PR TITLE
Fix: track and restore changed document fields from session storage

### DIFF
--- a/src-ui/src/app/components/document-detail/document-detail.component.spec.ts
+++ b/src-ui/src/app/components/document-detail/document-detail.component.spec.ts
@@ -518,6 +518,35 @@ describe('DocumentDetailComponent', () => {
     )
   })
 
+  it('should perform full patch if document was restored from local storage', () => {
+    currentUserHasObjectPermissions = true
+    initNormally()
+    const patchSpy = jest.spyOn(documentService, 'patch')
+    component['wasRestoredFromStorage'] = true
+    component.save()
+    expect(patchSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 3,
+        title: 'Doc 3',
+        content: 'text content',
+        correspondent: 11,
+        document_type: 21,
+        storage_path: 31,
+        archive_serial_number: null,
+        remove_inbox_tags: false,
+        tags: [41, 42, 43],
+        owner: null,
+        set_permissions: undefined,
+        custom_fields: [
+          {
+            field: 0,
+            value: 'custom foo bar',
+          },
+        ],
+      })
+    )
+  })
+
   it('should allow save and next', () => {
     initNormally()
     const nextDocId = 100

--- a/src-ui/src/app/components/document-detail/document-detail.component.spec.ts
+++ b/src-ui/src/app/components/document-detail/document-detail.component.spec.ts
@@ -1030,6 +1030,21 @@ describe('DocumentDetailComponent', () => {
     })
   })
 
+  it('should restore changed fields and mark as dirty', () => {
+    jest
+      .spyOn(activatedRoute, 'paramMap', 'get')
+      .mockReturnValue(of(convertToParamMap({ id: 3, section: 'details' })))
+    jest.spyOn(documentService, 'get').mockReturnValueOnce(of(doc))
+    const docWithChanges = Object.assign({}, doc)
+    docWithChanges.__changedFields = ['title', 'tags']
+    jest
+      .spyOn(openDocumentsService, 'getOpenDocument')
+      .mockReturnValue(docWithChanges)
+    fixture.detectChanges() // calls ngOnInit
+    expect(component.documentForm.get('title').dirty).toBeTruthy()
+    expect(component.documentForm.get('tags').dirty).toBeTruthy()
+  })
+
   it('should show custom field errors', () => {
     initNormally()
     component.error = {

--- a/src-ui/src/app/components/document-detail/document-detail.component.spec.ts
+++ b/src-ui/src/app/components/document-detail/document-detail.component.spec.ts
@@ -518,35 +518,6 @@ describe('DocumentDetailComponent', () => {
     )
   })
 
-  it('should perform full patch if document was restored from local storage', () => {
-    currentUserHasObjectPermissions = true
-    initNormally()
-    const patchSpy = jest.spyOn(documentService, 'patch')
-    component['wasRestoredFromStorage'] = true
-    component.save()
-    expect(patchSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        id: 3,
-        title: 'Doc 3',
-        content: 'text content',
-        correspondent: 11,
-        document_type: 21,
-        storage_path: 31,
-        archive_serial_number: null,
-        remove_inbox_tags: false,
-        tags: [41, 42, 43],
-        owner: null,
-        set_permissions: undefined,
-        custom_fields: [
-          {
-            field: 0,
-            value: 'custom foo bar',
-          },
-        ],
-      })
-    )
-  })
-
   it('should allow save and next', () => {
     initNormally()
     const nextDocId = 100

--- a/src-ui/src/app/components/document-detail/document-detail.component.spec.ts
+++ b/src-ui/src/app/components/document-detail/document-detail.component.spec.ts
@@ -1036,13 +1036,14 @@ describe('DocumentDetailComponent', () => {
       .mockReturnValue(of(convertToParamMap({ id: 3, section: 'details' })))
     jest.spyOn(documentService, 'get').mockReturnValueOnce(of(doc))
     const docWithChanges = Object.assign({}, doc)
-    docWithChanges.__changedFields = ['title', 'tags']
+    docWithChanges.__changedFields = ['title', 'tags', 'owner']
     jest
       .spyOn(openDocumentsService, 'getOpenDocument')
       .mockReturnValue(docWithChanges)
     fixture.detectChanges() // calls ngOnInit
     expect(component.documentForm.get('title').dirty).toBeTruthy()
     expect(component.documentForm.get('tags').dirty).toBeTruthy()
+    expect(component.documentForm.get('permissions_form').dirty).toBeTruthy()
   })
 
   it('should show custom field errors', () => {

--- a/src-ui/src/app/components/document-detail/document-detail.component.ts
+++ b/src-ui/src/app/components/document-detail/document-detail.component.ts
@@ -453,7 +453,11 @@ export class DocumentDetailComponent
             }
             if (openDocument.__changedFields) {
               openDocument.__changedFields.forEach((field) => {
-                this.documentForm.get(field)?.markAsDirty()
+                if (field === 'owner' || field === 'set_permissions') {
+                  this.documentForm.get('permissions_form').markAsDirty()
+                } else {
+                  this.documentForm.get(field)?.markAsDirty()
+                }
               })
             }
             this.updateComponent(openDocument)

--- a/src-ui/src/app/components/document-detail/document-detail.component.ts
+++ b/src-ui/src/app/components/document-detail/document-detail.component.ts
@@ -249,6 +249,7 @@ export class DocumentDetailComponent
   isDirty$: Observable<boolean>
   unsubscribeNotifier: Subject<any> = new Subject()
   docChangeNotifier: Subject<any> = new Subject()
+  private wasRestoredFromStorage = false
 
   requiresPassword: boolean = false
   password: string
@@ -456,6 +457,8 @@ export class DocumentDetailComponent
             this.openDocumentService.openDocument(doc)
             this.updateComponent(doc)
           }
+
+          this.wasRestoredFromStorage = !!openDocument
 
           this.titleSubject
             .pipe(
@@ -800,8 +803,10 @@ export class DocumentDetailComponent
     const changes = {
       id: this.document.id,
     }
+
     Object.keys(this.documentForm.controls).forEach((key) => {
-      if (this.documentForm.get(key).dirty) {
+      // If restored from sessionStorage, always send full patch
+      if (this.wasRestoredFromStorage || this.documentForm.get(key).dirty) {
         if (key === 'permissions_form') {
           changes['owner'] =
             this.documentForm.get('permissions_form').value['owner']

--- a/src-ui/src/app/components/document-detail/document-detail.component.ts
+++ b/src-ui/src/app/components/document-detail/document-detail.component.ts
@@ -249,7 +249,6 @@ export class DocumentDetailComponent
   isDirty$: Observable<boolean>
   unsubscribeNotifier: Subject<any> = new Subject()
   docChangeNotifier: Subject<any> = new Subject()
-  private wasRestoredFromStorage = false
 
   requiresPassword: boolean = false
   password: string
@@ -457,8 +456,6 @@ export class DocumentDetailComponent
             this.openDocumentService.openDocument(doc)
             this.updateComponent(doc)
           }
-
-          this.wasRestoredFromStorage = !!openDocument
 
           this.titleSubject
             .pipe(
@@ -803,10 +800,8 @@ export class DocumentDetailComponent
     const changes = {
       id: this.document.id,
     }
-
     Object.keys(this.documentForm.controls).forEach((key) => {
-      // If restored from sessionStorage, always send full patch
-      if (this.wasRestoredFromStorage || this.documentForm.get(key).dirty) {
+      if (this.documentForm.get(key).dirty) {
         if (key === 'permissions_form') {
           changes['owner'] =
             this.documentForm.get('permissions_form').value['owner']

--- a/src-ui/src/app/components/document-detail/document-detail.component.ts
+++ b/src-ui/src/app/components/document-detail/document-detail.component.ts
@@ -451,6 +451,11 @@ export class DocumentDetailComponent
                 ]
               delete openDocument['permissions_form']
             }
+            if (openDocument.__changedFields) {
+              openDocument.__changedFields.forEach((field) => {
+                this.documentForm.get(field)?.markAsDirty()
+              })
+            }
             this.updateComponent(openDocument)
           } else {
             this.openDocumentService.openDocument(doc)
@@ -514,7 +519,7 @@ export class DocumentDetailComponent
       )
       .subscribe({
         next: ({ doc, dirty }) => {
-          this.openDocumentService.setDirty(doc, dirty)
+          this.openDocumentService.setDirty(doc, dirty, this.getChangedFields())
         },
         error: (error) => {
           this.router.navigate(['404'], {

--- a/src-ui/src/app/data/document.ts
+++ b/src-ui/src/app/data/document.ts
@@ -158,4 +158,7 @@ export interface Document extends ObjectWithPermissions {
   remove_inbox_tags?: boolean
 
   page_count?: number
+
+  // Frontend only
+  __changedFields?: string[]
 }

--- a/src-ui/src/app/services/open-documents.service.spec.ts
+++ b/src-ui/src/app/services/open-documents.service.spec.ts
@@ -241,4 +241,15 @@ describe('OpenDocumentsService', () => {
     openDocumentsService.openDocument(doc)
     expect(consoleSpy).toHaveBeenCalled()
   })
+
+  it('should set dirty status with changed fields', () => {
+    subscriptions.push(
+      openDocumentsService.openDocument(documents[0]).subscribe()
+    )
+    const changedFields = { title: 'foo', content: 'bar' }
+    openDocumentsService.setDirty(documents[0], true, changedFields)
+    expect(
+      openDocumentsService.getOpenDocument(documents[0].id).__changedFields
+    ).toEqual(['title', 'content'])
+  })
 })

--- a/src-ui/src/app/services/open-documents.service.ts
+++ b/src-ui/src/app/services/open-documents.service.ts
@@ -85,15 +85,16 @@ export class OpenDocumentsService {
   }
 
   setDirty(doc: Document, dirty: boolean, changedFields: object = {}) {
-    if (!this.openDocuments.find((d) => d.id == doc.id)) return
+    const existingDoc = this.getOpenDocument(doc.id)
+    if (!existingDoc) return
     if (dirty) {
       this.dirtyDocuments.add(doc.id)
-      this.getOpenDocument(doc.id).__changedFields = Object.keys(
-        changedFields
-      ).filter((key) => key !== 'id')
+      existingDoc.__changedFields = Object.keys(changedFields).filter(
+        (key) => key !== 'id'
+      )
     } else {
       this.dirtyDocuments.delete(doc.id)
-      this.getOpenDocument(doc.id).__changedFields = []
+      existingDoc.__changedFields = []
     }
 
     this.save()

--- a/src-ui/src/app/services/open-documents.service.ts
+++ b/src-ui/src/app/services/open-documents.service.ts
@@ -84,10 +84,15 @@ export class OpenDocumentsService {
     this.save()
   }
 
-  setDirty(doc: Document, dirty: boolean) {
+  setDirty(doc: Document, dirty: boolean, changedFields: object = {}) {
     if (!this.openDocuments.find((d) => d.id == doc.id)) return
     if (dirty) this.dirtyDocuments.add(doc.id)
     else this.dirtyDocuments.delete(doc.id)
+
+    this.getOpenDocument(doc.id).__changedFields = Object.keys(
+      changedFields
+    ).filter((key) => key !== 'id')
+    this.save()
   }
 
   hasDirty(): boolean {

--- a/src-ui/src/app/services/open-documents.service.ts
+++ b/src-ui/src/app/services/open-documents.service.ts
@@ -86,12 +86,16 @@ export class OpenDocumentsService {
 
   setDirty(doc: Document, dirty: boolean, changedFields: object = {}) {
     if (!this.openDocuments.find((d) => d.id == doc.id)) return
-    if (dirty) this.dirtyDocuments.add(doc.id)
-    else this.dirtyDocuments.delete(doc.id)
+    if (dirty) {
+      this.dirtyDocuments.add(doc.id)
+      this.getOpenDocument(doc.id).__changedFields = Object.keys(
+        changedFields
+      ).filter((key) => key !== 'id')
+    } else {
+      this.dirtyDocuments.delete(doc.id)
+      this.getOpenDocument(doc.id).__changedFields = []
+    }
 
-    this.getOpenDocument(doc.id).__changedFields = Object.keys(
-      changedFields
-    ).filter((key) => key !== 'id')
     this.save()
   }
 


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Unfortunately #9744 broke this, good intentions and all. TL;DR we used to always send all fields on save, but now we only send changed ones, but when the doc is restored from local storage (switching between open docs) they were no longer dirty. This fixes that by tracking with a frontend-only '__changedFields' property.

Closes #10459

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
