### PR TITLE
Fix: include ignore for config logos in sanity checker

### DIFF
--- a/src/documents/sanity_checker.py
+++ b/src/documents/sanity_checker.py
@@ -12,6 +12,7 @@ from tqdm import tqdm
 
 from documents.models import Document
 from documents.models import PaperlessTask
+from paperless.config import GeneralConfig
 
 
 class SanityCheckMessages:
@@ -82,8 +83,10 @@ def check_sanity(*, progress=False, scheduled=True) -> SanityCheckMessages:
     if lockfile in present_files:
         present_files.remove(lockfile)
 
-    if settings.APP_LOGO:
-        logo_file = Path(settings.MEDIA_ROOT / settings.APP_LOGO).resolve()
+    general_config = GeneralConfig()
+    app_logo = general_config.app_logo or settings.APP_LOGO
+    if app_logo:
+        logo_file = Path(settings.MEDIA_ROOT / Path(app_logo.lstrip("/"))).resolve()
         if logo_file in present_files:
             present_files.remove(logo_file)
 


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Forgot to include fix for config logo =/

```sh
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 60/60 [00:00<00:00, 205.32it/s]
[2025-07-29 20:10:23,211] [INFO] [paperless.sanity_checker] Sanity checker detected no issues.
```

Closes #10472
See #9946

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
