### PR TITLE
Enhancement: Support for customizable Dateparser `PREFER_DAY_OF_MONTH` setting

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1054,10 +1054,10 @@ configured strategy:
 
     Defaults to `first`
 
-!!! note
-If set to "last" and the resolved date falls in the future, the parsed date will
-be ignored. This behavior is intentional, as Paperless only uses past and current
-dates for setting timestamps.
+    !!! note
+        If set to "last" and the resolved date falls in the future, the parsed date will
+        be ignored. This behavior is intentional, as Paperless only uses past and current
+        dates for setting timestamps.
 
 #### [`PAPERLESS_EMAIL_TASK_CRON=<cron expression>`](#PAPERLESS_EMAIL_TASK_CRON) {#PAPERLESS_EMAIL_TASK_CRON}
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1036,6 +1036,29 @@ Specifies which language Paperless should use when parsing dates from documents.
 !!! note
 This format differs from the `PAPERLESS_OCR_LANGUAGE` setting, which uses ISO 639-2 codes (3 letters, e.g., "eng+deu" for Tesseract OCR).
 
+#### [`PAPERLESS_DATE_PARSER_PREFER_DAY_OF_MONTH=<first|last|current>`](#PAPERLESS_DATE_PARSER_PREFER_DAY_OF_MONTH) {#PAPERLESS_DATE_PARSER_PREFER_DAY_OF_MONTH}
+
+: Date resolution for Month+Year only inputs
+
+: When determining the document date from inputs that specify only the month
+and year (e.g., "Jul 2025"), the full date should be resolved according to the
+configured strategy:
+
+    - first - Resolves to the first day of the specified month (e.g., "2025-07-01").
+    - last - Resolves to the last day of the specified month (e.g., "2025-07-31").
+    - current - Resolves to the current day of the month, based on today's date.
+      For example, if today's date is September 3rd, the resolved date will be
+      2025-07-03, using the same day with the specified month and year.
+
+    For more information refer to [dateparser documentation](https://dateparser.readthedocs.io/en/latest/settings.html#handling-incomplete-dates).
+
+    Defaults to `first`
+
+!!! note
+If set to "last" and the resolved date falls in the future, the parsed date will
+be ignored. This behavior is intentional, as Paperless only uses past and current
+dates for setting timestamps.
+
 #### [`PAPERLESS_EMAIL_TASK_CRON=<cron expression>`](#PAPERLESS_EMAIL_TASK_CRON) {#PAPERLESS_EMAIL_TASK_CRON}
 
 : Configures the scheduled email fetching frequency. The value

--- a/src/documents/parsers.py
+++ b/src/documents/parsers.py
@@ -276,7 +276,7 @@ def parse_date_generator(filename, text) -> Iterator[datetime.datetime]:
             ds,
             settings={
                 "DATE_ORDER": date_order,
-                "PREFER_DAY_OF_MONTH": "first",
+                "PREFER_DAY_OF_MONTH": settings.DATE_PARSER_PREFER_DAY_OF_MONTH,
                 "RETURN_AS_TIMEZONE_AWARE": True,
                 "TIMEZONE": settings.TIME_ZONE,
             },

--- a/src/documents/tests/test_date_parsing.py
+++ b/src/documents/tests/test_date_parsing.py
@@ -402,6 +402,38 @@ class TestDate:
             ),
         ]
 
+    def test_month_year_only_with_first(
+        self,
+        settings: SettingsWrapper,
+        settings_timezone: ZoneInfo,
+    ):
+        settings.DATE_PARSER_PREFER_DAY_OF_MONTH = "first"
+        text = "lorem ipsum\\Feb 2024\ndolor sit amet"
+        assert parse_date("", text) == datetime.datetime(
+            2024,
+            2,
+            1,
+            0,
+            0,
+            tzinfo=settings_timezone,
+        )
+
+    def test_month_year_only_with_last(
+        self,
+        settings: SettingsWrapper,
+        settings_timezone: ZoneInfo,
+    ):
+        settings.DATE_PARSER_PREFER_DAY_OF_MONTH = "last"
+        text = "lorem ipsum\\Feb 2024\ndolor sit amet"
+        assert parse_date("", text) == datetime.datetime(
+            2024,
+            2,
+            29,
+            0,
+            0,
+            tzinfo=settings_timezone,
+        )
+
     def test_filename_date_parse_valid_ymd(
         self,
         settings: SettingsWrapper,

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -1183,6 +1183,17 @@ POST_CONSUME_SCRIPT = os.getenv("PAPERLESS_POST_CONSUME_SCRIPT")
 DATE_ORDER = os.getenv("PAPERLESS_DATE_ORDER", "DMY")
 FILENAME_DATE_ORDER = os.getenv("PAPERLESS_FILENAME_DATE_ORDER")
 
+# When detecting date of the document, when only month and year are set (i.e. "Aug 2025"),
+# determine how full date should be resolved:
+# first (default) - first day of the month (2025-08-01)
+# last - last day of the month (2025-08-31)
+# current - current day as is now - i.e. if today is 3rd od Septempber,
+# the date will be resolved to 2025-08-03, regardless of parsed month being August
+DATE_PARSER_PREFER_DAY_OF_MONTH = os.getenv(
+    "PAPERLESS_DATE_PARSER_PREFER_DAY_OF_MONTH",
+    "first",
+)
+
 
 def _ocr_to_dateparser_languages(ocr_languages: str) -> list[str]:
     """
@@ -1259,7 +1270,6 @@ if os.getenv("PAPERLESS_DATE_PARSER_LANGUAGES"):
     )
 else:
     DATE_PARSER_LANGUAGES = _ocr_to_dateparser_languages(OCR_LANGUAGE)
-
 
 # Maximum number of dates taken from document start to end to show as suggestions for
 # `created` date in the frontend. Duplicates are removed, which can result in


### PR DESCRIPTION
## Proposed change

Edit: I'm sorry, I completely missed the part about opening the discussion. Not sure if it makes any sense, opening it now, but I can do it if it's better for keeping things organized.

First of all, I'm aware this may be a very specific use-case, so please feel free to close it, if you find it irrelevant. 

Basically I'm using paperless to manage a lot of specific kind of documents (work time sheets and reports), which do not have specified day, only month and a year (i.e. "Jul 2024"). Currently, hardcoded  paperless behavior for such dates is to set them as "first" day of the month (so 2024-07-01 in my example). However due to the nature of these documents, it's more preferable, if they are marked as "last day" (2024-07-31 here). Since `DateParser` has this behavior built in, the fix is as simple as adding another setting to configure it, which this PR implements.

The default of this setting is still set to "first", so no breaking change should occur.

## Type of change

- [ ] Bug fix: non-breaking change which fixes an issue.
- [x] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
