### PR TITLE
Chore: switch from os.path to pathlib.Path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -205,18 +205,9 @@ lint.per-file-ignores."docker/wait-for-redis.py" = [
   "INP001",
   "T201",
 ]
-lint.per-file-ignores."src/documents/management/commands/document_consumer.py" = [
-  "PTH",
-] # TODO Enable & remove
-lint.per-file-ignores."src/documents/migrations/1012_fix_archive_files.py" = [
-  "PTH",
-] # TODO Enable & remove
 lint.per-file-ignores."src/documents/models.py" = [
   "SIM115",
 ]
-lint.per-file-ignores."src/documents/parsers.py" = [
-  "PTH",
-] # TODO Enable & remove
 lint.per-file-ignores."src/paperless_tesseract/tests/test_parser.py" = [
   "RUF001",
 ]

--- a/src/documents/parsers.py
+++ b/src/documents/parsers.py
@@ -169,7 +169,7 @@ def run_convert(
     args += ["-depth", str(depth)] if depth else []
     args += ["-auto-orient"] if auto_orient else []
     args += ["-define", "pdf:use-cropbox=true"] if use_cropbox else []
-    args += [input_file, output_file]
+    args += [str(input_file), str(output_file)]
 
     logger.debug("Execute: " + " ".join(args), extra={"group": logging_group})
 
@@ -188,8 +188,8 @@ def get_default_thumbnail() -> Path:
     return (Path(__file__).parent / "resources" / "document.webp").resolve()
 
 
-def make_thumbnail_from_pdf_gs_fallback(in_path, temp_dir, logging_group=None) -> str:
-    out_path = os.path.join(temp_dir, "convert_gs.webp")
+def make_thumbnail_from_pdf_gs_fallback(in_path, temp_dir, logging_group=None) -> Path:
+    out_path: Path = Path(temp_dir) / "convert_gs.webp"
 
     # if convert fails, fall back to extracting
     # the first PDF page as a PNG using Ghostscript
@@ -199,7 +199,7 @@ def make_thumbnail_from_pdf_gs_fallback(in_path, temp_dir, logging_group=None) -
         extra={"group": logging_group},
     )
     # Ghostscript doesn't handle WebP outputs
-    gs_out_path = os.path.join(temp_dir, "gs_out.png")
+    gs_out_path: Path = Path(temp_dir) / "gs_out.png"
     cmd = [settings.GS_BINARY, "-q", "-sDEVICE=pngalpha", "-o", gs_out_path, in_path]
 
     try:
@@ -227,16 +227,16 @@ def make_thumbnail_from_pdf_gs_fallback(in_path, temp_dir, logging_group=None) -
         # The caller might expect a generated thumbnail that can be moved,
         # so we need to copy it before it gets moved.
         # https://github.com/paperless-ngx/paperless-ngx/issues/3631
-        default_thumbnail_path = os.path.join(temp_dir, "document.webp")
+        default_thumbnail_path: Path = Path(temp_dir) / "document.webp"
         copy_file_with_basic_stats(get_default_thumbnail(), default_thumbnail_path)
         return default_thumbnail_path
 
 
-def make_thumbnail_from_pdf(in_path, temp_dir, logging_group=None) -> Path:
+def make_thumbnail_from_pdf(in_path: Path, temp_dir: Path, logging_group=None) -> Path:
     """
     The thumbnail of a PDF is just a 500px wide image of the first page.
     """
-    out_path = temp_dir / "convert.webp"
+    out_path: Path = temp_dir / "convert.webp"
 
     # Run convert to get a decent thumbnail
     try:

--- a/src/documents/tests/test_classifier.py
+++ b/src/documents/tests/test_classifier.py
@@ -654,7 +654,7 @@ class TestClassifier(DirectoriesMixin, TestCase):
         },
     )
     @override_settings(
-        MODEL_FILE=(Path(__file__).parent / "data" / "model.pickle").as_posix(),
+        MODEL_FILE=str(Path(__file__).parent / "data" / "model.pickle"),
     )
     @pytest.mark.skip(
         reason="Disabled caching due to high memory usage - need to investigate.",

--- a/src/documents/tests/test_consumer.py
+++ b/src/documents/tests/test_consumer.py
@@ -254,7 +254,7 @@ class TestConsumer(
         # https://github.com/jonaswinkler/paperless-ng/discussions/1037
 
         filename = self.get_test_file()
-        shadow_file = Path(self.dirs.scratch_dir / "._sample.pdf")
+        shadow_file = Path(self.dirs.scratch_dir) / "._sample.pdf"
 
         shutil.copy(filename, shadow_file)
 

--- a/src/documents/tests/test_management_consumer.py
+++ b/src/documents/tests/test_management_consumer.py
@@ -258,66 +258,66 @@ class TestConsumer(DirectoriesMixin, ConsumerThreadMixin, TransactionTestCase):
     def test_is_ignored(self):
         test_paths = [
             {
-                "path": (Path(self.dirs.consumption_dir) / "foo.pdf").as_posix(),
+                "path": str(Path(self.dirs.consumption_dir) / "foo.pdf"),
                 "ignore": False,
             },
             {
-                "path": (
-                    Path(self.dirs.consumption_dir) / "foo" / "bar.pdf"
-                ).as_posix(),
+                "path": str(
+                    Path(self.dirs.consumption_dir) / "foo" / "bar.pdf",
+                ),
                 "ignore": False,
             },
             {
-                "path": (Path(self.dirs.consumption_dir) / ".DS_STORE").as_posix(),
+                "path": str(Path(self.dirs.consumption_dir) / ".DS_STORE"),
                 "ignore": True,
             },
             {
-                "path": (Path(self.dirs.consumption_dir) / ".DS_Store").as_posix(),
+                "path": str(Path(self.dirs.consumption_dir) / ".DS_Store"),
                 "ignore": True,
             },
             {
-                "path": (
-                    Path(self.dirs.consumption_dir) / ".stfolder" / "foo.pdf"
-                ).as_posix(),
+                "path": str(
+                    Path(self.dirs.consumption_dir) / ".stfolder" / "foo.pdf",
+                ),
                 "ignore": True,
             },
             {
-                "path": (Path(self.dirs.consumption_dir) / ".stfolder.pdf").as_posix(),
+                "path": str(Path(self.dirs.consumption_dir) / ".stfolder.pdf"),
                 "ignore": False,
             },
             {
-                "path": (
-                    Path(self.dirs.consumption_dir) / ".stversions" / "foo.pdf"
-                ).as_posix(),
+                "path": str(
+                    Path(self.dirs.consumption_dir) / ".stversions" / "foo.pdf",
+                ),
                 "ignore": True,
             },
             {
-                "path": (
-                    Path(self.dirs.consumption_dir) / ".stversions.pdf"
-                ).as_posix(),
+                "path": str(
+                    Path(self.dirs.consumption_dir) / ".stversions.pdf",
+                ),
                 "ignore": False,
             },
             {
-                "path": (Path(self.dirs.consumption_dir) / "._foo.pdf").as_posix(),
+                "path": str(Path(self.dirs.consumption_dir) / "._foo.pdf"),
                 "ignore": True,
             },
             {
-                "path": (Path(self.dirs.consumption_dir) / "my_foo.pdf").as_posix(),
+                "path": str(Path(self.dirs.consumption_dir) / "my_foo.pdf"),
                 "ignore": False,
             },
             {
-                "path": (
-                    Path(self.dirs.consumption_dir) / "._foo" / "bar.pdf"
-                ).as_posix(),
+                "path": str(
+                    Path(self.dirs.consumption_dir) / "._foo" / "bar.pdf",
+                ),
                 "ignore": True,
             },
             {
-                "path": (
+                "path": str(
                     Path(self.dirs.consumption_dir)
                     / "@eaDir"
                     / "SYNO@.fileindexdb"
-                    / "_1jk.fnm"
-                ).as_posix(),
+                    / "_1jk.fnm",
+                ),
                 "ignore": True,
             },
         ]
@@ -330,7 +330,7 @@ class TestConsumer(DirectoriesMixin, ConsumerThreadMixin, TransactionTestCase):
                 f'_is_ignored("{filepath}") != {expected_ignored_result}',
             )
 
-    @mock.patch("documents.management.commands.document_consumer.open")
+    @mock.patch("documents.management.commands.document_consumer.Path.open")
     def test_consume_file_busy(self, open_mock):
         # Calling this mock always raises this
         open_mock.side_effect = OSError

--- a/src/documents/tests/test_management_exporter.py
+++ b/src/documents/tests/test_management_exporter.py
@@ -230,9 +230,9 @@ class TestExportImport(
 
         for element in manifest:
             if element["model"] == "documents.document":
-                fname = (
-                    self.target / element[document_exporter.EXPORTER_FILE_NAME]
-                ).as_posix()
+                fname = str(
+                    self.target / element[document_exporter.EXPORTER_FILE_NAME],
+                )
                 self.assertIsFile(fname)
                 self.assertIsFile(
                     self.target / element[document_exporter.EXPORTER_THUMBNAIL_NAME],
@@ -462,9 +462,9 @@ class TestExportImport(
 
         call_command(*args)
 
-        expected_file = (
-            self.target / f"export-{timezone.localdate().isoformat()}.zip"
-        ).as_posix()
+        expected_file = str(
+            self.target / f"export-{timezone.localdate().isoformat()}.zip",
+        )
 
         self.assertIsFile(expected_file)
 
@@ -498,9 +498,9 @@ class TestExportImport(
         ):
             call_command(*args)
 
-        expected_file = (
-            self.target / f"export-{timezone.localdate().isoformat()}.zip"
-        ).as_posix()
+        expected_file = str(
+            self.target / f"export-{timezone.localdate().isoformat()}.zip",
+        )
 
         self.assertIsFile(expected_file)
 
@@ -544,9 +544,9 @@ class TestExportImport(
 
         call_command(*args)
 
-        expected_file = (
-            self.target / f"export-{timezone.localdate().isoformat()}.zip"
-        ).as_posix()
+        expected_file = str(
+            self.target / f"export-{timezone.localdate().isoformat()}.zip",
+        )
 
         self.assertIsFile(expected_file)
         self.assertIsNotFile(existing_file)

--- a/src/documents/tests/test_migration_archive_files.py
+++ b/src/documents/tests/test_migration_archive_files.py
@@ -19,15 +19,15 @@ migration_1012_obj = importlib.import_module(
 )
 
 
-def archive_name_from_filename(filename):
-    return Path(filename).stem + ".pdf"
+def archive_name_from_filename(filename: Path) -> Path:
+    return Path(filename.stem + ".pdf")
 
 
-def archive_path_old(self):
+def archive_path_old(self) -> Path:
     if self.filename:
-        fname = archive_name_from_filename(self.filename)
+        fname = archive_name_from_filename(Path(self.filename))
     else:
-        fname = f"{self.pk:07}.pdf"
+        fname = Path(f"{self.pk:07}.pdf")
 
     return Path(settings.ARCHIVE_DIR) / fname
 

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -679,7 +679,7 @@ def _parse_db_settings() -> dict:
     databases = {
         "default": {
             "ENGINE": "django.db.backends.sqlite3",
-            "NAME": str(DATA_DIR / "db.sqlite3"),
+            "NAME": DATA_DIR / "db.sqlite3",
             "OPTIONS": {},
         },
     }
@@ -807,7 +807,7 @@ LANGUAGES = [
     ("zh-tw", _("Chinese Traditional")),
 ]
 
-LOCALE_PATHS = [str(BASE_DIR / "locale")]
+LOCALE_PATHS = [BASE_DIR / "locale"]
 
 TIME_ZONE = os.getenv("PAPERLESS_TIME_ZONE", "UTC")
 
@@ -848,21 +848,21 @@ LOGGING = {
         "file_paperless": {
             "class": "concurrent_log_handler.ConcurrentRotatingFileHandler",
             "formatter": "verbose",
-            "filename": str(LOGGING_DIR / "paperless.log"),
+            "filename": LOGGING_DIR / "paperless.log",
             "maxBytes": LOGROTATE_MAX_SIZE,
             "backupCount": LOGROTATE_MAX_BACKUPS,
         },
         "file_mail": {
             "class": "concurrent_log_handler.ConcurrentRotatingFileHandler",
             "formatter": "verbose",
-            "filename": str(LOGGING_DIR / "mail.log"),
+            "filename": LOGGING_DIR / "mail.log",
             "maxBytes": LOGROTATE_MAX_SIZE,
             "backupCount": LOGROTATE_MAX_BACKUPS,
         },
         "file_celery": {
             "class": "concurrent_log_handler.ConcurrentRotatingFileHandler",
             "formatter": "verbose",
-            "filename": str(LOGGING_DIR / "celery.log"),
+            "filename": LOGGING_DIR / "celery.log",
             "maxBytes": LOGROTATE_MAX_SIZE,
             "backupCount": LOGROTATE_MAX_BACKUPS,
         },
@@ -921,7 +921,7 @@ CELERY_ACCEPT_CONTENT = ["application/json", "application/x-python-serialize"]
 CELERY_BEAT_SCHEDULE = _parse_beat_schedule()
 
 # https://docs.celeryq.dev/en/stable/userguide/configuration.html#beat-schedule-filename
-CELERY_BEAT_SCHEDULE_FILENAME = str(DATA_DIR / "celerybeat-schedule.db")
+CELERY_BEAT_SCHEDULE_FILENAME = DATA_DIR / "celerybeat-schedule.db"
 
 
 # Cachalot: Database read cache.

--- a/src/paperless_tesseract/tests/test_parser.py
+++ b/src/paperless_tesseract/tests/test_parser.py
@@ -69,13 +69,13 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
         """
         parser = RasterisedDocumentParser(uuid.uuid4())
         page_count = parser.get_page_count(
-            (self.SAMPLE_FILES / "simple-digital.pdf").as_posix(),
+            str(self.SAMPLE_FILES / "simple-digital.pdf"),
             "application/pdf",
         )
         self.assertEqual(page_count, 1)
 
         page_count = parser.get_page_count(
-            (self.SAMPLE_FILES / "multi-page-mixed.pdf").as_posix(),
+            str(self.SAMPLE_FILES / "multi-page-mixed.pdf"),
             "application/pdf",
         )
         self.assertEqual(page_count, 6)
@@ -92,7 +92,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
         parser = RasterisedDocumentParser(uuid.uuid4())
         with self.assertLogs("paperless.parsing.tesseract", level="WARNING") as cm:
             page_count = parser.get_page_count(
-                (self.SAMPLE_FILES / "password-protected.pdf").as_posix(),
+                str(self.SAMPLE_FILES / "password-protected.pdf"),
                 "application/pdf",
             )
             self.assertEqual(page_count, None)
@@ -101,7 +101,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
     def test_thumbnail(self):
         parser = RasterisedDocumentParser(uuid.uuid4())
         thumb = parser.get_thumbnail(
-            (self.SAMPLE_FILES / "simple-digital.pdf").as_posix(),
+            str(self.SAMPLE_FILES / "simple-digital.pdf"),
             "application/pdf",
         )
         self.assertIsFile(thumb)
@@ -109,7 +109,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
     @mock.patch("documents.parsers.run_convert")
     def test_thumbnail_fallback(self, m):
         def call_convert(input_file, output_file, **kwargs):
-            if ".pdf" in input_file:
+            if ".pdf" in str(input_file):
                 raise ParseError("Does not compute.")
             else:
                 run_convert(input_file=input_file, output_file=output_file, **kwargs)
@@ -118,7 +118,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
 
         parser = RasterisedDocumentParser(uuid.uuid4())
         thumb = parser.get_thumbnail(
-            (self.SAMPLE_FILES / "simple-digital.pdf").as_posix(),
+            str(self.SAMPLE_FILES / "simple-digital.pdf"),
             "application/pdf",
         )
         self.assertIsFile(thumb)
@@ -126,7 +126,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
     def test_thumbnail_encrypted(self):
         parser = RasterisedDocumentParser(uuid.uuid4())
         thumb = parser.get_thumbnail(
-            (self.SAMPLE_FILES / "encrypted.pdf").as_posix(),
+            str(self.SAMPLE_FILES / "encrypted.pdf"),
             "application/pdf",
         )
         self.assertIsFile(thumb)
@@ -134,17 +134,17 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
     def test_get_dpi(self):
         parser = RasterisedDocumentParser(None)
 
-        dpi = parser.get_dpi((self.SAMPLE_FILES / "simple-no-dpi.png").as_posix())
+        dpi = parser.get_dpi(str(self.SAMPLE_FILES / "simple-no-dpi.png"))
         self.assertEqual(dpi, None)
 
-        dpi = parser.get_dpi((self.SAMPLE_FILES / "simple.png").as_posix())
+        dpi = parser.get_dpi(str(self.SAMPLE_FILES / "simple.png"))
         self.assertEqual(dpi, 72)
 
     def test_simple_digital(self):
         parser = RasterisedDocumentParser(None)
 
         parser.parse(
-            (self.SAMPLE_FILES / "simple-digital.pdf").as_posix(),
+            str(self.SAMPLE_FILES / "simple-digital.pdf"),
             "application/pdf",
         )
 
@@ -156,7 +156,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
         parser = RasterisedDocumentParser(None)
 
         parser.parse(
-            (self.SAMPLE_FILES / "with-form.pdf").as_posix(),
+            str(self.SAMPLE_FILES / "with-form.pdf"),
             "application/pdf",
         )
 
@@ -172,7 +172,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
         parser = RasterisedDocumentParser(None)
 
         parser.parse(
-            (self.SAMPLE_FILES / "with-form.pdf").as_posix(),
+            str(self.SAMPLE_FILES / "with-form.pdf"),
             "application/pdf",
         )
 
@@ -186,7 +186,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
     def test_signed(self):
         parser = RasterisedDocumentParser(None)
 
-        parser.parse((self.SAMPLE_FILES / "signed.pdf").as_posix(), "application/pdf")
+        parser.parse(str(self.SAMPLE_FILES / "signed.pdf"), "application/pdf")
 
         self.assertIsNone(parser.archive_path)
         self.assertContainsStrings(
@@ -202,7 +202,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
         parser = RasterisedDocumentParser(None)
 
         parser.parse(
-            (self.SAMPLE_FILES / "encrypted.pdf").as_posix(),
+            str(self.SAMPLE_FILES / "encrypted.pdf"),
             "application/pdf",
         )
 
@@ -213,7 +213,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
     def test_with_form_error_notext(self):
         parser = RasterisedDocumentParser(None)
         parser.parse(
-            (self.SAMPLE_FILES / "with-form.pdf").as_posix(),
+            str(self.SAMPLE_FILES / "with-form.pdf"),
             "application/pdf",
         )
 
@@ -227,7 +227,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
         parser = RasterisedDocumentParser(None)
 
         parser.parse(
-            (self.SAMPLE_FILES / "with-form.pdf").as_posix(),
+            str(self.SAMPLE_FILES / "with-form.pdf"),
             "application/pdf",
         )
 
@@ -239,7 +239,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
     def test_image_simple(self):
         parser = RasterisedDocumentParser(None)
 
-        parser.parse((self.SAMPLE_FILES / "simple.png").as_posix(), "image/png")
+        parser.parse(str(self.SAMPLE_FILES / "simple.png"), "image/png")
 
         self.assertIsFile(parser.archive_path)
 
@@ -255,7 +255,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
             dest_file = Path(tempdir) / "simple-alpha.png"
             shutil.copy(sample_file, dest_file)
 
-            parser.parse(dest_file.as_posix(), "image/png")
+            parser.parse(str(dest_file), "image/png")
 
             self.assertIsFile(parser.archive_path)
 
@@ -265,7 +265,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
         parser = RasterisedDocumentParser(None)
 
         dpi = parser.calculate_a4_dpi(
-            (self.SAMPLE_FILES / "simple-no-dpi.png").as_posix(),
+            str(self.SAMPLE_FILES / "simple-no-dpi.png"),
         )
 
         self.assertEqual(dpi, 62)
@@ -277,7 +277,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
 
         def f():
             parser.parse(
-                (self.SAMPLE_FILES / "simple-no-dpi.png").as_posix(),
+                str(self.SAMPLE_FILES / "simple-no-dpi.png"),
                 "image/png",
             )
 
@@ -287,7 +287,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
     def test_image_no_dpi_default(self):
         parser = RasterisedDocumentParser(None)
 
-        parser.parse((self.SAMPLE_FILES / "simple-no-dpi.png").as_posix(), "image/png")
+        parser.parse(str(self.SAMPLE_FILES / "simple-no-dpi.png"), "image/png")
 
         self.assertIsFile(parser.archive_path)
 
@@ -299,7 +299,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
     def test_multi_page(self):
         parser = RasterisedDocumentParser(None)
         parser.parse(
-            (self.SAMPLE_FILES / "multi-page-digital.pdf").as_posix(),
+            str(self.SAMPLE_FILES / "multi-page-digital.pdf"),
             "application/pdf",
         )
         self.assertIsFile(parser.archive_path)
@@ -312,7 +312,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
     def test_multi_page_pages_skip(self):
         parser = RasterisedDocumentParser(None)
         parser.parse(
-            (self.SAMPLE_FILES / "multi-page-digital.pdf").as_posix(),
+            str(self.SAMPLE_FILES / "multi-page-digital.pdf"),
             "application/pdf",
         )
         self.assertIsFile(parser.archive_path)
@@ -325,7 +325,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
     def test_multi_page_pages_redo(self):
         parser = RasterisedDocumentParser(None)
         parser.parse(
-            (self.SAMPLE_FILES / "multi-page-digital.pdf").as_posix(),
+            str(self.SAMPLE_FILES / "multi-page-digital.pdf"),
             "application/pdf",
         )
         self.assertIsFile(parser.archive_path)
@@ -338,7 +338,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
     def test_multi_page_pages_force(self):
         parser = RasterisedDocumentParser(None)
         parser.parse(
-            (self.SAMPLE_FILES / "multi-page-digital.pdf").as_posix(),
+            str(self.SAMPLE_FILES / "multi-page-digital.pdf"),
             "application/pdf",
         )
         self.assertIsFile(parser.archive_path)
@@ -351,7 +351,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
     def test_multi_page_analog_pages_skip(self):
         parser = RasterisedDocumentParser(None)
         parser.parse(
-            (self.SAMPLE_FILES / "multi-page-images.pdf").as_posix(),
+            str(self.SAMPLE_FILES / "multi-page-images.pdf"),
             "application/pdf",
         )
         self.assertIsFile(parser.archive_path)
@@ -375,7 +375,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
         """
         parser = RasterisedDocumentParser(None)
         parser.parse(
-            (self.SAMPLE_FILES / "multi-page-images.pdf").as_posix(),
+            str(self.SAMPLE_FILES / "multi-page-images.pdf"),
             "application/pdf",
         )
         self.assertIsFile(parser.archive_path)
@@ -397,7 +397,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
         """
         parser = RasterisedDocumentParser(None)
         parser.parse(
-            (self.SAMPLE_FILES / "multi-page-images.pdf").as_posix(),
+            str(self.SAMPLE_FILES / "multi-page-images.pdf"),
             "application/pdf",
         )
         self.assertIsFile(parser.archive_path)
@@ -419,7 +419,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
         """
         parser = RasterisedDocumentParser(None)
         parser.parse(
-            (self.SAMPLE_FILES / "multi-page-digital.pdf").as_posix(),
+            str(self.SAMPLE_FILES / "multi-page-digital.pdf"),
             "application/pdf",
         )
         self.assertIsNone(parser.archive_path)
@@ -442,7 +442,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
         """
         parser = RasterisedDocumentParser(None)
         parser.parse(
-            (self.SAMPLE_FILES / "multi-page-images.pdf").as_posix(),
+            str(self.SAMPLE_FILES / "multi-page-images.pdf"),
             "application/pdf",
         )
 
@@ -467,7 +467,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
         """
         parser = RasterisedDocumentParser(None)
         parser.parse(
-            (self.SAMPLE_FILES / "multi-page-digital.pdf").as_posix(),
+            str(self.SAMPLE_FILES / "multi-page-digital.pdf"),
             "application/pdf",
         )
         self.assertIsNotNone(parser.archive_path)
@@ -490,7 +490,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
         """
         parser = RasterisedDocumentParser(None)
         parser.parse(
-            (self.SAMPLE_FILES / "multi-page-images.pdf").as_posix(),
+            str(self.SAMPLE_FILES / "multi-page-images.pdf"),
             "application/pdf",
         )
         self.assertIsNotNone(parser.archive_path)
@@ -513,7 +513,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
         """
         parser = RasterisedDocumentParser(None)
         parser.parse(
-            (self.SAMPLE_FILES / "multi-page-digital.pdf").as_posix(),
+            str(self.SAMPLE_FILES / "multi-page-digital.pdf"),
             "application/pdf",
         )
         self.assertIsNone(parser.archive_path)
@@ -536,7 +536,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
         """
         parser = RasterisedDocumentParser(None)
         parser.parse(
-            (self.SAMPLE_FILES / "multi-page-images.pdf").as_posix(),
+            str(self.SAMPLE_FILES / "multi-page-images.pdf"),
             "application/pdf",
         )
         self.assertIsNotNone(parser.archive_path)
@@ -559,7 +559,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
         """
         parser = RasterisedDocumentParser(None)
         parser.parse(
-            (self.SAMPLE_FILES / "multi-page-digital.pdf").as_posix(),
+            str(self.SAMPLE_FILES / "multi-page-digital.pdf"),
             "application/pdf",
         )
         self.assertIsNone(parser.archive_path)
@@ -582,7 +582,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
         """
         parser = RasterisedDocumentParser(None)
         parser.parse(
-            (self.SAMPLE_FILES / "multi-page-images.pdf").as_posix(),
+            str(self.SAMPLE_FILES / "multi-page-images.pdf"),
             "application/pdf",
         )
         self.assertIsNone(parser.archive_path)
@@ -605,7 +605,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
         """
         parser = RasterisedDocumentParser(None)
         parser.parse(
-            (self.SAMPLE_FILES / "multi-page-mixed.pdf").as_posix(),
+            str(self.SAMPLE_FILES / "multi-page-mixed.pdf"),
             "application/pdf",
         )
         self.assertIsNotNone(parser.archive_path)
@@ -636,7 +636,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
         """
         parser = RasterisedDocumentParser(None)
         parser.parse(
-            (self.SAMPLE_FILES / "single-page-mixed.pdf").as_posix(),
+            str(self.SAMPLE_FILES / "single-page-mixed.pdf"),
             "application/pdf",
         )
         self.assertIsNotNone(parser.archive_path)
@@ -673,7 +673,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
         """
         parser = RasterisedDocumentParser(None)
         parser.parse(
-            (self.SAMPLE_FILES / "multi-page-mixed.pdf").as_posix(),
+            str(self.SAMPLE_FILES / "multi-page-mixed.pdf"),
             "application/pdf",
         )
         self.assertIsNone(parser.archive_path)
@@ -685,7 +685,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
     @override_settings(OCR_MODE="skip", OCR_ROTATE_PAGES=True)
     def test_rotate(self):
         parser = RasterisedDocumentParser(None)
-        parser.parse((self.SAMPLE_FILES / "rotated.pdf").as_posix(), "application/pdf")
+        parser.parse(str(self.SAMPLE_FILES / "rotated.pdf"), "application/pdf")
         self.assertContainsStrings(
             parser.get_text(),
             [
@@ -707,7 +707,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
         """
         parser = RasterisedDocumentParser(None)
         parser.parse(
-            (self.SAMPLE_FILES / "multi-page-images.tiff").as_posix(),
+            str(self.SAMPLE_FILES / "multi-page-images.tiff"),
             "image/tiff",
         )
         self.assertIsFile(parser.archive_path)
@@ -752,9 +752,9 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
             - Text from all pages extracted
         """
         parser = RasterisedDocumentParser(None)
-        sample_file = (
-            self.SAMPLE_FILES / "multi-page-images-alpha-rgb.tiff"
-        ).as_posix()
+        sample_file = str(
+            self.SAMPLE_FILES / "multi-page-images-alpha-rgb.tiff",
+        )
         with tempfile.NamedTemporaryFile() as tmp_file:
             shutil.copy(sample_file, tmp_file.name)
             parser.parse(
@@ -843,7 +843,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
         parser = RasterisedDocumentParser(None)
 
         parser.parse(
-            (self.SAMPLE_FILES / "rtl-test.pdf").as_posix(),
+            str(self.SAMPLE_FILES / "rtl-test.pdf"),
             "application/pdf",
         )
 
@@ -858,7 +858,7 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
         self.assertRaises(
             ParseError,
             parser.parse,
-            (self.SAMPLE_FILES / "simple-digital.pdf").as_posix(),
+            str(self.SAMPLE_FILES / "simple-digital.pdf"),
             "application/pdf",
         )
 
@@ -868,32 +868,32 @@ class TestParserFileTypes(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
 
     def test_bmp(self):
         parser = RasterisedDocumentParser(None)
-        parser.parse((self.SAMPLE_FILES / "simple.bmp").as_posix(), "image/bmp")
+        parser.parse(str(self.SAMPLE_FILES / "simple.bmp"), "image/bmp")
         self.assertIsFile(parser.archive_path)
         self.assertIn("this is a test document", parser.get_text().lower())
 
     def test_jpg(self):
         parser = RasterisedDocumentParser(None)
-        parser.parse((self.SAMPLE_FILES / "simple.jpg").as_posix(), "image/jpeg")
+        parser.parse(str(self.SAMPLE_FILES / "simple.jpg"), "image/jpeg")
         self.assertIsFile(parser.archive_path)
         self.assertIn("this is a test document", parser.get_text().lower())
 
     def test_heic(self):
         parser = RasterisedDocumentParser(None)
-        parser.parse((self.SAMPLE_FILES / "simple.heic").as_posix(), "image/heic")
+        parser.parse(str(self.SAMPLE_FILES / "simple.heic"), "image/heic")
         self.assertIsFile(parser.archive_path)
         self.assertIn("pizza", parser.get_text().lower())
 
     @override_settings(OCR_IMAGE_DPI=200)
     def test_gif(self):
         parser = RasterisedDocumentParser(None)
-        parser.parse((self.SAMPLE_FILES / "simple.gif").as_posix(), "image/gif")
+        parser.parse(str(self.SAMPLE_FILES / "simple.gif"), "image/gif")
         self.assertIsFile(parser.archive_path)
         self.assertIn("this is a test document", parser.get_text().lower())
 
     def test_tiff(self):
         parser = RasterisedDocumentParser(None)
-        parser.parse((self.SAMPLE_FILES / "simple.tif").as_posix(), "image/tiff")
+        parser.parse(str(self.SAMPLE_FILES / "simple.tif"), "image/tiff")
         self.assertIsFile(parser.archive_path)
         self.assertIn("this is a test document", parser.get_text().lower())
 
@@ -901,7 +901,7 @@ class TestParserFileTypes(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
     def test_webp(self):
         parser = RasterisedDocumentParser(None)
         parser.parse(
-            (self.SAMPLE_FILES / "document.webp").as_posix(),
+            str(self.SAMPLE_FILES / "document.webp"),
             "image/webp",
         )
         self.assertIsFile(parser.archive_path)


### PR DESCRIPTION
## Proposed change

Switch some more python files from os.path to pathlib.Path.

Related to https://github.com/paperless-ngx/paperless-ngx/discussions/7861

## Type of change

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [x] Other. Please explain:

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
