### PR TITLE
Documentation: fix filters docs

### DIFF
--- a/docs/advanced_usage.md
+++ b/docs/advanced_usage.md
@@ -490,15 +490,15 @@ The `format_datetime`filter formats a datetime string or datetime object using P
 
 ```jinja2
 <!-- Format datetime object -->
-{{ created_at | format_datetime('%B %d, %Y at %I:%M %p') }}
+{{ created | datetime('%B %d, %Y at %I:%M %p') }}
 <!-- Output: "January 15, 2024 at 02:30 PM" -->
 
 <!-- Format datetime string -->
-{{ "2024-01-15T14:30:00" | format_datetime('%m/%d/%Y') }}
+{{ "2024-01-15T14:30:00" | datetime('%m/%d/%Y') }}
 <!-- Output: "01/15/2024" -->
 
 <!-- Custom formatting -->
-{{ timestamp | format_datetime('%A, %B %d, %Y') }}
+{{ timestamp | datetime('%A, %B %d, %Y') }}
 <!-- Output: "Monday, January 15, 2024" -->
 ```
 
@@ -531,27 +531,27 @@ This takes into account the provided locale for translation.
 
 ```jinja2
 <!-- Preset formats -->
-{{ created_date | localize_date('short', 'en_US') }}
+{{ document.created | localize_date('short', 'en_US') }}
 <!-- Output: "1/15/24" -->
 
-{{ created_date | localize_date('medium', 'en_US') }}
+{{ document.created | localize_date('medium', 'en_US') }}
 <!-- Output: "Jan 15, 2024" -->
 
-{{ created_date | localize_date('long', 'en_US') }}
+{{ document.created | localize_date('long', 'en_US') }}
 <!-- Output: "January 15, 2024" -->
 
-{{ created_date | localize_date('full', 'en_US') }}
+{{ document.created | localize_date('full', 'en_US') }}
 <!-- Output: "Monday, January 15, 2024" -->
 
 <!-- Different locales -->
-{{ created_date | localize_date('medium', 'fr_FR') }}
+{{ document.created | localize_date('medium', 'fr_FR') }}
 <!-- Output: "15 janv. 2024" -->
 
-{{ created_date | localize_date('medium', 'de_DE') }}
+{{ document.created | localize_date('medium', 'de_DE') }}
 <!-- Output: "15.01.2024" -->
 
 <!-- Custom patterns -->
-{{ created_date | localize_date('dd/MM/yyyy', 'en_GB') }}
+{{ document.created | localize_date('dd/MM/yyyy', 'en_GB') }}
 <!-- Output: "15/01/2024" -->
 ```
 

--- a/docs/advanced_usage.md
+++ b/docs/advanced_usage.md
@@ -469,12 +469,12 @@ The `get_cf_value` filter retrieves a value from custom field data with optional
 
 ##### Datetime Formatting
 
-The `format_datetime`filter formats a datetime string or datetime object using Python's strftime formatting.
+The `datetime`filter formats a datetime string or datetime object using Python's strftime formatting.
 
 ###### Syntax
 
 ```jinja2
-{{ datetime_value | format_datetime('%Y-%m-%d %H:%M:%S') }}
+{{ datetime_value | datetime('%Y-%m-%d %H:%M:%S') }}
 ```
 
 ###### Parameters
@@ -493,10 +493,6 @@ The `format_datetime`filter formats a datetime string or datetime object using P
 {{ created | datetime('%B %d, %Y at %I:%M %p') }}
 <!-- Output: "January 15, 2024 at 02:30 PM" -->
 
-<!-- Format datetime string -->
-{{ "2024-01-15T14:30:00" | datetime('%m/%d/%Y') }}
-<!-- Output: "01/15/2024" -->
-
 <!-- Custom formatting -->
 {{ timestamp | datetime('%A, %B %d, %Y') }}
 <!-- Output: "Monday, January 15, 2024" -->
@@ -508,7 +504,8 @@ for the possible codes and their meanings.
 ##### Date Localization
 
 The `localize_date` filter formats a date or datetime object into a localized string using Babel internationalization.
-This takes into account the provided locale for translation.
+This takes into account the provided locale for translation. Since this must be used on a date or datetime object,
+you must access the field directly, i.e. `document.created`.
 
 ###### Syntax
 

--- a/docs/advanced_usage.md
+++ b/docs/advanced_usage.md
@@ -469,7 +469,7 @@ The `get_cf_value` filter retrieves a value from custom field data with optional
 
 ##### Datetime Formatting
 
-The `datetime`filter formats a datetime string or datetime object using Python's strftime formatting.
+The `datetime` filter formats a datetime string or datetime object using Python's strftime formatting.
 
 ###### Syntax
 
@@ -494,7 +494,7 @@ The `datetime`filter formats a datetime string or datetime object using Python's
 <!-- Output: "January 15, 2024 at 02:30 PM" -->
 
 <!-- Custom formatting -->
-{{ timestamp | datetime('%A, %B %d, %Y') }}
+{{ custom_fields | get_cf_value('Date Field') | datetime('%A, %B %d, %Y') }}
 <!-- Output: "Monday, January 15, 2024" -->
 ```
 


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

As you said stumpy, only other change is that the second datetime example wasn't working for me:

```
[2025-08-17 07:33:54,425] [WARNING] [paperless.templating] Unknown error in filename generation: 'NoneType' object has no attribute 'strftime'
[2025-08-17 07:33:54,425] [WARNING] [paperless.templating] Invalid filename_format '{{ "2024-01-15T14:30:00" | datetime('%m/%d/%Y') }}', falling back to default
```

I also changed the third one to be a custom field for illustration purposes

<img width="510" height="723" alt="Screenshot 2025-08-17 at 7 34 13 AM" src="https://github.com/user-attachments/assets/4243fbdc-5cf2-44d7-bacb-130508900edc" />
<img width="509" height="726" alt="Screenshot 2025-08-17 at 7 27 26 AM" src="https://github.com/user-attachments/assets/cd8676a8-d8fa-4794-bb4e-749d235df05b" />
<img width="510" height="729" alt="Screenshot 2025-08-17 at 7 26 01 AM" src="https://github.com/user-attachments/assets/8907a221-668b-4963-9fec-765738fb36db" />


Closes #10596 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [x] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
