### PR TITLE
Performance: Cache django-guardian permissions when counting documents

### DIFF
--- a/src/documents/serialisers.py
+++ b/src/documents/serialisers.py
@@ -288,26 +288,33 @@ class OwnedObjectSerializer(
     def get_permissions(self, obj) -> dict:
         view_codename = f"view_{obj.__class__.__name__.lower()}"
         change_codename = f"change_{obj.__class__.__name__.lower()}"
-
+        users_with_view = self.context.get("users_with_view", {}).get(obj.pk, [])
+        users_with_change = self.context.get("users_with_change", {}).get(obj.pk, [])
+        groups_with_view = self.context.get("groups_with_view", {}).get(obj.pk, [])
+        groups_with_change = self.context.get("groups_with_change", {}).get(obj.pk, [])
         return {
             "view": {
-                "users": get_users_with_perms(
+                "users": users_with_view
+                or get_users_with_perms(
                     obj,
                     only_with_perms_in=[view_codename],
                     with_group_users=False,
                 ).values_list("id", flat=True),
-                "groups": get_groups_with_only_permission(
+                "groups": groups_with_view
+                or get_groups_with_only_permission(
                     obj,
                     codename=view_codename,
                 ).values_list("id", flat=True),
             },
             "change": {
-                "users": get_users_with_perms(
+                "users": users_with_change
+                or get_users_with_perms(
                     obj,
                     only_with_perms_in=[change_codename],
                     with_group_users=False,
                 ).values_list("id", flat=True),
-                "groups": get_groups_with_only_permission(
+                "groups": groups_with_change
+                or get_groups_with_only_permission(
                     obj,
                     codename=change_codename,
                 ).values_list("id", flat=True),

--- a/src/documents/serialisers.py
+++ b/src/documents/serialisers.py
@@ -288,36 +288,46 @@ class OwnedObjectSerializer(
     def get_permissions(self, obj) -> dict:
         view_codename = f"view_{obj.__class__.__name__.lower()}"
         change_codename = f"change_{obj.__class__.__name__.lower()}"
-        users_with_view = self.context.get("users_with_view", {}).get(obj.pk, [])
-        users_with_change = self.context.get("users_with_change", {}).get(obj.pk, [])
-        groups_with_view = self.context.get("groups_with_view", {}).get(obj.pk, [])
-        groups_with_change = self.context.get("groups_with_change", {}).get(obj.pk, [])
+        users_with_view = self.context.get("users_with_view", {}).get(
+            obj.pk,
+        ) or get_users_with_perms(
+            obj,
+            only_with_perms_in=[view_codename],
+            with_group_users=False,
+        ).values_list("id", flat=True)
+        users_with_change = self.context.get("users_with_change", {}).get(
+            obj.pk,
+            [],
+        ) or get_users_with_perms(
+            obj,
+            only_with_perms_in=[change_codename],
+            with_group_users=False,
+        ).values_list("id", flat=True)
+
+        groups_with_view = self.context.get("groups_with_view", {}).get(
+            obj.pk,
+            [],
+        ) or get_groups_with_only_permission(
+            obj,
+            codename=view_codename,
+        ).values_list("id", flat=True)
+
+        groups_with_change = self.context.get("groups_with_change", {}).get(
+            obj.pk,
+            [],
+        ) or get_groups_with_only_permission(
+            obj,
+            codename=change_codename,
+        ).values_list("id", flat=True)
+
         return {
             "view": {
-                "users": users_with_view
-                or get_users_with_perms(
-                    obj,
-                    only_with_perms_in=[view_codename],
-                    with_group_users=False,
-                ).values_list("id", flat=True),
-                "groups": groups_with_view
-                or get_groups_with_only_permission(
-                    obj,
-                    codename=view_codename,
-                ).values_list("id", flat=True),
+                "users": users_with_view,
+                "groups": groups_with_view,
             },
             "change": {
-                "users": users_with_change
-                or get_users_with_perms(
-                    obj,
-                    only_with_perms_in=[change_codename],
-                    with_group_users=False,
-                ).values_list("id", flat=True),
-                "groups": groups_with_change
-                or get_groups_with_only_permission(
-                    obj,
-                    codename=change_codename,
-                ).values_list("id", flat=True),
+                "users": users_with_change,
+                "groups": groups_with_change,
             },
         }
 

--- a/src/documents/serialisers.py
+++ b/src/documents/serialisers.py
@@ -288,14 +288,14 @@ class OwnedObjectSerializer(
     def get_permissions(self, obj) -> dict:
         view_codename = f"view_{obj.__class__.__name__.lower()}"
         change_codename = f"change_{obj.__class__.__name__.lower()}"
-        users_with_view = self.context.get("users_with_view", {}).get(
+        users_view_perms = self.context.get("users_view_perms", {}).get(
             obj.pk,
         ) or get_users_with_perms(
             obj,
             only_with_perms_in=[view_codename],
             with_group_users=False,
         ).values_list("id", flat=True)
-        users_with_change = self.context.get("users_with_change", {}).get(
+        users_change_perms = self.context.get("users_change_perms", {}).get(
             obj.pk,
             [],
         ) or get_users_with_perms(
@@ -304,7 +304,7 @@ class OwnedObjectSerializer(
             with_group_users=False,
         ).values_list("id", flat=True)
 
-        groups_with_view = self.context.get("groups_with_view", {}).get(
+        groups_view_perms = self.context.get("groups_view_perms", {}).get(
             obj.pk,
             [],
         ) or get_groups_with_only_permission(
@@ -312,7 +312,7 @@ class OwnedObjectSerializer(
             codename=view_codename,
         ).values_list("id", flat=True)
 
-        groups_with_change = self.context.get("groups_with_change", {}).get(
+        groups_change_perms = self.context.get("groups_change_perms", {}).get(
             obj.pk,
             [],
         ) or get_groups_with_only_permission(
@@ -322,12 +322,12 @@ class OwnedObjectSerializer(
 
         return {
             "view": {
-                "users": users_with_view,
-                "groups": groups_with_view,
+                "users": users_view_perms,
+                "groups": groups_view_perms,
             },
             "change": {
-                "users": users_with_change,
-                "groups": groups_with_change,
+                "users": users_change_perms,
+                "groups": groups_change_perms,
             },
         }
 

--- a/src/documents/serialisers.py
+++ b/src/documents/serialisers.py
@@ -6,6 +6,7 @@ import re
 from datetime import datetime
 from decimal import Decimal
 from typing import TYPE_CHECKING
+from typing import Literal
 
 import magic
 from celery import states
@@ -252,6 +253,35 @@ class OwnedObjectSerializer(
             except KeyError:
                 pass
 
+    def _get_perms(self, obj, codename: str, target: Literal["users", "groups"]):
+        """
+        Get the given permissions from context or from django-guardian.
+        Parameters:
+        - codename: e.g. 'view_tag' or 'change_tag'
+        - target: 'users' or 'groups'
+        """
+        key = f"{target}_{codename}_perms"
+        cached = self.context.get(key, {}).get(obj.pk)
+        if cached is not None:
+            return list(cached)
+
+        # Permission not found in the context, get it from guardian
+        if target == "users":
+            return list(
+                get_users_with_perms(
+                    obj,
+                    only_with_perms_in=[f"{codename}_{obj.__class__.__name__.lower()}"],
+                    with_group_users=False,
+                ).values_list("id", flat=True),
+            )
+        else:  # groups
+            return list(
+                get_groups_with_only_permission(
+                    obj,
+                    codename=f"{codename}_{obj.__class__.__name__.lower()}",
+                ).values_list("id", flat=True),
+            )
+
     @extend_schema_field(
         field={
             "type": "object",
@@ -286,48 +316,14 @@ class OwnedObjectSerializer(
         },
     )
     def get_permissions(self, obj) -> dict:
-        view_codename = f"view_{obj.__class__.__name__.lower()}"
-        change_codename = f"change_{obj.__class__.__name__.lower()}"
-        users_view_perms = self.context.get("users_view_perms", {}).get(
-            obj.pk,
-        ) or get_users_with_perms(
-            obj,
-            only_with_perms_in=[view_codename],
-            with_group_users=False,
-        ).values_list("id", flat=True)
-        users_change_perms = self.context.get("users_change_perms", {}).get(
-            obj.pk,
-            [],
-        ) or get_users_with_perms(
-            obj,
-            only_with_perms_in=[change_codename],
-            with_group_users=False,
-        ).values_list("id", flat=True)
-
-        groups_view_perms = self.context.get("groups_view_perms", {}).get(
-            obj.pk,
-            [],
-        ) or get_groups_with_only_permission(
-            obj,
-            codename=view_codename,
-        ).values_list("id", flat=True)
-
-        groups_change_perms = self.context.get("groups_change_perms", {}).get(
-            obj.pk,
-            [],
-        ) or get_groups_with_only_permission(
-            obj,
-            codename=change_codename,
-        ).values_list("id", flat=True)
-
         return {
             "view": {
-                "users": users_view_perms,
-                "groups": groups_view_perms,
+                "users": self._get_perms(obj, "view", "users"),
+                "groups": self._get_perms(obj, "view", "groups"),
             },
             "change": {
-                "users": users_change_perms,
-                "groups": groups_change_perms,
+                "users": self._get_perms(obj, "change", "users"),
+                "groups": self._get_perms(obj, "change", "groups"),
             },
         }
 

--- a/src/documents/serialisers.py
+++ b/src/documents/serialisers.py
@@ -256,9 +256,9 @@ class OwnedObjectSerializer(
     def _get_perms(self, obj, codename: str, target: Literal["users", "groups"]):
         """
         Get the given permissions from context or from django-guardian.
-        Parameters:
-        - codename: e.g. 'view_tag' or 'change_tag'
-        - target: 'users' or 'groups'
+
+        :param codename: The permission codename, e.g. 'view' or 'change'
+        :param target: 'users' or 'groups'
         """
         key = f"{target}_{codename}_perms"
         cached = self.context.get(key, {}).get(obj.pk)

--- a/src/documents/serialisers.py
+++ b/src/documents/serialisers.py
@@ -288,49 +288,29 @@ class OwnedObjectSerializer(
     def get_permissions(self, obj) -> dict:
         view_codename = f"view_{obj.__class__.__name__.lower()}"
         change_codename = f"change_{obj.__class__.__name__.lower()}"
-        view = self.context.get("view")
-        if view is None or not hasattr(view, "get_permission_mapping"):
-            return {
-                "view": {
-                    "users": get_users_with_perms(
-                        obj,
-                        only_with_perms_in=[view_codename],
-                        with_group_users=False,
-                    ).values_list("id", flat=True),
-                    "groups": get_groups_with_only_permission(
-                        obj,
-                        codename=view_codename,
-                    ).values_list("id", flat=True),
-                },
-                "change": {
-                    "users": get_users_with_perms(
-                        obj,
-                        only_with_perms_in=[change_codename],
-                        with_group_users=False,
-                    ).values_list("id", flat=True),
-                    "groups": get_groups_with_only_permission(
-                        obj,
-                        codename=change_codename,
-                    ).values_list("id", flat=True),
-                },
-            }
-        # Get from permission cache map if available
-        guardian_map = view.get_permission_mapping()
-        obj_map = guardian_map.get(
-            obj.id,
-            {
-                "view": {"users": set(), "groups": set()},
-                "change": {"users": set(), "groups": set()},
-            },
-        )
+
         return {
             "view": {
-                "users": list(obj_map["view"]["users"]),
-                "groups": list(obj_map["view"]["groups"]),
+                "users": get_users_with_perms(
+                    obj,
+                    only_with_perms_in=[view_codename],
+                    with_group_users=False,
+                ).values_list("id", flat=True),
+                "groups": get_groups_with_only_permission(
+                    obj,
+                    codename=view_codename,
+                ).values_list("id", flat=True),
             },
             "change": {
-                "users": list(obj_map["change"]["users"]),
-                "groups": list(obj_map["change"]["groups"]),
+                "users": get_users_with_perms(
+                    obj,
+                    only_with_perms_in=[change_codename],
+                    with_group_users=False,
+                ).values_list("id", flat=True),
+                "groups": get_groups_with_only_permission(
+                    obj,
+                    codename=change_codename,
+                ).values_list("id", flat=True),
             },
         }
 

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -335,10 +335,13 @@ class BulkPermissionMixin:
 
     def get_serializer_context(self):
         context = super().get_serializer_context()
-        if self.request.query_params.get("full_perms", "false").lower() in [
-            "true",
-            "1",
-        ]:
+        try:
+            full_perms = get_boolean(
+                str(self.request.query_params.get("full_perms", "false")),
+            )
+        except ValueError:
+            full_perms = False
+        if full_perms:
             # Detect pagination if available, to avoid querying unneeded permissions
             page = getattr(self, "paginator", None)
             if page and hasattr(page, "page"):
@@ -353,10 +356,10 @@ class BulkPermissionMixin:
                 queryset,
                 [codenames["view"], codenames["change"]],
             )
-            context["users_with_view"] = {
+            context["users_view_perms"] = {
                 pk: users_perms[pk][codenames["view"]] for pk in users_perms
             }
-            context["users_with_change"] = {
+            context["users_change_perms"] = {
                 pk: users_perms[pk][codenames["change"]] for pk in users_perms
             }
 
@@ -364,10 +367,10 @@ class BulkPermissionMixin:
                 queryset,
                 [codenames["view"], codenames["change"]],
             )
-            context["groups_with_view"] = {
+            context["groups_view_perms"] = {
                 pk: groups_perms[pk][codenames["view"]] for pk in groups_perms
             }
-            context["groups_with_change"] = {
+            context["groups_change_perms"] = {
                 pk: groups_perms[pk][codenames["change"]] for pk in groups_perms
             }
         return context

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -339,7 +339,14 @@ class BulkPermissionMixin:
             "true",
             "1",
         ]:
-            queryset = self.filter_queryset(self.get_queryset())
+            # Detect pagination if available, to avoid querying unneeded permissions
+            page = getattr(self, "paginator", None)
+            if page and hasattr(page, "page"):
+                queryset = page.page.object_list
+            elif hasattr(self, "page"):
+                queryset = self.page
+            else:
+                queryset = self.filter_queryset(self.get_queryset())
             codenames = self.get_permission_codenames()
 
             users_perms = self.get_users_with_object_perms(

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -305,14 +305,13 @@ class BulkPermissionMixin:
             content_type=ctype,
             object_pk__in=object_pks,
             permission__codename__in=perm_codenames,
-        ).select_related("user", "permission")
+        ).values_list("object_pk", "user_id", "permission__codename")
         result = {
             pk: {codename: [] for codename in perm_codenames} for pk in object_pks
         }
-        for perm in perms_qs:
-            pk = int(perm.object_pk)
-            codename = perm.permission.codename
-            result[pk][codename].append(perm.user_id)
+        for object_pk, user_id, codename in perms_qs:
+            pk = int(object_pk)
+            result[pk][codename].append(user_id)
         return result
 
     def get_groups_with_object_perms(self, objects, perm_codenames):
@@ -324,14 +323,14 @@ class BulkPermissionMixin:
             content_type=ctype,
             object_pk__in=object_pks,
             permission__codename__in=perm_codenames,
-        ).select_related("group", "permission")
+        ).values_list("object_pk", "group_id", "permission__codename")
         result = {
             pk: {codename: [] for codename in perm_codenames} for pk in object_pks
         }
-        for perm in perms_qs:
-            pk = int(perm.object_pk)
-            codename = perm.permission.codename
-            result[pk][codename].append(perm.group_id)
+
+        for object_pk, group_id, codename in perms_qs:
+            pk = int(object_pk)
+            result[pk][codename].append(group_id)
         return result
 
     def get_serializer_context(self):

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -19,6 +19,7 @@ from celery import states
 from django.conf import settings
 from django.contrib.auth.models import Group
 from django.contrib.auth.models import User
+from django.contrib.contenttypes.models import ContentType
 from django.db import connections
 from django.db.migrations.loader import MigrationLoader
 from django.db.migrations.recorder import MigrationRecorder
@@ -56,6 +57,8 @@ from drf_spectacular.utils import OpenApiParameter
 from drf_spectacular.utils import extend_schema
 from drf_spectacular.utils import extend_schema_view
 from drf_spectacular.utils import inline_serializer
+from guardian.models import GroupObjectPermission
+from guardian.models import UserObjectPermission
 from langdetect import detect
 from packaging import version as packaging_version
 from redis import Redis
@@ -254,7 +257,59 @@ class PassUserMixin(GenericAPIView):
         return super().get_serializer(*args, **kwargs)
 
 
-class PermissionsAwareDocumentCountMixin(PassUserMixin):
+class PermissionsAwareMixin(PassUserMixin):
+    """
+    Preload Django-Guardian permissions to avoid N+1 queries on models with permissions.
+    """
+
+    def list(self, request, *args, **kwargs):
+        response = super().list(request, *args, **kwargs)
+        self._preload_permissions()
+        return response
+
+    def retrieve(self, request, *args, **kwargs):
+        response = super().retrieve(request, *args, **kwargs)
+        self._preload_permissions()
+        return response
+
+    def _preload_permissions(self):
+        qs = self.get_queryset()
+        if not qs:
+            return
+
+        object_ids = list(qs.values_list("id", flat=True))
+        if not object_ids:
+            return
+
+        model = self.get_serializer_class().Meta.model
+        ctype = ContentType.objects.get_for_model(model)
+        perms_needed = list(self._permissions_cache.values())
+
+        user_perms = UserObjectPermission.objects.filter(
+            object_pk__in=object_ids,
+            content_type_id=ctype.id,
+            permission_id__in=[p.id for p in perms_needed],
+        ).select_related("user")
+
+        group_perms = GroupObjectPermission.objects.filter(
+            object_pk__in=object_ids,
+            content_type_id=ctype.id,
+            permission_id__in=[p.id for p in perms_needed],
+        ).select_related("group")
+
+        self._permission_mapping = {
+            obj_id: {"users": set(), "groups": set()} for obj_id in object_ids
+        }
+        for up in user_perms:
+            self._permission_mapping[up.object_pk]["users"].add(up.user_id)
+        for gp in group_perms:
+            self._permission_mapping[gp.object_pk]["groups"].add(gp.group_id)
+
+    def get_permission_mapping(self):
+        return getattr(self, "_permission_mapping", {})
+
+
+class PermissionsAwareDocumentCountMixin(PermissionsAwareMixin):
     """
     Mixin to add document count to queryset, permissions-aware if needed
     """


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Removes N+1 queries in tag, correspondent, storage path, custom field, and document type list views.
This reduces SQL queries from 160 to 9, and speeds up (~2-5x) the load time and search time of the following pages:
- Correspondents
- Tags
- Document Types
- Storage Paths
- Custom Fields


## TODO

- [x] Test a view
- [x] rename `users_with_view` -> `user_view_perms` etc.

## Feedback welcome

Initially, I wanted to solve this by prefetching permissions with Django-guardian, as they suggest in their documentation: https://django-guardian.readthedocs.io/en/latest/userguide/performance/

Unfortunately, I didn't manage to do it, so I ended up caching them myself in the view and retrieving them in the serializer.

This is a cool improvement on slow machines, but the code is too complex and can probably be simplified. Maybe it has to be rewritten completely. Feedback and suggestions are highly appreciated!

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
