### PR TITLE
Fix: prevent loss of changes when switching between open docs

### DIFF
--- a/src-ui/src/app/components/document-detail/document-detail.component.ts
+++ b/src-ui/src/app/components/document-detail/document-detail.component.ts
@@ -442,7 +442,11 @@ export class DocumentDetailComponent
               )
             }
 
-            if (this.documentForm.dirty) {
+            // Prevent mutating stale form values into the next document: only sync if it still matches the active document.
+            if (
+              this.documentForm.dirty &&
+              (this.document?.id === openDocument.id || !this.document)
+            ) {
               Object.assign(openDocument, this.documentForm.value)
               openDocument['owner'] =
                 this.documentForm.get('permissions_form').value['owner']
@@ -489,7 +493,11 @@ export class DocumentDetailComponent
                   this.store.getValue().title !==
                   this.documentForm.get('title').value
                 ) {
-                  this.openDocumentService.setDirty(doc, true)
+                  this.openDocumentService.setDirty(
+                    doc,
+                    true,
+                    this.getChangedFields()
+                  )
                 }
               },
             })

--- a/src-ui/src/app/components/document-detail/document-detail.component.ts
+++ b/src-ui/src/app/components/document-detail/document-detail.component.ts
@@ -690,6 +690,11 @@ export class DocumentDetailComponent
 
     this.documentForm.patchValue(docFormValues, { emitEvent: false })
     if (!this.userCanEdit) this.documentForm.disable()
+    setTimeout(() => {
+      // check again after a tick in case form was dirty
+      if (!this.userCanEdit) this.documentForm.disable()
+      else this.documentForm.enable()
+    }, 10)
   }
 
   get customFieldFormFields(): FormArray {


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

For the tiny diff, one of the trickiest things I've ever had to track down. Frankly, this logic is sorely in need of a complete refactor.

https://github.com/user-attachments/assets/0510a153-9971-42fc-9390-61c10c7539a1

Related to #9744 / #10468

Closes #10658

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
