### PR TITLE
Development: allow devcontainer pytest to find tests

### DIFF
--- a/.devcontainer/vscode/settings.json
+++ b/.devcontainer/vscode/settings.json
@@ -1,11 +1,10 @@
 {
-    "python.testing.pytestArgs": [
-        "src"
-    ],
+    "python.testing.pytestArgs": [],
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,
     "files.watcherExclude": {
         "**/.venv/**": true,
         "**/pytest_cache/**": true
-    }
+    },
+    "python.testing.cwd": "${workspaceFolder}/src"
 }

--- a/src-ui/package.json
+++ b/src-ui/package.json
@@ -78,5 +78,6 @@
       "lmdb",
       "msgpackr-extract"
     ]
-  }
+  },
+  "packageManager": "pnpm@10.15.0+sha512.486ebc259d3e999a4e8691ce03b5cac4a71cbeca39372a9b762cb500cfdf0873e2cb16abe3d951b1ee2cf012503f027b98b6584e4df22524e0c7450d9ec7aa7b"
 }

--- a/src-ui/package.json
+++ b/src-ui/package.json
@@ -78,6 +78,5 @@
       "lmdb",
       "msgpackr-extract"
     ]
-  },
-  "packageManager": "pnpm@10.15.0+sha512.486ebc259d3e999a4e8691ce03b5cac4a71cbeca39372a9b762cb500cfdf0873e2cb16abe3d951b1ee2cf012503f027b98b6584e4df22524e0c7450d9ec7aa7b"
+  }
 }


### PR DESCRIPTION

## Proposed change

Using the devcontainer and pytest integration of vscode is a nice option to run tests an debug them inline to the code.
Currently the settings for pytest are not set correctly, that pytest can find the tests located in the src folder.
With this fix, the testintegration can find the tests and display them in vscode.

Also setting up the environment needs pnmp as package manager which is now referenced in the package file.

## Type of change


- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:


- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
