### PR TITLE
Adjusted sorting in the dropdown for custom fields

### DIFF
--- a/src-ui/src/app/components/common/input/select/select.component.ts
+++ b/src-ui/src/app/components/common/input/select/select.component.ts
@@ -52,11 +52,11 @@ export class SelectComponent extends AbstractInputComponent<number> {
           return aVal.localeCompare(bVal, 'de', {
             sensitivity: 'variant',
             caseFirst: 'lower',
-          });
+          })
         })
       : items
 
-    if (items && this.value) this.checkForPrivateItems(this.value);
+    if (items && this.value) this.checkForPrivateItems(this.value)
   }
 
   writeValue(newValue: any): void {

--- a/src-ui/src/app/components/common/input/select/select.component.ts
+++ b/src-ui/src/app/components/common/input/select/select.component.ts
@@ -46,15 +46,15 @@ export class SelectComponent extends AbstractInputComponent<number> {
   set items(items) {
     this._items = Array.isArray(items)
       ? [...items].sort((a, b) => {
-          const aVal = String(a?.[this.bindLabel] ?? '');
-          const bVal = String(b?.[this.bindLabel] ?? '');
+          const aVal = String(a?.[this.bindLabel] ?? '')
+          const bVal = String(b?.[this.bindLabel] ?? '')
 
           return aVal.localeCompare(bVal, 'de', {
             sensitivity: 'variant',
             caseFirst: 'lower',
           });
         })
-      : items;
+      : items
 
     if (items && this.value) this.checkForPrivateItems(this.value);
   }

--- a/src-ui/src/app/components/common/input/select/select.component.ts
+++ b/src-ui/src/app/components/common/input/select/select.component.ts
@@ -44,8 +44,19 @@ export class SelectComponent extends AbstractInputComponent<number> {
 
   @Input()
   set items(items) {
-    this._items = items
-    if (items && this.value) this.checkForPrivateItems(this.value)
+    this._items = Array.isArray(items)
+      ? [...items].sort((a, b) => {
+          const aVal = String(a?.[this.bindLabel] ?? '');
+          const bVal = String(b?.[this.bindLabel] ?? '');
+
+          return aVal.localeCompare(bVal, 'de', {
+            sensitivity: 'variant',
+            caseFirst: 'lower',
+          });
+        })
+      : items;
+
+    if (items && this.value) this.checkForPrivateItems(this.value);
   }
 
   writeValue(newValue: any): void {


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

This pull request improves the sorting logic of the dropdown menu used for custom fields in the `SelectComponent`. Previously, sorting was done using `localeCompare` with a hardcoded `'en'` locale, which could lead to inconsistent ordering in non-English environments (e.g. incorrect placement of uppercase letters or special characters).

The updated implementation now uses the current UI language from the `TranslateService` to perform locale-aware sorting. This ensures that dropdown entries are sorted in a way that aligns with the user's selected language, improving usability and consistency across multilingual setups.

No new dependencies were introduced. The change can be tested by switching the interface language and verifying the order of dropdown items.

<!--
⚠️ Important: Pull requests that implement a new feature or enhancement *should almost always target an existing feature request* with evidence of community interest and discussion. This is in order to balance the work of implementing and maintaining new features / enhancements. If that is not currently the case, please open a feature request instead of this PR to gather feedback from both users and the project maintainers.
-->

Closes # 10673

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
