### PR TITLE
Performance: Cache (again) document thumbnails on the frontend

### DIFF
--- a/src-ui/src/app/components/document-detail/document-detail.component.ts
+++ b/src-ui/src/app/components/document-detail/document-detail.component.ts
@@ -411,7 +411,14 @@ export class DocumentDetailComponent
             err.message ?? err.toString()
           }`),
       })
-    this.thumbUrl = this.documentsService.getThumbUrl(documentId)
+    // Load the thumbnail with specified version if available from the list view
+    const docFromList = this.documentListViewService.documents.find(
+      (doc) => doc.id === documentId
+    )
+    this.thumbUrl = this.documentsService.getThumbUrl(
+      documentId,
+      docFromList?.thumb_rev
+    )
     this.documentsService
       .get(documentId)
       .pipe(
@@ -429,11 +436,22 @@ export class DocumentDetailComponent
             this.router.navigate(['404'], { replaceUrl: true })
             return
           }
+
           this.documentId = doc.id
           this.suggestions = null
           const openDocument = this.openDocumentService.getOpenDocument(
             this.documentId
           )
+          if (
+            docFromList?.thumb_rev &&
+            docFromList.thumb_rev != doc.thumb_rev
+          ) {
+            // The document's thumbnail has been refreshed in the meantime,
+            // so we need to update it in our local list.
+            // No need to fetch the actual new thumbnail now,
+            // as the preview will quickly replace it.
+            docFromList.thumb_rev = doc.thumb_rev
+          }
           const useDoc = openDocument || doc
           if (openDocument) {
             if (

--- a/src-ui/src/app/components/document-list/document-card-large/document-card-large.component.ts
+++ b/src-ui/src/app/components/document-list/document-card-large/document-card-large.component.ts
@@ -146,7 +146,10 @@ export class DocumentCardLargeComponent
   }
 
   getThumbUrl() {
-    return this.documentService.getThumbUrl(this.document.id)
+    return this.documentService.getThumbUrl(
+      this.document.id,
+      this.document.thumb_rev
+    )
   }
 
   getDownloadUrl() {

--- a/src-ui/src/app/components/document-list/document-card-small/document-card-small.component.ts
+++ b/src-ui/src/app/components/document-list/document-card-small/document-card-small.component.ts
@@ -113,7 +113,10 @@ export class DocumentCardSmallComponent
   }
 
   getThumbUrl() {
-    return this.documentService.getThumbUrl(this.document.id)
+    return this.documentService.getThumbUrl(
+      this.document.id,
+      this.document.thumb_rev
+    )
   }
 
   getDownloadUrl() {

--- a/src-ui/src/app/data/document.ts
+++ b/src-ui/src/app/data/document.ts
@@ -146,6 +146,8 @@ export interface Document extends ObjectWithPermissions {
 
   thumbnail_url?: string
 
+  thumb_rev?: string
+
   archive_serial_number?: number
 
   notes?: DocumentNote[]

--- a/src-ui/src/app/services/rest/document.service.ts
+++ b/src-ui/src/app/services/rest/document.service.ts
@@ -172,8 +172,12 @@ export class DocumentService extends AbstractPaperlessService<Document> {
     return url.toString()
   }
 
-  getThumbUrl(id: number): string {
-    return this.getResourceUrl(id, 'thumb')
+  getThumbUrl(id: number, rev: string = null): string {
+    if (rev) {
+      return `${this.getResourceUrl(id, 'thumb')}?v=${rev}`
+    } else {
+      return this.getResourceUrl(id, 'thumb')
+    }
   }
 
   getDownloadUrl(id: number, original: boolean = false): string {


### PR DESCRIPTION
## Proposed change
This relates to this discussion: https://github.com/paperless-ngx/paperless-ngx/discussions/9378
Implement a cache-busting strategy for the document thumbnails, so they can be cached for a long time and refreshed as soon as they change on the API.

This re-enables caching for thumbnails without causing these reported bugs:
- https://github.com/paperless-ngx/paperless-ngx/issues/8344
- https://github.com/paperless-ngx/paperless-ngx/issues/8607

Also, I added the `private` cache-control property, so the thumbnails are not cached by CDN, shared caches, or whatever. To be discussed, but I'm worried it could leak sensitive data.
Edit: Indeed, it was the case before caching was disabled by this PR: https://github.com/paperless-ngx/paperless-ngx/pull/8611
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Details

- Add `tumb_rev` field so the frontend can be informed when a new thumbnail version is available
- The thumbnails are cached in the document list view and the document detailed view
- No stale data: as soon as a thumbnail is modified and the frontend reloads the detail or list view, it knows which thumbnail has to be refreshed.

A note on thumb_rev: it's a shortened MD5 hash based on the document ID and the thumbnail's last modified timestamp. It has to be computed fast, and it ought to be short. It's 16 bits long (3 characters in the Json payload): the collision probability is 1/65536. If it should happen, the only impact is that the browser keeps a stale thumbnail until the thumbnail changes on the API or, more probably, until the client cache is cleared, which happens quite quickly anyway.

## TODO
- [ ] Front-end testing? I'm not a front-end developer, so this part may need a careful review
- [ ] The API decorator looks awkward, it might be simplified?
- [ ] Discuss the `private` cache-control property

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
