### PR TITLE
Feature: Support interleaved page merging

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -301,6 +301,7 @@ The following methods are supported:
         -   `"metadata_document_id": DOC_ID` apply metadata (tags, correspondent, etc.) from this document to the merged document.
         -   `"delete_originals": true` to delete the original documents. This requires the calling user being the owner of
             all documents that are merged.
+        -   `"interleaved": true` to interleave pages (requires exactly 2 documents).
 -   `split`
     -   Requires `parameters`:
         -   `"pages": [..]` The list should be a list of pages and/or a ranges, separated by commas e.g. `"[1,2-3,4,5-7]"`

--- a/src-ui/src/app/components/common/confirm-dialog/merge-confirm-dialog/merge-confirm-dialog.component.html
+++ b/src-ui/src/app/components/common/confirm-dialog/merge-confirm-dialog/merge-confirm-dialog.component.html
@@ -35,6 +35,10 @@
       <input class="form-check-input" type="checkbox" role="switch" id="deleteOriginalsSwitch" [(ngModel)]="deleteOriginals" [disabled]="!userOwnsAllDocuments">
       <label class="form-check-label" for="deleteOriginalsSwitch" i18n>Delete original documents after successful merge</label>
     </div>
+    <div class="form-check form-switch mt-2">
+      <input class="form-check-input" type="checkbox" role="switch" id="interleavedSwitch" [(ngModel)]="interleaved">
+      <label class="form-check-label" for="interleavedSwitch" i18n>Interleave pages (only for 2 documents)</label>
+    </div>
     @if (!archiveFallback) {
       <p class="small text-muted fst-italic mt-4" i18n>Note that only PDFs will be included.</p>
     }

--- a/src-ui/src/app/components/common/confirm-dialog/merge-confirm-dialog/merge-confirm-dialog.component.ts
+++ b/src-ui/src/app/components/common/confirm-dialog/merge-confirm-dialog/merge-confirm-dialog.component.ts
@@ -33,6 +33,7 @@ export class MergeConfirmDialogComponent
   public documentIDs: number[] = []
   public archiveFallback: boolean = false
   public deleteOriginals: boolean = false
+  public interleaved: boolean = false
   private _documents: Document[] = []
   get documents(): Document[] {
     return this._documents

--- a/src-ui/src/app/components/document-list/bulk-editor/bulk-editor.component.ts
+++ b/src-ui/src/app/components/document-list/bulk-editor/bulk-editor.component.ts
@@ -861,6 +861,9 @@ export class BulkEditorComponent
         if (mergeDialog.archiveFallback) {
           args['archive_fallback'] = true
         }
+        if (mergeDialog.interleaved) {
+          args['interleaved'] = true
+        }
         mergeDialog.buttonsEnabled = false
         this.executeBulkOperation(modal, 'merge', args, mergeDialog.documentIDs)
         this.toastService.showInfo(

--- a/src/documents/serialisers.py
+++ b/src/documents/serialisers.py
@@ -1604,6 +1604,11 @@ class BulkEditSerializer(
                 raise serializers.ValidationError("archive_fallback must be a boolean")
         else:
             parameters["archive_fallback"] = False
+        if "interleaved" in parameters:
+            if not isinstance(parameters["interleaved"], bool):
+                raise serializers.ValidationError("interleaved must be a boolean")
+        else:
+            parameters["interleaved"] = False
 
     def _validate_parameters_edit_pdf(self, parameters, document_id):
         if "operations" not in parameters:


### PR DESCRIPTION
## Proposed change

Some printers only have one sided automatic document feeder (ADF) which isn't really helpful when we need to scan double sided documents. Fortunately we can scan batch from both sides and merge pages in interleaved way.

**How to use this feature?**

Simply scan batch of papers from one side (first page goes first), flip the whole batch (last page goes first) and scan again. Select newly scanned documents and merge them with "Interleave pages" feature. That's it - you have scanned double sided documents with minimal effort.

**Why?**
This improved my life a lot and I think more people will be happy to have it 😄 

## Type of change

- [ ] Bug fix: non-breaking change which fixes an issue.
- [x] New feature / Enhancement: non-breaking change which adds functionality.
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [X] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [X] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [X] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [X] I have made corresponding changes to the documentation as needed.
- [X] I have checked my modifications for any breaking changes.
