### PR TITLE
Documentation: update docs for PAPERLESS_THREADS_PER_WORKER

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -980,21 +980,10 @@ paperless will process in parallel on a single document.
         process very large documents faster, use a higher thread per worker
         count.
 
-    The default is a balance between the two, according to your CPU core
-    count, with a slight favor towards threads per worker:
-
-    | CPU core count | Workers | Threads |
-    | -------------- | ------- | ------- |
-    | > 1            | > 1     | > 1     |
-    | > 2            | > 2     | > 1     |
-    | > 4            | > 2     | > 2     |
-    | > 6            | > 2     | > 3     |
-    | > 8            | > 2     | > 4     |
-    | > 12           | > 3     | > 4     |
-    | > 16           | > 4     | > 4     |
-
-    If you only specify PAPERLESS_TASK_WORKERS, paperless will adjust
-    PAPERLESS_THREADS_PER_WORKER automatically.
+    The default depends on `PAPERLESS_THREADS_PER_WORKER` and is
+    calculated so that the total number of threads is at most
+    equal to the total number of (logical) CPU cores (and possibly
+    less due to rounding).
 
 #### [`PAPERLESS_WORKER_TIMEOUT=<num>`](#PAPERLESS_WORKER_TIMEOUT) {#PAPERLESS_WORKER_TIMEOUT}
 


### PR DESCRIPTION
Follow-up to #11005.

## Proposed change

In #1227, the default for [`PAPERLESS_TASK_WORKERS`](https://docs.paperless-ngx.com/configuration/#PAPERLESS_TASK_WORKERS) was set to 1. While this was adapted in the linked documentation section, the default for [`PAPERLESS_THREADS_PER_WORKER`](https://docs.paperless-ngx.com/configuration/#PAPERLESS_THREADS_PER_WORKER) depends on the value of `PAPERLESS_TASK_WORKERS`, so that section is now a bit confusing. This PR fixes that.

## Type of change

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [x] Documentation only.
- [ ] Other. Please explain:

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
