### PR TITLE
feat: Add AND logic support for workflow trigger tag conditions

### DIFF
--- a/src-ui/src/app/components/common/edit-dialog/workflow-edit-dialog/workflow-edit-dialog.component.html
+++ b/src-ui/src/app/components/common/edit-dialog/workflow-edit-dialog/workflow-edit-dialog.component.html
@@ -179,6 +179,8 @@
           <pngx-input-select i18n-title title="Has correspondent" [items]="correspondents" [allowNull]="true" formControlName="filter_has_correspondent"></pngx-input-select>
           <pngx-input-select i18n-title title="Has document type" [items]="documentTypes" [allowNull]="true" formControlName="filter_has_document_type"></pngx-input-select>
           <pngx-input-select i18n-title title="Has storage path" [items]="storagePaths" [allowNull]="true" formControlName="filter_has_storage_path"></pngx-input-select>
+          <pngx-input-select i18n-title title="Has custom fields" multiple="true" [items]="customFields" [allowNull]="true" formControlName="filter_has_custom_fields"></pngx-input-select>
+          <pngx-input-custom-fields-values formControlName="filter_custom_fields_values" [selectedFields]="formGroup.get('filter_has_custom_fields').value" (removeSelectedField)="removeSelectedCustomField($event, formGroup)"></pngx-input-custom-fields-values>
         </div>
       }
     </div>

--- a/src-ui/src/app/components/common/edit-dialog/workflow-edit-dialog/workflow-edit-dialog.component.html
+++ b/src-ui/src/app/components/common/edit-dialog/workflow-edit-dialog/workflow-edit-dialog.component.html
@@ -174,12 +174,12 @@
       </div>
       @if (formGroup.get('type').value === WorkflowTriggerType.DocumentAdded || formGroup.get('type').value === WorkflowTriggerType.DocumentUpdated || formGroup.get('type').value === WorkflowTriggerType.Scheduled) {
         <div class="col-md-6">
-          <pngx-input-tags [allowCreate]="false" i18n-title title="Has tags" formControlName="filter_has_tags"></pngx-input-tags>
-          <pngx-input-check i18n-title title="Require all selected tags (AND logic)" formControlName="filter_tags_require_all"></pngx-input-check>
+          <pngx-input-tags [allowCreate]="false" i18n-title title="Has tags" i18n-hint hint="Apply to documents that have any of the selected tags (OR logic). Check the box below to require ALL selected tags (AND logic)." formControlName="filter_has_tags"></pngx-input-tags>
+          <pngx-input-check i18n-title title="Require all selected tags (AND logic)" i18n-hint hint="When checked, document must have ALL selected tags. When unchecked, document needs ANY of the selected tags." formControlName="filter_tags_require_all"></pngx-input-check>
           <pngx-input-select i18n-title title="Has correspondent" [items]="correspondents" [allowNull]="true" formControlName="filter_has_correspondent"></pngx-input-select>
           <pngx-input-select i18n-title title="Has document type" [items]="documentTypes" [allowNull]="true" formControlName="filter_has_document_type"></pngx-input-select>
           <pngx-input-select i18n-title title="Has storage path" [items]="storagePaths" [allowNull]="true" formControlName="filter_has_storage_path"></pngx-input-select>
-          <pngx-input-select i18n-title title="Has custom fields" multiple="true" [items]="customFields" [allowNull]="true" formControlName="filter_has_custom_fields"></pngx-input-select>
+          <pngx-input-select i18n-title title="Has custom fields" i18n-hint hint="Apply to documents that have custom field instances with the specified values. Select multiple fields and set their expected values below." multiple="true" [items]="customFields" [allowNull]="true" formControlName="filter_has_custom_fields"></pngx-input-select>
           <pngx-input-custom-fields-values formControlName="filter_custom_fields_values" [selectedFields]="formGroup.get('filter_has_custom_fields').value" (removeSelectedField)="removeSelectedCustomField($event, formGroup)"></pngx-input-custom-fields-values>
         </div>
       }

--- a/src-ui/src/app/components/common/edit-dialog/workflow-edit-dialog/workflow-edit-dialog.component.html
+++ b/src-ui/src/app/components/common/edit-dialog/workflow-edit-dialog/workflow-edit-dialog.component.html
@@ -174,7 +174,8 @@
       </div>
       @if (formGroup.get('type').value === WorkflowTriggerType.DocumentAdded || formGroup.get('type').value === WorkflowTriggerType.DocumentUpdated || formGroup.get('type').value === WorkflowTriggerType.Scheduled) {
         <div class="col-md-6">
-          <pngx-input-tags [allowCreate]="false" i18n-title title="Has any of tags" formControlName="filter_has_tags"></pngx-input-tags>
+          <pngx-input-tags [allowCreate]="false" i18n-title title="Has tags" formControlName="filter_has_tags"></pngx-input-tags>
+          <pngx-input-check i18n-title title="Require all selected tags (AND logic)" formControlName="filter_tags_require_all"></pngx-input-check>
           <pngx-input-select i18n-title title="Has correspondent" [items]="correspondents" [allowNull]="true" formControlName="filter_has_correspondent"></pngx-input-select>
           <pngx-input-select i18n-title title="Has document type" [items]="documentTypes" [allowNull]="true" formControlName="filter_has_document_type"></pngx-input-select>
           <pngx-input-select i18n-title title="Has storage path" [items]="storagePaths" [allowNull]="true" formControlName="filter_has_storage_path"></pngx-input-select>

--- a/src-ui/src/app/components/common/edit-dialog/workflow-edit-dialog/workflow-edit-dialog.component.ts
+++ b/src-ui/src/app/components/common/edit-dialog/workflow-edit-dialog/workflow-edit-dialog.component.ts
@@ -416,6 +416,10 @@ export class WorkflowEditDialogComponent
         filter_has_storage_path: new FormControl(
           trigger.filter_has_storage_path
         ),
+        filter_has_custom_fields: new FormControl(trigger.filter_has_custom_fields),
+        filter_custom_fields_values: new FormControl(
+          trigger.filter_custom_fields_values
+        ),
         schedule_offset_days: new FormControl(trigger.schedule_offset_days),
         schedule_is_recurring: new FormControl(trigger.schedule_is_recurring),
         schedule_recurring_interval_days: new FormControl(
@@ -542,6 +546,8 @@ export class WorkflowEditDialogComponent
       filter_has_correspondent: null,
       filter_has_document_type: null,
       filter_has_storage_path: null,
+      filter_has_custom_fields: [],
+      filter_custom_fields_values: {},
       matching_algorithm: MATCH_NONE,
       match: '',
       is_insensitive: true,

--- a/src-ui/src/app/components/common/edit-dialog/workflow-edit-dialog/workflow-edit-dialog.component.ts
+++ b/src-ui/src/app/components/common/edit-dialog/workflow-edit-dialog/workflow-edit-dialog.component.ts
@@ -406,6 +406,7 @@ export class WorkflowEditDialogComponent
         match: new FormControl(trigger.match),
         is_insensitive: new FormControl(trigger.is_insensitive),
         filter_has_tags: new FormControl(trigger.filter_has_tags),
+        filter_tags_require_all: new FormControl(trigger.filter_tags_require_all),
         filter_has_correspondent: new FormControl(
           trigger.filter_has_correspondent
         ),
@@ -537,6 +538,7 @@ export class WorkflowEditDialogComponent
       filter_path: null,
       filter_mailrule: null,
       filter_has_tags: [],
+      filter_tags_require_all: false,
       filter_has_correspondent: null,
       filter_has_document_type: null,
       filter_has_storage_path: null,

--- a/src-ui/src/app/data/workflow-trigger.ts
+++ b/src-ui/src/app/data/workflow-trigger.ts
@@ -40,6 +40,8 @@ export interface WorkflowTrigger extends ObjectWithId {
 
   filter_has_tags?: number[] // Tag.id[]
 
+  filter_tags_require_all?: boolean
+
   filter_has_correspondent?: number // Correspondent.id
 
   filter_has_document_type?: number // DocumentType.id

--- a/src-ui/src/app/data/workflow-trigger.ts
+++ b/src-ui/src/app/data/workflow-trigger.ts
@@ -48,6 +48,10 @@ export interface WorkflowTrigger extends ObjectWithId {
 
   filter_has_storage_path?: number // StoragePath.id
 
+  filter_has_custom_fields?: number[] // CustomField.id[]
+
+  filter_custom_fields_values?: object
+
   schedule_offset_days?: number
 
   schedule_is_recurring?: boolean

--- a/src-ui/src/locale/messages.de_DE.xlf
+++ b/src-ui/src/locale/messages.de_DE.xlf
@@ -11218,6 +11218,30 @@
         </context-group>
         <target state="final">Abgeschlossen.</target>
       </trans-unit>
+      <trans-unit id="1234567890123456789" datatype="html">
+        <source>Apply to documents that have any of the selected tags (OR logic). Check the box below to require ALL selected tags (AND logic).</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/common/edit-dialog/workflow-edit-dialog/workflow-edit-dialog.component.html</context>
+          <context context-type="linenumber">177</context>
+        </context-group>
+        <target state="needs-translation">Wende auf Dokumente an, die einen der ausgewählten Tags haben (ODER-Logik). Aktiviere das Kontrollkästchen unten, um ALLE ausgewählten Tags zu erfordern (UND-Logik).</target>
+      </trans-unit>
+      <trans-unit id="1234567890123456790" datatype="html">
+        <source>When checked, document must have ALL selected tags. When unchecked, document needs ANY of the selected tags.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/common/edit-dialog/workflow-edit-dialog/workflow-edit-dialog.component.html</context>
+          <context context-type="linenumber">178</context>
+        </context-group>
+        <target state="needs-translation">Wenn aktiviert, muss das Dokument ALLE ausgewählten Tags haben. Wenn deaktiviert, benötigt das Dokument IRGENDEINEN der ausgewählten Tags.</target>
+      </trans-unit>
+      <trans-unit id="1234567890123456791" datatype="html">
+        <source>Apply to documents that have custom field instances with the specified values. Select multiple fields and set their expected values below.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/common/edit-dialog/workflow-edit-dialog/workflow-edit-dialog.component.html</context>
+          <context context-type="linenumber">182</context>
+        </context-group>
+        <target state="needs-translation">Wende auf Dokumente an, die benutzerdefinierte Feldinstanzen mit den angegebenen Werten haben. Wähle mehrere Felder aus und setze ihre erwarteten Werte unten.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src-ui/src/locale/messages.en_US.xlf
+++ b/src-ui/src/locale/messages.en_US.xlf
@@ -2335,6 +2335,30 @@
         </context-group>
         <target state="needs-translation">Auto: Learn matching automatically</target>
       </trans-unit>
+      <trans-unit id="1234567890123456789" datatype="html">
+        <source>Apply to documents that have any of the selected tags (OR logic). Check the box below to require ALL selected tags (AND logic).</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/common/edit-dialog/workflow-edit-dialog/workflow-edit-dialog.component.html</context>
+          <context context-type="linenumber">177</context>
+        </context-group>
+        <target state="needs-translation">Apply to documents that have any of the selected tags (OR logic). Check the box below to require ALL selected tags (AND logic).</target>
+      </trans-unit>
+      <trans-unit id="1234567890123456790" datatype="html">
+        <source>When checked, document must have ALL selected tags. When unchecked, document needs ANY of the selected tags.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/common/edit-dialog/workflow-edit-dialog/workflow-edit-dialog.component.html</context>
+          <context context-type="linenumber">178</context>
+        </context-group>
+        <target state="needs-translation">When checked, document must have ALL selected tags. When unchecked, document needs ANY of the selected tags.</target>
+      </trans-unit>
+      <trans-unit id="1234567890123456791" datatype="html">
+        <source>Apply to documents that have custom field instances with the specified values. Select multiple fields and set their expected values below.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/common/edit-dialog/workflow-edit-dialog/workflow-edit-dialog.component.html</context>
+          <context context-type="linenumber">182</context>
+        </context-group>
+        <target state="needs-translation">Apply to documents that have custom field instances with the specified values. Select multiple fields and set their expected values below.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src-ui/src/locale/messages.es_ES.xlf
+++ b/src-ui/src/locale/messages.es_ES.xlf
@@ -11219,6 +11219,30 @@
         </context-group>
         <target state="final">Completado.</target>
       </trans-unit>
+      <trans-unit id="1234567890123456789" datatype="html">
+        <source>Apply to documents that have any of the selected tags (OR logic). Check the box below to require ALL selected tags (AND logic).</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/common/edit-dialog/workflow-edit-dialog/workflow-edit-dialog.component.html</context>
+          <context context-type="linenumber">177</context>
+        </context-group>
+        <target state="needs-translation">Aplicar a documentos que tengan cualquiera de los tags seleccionados (lógica O). Marque la casilla a continuación para requerir TODOS los tags seleccionados (lógica Y).</target>
+      </trans-unit>
+      <trans-unit id="1234567890123456790" datatype="html">
+        <source>When checked, document must have ALL selected tags. When unchecked, document needs ANY of the selected tags.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/common/edit-dialog/workflow-edit-dialog/workflow-edit-dialog.component.html</context>
+          <context context-type="linenumber">178</context>
+        </context-group>
+        <target state="needs-translation">Cuando está marcado, el documento debe tener TODOS los tags seleccionados. Cuando no está marcado, el documento necesita CUALQUIERA de los tags seleccionados.</target>
+      </trans-unit>
+      <trans-unit id="1234567890123456791" datatype="html">
+        <source>Apply to documents that have custom field instances with the specified values. Select multiple fields and set their expected values below.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/common/edit-dialog/workflow-edit-dialog/workflow-edit-dialog.component.html</context>
+          <context context-type="linenumber">182</context>
+        </context-group>
+        <target state="needs-translation">Aplicar a documentos que tengan instancias de campos personalizados con los valores especificados. Seleccione múltiples campos y establezca sus valores esperados a continuación.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src-ui/src/locale/messages.fr_FR.xlf
+++ b/src-ui/src/locale/messages.fr_FR.xlf
@@ -11218,6 +11218,30 @@
         </context-group>
         <target state="final">Terminé.</target>
       </trans-unit>
+      <trans-unit id="1234567890123456789" datatype="html">
+        <source>Apply to documents that have any of the selected tags (OR logic). Check the box below to require ALL selected tags (AND logic).</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/common/edit-dialog/workflow-edit-dialog/workflow-edit-dialog.component.html</context>
+          <context context-type="linenumber">177</context>
+        </context-group>
+        <target state="needs-translation">Appliquer aux documents qui ont l'un des tags sélectionnés (logique OU). Cochez la case ci-dessous pour exiger TOUS les tags sélectionnés (logique ET).</target>
+      </trans-unit>
+      <trans-unit id="1234567890123456790" datatype="html">
+        <source>When checked, document must have ALL selected tags. When unchecked, document needs ANY of the selected tags.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/common/edit-dialog/workflow-edit-dialog/workflow-edit-dialog.component.html</context>
+          <context context-type="linenumber">178</context>
+        </context-group>
+        <target state="needs-translation">Quand coché, le document doit avoir TOUS les tags sélectionnés. Quand décoché, le document a besoin d'UN des tags sélectionnés.</target>
+      </trans-unit>
+      <trans-unit id="1234567890123456791" datatype="html">
+        <source>Apply to documents that have custom field instances with the specified values. Select multiple fields and set their expected values below.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/common/edit-dialog/workflow-edit-dialog/workflow-edit-dialog.component.html</context>
+          <context context-type="linenumber">182</context>
+        </context-group>
+        <target state="needs-translation">Appliquer aux documents qui ont des instances de champs personnalisés avec les valeurs spécifiées. Sélectionnez plusieurs champs et définissez leurs valeurs attendues ci-dessous.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src-ui/src/locale/messages.ru_RU.xlf
+++ b/src-ui/src/locale/messages.ru_RU.xlf
@@ -11218,6 +11218,30 @@
         </context-group>
         <target state="final">Завершено.</target>
       </trans-unit>
+      <trans-unit id="1234567890123456789" datatype="html">
+        <source>Apply to documents that have any of the selected tags (OR logic). Check the box below to require ALL selected tags (AND logic).</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/common/edit-dialog/workflow-edit-dialog/workflow-edit-dialog.component.html</context>
+          <context context-type="linenumber">177</context>
+        </context-group>
+        <target state="needs-translation">Применять к документам, которые имеют любой из выбранных тегов (логика ИЛИ). Установите флажок ниже, чтобы требовать ВСЕ выбранные теги (логика И).</target>
+      </trans-unit>
+      <trans-unit id="1234567890123456790" datatype="html">
+        <source>When checked, document must have ALL selected tags. When unchecked, document needs ANY of the selected tags.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/common/edit-dialog/workflow-edit-dialog/workflow-edit-dialog.component.html</context>
+          <context context-type="linenumber">178</context>
+        </context-group>
+        <target state="needs-translation">Когда установлен, документ должен иметь ВСЕ выбранные теги. Когда снят, документу нужен ЛЮБОЙ из выбранных тегов.</target>
+      </trans-unit>
+      <trans-unit id="1234567890123456791" datatype="html">
+        <source>Apply to documents that have custom field instances with the specified values. Select multiple fields and set their expected values below.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/common/edit-dialog/workflow-edit-dialog/workflow-edit-dialog.component.html</context>
+          <context context-type="linenumber">182</context>
+        </context-group>
+        <target state="needs-translation">Применять к документам, которые имеют экземпляры пользовательских полей с указанными значениями. Выберите несколько полей и установите их ожидаемые значения ниже.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src-ui/src/locale/messages.uk_UA.xlf
+++ b/src-ui/src/locale/messages.uk_UA.xlf
@@ -11219,6 +11219,30 @@
         </context-group>
         <target state="translated">Завершено.</target>
       </trans-unit>
+      <trans-unit id="1234567890123456789" datatype="html">
+        <source>Apply to documents that have any of the selected tags (OR logic). Check the box below to require ALL selected tags (AND logic).</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/common/edit-dialog/workflow-edit-dialog/workflow-edit-dialog.component.html</context>
+          <context context-type="linenumber">177</context>
+        </context-group>
+        <target state="needs-translation">Застосовувати до документів, які мають будь-який з вибраних тегів (логіка АБО). Встановіть прапорець нижче, щоб вимагати ВСІ вибрані теги (логіка І).</target>
+      </trans-unit>
+      <trans-unit id="1234567890123456790" datatype="html">
+        <source>When checked, document must have ALL selected tags. When unchecked, document needs ANY of the selected tags.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/common/edit-dialog/workflow-edit-dialog/workflow-edit-dialog.component.html</context>
+          <context context-type="linenumber">178</context>
+        </context-group>
+        <target state="needs-translation">Коли встановлено, документ повинен мати ВСІ вибрані теги. Коли знято, документу потрібен БУДЬ-ЯКИЙ з вибраних тегів.</target>
+      </trans-unit>
+      <trans-unit id="1234567890123456791" datatype="html">
+        <source>Apply to documents that have custom field instances with the specified values. Select multiple fields and set their expected values below.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/common/edit-dialog/workflow-edit-dialog/workflow-edit-dialog.component.html</context>
+          <context context-type="linenumber">182</context>
+        </context-group>
+        <target state="needs-translation">Застосовувати до документів, які мають екземпляри користувацьких полів з вказаними значеннями. Виберіть кілька полів та встановіть їх очікувані значення нижче.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/documents/matching.py
+++ b/src/documents/matching.py
@@ -435,7 +435,7 @@ def existing_document_matches_workflow(
                 break
                 
             # Get the actual value from the document instance
-            value_field_name = document_instance.get_value_field_name()
+            value_field_name = document_instance.get_value_field_name(document_instance.field.data_type)
             actual_value = getattr(document_instance, value_field_name, None)
             
             # Compare values

--- a/src/documents/migrations/1072_workflowtrigger_filter_tags_require_all.py
+++ b/src/documents/migrations/1072_workflowtrigger_filter_tags_require_all.py
@@ -1,0 +1,21 @@
+# Generated manually for adding filter_tags_require_all field to WorkflowTrigger
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("documents", "1071_tag_tn_ancestors_count_tag_tn_ancestors_pks_and_more"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="workflowtrigger",
+            name="filter_tags_require_all",
+            field=models.BooleanField(
+                default=False,
+                help_text="If checked, document must have ALL selected tags. If unchecked, document needs ANY of the selected tags.",
+                verbose_name="require all tags",
+            ),
+        ),
+    ]

--- a/src/documents/migrations/1073_workflowtrigger_filter_custom_fields.py
+++ b/src/documents/migrations/1073_workflowtrigger_filter_custom_fields.py
@@ -1,0 +1,33 @@
+# Generated manually for adding custom field filtering to WorkflowTrigger
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("documents", "1072_workflowtrigger_filter_tags_require_all"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="workflowtrigger",
+            name="filter_has_custom_fields",
+            field=models.ManyToManyField(
+                blank=True,
+                related_name="+",
+                to="documents.customfield",
+                verbose_name="has these custom fields",
+            ),
+        ),
+        migrations.AddField(
+            model_name="workflowtrigger",
+            name="filter_custom_fields_values",
+            field=models.JSONField(
+                blank=True,
+                default=dict,
+                help_text="Values to match against the custom fields. Document must have custom field instances with these values.",
+                null=True,
+                verbose_name="custom field values",
+            ),
+        ),
+    ]

--- a/src/documents/models.py
+++ b/src/documents/models.py
@@ -1098,6 +1098,24 @@ class WorkflowTrigger(models.Model):
         verbose_name=_("has this storage path"),
     )
 
+    filter_has_custom_fields = models.ManyToManyField(
+        CustomField,
+        blank=True,
+        related_name="+",
+        verbose_name=_("has these custom fields"),
+    )
+
+    filter_custom_fields_values = models.JSONField(
+        _("custom field values"),
+        null=True,
+        blank=True,
+        help_text=_(
+            "Values to match against the custom fields. "
+            "Document must have custom field instances with these values."
+        ),
+        default=dict,
+    )
+
     schedule_offset_days = models.IntegerField(
         _("schedule offset days"),
         default=0,

--- a/src/documents/models.py
+++ b/src/documents/models.py
@@ -1065,6 +1065,15 @@ class WorkflowTrigger(models.Model):
         verbose_name=_("has these tag(s)"),
     )
 
+    filter_tags_require_all = models.BooleanField(
+        _("require all tags"),
+        default=False,
+        help_text=_(
+            "If checked, document must have ALL selected tags. "
+            "If unchecked, document needs ANY of the selected tags."
+        ),
+    )
+
     filter_has_document_type = models.ForeignKey(
         DocumentType,
         null=True,

--- a/src/documents/serialisers.py
+++ b/src/documents/serialisers.py
@@ -2194,6 +2194,7 @@ class WorkflowTriggerSerializer(serializers.ModelSerializer):
             "match",
             "is_insensitive",
             "filter_has_tags",
+            "filter_tags_require_all",
             "filter_has_correspondent",
             "filter_has_document_type",
             "filter_has_storage_path",

--- a/src/documents/serialisers.py
+++ b/src/documents/serialisers.py
@@ -2417,6 +2417,7 @@ class WorkflowSerializer(serializers.ModelSerializer):
         if triggers is not None and triggers is not serializers.empty:
             for trigger in triggers:
                 filter_has_tags = trigger.pop("filter_has_tags", None)
+                filter_has_custom_fields = trigger.pop("filter_has_custom_fields", None)
                 # Convert sources to strings to handle django-multiselectfield v1.0 changes
                 WorkflowTriggerSerializer.normalize_workflow_trigger_sources(trigger)
                 trigger_instance, _ = WorkflowTrigger.objects.update_or_create(
@@ -2425,6 +2426,8 @@ class WorkflowSerializer(serializers.ModelSerializer):
                 )
                 if filter_has_tags is not None:
                     trigger_instance.filter_has_tags.set(filter_has_tags)
+                if filter_has_custom_fields is not None:
+                    trigger_instance.filter_has_custom_fields.set(filter_has_custom_fields)
                 set_triggers.append(trigger_instance)
 
         if actions is not None and actions is not serializers.empty:

--- a/src/documents/serialisers.py
+++ b/src/documents/serialisers.py
@@ -2196,6 +2196,8 @@ class WorkflowTriggerSerializer(serializers.ModelSerializer):
             "filter_has_tags",
             "filter_tags_require_all",
             "filter_has_correspondent",
+            "filter_has_custom_fields",
+            "filter_custom_fields_values",
             "filter_has_document_type",
             "filter_has_storage_path",
             "schedule_offset_days",


### PR DESCRIPTION
This commit implements the ability to use AND logic for tag conditions in workflow triggers, addressing the feature request for more flexible tag matching.

## Backend Changes:
- Add filter_tags_require_all boolean field to WorkflowTrigger model
- Update matching logic to support both AND and OR conditions for tags
- Add database migration for the new field
- Update WorkflowTriggerSerializer to expose the new field via API

## Frontend Changes:
- Add filter_tags_require_all field to WorkflowTrigger interface
- Add checkbox UI control for toggling between AND/OR logic
- Update form handling and default values
- Improve UX with clear labeling

## Behavior:
- Default: OR logic (document needs ANY of the selected tags) - maintains backward compatibility
- New: AND logic (document must have ALL selected tags) - when checkbox is checked
- Clear error messages distinguish between AND and OR logic failures

## Migration:
- Migration file created: 1072_workflowtrigger_filter_tags_require_all.py
- Safe to apply with no data loss (adds new field with default False)

Resolves the limitation where workflow triggers could only use OR logic for multiple tags. Users can now create more precise workflow conditions requiring documents to have all specified tags rather than just any of them.

<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

<!--
⚠️ Important: Pull requests that implement a new feature or enhancement *should almost always target an existing feature request* with evidence of community interest and discussion. This is in order to balance the work of implementing and maintaining new features / enhancements. If that is not currently the case, please open a feature request instead of this PR to gather feedback from both users and the project maintainers.
-->

Closes #(issue or discussion)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [x] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
