### PR TITLE
Change behaviour of "SaveEditNext"-Shorcut

### DIFF
--- a/src-ui/src/app/components/document-detail/document-detail.component.ts
+++ b/src-ui/src/app/components/document-detail/document-detail.component.ts
@@ -615,7 +615,8 @@ export class DocumentDetailComponent
       })
       .pipe(takeUntil(this.unsubscribeNotifier))
       .subscribe(() => {
-        if (this.openDocumentService.isDirty(this.document)) this.saveEditNext()
+        if (this.openDocumentService.isDirty(this.document))
+          this.saveEditNextShortcut()
       })
   }
 
@@ -845,6 +846,11 @@ export class DocumentDetailComponent
       }
     })
     return changes
+  }
+
+  saveEditNextShortcut() {
+    if (this.hasNext()) return this.saveEditNext()
+    return this.save(true)
   }
 
   save(close: boolean = false) {


### PR DESCRIPTION
## Proposed change


The "SaveEditNext" shorcut used to always try to open the next document. If no next document existed, an error would be thrown and displayed to the user.

A new SaveEditNextShorcut routine was added. It checks, if a next document exists. If so, it does run SaveEditNext as before. If not, it does run Save with parameter close=true, resulting in the document being saved and the detail window being closed.

I deliberately chose to add a new routine, in order to seperate responsibilites and maintain backwards compatibility for any custom changes, users might have made in their forks. The new routine is only responsible for checking, which routine should be run, whilst the existing routines remain untouched.

This streamlines the workflow for powerusers. Reaching the end of stack isn't really an error, so it shouldn't result in an error splash. From my POV, closing the window is an intuitive reaction, such as taking the last document from your desk will make you see the empty desk.

Closes #11024 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [X] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [X] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [X] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [X] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [X] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [X] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [X] I have made corresponding changes to the documentation as needed.
- [X] I have checked my modifications for any breaking changes.
