### PR TITLE
Enhancement: use friendly file names when emailing documents

### DIFF
--- a/src/documents/signals/handlers.py
+++ b/src/documents/signals/handlers.py
@@ -1164,12 +1164,13 @@ def run_workflows(
         try:
             attachments = []
             if action.email.include_document and original_file:
-                attachments = [(original_file, document.mime_type)]
+                attachments = [document]
             n_messages = send_email(
                 subject=subject,
                 body=body,
                 to=action.email.to.split(","),
                 attachments=attachments,
+                use_archive=False,
             )
             logger.debug(
                 f"Sent {n_messages} notification email(s) to {action.email.to}",

--- a/src/documents/tests/test_api_documents.py
+++ b/src/documents/tests/test_api_documents.py
@@ -3022,7 +3022,8 @@ class TestDocumentApi(DirectoriesMixin, DocumentConsumeDelayMixin, APITestCase):
         )
 
         self.assertEqual(len(mail.outbox), 1)
-        self.assertEqual(mail.outbox[0].attachments[0][0], "archive.pdf")
+        expected_filename = f"{doc.created} test.pdf"
+        self.assertEqual(mail.outbox[0].attachments[0][0], expected_filename)
 
         self.client.post(
             f"/api/documents/{doc2.pk}/email/",
@@ -3035,7 +3036,8 @@ class TestDocumentApi(DirectoriesMixin, DocumentConsumeDelayMixin, APITestCase):
         )
 
         self.assertEqual(len(mail.outbox), 2)
-        self.assertEqual(mail.outbox[1].attachments[0][0], "test2.pdf")
+        expected_filename2 = f"{doc2.created} test2.pdf"
+        self.assertEqual(mail.outbox[1].attachments[0][0], expected_filename2)
 
     @mock.patch("django.core.mail.message.EmailMessage.send", side_effect=Exception)
     def test_email_document_errors(self, mocked_send):

--- a/src/documents/tests/test_api_email.py
+++ b/src/documents/tests/test_api_email.py
@@ -351,11 +351,20 @@ class TestEmail(DirectoriesMixin, SampleDirMixin, APITestCase):
         )
         shutil.copy(self.SAMPLE_DIR / "simple.pdf", doc3.source_path)
 
+        doc4 = Document.objects.create(
+            title="test1",
+            mime_type="application/pdf",
+            content="this is document 4",
+            checksum="4",
+            filename="test4.pdf",
+        )
+        shutil.copy(self.SAMPLE_DIR / "simple.pdf", doc4.source_path)
+
         response = self.client.post(
             self.ENDPOINT,
             json.dumps(
                 {
-                    "documents": [self.doc1.pk, doc3.pk],
+                    "documents": [self.doc1.pk, doc3.pk, doc4.pk],
                     "addresses": "test@example.com",
                     "subject": "Test",
                     "message": "Test message",
@@ -368,9 +377,10 @@ class TestEmail(DirectoriesMixin, SampleDirMixin, APITestCase):
         self.assertEqual(len(mail.outbox), 1)
 
         attachment_names = [att[0] for att in mail.outbox[0].attachments]
-        self.assertEqual(len(attachment_names), 2)
+        self.assertEqual(len(attachment_names), 3)
         self.assertIn(f"{self.doc1!s}.pdf", attachment_names)
         self.assertIn(f"{doc3!s}_01.pdf", attachment_names)
+        self.assertIn(f"{doc3!s}_02.pdf", attachment_names)
 
     @mock.patch(
         "django.core.mail.message.EmailMessage.send",

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -1207,21 +1207,13 @@ class DocumentViewSet(
             ):
                 return HttpResponseForbidden("Insufficient permissions")
 
-        attachments = []
-        for doc in documents:
-            attachment_path = (
-                doc.archive_path
-                if use_archive_version and doc.has_archive_version
-                else doc.source_path
-            )
-            attachments.append((attachment_path, doc.mime_type))
-
         try:
             send_email(
                 subject=subject,
                 body=message,
                 to=addresses,
-                attachments=attachments,
+                attachments=documents,
+                use_archive=use_archive_version,
             )
 
             logger.debug(


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Currently, when emailing documents, paperless uses the actual filename on disk for the attachment name (e.g. `0000235.pdf`) which is not very convenient, especially when sending multiple documents.

This PR changes that behavior, using the public filename (see `Document.get_public_filename`) instead. Duplicate names are handled by appending a count, e.g., `_01`.

I assume that changing the file names in email attachments, does not constitute a breaking change.

Closes #11041

## Type of change

- [ ] Bug fix: non-breaking change which fixes an issue.
- [x] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
