### PR TITLE
change dark mode text color to a brighter shade

### DIFF
--- a/src-ui/src/theme.scss
+++ b/src-ui/src/theme.scss
@@ -34,7 +34,7 @@
 
 // Dark text colors allow for maintain contrast with theme color changes
 $text-color-light-bg: #212529;
-$text-color-dark-bg: #abb2bf;
+$text-color-dark-bg: #dfdfdf;
 $text-color-dark-bg-accent: color.adjust($text-color-dark-bg, $lightness: 10%);
 // Taken from bootstrap
 $form-check-input-checked-bg-image-dark: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><path fill='none' stroke='#{$text-color-light-bg}' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='M6 10l3 3l6-6'/></svg>");

--- a/src/documents/static/base.css
+++ b/src/documents/static/base.css
@@ -76,7 +76,7 @@ body {
   /* From theme_dark.scss */
   body {
     --bs-body-bg: #161618;
-    --bs-body-color: #abb2bf;
+    --bs-body-color: #dfdfdf;
     --bs-body-color-rgb: 171, 178, 191;
     --bs-border-color: #47494f;
   }
@@ -86,10 +86,10 @@ body {
   }
 
   svg.logo .text {
-    fill: #abb2bf !important;
+    fill: #dfdfdf !important;
   }
 
   .byline {
-    color: #abb2bf;
+    color: #dfdfdf;
   }
 }


### PR DESCRIPTION
## Proposed change

i just changed the text color to be a bit more readable and give it slightly more contrast from the background.

Take it as suggestion, a quick fix. A better way would be to allow injecting custom css.

## Type of change

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [x] Other. Please explain: Style Change

## Checklist:

- [X] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [X] I have checked my modifications for any breaking changes.
