### PR TITLE
Tweak: improve tag parent validation error handling

### DIFF
--- a/src/documents/models.py
+++ b/src/documents/models.py
@@ -132,7 +132,7 @@ class Tag(MatchingModel, TreeNodeModel):
         height = 0 if self.pk is None else self.get_depth()
         deepest_new_depth = (new_parent_depth + 1) + height
         if deepest_new_depth > self.MAX_NESTING_DEPTH:
-            raise ValidationError(_("Maximum nesting depth exceeded."))
+            raise ValidationError({"parent": _("Maximum nesting depth exceeded.")})
 
         return super().clean()
 

--- a/src/documents/serialisers.py
+++ b/src/documents/serialisers.py
@@ -635,7 +635,7 @@ class TagSerializer(MatchingModelSerializer, OwnedObjectSerializer):
                 temp.clean()
             except ValidationError as e:
                 logger.debug("Tag parent validation failed: %s", e)
-                raise serializers.ValidationError({"parent": _("Invalid parent tag.")})
+                raise e
 
         return super().validate(attrs)
 

--- a/src/documents/tests/test_tag_hierarchy.py
+++ b/src/documents/tests/test_tag_hierarchy.py
@@ -171,7 +171,7 @@ class TestTagHierarchy(APITestCase):
         )
         assert resp_fail.status_code == 400
         assert "parent" in resp_fail.data
-        assert "Invalid" in str(resp_fail.data["parent"])
+        assert "Maximum nesting depth exceeded" in str(resp_fail.data["parent"])
 
     def test_max_depth_on_move_subtree(self):
         a = Tag.objects.create(name="A2")
@@ -191,7 +191,7 @@ class TestTagHierarchy(APITestCase):
         )
         assert resp_fail.status_code == 400
         assert "Maximum nesting depth exceeded" in str(
-            resp_fail.data["non_field_errors"],
+            resp_fail.data["parent"],
         )
 
         # Moving X under C (depth 3) should be allowed (deepest becomes 5)


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Just making the error message more helpful

<img width="511" height="638" alt="Screenshot 2025-10-20 at 10 23 03 PM" src="https://github.com/user-attachments/assets/47a25db6-d871-4603-b771-45f79bce3570" />

(as opposed to: "Invalid parent tag")

Closes #(issue or discussion)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
