### PR TITLE
Fix: retrieve document_count for tag children

### DIFF
--- a/src/documents/serialisers.py
+++ b/src/documents/serialisers.py
@@ -21,7 +21,6 @@ from django.core.validators import MaxLengthValidator
 from django.core.validators import RegexValidator
 from django.core.validators import integer_validator
 from django.db.models import Count
-from django.db.models import Q
 from django.utils.crypto import get_random_string
 from django.utils.dateparse import parse_datetime
 from django.utils.text import slugify
@@ -67,8 +66,8 @@ from documents.models import WorkflowActionEmail
 from documents.models import WorkflowActionWebhook
 from documents.models import WorkflowTrigger
 from documents.parsers import is_mime_type_supported
+from documents.permissions import get_document_count_filter_for_user
 from documents.permissions import get_groups_with_only_permission
-from documents.permissions import get_objects_for_user_owner_aware
 from documents.permissions import set_permissions_for_object
 from documents.templating.filepath import validate_filepath_template_and_render
 from documents.templating.utils import convert_format_str_to_template_format
@@ -579,17 +578,7 @@ class TagSerializer(MatchingModelSerializer, OwnedObjectSerializer):
         if filter_q is None:
             request = self.context.get("request")
             user = getattr(request, "user", None) if request else None
-            if user is None or getattr(user, "is_superuser", False):
-                filter_q = Q(documents__deleted_at__isnull=True)
-            else:
-                filter_q = Q(
-                    documents__deleted_at__isnull=True,
-                    documents__id__in=get_objects_for_user_owner_aware(
-                        user,
-                        "documents.view_document",
-                        Document,
-                    ).values_list("id", flat=True),
-                )
+            filter_q = get_document_count_filter_for_user(user)
             self.context["document_count_filter"] = filter_q
         serializer = TagSerializer(
             obj.get_children_queryset()

--- a/src/documents/tests/test_tag_hierarchy.py
+++ b/src/documents/tests/test_tag_hierarchy.py
@@ -9,6 +9,7 @@ from documents.models import Tag
 from documents.models import Workflow
 from documents.models import WorkflowAction
 from documents.models import WorkflowTrigger
+from documents.serialisers import TagSerializer
 from documents.signals.handlers import run_workflows
 
 
@@ -138,6 +139,13 @@ class TestTagHierarchy(APITestCase):
         child_entry = children[0]
         assert child_entry["id"] == self.child.pk
         assert child_entry["document_count"] == 1
+
+    def test_tag_serializer_populates_document_filter_context(self):
+        context = {}
+
+        serializer = TagSerializer(self.parent, context=context)
+        assert serializer.data  # triggers serialization
+        assert "document_count_filter" in context
 
     def test_cannot_set_parent_to_self(self):
         tag = Tag.objects.create(name="Selfie")

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -366,7 +366,9 @@ class PermissionsAwareDocumentCountMixin(BulkPermissionMixin, PassUserMixin):
 
     def get_document_count_filter(self):
         user = getattr(self.request, "user", None)
-        if user is None or user.is_superuser:
+        if user is None or not getattr(user, "is_authenticated", False):
+            return Q(documents__deleted_at__isnull=True, documents__owner__isnull=True)
+        elif user.is_superuser:
             return Q(documents__deleted_at__isnull=True)
         return Q(
             documents__deleted_at__isnull=True,

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -141,6 +141,7 @@ from documents.permissions import AcknowledgeTasksPermissions
 from documents.permissions import PaperlessAdminPermissions
 from documents.permissions import PaperlessNotePermissions
 from documents.permissions import PaperlessObjectPermissions
+from documents.permissions import get_document_count_filter_for_user
 from documents.permissions import get_objects_for_user_owner_aware
 from documents.permissions import has_perms_owner_aware
 from documents.permissions import set_permissions_for_object
@@ -365,19 +366,9 @@ class PermissionsAwareDocumentCountMixin(BulkPermissionMixin, PassUserMixin):
     """
 
     def get_document_count_filter(self):
-        user = getattr(self.request, "user", None)
-        if user is None or not getattr(user, "is_authenticated", False):
-            return Q(documents__deleted_at__isnull=True, documents__owner__isnull=True)
-        elif user.is_superuser:
-            return Q(documents__deleted_at__isnull=True)
-        return Q(
-            documents__deleted_at__isnull=True,
-            documents__id__in=get_objects_for_user_owner_aware(
-                user,
-                "documents.view_document",
-                Document,
-            ).values_list("id", flat=True),
-        )
+        request = getattr(self, "request", None)
+        user = getattr(request, "user", None) if request else None
+        return get_document_count_filter_for_user(user)
 
     def get_queryset(self):
         filter = self.get_document_count_filter()


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

A little tricky but I think we can reuse the count filter to retrieve them for children

Closes #11113

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
