### PR TITLE
Fix: resolve migration warning in 2.19.2

### DIFF
--- a/src/documents/migrations/1073_migrate_workflow_title_jinja.py
+++ b/src/documents/migrations/1073_migrate_workflow_title_jinja.py
@@ -35,15 +35,13 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.AlterField(
-            model_name="WorkflowAction",
+            model_name="workflowaction",
             name="assign_title",
             field=models.TextField(
-                null=True,
                 blank=True,
-                help_text=(
-                    "Assign a document title, can be a JINJA2 template, "
-                    "see documentation.",
-                ),
+                help_text="Assign a document title, must  be a Jinja2 template, see documentation.",
+                null=True,
+                verbose_name="assign title",
             ),
         ),
         migrations.RunPython(


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

When I re-added the missing migration in #11131 I just pulled the old file from the original PR, which I guess was somehow generated differently than Django prefers, so it now gives the warning in the linked thread. Given the differences look inconsequential I was thinking it's ok to change this but LMK if you disagree. The only potential actual difference seems to be the capitalization of `model_name`.

The alternative of course would be generate a new migration 1074, which when I did it looked like:

```
        migrations.AlterField(
            model_name="workflowaction",
            name="assign_title",
            field=models.TextField(
                blank=True,
                help_text="Assign a document title, must  be a Jinja2 template, see documentation.",
                null=True,
                verbose_name="assign title",
            ),
        ),
```

(which is what I copy + pasted into this PR).

Closes #11156

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
