### PR TITLE
Fix: refactor nested sorting in filterable dropdowns

### DIFF
--- a/src-ui/src/app/components/common/filterable-dropdown/filterable-dropdown.component.spec.ts
+++ b/src-ui/src/app/components/common/filterable-dropdown/filterable-dropdown.component.spec.ts
@@ -564,6 +564,73 @@ describe('FilterableDropdownComponent & FilterableDropdownSelectionModel', () =>
     ])
   })
 
+  it('keeps children with their parent when parent has document count', () => {
+    const parent: Tag = {
+      id: 10,
+      name: 'Parent Tag',
+      orderIndex: 0,
+      document_count: 2,
+    }
+    const child: Tag = {
+      id: 11,
+      name: 'Child Tag',
+      parent: parent.id,
+      orderIndex: 1,
+      document_count: 0,
+    }
+    const otherRoot: Tag = {
+      id: 20,
+      name: 'Other Tag',
+      orderIndex: 2,
+      document_count: 0,
+    }
+
+    component.selectionModel.items = [parent, child, otherRoot]
+    component.selectionModel = selectionModel
+    component.documentCounts = [
+      { id: parent.id, document_count: 2 },
+      { id: otherRoot.id, document_count: 0 },
+    ]
+    selectionModel.apply()
+
+    expect(component.selectionModel.items).toEqual([
+      nullItem,
+      parent,
+      child,
+      otherRoot,
+    ])
+  })
+
+  it('keeps selected branches ahead of document-based ordering', () => {
+    const selectedRoot: Tag = {
+      id: 30,
+      name: 'Selected Root',
+      orderIndex: 0,
+      document_count: 0,
+    }
+    const otherRoot: Tag = {
+      id: 40,
+      name: 'Other Root',
+      orderIndex: 1,
+      document_count: 2,
+    }
+
+    component.selectionModel.items = [selectedRoot, otherRoot]
+    component.selectionModel = selectionModel
+    selectionModel.set(selectedRoot.id, ToggleableItemState.Selected)
+    component.documentCounts = [
+      { id: selectedRoot.id, document_count: 0 },
+      { id: otherRoot.id, document_count: 2 },
+    ]
+    selectionModel.apply()
+
+    expect(component.selectionModel.items).toEqual([
+      nullItem,
+      selectedRoot,
+      otherRoot,
+    ])
+  })
+
   it('should set support create, keep open model and call createRef method', fakeAsync(() => {
     component.selectionModel.items = items
     component.icon = 'tag-fill'

--- a/src-ui/src/app/components/common/filterable-dropdown/filterable-dropdown.component.spec.ts
+++ b/src-ui/src/app/components/common/filterable-dropdown/filterable-dropdown.component.spec.ts
@@ -715,6 +715,16 @@ describe('FilterableDropdownComponent & FilterableDropdownSelectionModel', () =>
     expect(getRootDocCount(rootWithoutSelection.id)).toEqual(4)
   })
 
+  it('defaults to zero document count when neither selection nor model provide it', () => {
+    const rootWithoutCounts: Tag = { id: 91, name: 'Fallback Zero Root' }
+    selectionModel.items = [rootWithoutCounts]
+    selectionModel.documentCounts = []
+
+    const getRootDocCount = (selectionModel as any).createRootDocCounter()
+
+    expect(getRootDocCount(rootWithoutCounts.id)).toEqual(0)
+  })
+
   it('should set support create, keep open model and call createRef method', fakeAsync(() => {
     component.selectionModel.items = items
     component.icon = 'tag-fill'

--- a/src-ui/src/app/components/common/filterable-dropdown/filterable-dropdown.component.spec.ts
+++ b/src-ui/src/app/components/common/filterable-dropdown/filterable-dropdown.component.spec.ts
@@ -701,6 +701,20 @@ describe('FilterableDropdownComponent & FilterableDropdownSelectionModel', () =>
     expect(getRootDocCount(memoRoot.id)).toEqual(9)
   })
 
+  it('falls back to model stored document counts if selection data missing entry', () => {
+    const rootWithoutSelection: Tag = {
+      id: 90,
+      name: 'Fallback Root',
+      document_count: 4,
+    }
+    selectionModel.items = [rootWithoutSelection]
+    selectionModel.documentCounts = []
+
+    const getRootDocCount = (selectionModel as any).createRootDocCounter()
+
+    expect(getRootDocCount(rootWithoutSelection.id)).toEqual(4)
+  })
+
   it('should set support create, keep open model and call createRef method', fakeAsync(() => {
     component.selectionModel.items = items
     component.icon = 'tag-fill'

--- a/src-ui/src/app/components/common/filterable-dropdown/filterable-dropdown.component.ts
+++ b/src-ui/src/app/components/common/filterable-dropdown/filterable-dropdown.component.ts
@@ -420,12 +420,13 @@ export class FilterableDropdownSelectionModel {
 
   private createRootFinder(
     parentById: Map<number, number | null>
-  ): (id: number) => number | null {
-    const rootMemo = new Map<number, number | null>()
+  ): (id: number) => number {
+    const rootMemo = new Map<number, number>()
 
-    const findRootId = (id: number): number | null => {
-      if (rootMemo.has(id)) {
-        return rootMemo.get(id) ?? null
+    const findRootId = (id: number): number => {
+      const cached = rootMemo.get(id)
+      if (cached !== undefined) {
+        return cached
       }
 
       const parentId = parentById.get(id)
@@ -442,15 +443,13 @@ export class FilterableDropdownSelectionModel {
     return findRootId
   }
 
-  private createRootDocCounter(): (rootId: number | null) => number {
+  private createRootDocCounter(): (rootId: number) => number {
     const docCountMemo = new Map<number, number>()
 
-    return (rootId: number | null): number => {
-      if (rootId === null) {
-        return 0
-      }
-      if (docCountMemo.has(rootId)) {
-        return docCountMemo.get(rootId) ?? 0
+    return (rootId: number): number => {
+      const cached = docCountMemo.get(rootId)
+      if (cached !== undefined) {
+        return cached
       }
 
       const explicit = this.getDocumentCount(rootId)
@@ -471,8 +470,8 @@ export class FilterableDropdownSelectionModel {
   }
 
   private buildBranchSummaries(
-    findRootId: (id: number) => number | null,
-    getRootDocCount: (rootId: number | null) => number
+    findRootId: (id: number) => number,
+    getRootDocCount: (rootId: number) => number
   ): Map<string, BranchSummary> {
     const summaries = new Map<string, BranchSummary>()
 
@@ -509,7 +508,7 @@ export class FilterableDropdownSelectionModel {
   private describeBranchItem(
     item: MatchingModel,
     index: number,
-    findRootId: (id: number) => number | null
+    findRootId: (id: number) => number
   ): { key: string; special: boolean; rootId: number | null } {
     if (item?.id === null) {
       return { key: 'null', special: true, rootId: null }
@@ -521,9 +520,6 @@ export class FilterableDropdownSelectionModel {
 
     if (typeof item?.id === 'number') {
       const rootId = findRootId(item.id)
-      if (rootId === null) {
-        return { key: `misc-${index}`, special: false, rootId: null }
-      }
       return { key: `root-${rootId}`, special: false, rootId }
     }
 

--- a/src-ui/src/app/components/common/filterable-dropdown/filterable-dropdown.component.ts
+++ b/src-ui/src/app/components/common/filterable-dropdown/filterable-dropdown.component.ts
@@ -444,20 +444,19 @@ export class FilterableDropdownSelectionModel {
 
     const summaries = new Map<string, BranchSummary>()
 
-    this._items.forEach((item, index) => {
+    for (const [index, item] of this._items.entries()) {
       const isNullItem = item?.id === null
       const isNegativeNull = item?.id === NEGATIVE_NULL_FILTER_VALUE
-      const numericId =
-        typeof item?.id === 'number' ? (item.id as number) : null
-      const rootId = numericId !== null ? findRootId(numericId) : null
+      const rootId = item?.id !== null ? findRootId(item.id) : null
 
-      const key = isNullItem
-        ? 'null'
-        : isNegativeNull
-          ? 'neg-null'
-          : rootId !== null
-            ? `root-${rootId}`
-            : `misc-${index}`
+      let key: string = `misc-${index}`
+      if (isNullItem) {
+        key = 'null'
+      } else if (isNegativeNull) {
+        key = 'neg-null'
+      } else if (rootId !== null) {
+        key = `root-${rootId}`
+      }
 
       let summary = summaries.get(key)
       if (!summary) {
@@ -477,16 +476,22 @@ export class FilterableDropdownSelectionModel {
 
       if (
         !summary.special &&
-        numericId !== null &&
-        this.getNonTemporary(numericId) !== ToggleableItemState.NotSelected
+        item?.id !== null &&
+        this.getNonTemporary(item.id) !== ToggleableItemState.NotSelected
       ) {
         summary.selected = true
       }
-    })
+    }
 
     const orderedBranches = Array.from(summaries.values()).sort((a, b) => {
-      const aRank = a.special ? -1 : a.selected ? 0 : 1
-      const bRank = b.special ? -1 : b.selected ? 0 : 1
+      const getBranchRank = (s: BranchSummary) => {
+        if (s.special) return -1
+        if (s.selected) return 0
+        return 1
+      }
+
+      const aRank = getBranchRank(a)
+      const bRank = getBranchRank(b)
 
       if (aRank !== bRank) {
         return aRank - bRank

--- a/src-ui/src/app/components/common/filterable-dropdown/filterable-dropdown.component.ts
+++ b/src-ui/src/app/components/common/filterable-dropdown/filterable-dropdown.component.ts
@@ -476,7 +476,7 @@ export class FilterableDropdownSelectionModel {
   ): Map<string, BranchSummary> {
     const summaries = new Map<string, BranchSummary>()
 
-    this._items.forEach((item, index) => {
+    for (const [index, item] of this._items.entries()) {
       const { key, special, rootId } = this.describeBranchItem(
         item,
         index,
@@ -501,7 +501,7 @@ export class FilterableDropdownSelectionModel {
       if (this.shouldMarkSummarySelected(summary, item)) {
         summary.selected = true
       }
-    })
+    }
 
     return summaries
   }


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Yikes.

<img width="1759" height="1262" alt="Screenshot 2025-10-28 at 4 15 01 PM" src="https://github.com/user-attachments/assets/0b99ec50-bac4-49b4-897d-a73ab83a187c" />
<img width="1759" height="1262" alt="Screenshot 2025-10-28 at 4 15 09 PM" src="https://github.com/user-attachments/assets/3e23d111-6a98-4fdc-a1cc-ad6f7dd4337f" />


Closes #11210

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
