### PR TITLE
Fix: de-deduplicate children in tag list when filtering

### DIFF
--- a/src-ui/src/app/components/manage/tag-list/tag-list.component.spec.ts
+++ b/src-ui/src/app/components/manage/tag-list/tag-list.component.spec.ts
@@ -73,9 +73,14 @@ describe('TagListComponent', () => {
     )
   })
 
-  it('should filter out child tags if name filter is empty, otherwise show all', () => {
+  it('should omit matching children from top level when their parent is present', () => {
     const tags = [
-      { id: 1, name: 'Tag1', parent: null },
+      {
+        id: 1,
+        name: 'Tag1',
+        parent: null,
+        children: [{ id: 2, name: 'Tag2', parent: 1 }],
+      },
       { id: 2, name: 'Tag2', parent: 1 },
       { id: 3, name: 'Tag3', parent: null },
     ]
@@ -86,7 +91,13 @@ describe('TagListComponent', () => {
 
     component['_nameFilter'] = 'Tag2' // Simulate non-empty name filter
     const filteredWithName = component.filterData(tags as any)
-    expect(filteredWithName.length).toBe(3)
+    expect(filteredWithName.length).toBe(2)
+    expect(filteredWithName.find((t) => t.id === 2)).toBeUndefined()
+    expect(
+      filteredWithName
+        .find((t) => t.id === 1)
+        ?.children?.some((c) => c.id === 2)
+    ).toBe(true)
   })
 
   it('should request only parent tags when no name filter is applied', () => {

--- a/src-ui/src/app/components/manage/tag-list/tag-list.component.ts
+++ b/src-ui/src/app/components/manage/tag-list/tag-list.component.ts
@@ -69,9 +69,13 @@ export class TagListComponent extends ManagementListComponent<Tag> {
   }
 
   filterData(data: Tag[]) {
-    return this.nameFilter?.length
-      ? [...data]
-      : data.filter((tag) => !tag.parent)
+    if (!this.nameFilter?.length) {
+      return data.filter((tag) => !tag.parent)
+    }
+
+    // When filtering by name, exclude children if their parent is also present
+    const availableIds = new Set(data.map((tag) => tag.id))
+    return data.filter((tag) => !tag.parent || !availableIds.has(tag.parent))
   }
 
   protected override getSelectableIDs(tags: Tag[]): number[] {


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<img width="1759" height="1262" alt="Screenshot 2025-10-30 at 6 53 03 AM" src="https://github.com/user-attachments/assets/a1e7d343-fbfa-4d73-b90c-d5b7ddddc722" />

Closes #11226

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
