### PR TITLE
Fix: ensure custom field query propagation, change detection

### DIFF
--- a/src-ui/src/app/components/common/custom-fields-query-dropdown/custom-fields-query-dropdown.component.spec.ts
+++ b/src-ui/src/app/components/common/custom-fields-query-dropdown/custom-fields-query-dropdown.component.spec.ts
@@ -354,5 +354,13 @@ describe('CustomFieldsQueryDropdownComponent', () => {
       model.removeElement(atom)
       expect(completeSpy).toHaveBeenCalled()
     })
+
+    it('should subscribe to existing elements when queries are assigned', () => {
+      const expression = new CustomFieldQueryExpression()
+      const nextSpy = jest.spyOn(model.changed, 'next')
+      model.queries = [expression]
+      expression.changed.next(expression)
+      expect(nextSpy).toHaveBeenCalledWith(model)
+    })
   })
 })

--- a/src-ui/src/app/components/common/custom-fields-query-dropdown/custom-fields-query-dropdown.component.ts
+++ b/src-ui/src/app/components/common/custom-fields-query-dropdown/custom-fields-query-dropdown.component.ts
@@ -185,7 +185,9 @@ export class CustomFieldQueriesModel {
   }
 
   private teardownRootSubscriptions() {
-    this.rootSubscriptions.forEach((subscription) => subscription.unsubscribe())
+    for (const subscription of this.rootSubscriptions) {
+      subscription.unsubscribe()
+    }
     this.rootSubscriptions = []
   }
 }

--- a/src-ui/src/app/utils/custom-field-query-element.spec.ts
+++ b/src-ui/src/app/utils/custom-field-query-element.spec.ts
@@ -1,4 +1,3 @@
-import { fakeAsync, tick } from '@angular/core/testing'
 import {
   CustomFieldQueryElementType,
   CustomFieldQueryLogicalOperator,
@@ -111,13 +110,26 @@ describe('CustomFieldQueryAtom', () => {
     expect(atom.serialize()).toEqual([1, 'operator', 'value'])
   })
 
-  it('should emit changed on value change after debounce', fakeAsync(() => {
+  it('should emit changed on value change immediately', () => {
     const atom = new CustomFieldQueryAtom()
     const changeSpy = jest.spyOn(atom.changed, 'next')
     atom.value = 'new value'
-    tick(1000)
     expect(changeSpy).toHaveBeenCalled()
-  }))
+  })
+
+  it('should ignore duplicate array emissions', () => {
+    const atom = new CustomFieldQueryAtom()
+    atom.operator = CustomFieldQueryOperator.In
+    const changeSpy = jest.fn()
+    atom.changed.subscribe(changeSpy)
+
+    atom.value = [1, 2]
+    expect(changeSpy).toHaveBeenCalledTimes(1)
+
+    changeSpy.mockClear()
+    atom.value = [1, 2]
+    expect(changeSpy).not.toHaveBeenCalled()
+  })
 })
 
 describe('CustomFieldQueryExpression', () => {

--- a/src-ui/src/app/utils/custom-field-query-element.spec.ts
+++ b/src-ui/src/app/utils/custom-field-query-element.spec.ts
@@ -130,6 +130,18 @@ describe('CustomFieldQueryAtom', () => {
     atom.value = [1, 2]
     expect(changeSpy).not.toHaveBeenCalled()
   })
+
+  it('should emit when array values differ while length matches', () => {
+    const atom = new CustomFieldQueryAtom()
+    atom.operator = CustomFieldQueryOperator.In
+    const changeSpy = jest.fn()
+    atom.changed.subscribe(changeSpy)
+
+    atom.value = [1, 2]
+    changeSpy.mockClear()
+    atom.value = [1, 3]
+    expect(changeSpy).toHaveBeenCalledTimes(1)
+  })
 })
 
 describe('CustomFieldQueryExpression', () => {

--- a/src-ui/src/app/utils/custom-field-query-element.ts
+++ b/src-ui/src/app/utils/custom-field-query-element.ts
@@ -1,4 +1,4 @@
-import { Subject, debounceTime, distinctUntilChanged } from 'rxjs'
+import { Subject, distinctUntilChanged } from 'rxjs'
 import { v4 as uuidv4 } from 'uuid'
 import {
   CUSTOM_FIELD_QUERY_VALUE_TYPES_BY_OPERATOR,
@@ -110,7 +110,22 @@ export class CustomFieldQueryAtom extends CustomFieldQueryElement {
 
   protected override connectValueModelChanged(): void {
     this.valueModelChanged
-      .pipe(debounceTime(1000), distinctUntilChanged())
+      .pipe(
+        distinctUntilChanged((previous, current) => {
+          if (Array.isArray(previous) && Array.isArray(current)) {
+            if (previous.length !== current.length) {
+              return false
+            }
+            for (let i = 0; i < previous.length; i++) {
+              if (previous[i] !== current[i]) {
+                return false
+              }
+            }
+            return true
+          }
+          return previous === current
+        })
+      )
       .subscribe(() => {
         this.changed.next(this)
       })


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Things are just getting complicated, I suppose. One issue is propagation of "atoms" all the way up, the other is calculating changes between models. These issues actually pre-date the inclusion of cf queries in workflow triggers but aren't noticeable because we use two-way binding in the filter editor.


https://github.com/user-attachments/assets/7b617f1d-88e9-4acd-9f68-92193db11116



Closes #11290

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
