### PR TITLE
Documentation: update placeholder descriptions to use '-none-'

### DIFF
--- a/docs/advanced_usage.md
+++ b/docs/advanced_usage.md
@@ -303,9 +303,9 @@ will create a directory structure as follows:
 
 Paperless provides the following variables for use within filenames:
 
--   `{{ asn }}`: The archive serial number of the document, or "none".
--   `{{ correspondent }}`: The name of the correspondent, or "none".
--   `{{ document_type }}`: The name of the document type, or "none".
+-   `{{ asn }}`: The archive serial number of the document, or "-none-".
+-   `{{ correspondent }}`: The name of the correspondent, or "-none-".
+-   `{{ document_type }}`: The name of the document type, or "-none-".
 -   `{{ tag_list }}`: A comma separated list of all tags assigned to the
     document.
 -   `{{ title }}`: The title of the document.
@@ -329,8 +329,8 @@ Paperless provides the following variables for use within filenames:
 -   `{{ added_month_name_short }}`: Month added abbreviated name, as per
     locale
 -   `{{ added_day }}`: Day added only (number 01-31).
--   `{{ owner_username }}`: Username of document owner, if any, or "none"
--   `{{ original_name }}`: Document original filename, minus the extension, if any, or "none"
+-   `{{ owner_username }}`: Username of document owner, if any, or "-none-"
+-   `{{ original_name }}`: Document original filename, minus the extension, if any, or "-none-"
 -   `{{ doc_pk }}`: The paperless identifier (primary key) for the document.
 
 !!! warning
@@ -374,7 +374,7 @@ paperless will fall back to using the default naming scheme instead.
 You can affect how empty placeholders are treated by changing the
 [`PAPERLESS_FILENAME_FORMAT_REMOVE_NONE`](configuration.md#PAPERLESS_FILENAME_FORMAT_REMOVE_NONE) setting.
 
-Enabling this results in all empty placeholders resolving to "" instead of "none" as stated above. Spaces
+Enabling this results in all empty placeholders resolving to "" instead of "-none-" as stated above. Spaces
 before empty placeholders are removed as well, empty directories are omitted.
 
 ### Storage paths


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

<!--
⚠️ Important: Pull requests that implement a new feature or enhancement *should almost always target an existing feature request* with evidence of community interest and discussion. This is in order to balance the work of implementing and maintaining new features / enhancements. If that is not currently the case, please open a feature request instead of this PR to gather feedback from both users and the project maintainers.
-->

Closes #11312 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [x] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
