### PR TITLE
Fix: update Outlook refresh token when refreshed

### DIFF
--- a/src/paperless_mail/oauth.py
+++ b/src/paperless_mail/oauth.py
@@ -103,6 +103,9 @@ class PaperlessMailOAuth2Manager:
                         refresh_token=account.refresh_token,
                     ),
                 )
+            if "refresh_token" in result:
+                # Outlook returns a new refresh token on refresh, Gmail does not
+                account.refresh_token = result["refresh_token"]
             account.password = result["access_token"]
             account.expiration = timezone.now() + timedelta(
                 seconds=result["expires_in"],


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Of course, Microsoft doing things their own way. I confirmed that Google does not pass this back (so we do need the conditional), MS does, and that using the new refresh token works fine. Of course, it'll take 90 days to see if it makes a difference but seems safe enough to try and I agree with the interpretation of the [docs](https://learn.microsoft.com/en-us/entra/identity-platform/refresh-tokens)

```
[2025-11-11 07:42:34,073] [WARNING] [celery.redirected] {'token_type': 'Bearer', 'scope': 'https://outlook.office.com/IMAP.AccessAsUser.All https://outlook.office.com/Mail.ReadWrite', 'expires_in': 3599, 'ext_expires_in': 3599, 'access_token': '***', 'refresh_token': '***', 'expires_at': 1762879353}
[2025-11-11 07:42:34,075] [DEBUG] [paperless_mail] Successfully refreshed oauth token for account Outlook OAuth 2025-11-11 15:35:06.900243+00:00
[2025-11-11 07:43:53,646] [WARNING] [celery.redirected] Using new refresh token from result
[2025-11-11 07:43:53,646] [WARNING] [celery.redirected] {'token_type': 'Bearer', 'scope': 'https://outlook.office.com/IMAP.AccessAsUser.All https://outlook.office.com/Mail.ReadWrite', 'expires_in': 3599, 'ext_expires_in': 3599, 'access_token': '***', 'refresh_token': '***', 'expires_at': 1762879432}
[2025-11-11 07:43:53,650] [DEBUG] [paperless_mail] Successfully refreshed oauth token for account Outlook OAuth 2025-11-11 15:35:06.900243+00:00
```
```
[2025-11-11 07:45:08,797] [WARNING] [celery.redirected] {'access_token': '**', 'expires_in': 3599, 'scope': 'https://mail.google.com/', 'token_type': 'Bearer', 'expires_at': 1762879507}
[2025-11-11 07:45:08,799] [DEBUG] [paperless_mail] Successfully refreshed oauth token for account Gmail OAuth 2025-11-11 15:44:38.028119+00:00
```

Closes #10211

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
