### PR TITLE
Fix: include BASE_URL when constructing `doc_url` for workflows

### DIFF
--- a/src/documents/signals/handlers.py
+++ b/src/documents/signals/handlers.py
@@ -1095,7 +1095,9 @@ def run_workflows(
 
         if not use_overrides:
             title = document.title
-            doc_url = f"{settings.PAPERLESS_URL}/documents/{document.pk}/"
+            doc_url = (
+                f"{settings.PAPERLESS_URL}{settings.BASE_URL}documents/{document.pk}/"
+            )
             correspondent = (
                 document.correspondent.name if document.correspondent else ""
             )
@@ -1199,7 +1201,9 @@ def run_workflows(
     def webhook_action():
         if not use_overrides:
             title = document.title
-            doc_url = f"{settings.PAPERLESS_URL}/documents/{document.pk}/"
+            doc_url = (
+                f"{settings.PAPERLESS_URL}{settings.BASE_URL}documents/{document.pk}/"
+            )
             correspondent = (
                 document.correspondent.name if document.correspondent else ""
             )

--- a/src/documents/tests/test_workflows.py
+++ b/src/documents/tests/test_workflows.py
@@ -3144,9 +3144,11 @@ class TestWorkflows(
 
     @override_settings(
         PAPERLESS_URL="http://localhost:8000",
+        PAPERLESS_FORCE_SCRIPT_NAME="/paperless",
+        BASE_URL="/paperless/",
     )
     @mock.patch("documents.signals.handlers.send_webhook.delay")
-    def test_workflow_webhook_action_body(self, mock_post):
+    def test_workflow_webhook_action_body_with_subpath(self, mock_post):
         """
         GIVEN:
             - Document updated workflow with webhook action which uses body
@@ -3195,7 +3197,7 @@ class TestWorkflows(
 
         mock_post.assert_called_once_with(
             url="http://paperless-ngx.com",
-            data=f"Test message: http://localhost:8000/documents/{doc.id}/",
+            data=f"Test message: http://localhost:8000/paperless/documents/{doc.id}/",
             headers={},
             files=None,
             as_json=False,

--- a/src/documents/tests/test_workflows.py
+++ b/src/documents/tests/test_workflows.py
@@ -3148,7 +3148,7 @@ class TestWorkflows(
         BASE_URL="/paperless/",
     )
     @mock.patch("documents.signals.handlers.send_webhook.delay")
-    def test_workflow_webhook_action_body_with_subpath(self, mock_post):
+    def test_workflow_webhook_action_body(self, mock_post):
         """
         GIVEN:
             - Document updated workflow with webhook action which uses body


### PR DESCRIPTION
## Proposed change

Include `BASE_URL` when constructing `doc_url` for workflows. Previously this was constructing incomplete URLs that omitted the subpath from `PAPERLESS_FORCE_SCRIPT_NAME`.

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

<!--
⚠️ Important: Pull requests that implement a new feature or enhancement *should almost always target an existing feature request* with evidence of community interest and discussion. This is in order to balance the work of implementing and maintaining new features / enhancements. If that is not currently the case, please open a feature request instead of this PR to gather feedback from both users and the project maintainers.
-->

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
