### PR TITLE
Feature 10606 reorder custom fields

### DIFF
--- a/src-ui/src/app/components/document-detail/document-detail.component.html
+++ b/src-ui/src/app/components/document-detail/document-detail.component.html
@@ -134,99 +134,111 @@
               <pngx-input-select [items]="storagePaths" i18n-title title="Storage path" formControlName="storage_path" [allowNull]="true" [showFilter]="true" [horizontal]="true" (filterDocuments)="filterDocuments($event, DataType.StoragePath)"
               (createNew)="createStoragePath($event)" [hideAddButton]="createDisabled(DataType.StoragePath)" [suggestions]="suggestions?.storage_paths" i18n-placeholder placeholder="Default" *pngxIfPermissions="{ action: PermissionAction.View, type: PermissionType.StoragePath }"></pngx-input-select>
               <pngx-input-tags formControlName="tags" [suggestions]="suggestions?.tags" [showFilter]="true" [horizontal]="true" (filterDocuments)="filterDocuments($event, DataType.Tag)" [hideAddButton]="createDisabled(DataType.Tag)" *pngxIfPermissions="{ action: PermissionAction.View, type: PermissionType.Tag }"></pngx-input-tags>
-              @for (fieldInstance of document?.custom_fields; track fieldInstance.field; let i = $index) {
-                <div [formGroup]="customFieldFormFields.controls[i]">
-                  @switch (getCustomFieldFromInstance(fieldInstance)?.data_type) {
-                    @case (CustomFieldDataType.String) {
-                      <pngx-input-text formControlName="value"
-                      [title]="getCustomFieldFromInstance(fieldInstance)?.name"
-                      [removable]="userCanEdit"
-                      (removed)="removeField(fieldInstance)"
-                      [horizontal]="true"
-                      [error]="getCustomFieldError(i)"></pngx-input-text>
-                    }
-                    @case (CustomFieldDataType.Date) {
-                      <pngx-input-date formControlName="value"
-                      [title]="getCustomFieldFromInstance(fieldInstance)?.name"
-                      [removable]="userCanEdit"
-                      (removed)="removeField(fieldInstance)"
-                      [horizontal]="true"
-                      [error]="getCustomFieldError(i)"></pngx-input-date>
-                    }
-                    @case (CustomFieldDataType.Integer) {
-                      <pngx-input-number formControlName="value"
-                      [title]="getCustomFieldFromInstance(fieldInstance)?.name"
-                      [removable]="userCanEdit"
-                      (removed)="removeField(fieldInstance)"
-                      [horizontal]="true"
-                      [showAdd]="false"
-                      [error]="getCustomFieldError(i)"></pngx-input-number>
-                    }
-                    @case (CustomFieldDataType.Float) {
-                      <pngx-input-number formControlName="value"
-                      [title]="getCustomFieldFromInstance(fieldInstance)?.name"
-                      [removable]="userCanEdit"
-                      (removed)="removeField(fieldInstance)"
-                      [horizontal]="true"
-                      [showAdd]="false"
-                      [step]=".1"
-                      [error]="getCustomFieldError(i)"></pngx-input-number>
-                    }
-                    @case (CustomFieldDataType.Monetary) {
-                      <pngx-input-monetary formControlName="value"
-                      [title]="getCustomFieldFromInstance(fieldInstance)?.name"
-                      [defaultCurrency]="getCustomFieldFromInstance(fieldInstance)?.extra_data?.default_currency"
-                      [removable]="userCanEdit"
-                      (removed)="removeField(fieldInstance)"
-                      [horizontal]="true"
-                      [error]="getCustomFieldError(i)"></pngx-input-monetary>
-                    }
-                    @case (CustomFieldDataType.Boolean) {
-                      <pngx-input-check formControlName="value"
-                      [title]="getCustomFieldFromInstance(fieldInstance)?.name"
-                      [removable]="userCanEdit"
-                      (removed)="removeField(fieldInstance)"
-                      [horizontal]="true"></pngx-input-check>
-                    }
-                    @case (CustomFieldDataType.Url) {
-                      <pngx-input-url formControlName="value"
-                      [title]="getCustomFieldFromInstance(fieldInstance)?.name"
-                      [removable]="userCanEdit"
-                      (removed)="removeField(fieldInstance)"
-                      [horizontal]="true"
-                      [error]="getCustomFieldError(i)"></pngx-input-url>
-                    }
-                    @case (CustomFieldDataType.DocumentLink) {
-                      <pngx-input-document-link formControlName="value"
-                      [title]="getCustomFieldFromInstance(fieldInstance)?.name"
-                      [parentDocumentID]="documentId"
-                      [removable]="userCanEdit"
-                      (removed)="removeField(fieldInstance)"
-                      [horizontal]="true"
-                      [error]="getCustomFieldError(i)"></pngx-input-document-link>
-                    }
-                    @case (CustomFieldDataType.Select) {
-                      <pngx-input-select formControlName="value"
-                      [title]="getCustomFieldFromInstance(fieldInstance)?.name"
-                      [items]="getCustomFieldFromInstance(fieldInstance)?.extra_data.select_options"
-                      bindLabel="label"
-                      [allowNull]="true"
-                      [horizontal]="true"
-                      [removable]="userCanEdit"
-                      (removed)="removeField(fieldInstance)"
-                      [error]="getCustomFieldError(i)"></pngx-input-select>
-                    }
-                    @case (CustomFieldDataType.LongText) {
-                      <pngx-input-textarea formControlName="value"
-                      [title]="getCustomFieldFromInstance(fieldInstance)?.name"
-                      [removable]="userCanEdit"
-                      (removed)="removeField(fieldInstance)"
-                      [horizontal]="true"
-                      [error]="getCustomFieldError(i)"></pngx-input-textarea>
-                    }
-                  }
-                </div>
-              }
+
+              <!-- Custom Fields Container -->
+              <div cdkDropList (cdkDropListDropped)="onCustomFieldDrop($event)">
+                @for (fieldInstance of document?.custom_fields; track fieldInstance.field; let i = $index) {
+                  <div cdkDrag class="position-relative" cdkDragPreviewContainer="parent">
+                    <div class="d-flex align-items-start">
+                      <div class="flex-grow-1" [formGroup]="customFieldFormFields.controls[i]">
+	                      @switch (getCustomFieldFromInstance(fieldInstance)?.data_type) {
+	                        @case (CustomFieldDataType.String) {
+	                          <pngx-input-text formControlName="value"
+	                          [title]="getCustomFieldFromInstance(fieldInstance)?.name"
+	                          [removable]="userCanEdit"
+	                          (removed)="removeField(fieldInstance)"
+	                          [horizontal]="true"
+	                          [error]="getCustomFieldError(i)"></pngx-input-text>
+	                        }
+	                        @case (CustomFieldDataType.Date) {
+	                          <pngx-input-date formControlName="value"
+	                          [title]="getCustomFieldFromInstance(fieldInstance)?.name"
+	                          [removable]="userCanEdit"
+	                          (removed)="removeField(fieldInstance)"
+	                          [horizontal]="true"
+	                          [error]="getCustomFieldError(i)"></pngx-input-date>
+	                        }
+	                        @case (CustomFieldDataType.Integer) {
+	                          <pngx-input-number formControlName="value"
+	                          [title]="getCustomFieldFromInstance(fieldInstance)?.name"
+	                          [removable]="userCanEdit"
+	                          (removed)="removeField(fieldInstance)"
+	                          [horizontal]="true"
+	                          [showAdd]="false"
+	                          [error]="getCustomFieldError(i)"></pngx-input-number>
+	                        }
+	                        @case (CustomFieldDataType.Float) {
+	                          <pngx-input-number formControlName="value"
+	                          [title]="getCustomFieldFromInstance(fieldInstance)?.name"
+	                          [removable]="userCanEdit"
+	                          (removed)="removeField(fieldInstance)"
+	                          [horizontal]="true"
+	                          [showAdd]="false"
+	                          [step]=".1"
+	                          [error]="getCustomFieldError(i)"></pngx-input-number>
+	                        }
+	                        @case (CustomFieldDataType.Monetary) {
+	                          <pngx-input-monetary formControlName="value"
+	                          [title]="getCustomFieldFromInstance(fieldInstance)?.name"
+	                          [defaultCurrency]="getCustomFieldFromInstance(fieldInstance)?.extra_data?.default_currency"
+	                          [removable]="userCanEdit"
+	                          (removed)="removeField(fieldInstance)"
+	                          [horizontal]="true"
+	                          [error]="getCustomFieldError(i)"></pngx-input-monetary>
+	                        }
+	                        @case (CustomFieldDataType.Boolean) {
+	                          <pngx-input-check formControlName="value"
+	                          [title]="getCustomFieldFromInstance(fieldInstance)?.name"
+	                          [removable]="userCanEdit"
+	                          (removed)="removeField(fieldInstance)"
+	                          [horizontal]="true"
+	                          [error]="getCustomFieldError(i)"></pngx-input-check>
+	                        }
+	                        @case (CustomFieldDataType.Url) {
+	                          <pngx-input-url formControlName="value"
+	                          [title]="getCustomFieldFromInstance(fieldInstance)?.name"
+	                          [removable]="userCanEdit"
+	                          (removed)="removeField(fieldInstance)"
+	                          [horizontal]="true"
+	                          [error]="getCustomFieldError(i)"></pngx-input-url>
+	                        }
+	                        @case (CustomFieldDataType.DocumentLink) {
+	                          <pngx-input-document-link formControlName="value"
+	                          [title]="getCustomFieldFromInstance(fieldInstance)?.name"
+	                          [parentDocumentID]="documentId"
+	                          [removable]="userCanEdit"
+	                          (removed)="removeField(fieldInstance)"
+	                          [horizontal]="true"
+	                          [error]="getCustomFieldError(i)"></pngx-input-document-link>
+	                        }
+	                        @case (CustomFieldDataType.Select) {
+	                          <pngx-input-select formControlName="value"
+	                          [title]="getCustomFieldFromInstance(fieldInstance)?.name"
+	                          [items]="getCustomFieldFromInstance(fieldInstance)?.extra_data.select_options"
+	                          bindLabel="label"
+	                          [allowNull]="true"
+	                          [horizontal]="true"
+	                          [removable]="userCanEdit"
+	                          (removed)="removeField(fieldInstance)"
+	                          [error]="getCustomFieldError(i)"></pngx-input-select>
+	                        }
+	                        @case (CustomFieldDataType.LongText) {
+	                          <pngx-input-textarea formControlName="value"
+	                          [title]="getCustomFieldFromInstance(fieldInstance)?.name"
+	                          [removable]="userCanEdit"
+	                          (removed)="removeField(fieldInstance)"
+	                          [horizontal]="true"
+	                          [error]="getCustomFieldError(i)"></pngx-input-textarea>
+	                        }
+                        }
+                      </div>
+                      <div class="ms-2 d-flex align-items-center" cdkDragHandle style="height: 38px;">
+                        <i-bs name="grip-vertical" class="text-muted"></i-bs>
+                      </div>
+                    </div>
+                  </div>
+                }
+              </div>
             </div>
 
             <div class="d-flex border-top pt-3">

--- a/src-ui/src/app/components/document-detail/document-detail.component.html
+++ b/src-ui/src/app/components/document-detail/document-detail.component.html
@@ -122,7 +122,7 @@
         <li [ngbNavItem]="DocumentDetailNavIDs.Details">
           <a ngbNavLink i18n>Details</a>
           <ng-template ngbNavContent>
-            <div>
+            <div cdkDropList (cdkDropListDropped)="onCustomFieldDrop($event)">
               <pngx-input-text #inputTitle i18n-title title="Title" formControlName="title" [horizontal]="true" (keyup)="titleKeyUp($event)" [error]="error?.title"></pngx-input-text>
               <pngx-input-number i18n-title title="Archive serial number" [error]="error?.archive_serial_number" [horizontal]="true" formControlName='archive_serial_number'></pngx-input-number>
               <pngx-input-date i18n-title title="Date created" formControlName="created" [suggestions]="suggestions?.dates" [showFilter]="true" [horizontal]="true" (filterDocuments)="filterDocuments($event)"
@@ -135,110 +135,102 @@
               (createNew)="createStoragePath($event)" [hideAddButton]="createDisabled(DataType.StoragePath)" [suggestions]="suggestions?.storage_paths" i18n-placeholder placeholder="Default" *pngxIfPermissions="{ action: PermissionAction.View, type: PermissionType.StoragePath }"></pngx-input-select>
               <pngx-input-tags formControlName="tags" [suggestions]="suggestions?.tags" [showFilter]="true" [horizontal]="true" (filterDocuments)="filterDocuments($event, DataType.Tag)" [hideAddButton]="createDisabled(DataType.Tag)" *pngxIfPermissions="{ action: PermissionAction.View, type: PermissionType.Tag }"></pngx-input-tags>
 
-              <!-- Custom Fields Container -->
-              <div cdkDropList (cdkDropListDropped)="onCustomFieldDrop($event)">
-                @for (fieldInstance of document?.custom_fields; track fieldInstance.field; let i = $index) {
-                  <div cdkDrag class="position-relative" cdkDragPreviewContainer="parent">
-                    <div class="d-flex align-items-start">
-                      <div class="flex-grow-1" [formGroup]="customFieldFormFields.controls[i]">
-	                      @switch (getCustomFieldFromInstance(fieldInstance)?.data_type) {
-	                        @case (CustomFieldDataType.String) {
-	                          <pngx-input-text formControlName="value"
-	                          [title]="getCustomFieldFromInstance(fieldInstance)?.name"
-	                          [removable]="userCanEdit"
-	                          (removed)="removeField(fieldInstance)"
-	                          [horizontal]="true"
-	                          [error]="getCustomFieldError(i)"></pngx-input-text>
-	                        }
-	                        @case (CustomFieldDataType.Date) {
-	                          <pngx-input-date formControlName="value"
-	                          [title]="getCustomFieldFromInstance(fieldInstance)?.name"
-	                          [removable]="userCanEdit"
-	                          (removed)="removeField(fieldInstance)"
-	                          [horizontal]="true"
-	                          [error]="getCustomFieldError(i)"></pngx-input-date>
-	                        }
-	                        @case (CustomFieldDataType.Integer) {
-	                          <pngx-input-number formControlName="value"
-	                          [title]="getCustomFieldFromInstance(fieldInstance)?.name"
-	                          [removable]="userCanEdit"
-	                          (removed)="removeField(fieldInstance)"
-	                          [horizontal]="true"
-	                          [showAdd]="false"
-	                          [error]="getCustomFieldError(i)"></pngx-input-number>
-	                        }
-	                        @case (CustomFieldDataType.Float) {
-	                          <pngx-input-number formControlName="value"
-	                          [title]="getCustomFieldFromInstance(fieldInstance)?.name"
-	                          [removable]="userCanEdit"
-	                          (removed)="removeField(fieldInstance)"
-	                          [horizontal]="true"
-	                          [showAdd]="false"
-	                          [step]=".1"
-	                          [error]="getCustomFieldError(i)"></pngx-input-number>
-	                        }
-	                        @case (CustomFieldDataType.Monetary) {
-	                          <pngx-input-monetary formControlName="value"
-	                          [title]="getCustomFieldFromInstance(fieldInstance)?.name"
-	                          [defaultCurrency]="getCustomFieldFromInstance(fieldInstance)?.extra_data?.default_currency"
-	                          [removable]="userCanEdit"
-	                          (removed)="removeField(fieldInstance)"
-	                          [horizontal]="true"
-	                          [error]="getCustomFieldError(i)"></pngx-input-monetary>
-	                        }
-	                        @case (CustomFieldDataType.Boolean) {
-	                          <pngx-input-check formControlName="value"
-	                          [title]="getCustomFieldFromInstance(fieldInstance)?.name"
-	                          [removable]="userCanEdit"
-	                          (removed)="removeField(fieldInstance)"
-	                          [horizontal]="true"
-	                          [error]="getCustomFieldError(i)"></pngx-input-check>
-	                        }
-	                        @case (CustomFieldDataType.Url) {
-	                          <pngx-input-url formControlName="value"
-	                          [title]="getCustomFieldFromInstance(fieldInstance)?.name"
-	                          [removable]="userCanEdit"
-	                          (removed)="removeField(fieldInstance)"
-	                          [horizontal]="true"
-	                          [error]="getCustomFieldError(i)"></pngx-input-url>
-	                        }
-	                        @case (CustomFieldDataType.DocumentLink) {
-	                          <pngx-input-document-link formControlName="value"
-	                          [title]="getCustomFieldFromInstance(fieldInstance)?.name"
-	                          [parentDocumentID]="documentId"
-	                          [removable]="userCanEdit"
-	                          (removed)="removeField(fieldInstance)"
-	                          [horizontal]="true"
-	                          [error]="getCustomFieldError(i)"></pngx-input-document-link>
-	                        }
-	                        @case (CustomFieldDataType.Select) {
-	                          <pngx-input-select formControlName="value"
-	                          [title]="getCustomFieldFromInstance(fieldInstance)?.name"
-	                          [items]="getCustomFieldFromInstance(fieldInstance)?.extra_data.select_options"
-	                          bindLabel="label"
-	                          [allowNull]="true"
-	                          [horizontal]="true"
-	                          [removable]="userCanEdit"
-	                          (removed)="removeField(fieldInstance)"
-	                          [error]="getCustomFieldError(i)"></pngx-input-select>
-	                        }
-	                        @case (CustomFieldDataType.LongText) {
-	                          <pngx-input-textarea formControlName="value"
-	                          [title]="getCustomFieldFromInstance(fieldInstance)?.name"
-	                          [removable]="userCanEdit"
-	                          (removed)="removeField(fieldInstance)"
-	                          [horizontal]="true"
-	                          [error]="getCustomFieldError(i)"></pngx-input-textarea>
-	                        }
-                        }
-                      </div>
-                      <div class="ms-2 d-flex align-items-center" cdkDragHandle style="height: 38px;">
-                        <i-bs name="grip-vertical" class="text-muted"></i-bs>
-                      </div>
-                    </div>
+               @for (fieldInstance of document?.custom_fields; track fieldInstance.field; let i = $index) {
+                <div cdkDrag class="custom-field-draggable" [formGroup]="customFieldFormFields.controls[i]">
+	                @switch (getCustomFieldFromInstance(fieldInstance)?.data_type) {
+	                  @case (CustomFieldDataType.String) {
+	                    <pngx-input-text formControlName="value"
+	                    [title]="getCustomFieldFromInstance(fieldInstance)?.name"
+	                    [removable]="userCanEdit"
+	                    (removed)="removeField(fieldInstance)"
+	                    [horizontal]="true"
+	                    [error]="getCustomFieldError(i)"></pngx-input-text>
+	                  }
+	                  @case (CustomFieldDataType.Date) {
+	                    <pngx-input-date formControlName="value"
+	                    [title]="getCustomFieldFromInstance(fieldInstance)?.name"
+	                    [removable]="userCanEdit"
+	                    (removed)="removeField(fieldInstance)"
+	                    [horizontal]="true"
+	                    [error]="getCustomFieldError(i)"></pngx-input-date>
+	                  }
+	                  @case (CustomFieldDataType.Integer) {
+	                    <pngx-input-number formControlName="value"
+	                    [title]="getCustomFieldFromInstance(fieldInstance)?.name"
+	                    [removable]="userCanEdit"
+	                    (removed)="removeField(fieldInstance)"
+	                    [horizontal]="true"
+	                    [showAdd]="false"
+	                    [error]="getCustomFieldError(i)"></pngx-input-number>
+	                  }
+	                  @case (CustomFieldDataType.Float) {
+	                    <pngx-input-number formControlName="value"
+	                    [title]="getCustomFieldFromInstance(fieldInstance)?.name"
+	                    [removable]="userCanEdit"
+	                    (removed)="removeField(fieldInstance)"
+	                    [horizontal]="true"
+	                    [showAdd]="false"
+	                    [step]=".1"
+	                    [error]="getCustomFieldError(i)"></pngx-input-number>
+	                  }
+	                  @case (CustomFieldDataType.Monetary) {
+	                    <pngx-input-monetary formControlName="value"
+	                    [title]="getCustomFieldFromInstance(fieldInstance)?.name"
+	                    [defaultCurrency]="getCustomFieldFromInstance(fieldInstance)?.extra_data?.default_currency"
+	                    [removable]="userCanEdit"
+	                    (removed)="removeField(fieldInstance)"
+	                    [horizontal]="true"
+	                    [error]="getCustomFieldError(i)"></pngx-input-monetary>
+	                  }
+	                  @case (CustomFieldDataType.Boolean) {
+	                    <pngx-input-check formControlName="value"
+	                    [title]="getCustomFieldFromInstance(fieldInstance)?.name"
+	                    [removable]="userCanEdit"
+	                    (removed)="removeField(fieldInstance)"
+                        [horizontal]="true"></pngx-input-check>
+	                  }
+	                  @case (CustomFieldDataType.Url) {
+	                    <pngx-input-url formControlName="value"
+	                    [title]="getCustomFieldFromInstance(fieldInstance)?.name"
+	                    [removable]="userCanEdit"
+	                    (removed)="removeField(fieldInstance)"
+	                    [horizontal]="true"
+	                    [error]="getCustomFieldError(i)"></pngx-input-url>
+	                  }
+	                  @case (CustomFieldDataType.DocumentLink) {
+	                    <pngx-input-document-link formControlName="value"
+	                    [title]="getCustomFieldFromInstance(fieldInstance)?.name"
+	                    [parentDocumentID]="documentId"
+	                    [removable]="userCanEdit"
+	                    (removed)="removeField(fieldInstance)"
+	                    [horizontal]="true"
+	                    [error]="getCustomFieldError(i)"></pngx-input-document-link>
+	                  }
+	                  @case (CustomFieldDataType.Select) {
+	                    <pngx-input-select formControlName="value"
+	                    [title]="getCustomFieldFromInstance(fieldInstance)?.name"
+	                    [items]="getCustomFieldFromInstance(fieldInstance)?.extra_data.select_options"
+	                    bindLabel="label"
+	                    [allowNull]="true"
+	                    [horizontal]="true"
+	                    [removable]="userCanEdit"
+	                    (removed)="removeField(fieldInstance)"
+	                    [error]="getCustomFieldError(i)"></pngx-input-select>
+	                  }
+	                  @case (CustomFieldDataType.LongText) {
+	                    <pngx-input-textarea formControlName="value"
+	                    [title]="getCustomFieldFromInstance(fieldInstance)?.name"
+	                    [removable]="userCanEdit"
+	                    (removed)="removeField(fieldInstance)"
+	                    [horizontal]="true"
+	                    [error]="getCustomFieldError(i)"></pngx-input-textarea>
+	                  }
+                  }
+                  <div class="drag-handle" cdkDragHandle>
+                    <i-bs name="grip-vertical" class="text-muted"></i-bs>
                   </div>
-                }
-              </div>
+                </div>
+              }
             </div>
 
             <div class="d-flex border-top pt-3">

--- a/src-ui/src/app/components/document-detail/document-detail.component.scss
+++ b/src-ui/src/app/components/document-detail/document-detail.component.scss
@@ -98,6 +98,19 @@ textarea.rtl {
   box-shadow: 0 5px 5px -3px rgba(0, 0, 0, 0.2),
               0 8px 10px 1px rgba(0, 0, 0, 0.14),
               0 3px 14px 2px rgba(0, 0, 0, 0.12);
+  // Remove scrollbars from drag preview
+  overflow: hidden !important;
+
+  // Remove scrollbars from any child elements in the drag preview
+  * {
+    overflow: hidden !important;
+    scrollbar-width: none !important; // Firefox
+    -ms-overflow-style: none !important; // Internet Explorer and Edge
+
+    &::-webkit-scrollbar {
+      display: none !important; // Chrome, Safari, Opera
+    }
+  }
 }
 
 .cdk-drag-placeholder {

--- a/src-ui/src/app/components/document-detail/document-detail.component.scss
+++ b/src-ui/src/app/components/document-detail/document-detail.component.scss
@@ -90,3 +90,97 @@ textarea.rtl {
     object-position: top;
   }
 }
+
+// Custom field drag and drop styling
+.cdk-drag-preview {
+  box-sizing: border-box;
+  border-radius: 4px;
+  box-shadow: 0 5px 5px -3px rgba(0, 0, 0, 0.2),
+              0 8px 10px 1px rgba(0, 0, 0, 0.14),
+              0 3px 14px 2px rgba(0, 0, 0, 0.12);
+}
+
+.cdk-drag-placeholder {
+  opacity: 0.3;
+}
+
+.cdk-drag-animating {
+  transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
+}
+
+.cdk-drop-list-dragging .cdk-drag:not(.cdk-drag-placeholder) {
+  transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
+}
+
+// Drag handle styling
+[cdkDragHandle] {
+  cursor: grab;
+  padding: 0.25rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 32px;
+
+  &:hover {
+    background-color: rgba(0, 0, 0, 0.05);
+    border-radius: 3px;
+  }
+
+  &:active {
+    cursor: grabbing;
+    background-color: rgba(0, 0, 0, 0.1);
+  }
+
+  i-bs {
+    pointer-events: none;
+  }
+}
+
+// Custom field container alignment fixes
+.d-flex.align-items-start {
+  // Ensure the drag handle aligns properly with the input row
+  align-items: flex-start !important;
+
+  .flex-grow-1 {
+    // Ensure pngx components align properly
+    ::ng-deep .mb-3 {
+      margin-bottom: 0 !important;
+    }
+
+    ::ng-deep .form-label {
+      margin-top: 0;
+      margin-bottom: 0.5rem;
+      font-size: 0.875rem;
+      font-weight: 400;
+      color: var(--bs-body-color);
+    }
+
+    ::ng-deep .btn-sm {
+      line-height: 1.25;
+      padding: 0.25rem 0.5rem;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.25rem;
+
+      i, fa-icon, svg {
+        margin: 0;
+        vertical-align: baseline;
+      }
+    }
+  }
+}
+
+// Prevent text selection during drag
+.cdk-drag {
+  user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+
+  &.cdk-drag-dragging {
+    user-select: none !important;
+    -webkit-user-select: none !important;
+    -moz-user-select: none !important;
+    -ms-user-select: none !important;
+  }
+}

--- a/src-ui/src/app/components/document-detail/document-detail.component.scss
+++ b/src-ui/src/app/components/document-detail/document-detail.component.scss
@@ -112,75 +112,34 @@ textarea.rtl {
   transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
 }
 
-// Drag handle styling
-[cdkDragHandle] {
-  cursor: grab;
-  padding: 0.25rem;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 32px;
+// Styling for draggable custom fields
+.custom-field-draggable {
+  position: relative;
+  margin-bottom: 1rem;
 
-  &:hover {
-    background-color: rgba(0, 0, 0, 0.05);
+  .drag-handle {
+    position: absolute;
+    left: -24px; // Position to the left of the remove button which appears at left: 0
+    top: 50%;
+    transform: translateY(-50%);
+    cursor: move;
+    padding: 2px 4px;
     border-radius: 3px;
-  }
+    z-index: 10;
+    opacity: 0;
+    transition: opacity 0.2s ease;
 
-  &:active {
-    cursor: grabbing;
-    background-color: rgba(0, 0, 0, 0.1);
-  }
-
-  i-bs {
-    pointer-events: none;
-  }
-}
-
-// Custom field container alignment fixes
-.d-flex.align-items-start {
-  // Ensure the drag handle aligns properly with the input row
-  align-items: flex-start !important;
-
-  .flex-grow-1 {
-    // Ensure pngx components align properly
-    ::ng-deep .mb-3 {
-      margin-bottom: 0 !important;
+    &:hover {
+      background-color: rgba(0, 0, 0, 0.05);
     }
 
-    ::ng-deep .form-label {
-      margin-top: 0;
-      margin-bottom: 0.5rem;
-      font-size: 0.875rem;
-      font-weight: 400;
-      color: var(--bs-body-color);
-    }
-
-    ::ng-deep .btn-sm {
-      line-height: 1.25;
-      padding: 0.25rem 0.5rem;
-      display: inline-flex;
-      align-items: center;
-      gap: 0.25rem;
-
-      i, fa-icon, svg {
-        margin: 0;
-        vertical-align: baseline;
-      }
+    i-bs {
+      font-size: 0.75rem;
+      color: #6c757d;
     }
   }
-}
 
-// Prevent text selection during drag
-.cdk-drag {
-  user-select: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-
-  &.cdk-drag-dragging {
-    user-select: none !important;
-    -webkit-user-select: none !important;
-    -moz-user-select: none !important;
-    -ms-user-select: none !important;
+  &:hover .drag-handle {
+    opacity: 1;
   }
 }

--- a/src-ui/src/app/components/document-detail/document-detail.component.ts
+++ b/src-ui/src/app/components/document-detail/document-detail.component.ts
@@ -859,16 +859,9 @@ export class DocumentDetailComponent
               value: fieldData.value,
             }
 
-            // Only include 'created' field if:
-            // 1. Custom field order has been changed (reordering occurred), OR
-            // 2. The field had an existing 'created' value (it's an existing field being modified)
-            const documentField = this.document.custom_fields[index]
-            const hasExistingCreated = documentField?.created !== undefined
-
-            if (
-              this.customFieldOrderChanged ||
-              (hasExistingCreated && fieldData.created)
-            ) {
+            // Only include 'created' field if custom field order has been changed (reordering occurred)
+            if (this.customFieldOrderChanged) {
+              const documentField = this.document.custom_fields[index]
               result.created =
                 documentField?.created || fieldData.created || new Date()
             }

--- a/src-ui/src/app/components/document-detail/document-detail.component.ts
+++ b/src-ui/src/app/components/document-detail/document-detail.component.ts
@@ -343,9 +343,18 @@ export class DocumentDetailComponent
   }
 
   private mapDocToForm(doc: Document): any {
+    // Transform custom_fields to match FormControl structure
+    const transformedCustomFields =
+      doc.custom_fields?.map((fieldInstance) => ({
+        field: fieldInstance.field,
+        value: fieldInstance.value,
+        created: fieldInstance.created || null,
+      })) || []
+
     return {
       ...doc,
       permissions_form: { owner: doc.owner, set_permissions: doc.permissions },
+      custom_fields: transformedCustomFields,
     }
   }
 
@@ -835,11 +844,7 @@ export class DocumentDetailComponent
           }
           this.title = doc.title
           this.updateFormForCustomFields()
-          // Exclude custom_fields from patchValue since we handle them separately
-          const { custom_fields, ...docWithoutCustomFields } = doc
-          this.documentForm.patchValue(docWithoutCustomFields)
-          // Ensure custom fields form control is marked as pristine after structure update
-          this.documentForm.get('custom_fields').markAsPristine()
+          this.documentForm.patchValue(this.mapDocToForm(doc))
           this.documentForm.markAsPristine()
           this.openDocumentService.setDirty(doc, false)
         },

--- a/src-ui/src/app/components/document-detail/document-detail.component.ts
+++ b/src-ui/src/app/components/document-detail/document-detail.component.ts
@@ -343,19 +343,23 @@ export class DocumentDetailComponent
   }
 
   private mapDocToForm(doc: Document): any {
-    // Transform custom_fields to match FormControl structure
-    const transformedCustomFields =
-      doc.custom_fields?.map((fieldInstance) => ({
+    return {
+      ...doc,
+      permissions_form: { owner: doc.owner, set_permissions: doc.permissions },
+      custom_fields: this.transformCustomFieldsForForm(doc.custom_fields),
+    }
+  }
+
+  private transformCustomFieldsForForm(
+    customFields: CustomFieldInstance[]
+  ): any[] {
+    return (
+      customFields?.map((fieldInstance) => ({
         field: fieldInstance.field,
         value: fieldInstance.value,
         created: fieldInstance.created || null,
       })) || []
-
-    return {
-      ...doc,
-      permissions_form: { owner: doc.owner, set_permissions: doc.permissions },
-      custom_fields: transformedCustomFields,
-    }
+    )
   }
 
   private mapFormToDoc(value: any): any {
@@ -388,14 +392,6 @@ export class DocumentDetailComponent
     currentDocument: Document,
     originalDocument: Document
   ): void {
-    // Transform custom_fields to match the form control structure
-    const transformedCustomFields =
-      originalDocument.custom_fields?.map((fieldInstance) => ({
-        field: fieldInstance.field,
-        value: fieldInstance.value,
-        created: fieldInstance.created || null,
-      })) || []
-
     this.store = new BehaviorSubject({
       title: originalDocument.title,
       content: originalDocument.content,
@@ -409,7 +405,9 @@ export class DocumentDetailComponent
         owner: originalDocument.owner,
         set_permissions: originalDocument.permissions,
       },
-      custom_fields: transformedCustomFields,
+      custom_fields: this.transformCustomFieldsForForm(
+        originalDocument.custom_fields
+      ),
     })
     this.isDirty$ = dirtyCheck(this.documentForm, this.store.asObservable())
     this.isDirty$
@@ -909,11 +907,9 @@ export class DocumentDetailComponent
           const updatedValues = {
             ...this.documentForm.value,
             tags: [...docValues.tags],
-            custom_fields: this.document.custom_fields.map((fieldInstance) => ({
-              field: fieldInstance.field,
-              value: fieldInstance.value,
-              created: fieldInstance.created || null,
-            })),
+            custom_fields: this.transformCustomFieldsForForm(
+              this.document.custom_fields
+            ),
           }
 
           this.store.next(updatedValues)

--- a/src-ui/src/app/components/document-detail/document-detail.component.ts
+++ b/src-ui/src/app/components/document-detail/document-detail.component.ts
@@ -853,21 +853,10 @@ export class DocumentDetailComponent
         } else if (key === 'custom_fields') {
           const formValue = this.documentForm.get(key).value
 
-          // Validate and clean custom field values
           const cleanedCustomFields = formValue.map((fieldData, index) => {
-            let cleanValue = fieldData.value
-            if (typeof cleanValue === 'number' && isNaN(cleanValue)) {
-              cleanValue = null
-            } else if (
-              typeof cleanValue === 'string' &&
-              (cleanValue.trim() === 'NaN' || cleanValue.trim() === '')
-            ) {
-              cleanValue = null
-            }
-
             const result: any = {
               field: fieldData.field,
-              value: cleanValue,
+              value: fieldData.value,
             }
 
             // Only include 'created' field if:

--- a/src-ui/src/app/components/document-detail/document-detail.component.ts
+++ b/src-ui/src/app/components/document-detail/document-detail.component.ts
@@ -1388,7 +1388,7 @@ export class DocumentDetailComponent
           new FormGroup({
             field: new FormControl(fieldInstance.field),
             value: new FormControl(fieldInstance.value),
-            created: new FormControl(fieldInstance.created),
+            created: new FormControl(fieldInstance.created || null),
           }),
           { emitEvent }
         )
@@ -1401,7 +1401,7 @@ export class DocumentDetailComponent
       field: field.id,
       value: null,
       document: this.documentId,
-      created: new Date(),
+      // Don't add created timestamp for new fields - only for reordering
     })
     this.updateFormForCustomFields(true)
     this.documentForm.get('custom_fields').markAsDirty()

--- a/src-ui/src/app/components/document-detail/document-detail.component.ts
+++ b/src-ui/src/app/components/document-detail/document-detail.component.ts
@@ -1393,23 +1393,10 @@ export class DocumentDetailComponent
     this.customFieldFormFields.clear({ emitEvent: false })
     if (this.document?.custom_fields) {
       this.document.custom_fields.forEach((fieldInstance, index) => {
-        // Validate and clean the value to prevent NaN errors
-        let cleanValue = fieldInstance.value
-        if (typeof cleanValue === 'number' && isNaN(cleanValue)) {
-          cleanValue = null
-          fieldInstance.value = null
-        } else if (
-          typeof cleanValue === 'string' &&
-          cleanValue.trim() === 'NaN'
-        ) {
-          cleanValue = null
-          fieldInstance.value = null
-        }
-
         this.customFieldFormFields.push(
           new FormGroup({
             field: new FormControl(fieldInstance.field),
-            value: new FormControl(cleanValue),
+            value: new FormControl(fieldInstance.value),
             created: new FormControl(fieldInstance.created),
           }),
           { emitEvent }

--- a/src-ui/src/app/components/document-detail/document-detail.component.ts
+++ b/src-ui/src/app/components/document-detail/document-detail.component.ts
@@ -859,11 +859,9 @@ export class DocumentDetailComponent
               value: fieldData.value,
             }
 
-            // Only include 'created' field if custom field order has been changed (reordering occurred)
-            if (this.customFieldOrderChanged) {
-              const documentField = this.document.custom_fields[index]
-              result.created =
-                documentField?.created || fieldData.created || new Date()
+            // Include created field for order persistence if available
+            if (fieldData.created) {
+              result.created = fieldData.created
             }
 
             return result

--- a/src-ui/src/app/components/document-detail/document-detail.component.ts
+++ b/src-ui/src/app/components/document-detail/document-detail.component.ts
@@ -859,18 +859,8 @@ export class DocumentDetailComponent
               value: fieldData.value,
             }
 
-            // Only include created field if:
-            // 1. Custom field order has been changed (reordering occurred), OR
-            // 2. This is an existing field that already had a created timestamp
-            const documentField = this.document.custom_fields[index]
-            const isExistingField =
-              documentField &&
-              documentField.created &&
-              fieldData.created &&
-              documentField.created.getTime() ===
-                new Date(fieldData.created).getTime()
-
-            if (this.customFieldOrderChanged || isExistingField) {
+            // Only include created field if custom field order has been changed (reordering occurred)
+            if (this.customFieldOrderChanged) {
               result.created = fieldData.created
             }
 

--- a/src-ui/src/app/components/document-detail/document-detail.component.ts
+++ b/src-ui/src/app/components/document-detail/document-detail.component.ts
@@ -859,8 +859,18 @@ export class DocumentDetailComponent
               value: fieldData.value,
             }
 
-            // Include created field for order persistence if available
-            if (fieldData.created) {
+            // Only include created field if:
+            // 1. Custom field order has been changed (reordering occurred), OR
+            // 2. This is an existing field that already had a created timestamp
+            const documentField = this.document.custom_fields[index]
+            const isExistingField =
+              documentField &&
+              documentField.created &&
+              fieldData.created &&
+              documentField.created.getTime() ===
+                new Date(fieldData.created).getTime()
+
+            if (this.customFieldOrderChanged || isExistingField) {
               result.created = fieldData.created
             }
 

--- a/src-ui/src/app/data/custom-field-instance.ts
+++ b/src-ui/src/app/data/custom-field-instance.ts
@@ -5,5 +5,4 @@ export interface CustomFieldInstance extends ObjectWithId {
   field: number // CustomField
   created: Date
   value?: any
-  position?: number
 }

--- a/src-ui/src/app/data/custom-field-instance.ts
+++ b/src-ui/src/app/data/custom-field-instance.ts
@@ -5,4 +5,5 @@ export interface CustomFieldInstance extends ObjectWithId {
   field: number // CustomField
   created: Date
   value?: any
+  position?: number
 }

--- a/src-ui/src/app/data/custom-field-instance.ts
+++ b/src-ui/src/app/data/custom-field-instance.ts
@@ -3,6 +3,6 @@ import { ObjectWithId } from './object-with-id'
 export interface CustomFieldInstance extends ObjectWithId {
   document: number // Document
   field: number // CustomField
-  created?: Date
+  created: Date
   value?: any
 }

--- a/src-ui/src/app/data/custom-field-instance.ts
+++ b/src-ui/src/app/data/custom-field-instance.ts
@@ -3,6 +3,6 @@ import { ObjectWithId } from './object-with-id'
 export interface CustomFieldInstance extends ObjectWithId {
   document: number // Document
   field: number // CustomField
-  created: Date
+  created?: Date
   value?: any
 }

--- a/src/documents/models.py
+++ b/src/documents/models.py
@@ -920,7 +920,7 @@ class CustomFieldInstance(SoftDeleteModel):
     value_long_text = models.TextField(null=True)
 
     class Meta:
-        ordering = ["created"]
+        ordering = ("created",)
         verbose_name = _("custom field instance")
         verbose_name_plural = _("custom field instances")
         constraints = [

--- a/src/documents/models.py
+++ b/src/documents/models.py
@@ -857,7 +857,6 @@ class CustomFieldInstance(SoftDeleteModel):
         _("created"),
         default=timezone.now,
         db_index=True,
-        editable=False,
     )
 
     document = models.ForeignKey(
@@ -921,7 +920,7 @@ class CustomFieldInstance(SoftDeleteModel):
     value_long_text = models.TextField(null=True)
 
     class Meta:
-        ordering = ("created",)
+        ordering = ["created"]
         verbose_name = _("custom field instance")
         verbose_name_plural = _("custom field instances")
         constraints = [

--- a/src/documents/serialisers.py
+++ b/src/documents/serialisers.py
@@ -809,6 +809,7 @@ class ReadWriteSerializerMethodField(serializers.SerializerMethodField):
 class CustomFieldInstanceSerializer(serializers.ModelSerializer):
     field = serializers.PrimaryKeyRelatedField(queryset=CustomField.objects.all())
     value = ReadWriteSerializerMethodField(allow_null=True)
+    created = serializers.DateTimeField(write_only=True, required=False)
 
     def create(self, validated_data):
         # An instance is attached to a document

--- a/src/documents/serialisers.py
+++ b/src/documents/serialisers.py
@@ -826,10 +826,16 @@ class CustomFieldInstanceSerializer(serializers.ModelSerializer):
 
         # Actually update or create the instance, providing the value
         # to fill in the correct attribute based on the type
+        defaults = {data_store_name: validated_data["value"]}
+
+        # If created timestamp is provided, use it to maintain custom field order
+        if "created" in validated_data:
+            defaults["created"] = validated_data["created"]
+
         instance, _ = CustomFieldInstance.objects.update_or_create(
             document=document,
             field=custom_field,
-            defaults={data_store_name: validated_data["value"]},
+            defaults=defaults,
         )
         return instance
 
@@ -947,6 +953,7 @@ class CustomFieldInstanceSerializer(serializers.ModelSerializer):
         fields = [
             "value",
             "field",
+            "created",
         ]
 
 


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Let the user allow to reorder custom fields.

The changes allow the user to reorder custom fields. See video:

https://github.com/user-attachments/assets/59c574b4-a822-47b2-ae47-5b355b8aa01e

Closes #10606 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [x] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
