### PR TITLE
Fix: Reversed logic for filename formatting checkbox

### DIFF
--- a/src-ui/src/app/components/document-list/bulk-editor/bulk-editor.component.ts
+++ b/src-ui/src/app/components/document-list/bulk-editor/bulk-editor.component.ts
@@ -105,7 +105,7 @@ export class BulkEditorComponent
   downloadForm = new FormGroup({
     downloadFileTypeArchive: new FormControl(true),
     downloadFileTypeOriginals: new FormControl(false),
-    downloadUseFormatting: new FormControl(false),
+    downloadUseFormatting: new FormControl(true),
   })
 
   @Input()

--- a/src/documents/bulk_download.py
+++ b/src/documents/bulk_download.py
@@ -15,11 +15,11 @@ class BulkArchiveStrategy:
     def __init__(self, zipf: ZipFile, *, follow_formatting: bool = False) -> None:
         self.zipf: ZipFile = zipf
         if follow_formatting:
+            self.make_unique_filename = self._filename_only
+        else:
             self.make_unique_filename: Callable[..., Path | str] = (
                 self._formatted_filepath
             )
-        else:
-            self.make_unique_filename = self._filename_only
 
     def _filename_only(
         self,


### PR DESCRIPTION

## Proposed change

This fix corrects the logic of the 'Use formatted filename' checkbox in the bulk download feature.

Currently the checkbox is unchecked by default but the initial filename formatting strategy (`_formatted_filepath`) is chosen. If checked, however, the `_filename_only` name strategy is applied. This is opposite to what the checkbox label says.

This PR reverses the file naming strategy selection and checks the checkbox by default which keeps the default behaviour and fixes the UI.

As this is just a minor change, I did not set up a testing environment. I am happy to do so, though, if deemed necessary.

## Type of change

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
