### PR TITLE
Chore: replace test image URLs with our own links

### DIFF
--- a/src/paperless_mail/tests/samples/html.eml
+++ b/src/paperless_mail/tests/samples/html.eml
@@ -55,7 +55,7 @@ Content-Transfer-Encoding: 7bit
 		<p>Some Text</p>
 		<p>
 			<img src="cid:part1.pNdUSz0s.D3NqVtPg@example.de" alt="Has to be rewritten to work..">
-			<img src="https://upload.wikimedia.org/wikipedia/en/f/f7/RickRoll.png" alt="This image should not be shown.">
+			<img src="https://docs.paperless-ngx.com/assets/logo_full_white.svg" alt="This image should not be shown.">
 		</p>
 
 		<p>and an embedded image.<br>

--- a/src/paperless_mail/tests/samples/sample.html
+++ b/src/paperless_mail/tests/samples/sample.html
@@ -6,7 +6,7 @@
       <p>Some Text</p>
       <p>
 				<img src="cid:part1.pNdUSz0s.D3NqVtPg@example.de" alt="Has to be rewritten to work..">
-				<img src="https://upload.wikimedia.org/wikipedia/en/f/f7/RickRoll.png" alt="This image should not be shown.">
+				<img src="https://docs.paperless-ngx.com/assets/logo_full_white.svg" alt="This image should not be shown.">
 			</p>
 
       <p>and an embedded image.<br>

--- a/src/paperless_mail/tests/test_parsers_live.py
+++ b/src/paperless_mail/tests/test_parsers_live.py
@@ -2,7 +2,6 @@ import os
 import shutil
 import subprocess
 import tempfile
-import time
 from pathlib import Path
 
 import httpx
@@ -54,34 +53,6 @@ class TestUrlCanary:
     Verify certain URLs are still available so testing is valid still
     """
 
-    @classmethod
-    def _fetch_wikimedia(cls, url: str) -> httpx.Response:
-        """
-        Wikimedia occasionally throttles automated requests (HTTP 429). Retry a few
-        times with a short backoff so the tests stay stable, and skip if throttling
-        persists.
-        """
-        last_resp: httpx.Response | None = None
-        # Wikimedia rejects requests without a browser-like User-Agent header and returns 403.
-        headers = {
-            "User-Agent": (
-                "Mozilla/5.0 (X11; Linux x86_64) "
-                "AppleWebKit/537.36 (KHTML, like Gecko) "
-                "Chrome/123.0.0.0 Safari/537.36"
-            ),
-        }
-        for delay in (0, 1, 2):
-            resp = httpx.get(url, headers=headers, timeout=30.0)
-            if resp.status_code != httpx.codes.TOO_MANY_REQUESTS:
-                return resp
-            last_resp = resp
-            time.sleep(delay)
-
-        pytest.skip(
-            "Wikimedia throttled the canary request with HTTP 429; try rerunning later.",
-        )
-        return last_resp  # pragma: no cover
-
     def test_online_image_exception_on_not_available(self):
         """
         GIVEN:
@@ -96,8 +67,8 @@ class TestUrlCanary:
         whether this image stays online forever, so here we check if we can detect if is not
         available anymore.
         """
-        resp = self._fetch_wikimedia(
-            "https://upload.wikimedia.org/wikipedia/en/f/f7/nonexistent.png",
+        resp = httpx.get(
+            "https://docs.paperless-ngx.com/assets/non-existent.png",
         )
         with pytest.raises(httpx.HTTPStatusError) as exec_info:
             resp.raise_for_status()
@@ -119,8 +90,8 @@ class TestUrlCanary:
         """
 
         # Now check the URL used in samples/sample.html
-        resp = self._fetch_wikimedia(
-            "https://upload.wikimedia.org/wikipedia/en/f/f7/RickRoll.png",
+        resp = httpx.get(
+            "https://docs.paperless-ngx.com/assets/logo_full_white.svg",
         )
         resp.raise_for_status()
 


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

As fun as it was to have the RickRoll image in there, all the drama is not worth it.

Closes #(issue or discussion)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
