### PR TITLE
Fix: prevent focus loss from change detection in cf query dropdown

### DIFF
--- a/src-ui/src/app/components/document-list/filter-editor/filter-editor.component.ts
+++ b/src-ui/src/app/components/document-list/filter-editor/filter-editor.component.ts
@@ -400,6 +400,9 @@ export class FilterEditorComponent
 
   @Input()
   set filterRules(value: FilterRule[]) {
+    if (value === this._filterRules) {
+      return
+    }
     this._filterRules = value
 
     this.documentTypeSelectionModel.clear(false)
@@ -1098,7 +1101,13 @@ export class FilterEditorComponent
   rulesModified: boolean = false
 
   updateRules() {
-    this.filterRulesChange.next(this.filterRules)
+    const updatedRules = this.filterRules
+    this._filterRules = updatedRules
+    this.rulesModified = filterRulesDiffer(
+      this._unmodifiedFilterRules,
+      updatedRules
+    )
+    this.filterRulesChange.next(updatedRules)
   }
 
   get textFilter() {


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Change detection is always fun

https://github.com/user-attachments/assets/e4238388-a475-4f40-a908-fe4417298387



Closes #11408

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
