### PR TITLE
Performance: Replace duplicated static files with symlinks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -254,7 +254,8 @@ RUN set -eux \
     && chown --from root:root --changes --recursive paperless:paperless /usr/src/paperless \
   && echo "Collecting static files" \
     && s6-setuidgid paperless python3 manage.py collectstatic --clear --no-input --link \
-    && s6-setuidgid paperless python3 manage.py compilemessages
+    && s6-setuidgid paperless python3 manage.py compilemessages \
+    && /usr/local/bin/deduplicate.py --verbose /usr/src/paperless/static/
 
 VOLUME ["/usr/src/paperless/data", \
         "/usr/src/paperless/media", \

--- a/docker/rootfs/usr/local/bin/deduplicate.py
+++ b/docker/rootfs/usr/local/bin/deduplicate.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""
+File deduplication script that replaces identical files with symlinks.
+Uses SHA256 hashing to identify duplicate files.
+"""
+
+import hashlib
+from collections import defaultdict
+from pathlib import Path
+
+import click
+import humanize
+
+
+def calculate_sha256(filepath: Path) -> str | None:
+    sha256_hash = hashlib.sha256()
+    try:
+        with filepath.open("rb") as f:
+            # Read file in chunks to handle large files efficiently
+            while chunk := f.read(65536):  # 64KB chunks
+                sha256_hash.update(chunk)
+        return sha256_hash.hexdigest()
+    except OSError as e:
+        click.echo(f"Error reading {filepath}: {e}\n", err=True)
+        return None
+
+
+def find_duplicate_files(directory: Path) -> dict[str, list[Path]]:
+    """
+    Recursively scan directory and group files by their SHA256 hash.
+    Returns a dictionary mapping hash -> list of file paths.
+    """
+    hash_to_files: dict[str, list[Path]] = defaultdict(list)
+
+    for filepath in directory.rglob("*"):
+        # Skip symlinks
+        if filepath.is_symlink():
+            continue
+
+        # Skip if not a regular file
+        if not filepath.is_file():
+            continue
+
+        file_hash = calculate_sha256(filepath)
+        if file_hash:
+            hash_to_files[file_hash].append(filepath)
+
+    # Filter to only return hashes with duplicates
+    return {h: files for h, files in hash_to_files.items() if len(files) > 1}
+
+
+def replace_with_symlinks(
+    duplicate_groups: dict[str, list[Path]],
+    *,
+    dry_run: bool = False,
+) -> tuple[int, int]:
+    """
+    Replace duplicate files with symlinks to the first occurrence.
+    Returns (number_of_files_replaced, space_saved_in_bytes).
+    """
+    total_duplicates = 0
+    space_saved = 0
+
+    for file_hash, file_list in duplicate_groups.items():
+        # Keep the first file as the original, replace others with symlinks
+        original_file = file_list[0]
+        duplicates = file_list[1:]
+
+        click.echo(f"Found {len(duplicates)} duplicate(s) of: {original_file}\n")
+
+        for duplicate in duplicates:
+            try:
+                # Get file size before deletion
+                file_size = duplicate.stat().st_size
+
+                if dry_run:
+                    click.echo(f"  [DRY RUN] Would replace: {duplicate}\n")
+                else:
+                    # Remove the duplicate file
+                    duplicate.unlink()
+
+                    # Create relative symlink if possible, otherwise absolute
+                    try:
+                        # Try to create a relative symlink
+                        rel_path = original_file.relative_to(duplicate.parent)
+                        duplicate.symlink_to(rel_path)
+                        click.echo(f"  Replaced: {duplicate} -> {rel_path}\n")
+                    except ValueError:
+                        # Fall back to absolute path
+                        duplicate.symlink_to(original_file.resolve())
+                        click.echo(f"  Replaced: {duplicate} -> {original_file}\n")
+
+                    space_saved += file_size
+
+                total_duplicates += 1
+
+            except OSError as e:
+                click.echo(f"  Error replacing {duplicate}: {e}\n", err=True)
+
+    return total_duplicates, space_saved
+
+
+@click.command()
+@click.argument(
+    "directory",
+    type=click.Path(
+        exists=True,
+        file_okay=False,
+        dir_okay=True,
+        readable=True,
+        path_type=Path,
+    ),
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Show what would be done without making changes",
+)
+@click.option("--verbose", "-v", is_flag=True, help="Show verbose output")
+def deduplicate(directory: Path, *, dry_run: bool, verbose: bool) -> None:
+    """
+    Recursively search DIRECTORY for identical files and replace them with symlinks.
+
+    Uses SHA256 hashing to identify duplicate files. The first occurrence of each
+    unique file is kept, and all duplicates are replaced with symlinks pointing to it.
+    """
+    directory = directory.resolve()
+
+    click.echo(f"Scanning directory: {directory}")
+    if dry_run:
+        click.echo("Running in DRY RUN mode - no changes will be made\n")
+
+    # Find all duplicate files
+    click.echo("Calculating file hashes...\n")
+    duplicate_groups = find_duplicate_files(directory)
+
+    if not duplicate_groups:
+        click.echo("No duplicate files found!\n")
+        return
+
+    total_files = sum(len(files) - 1 for files in duplicate_groups.values())
+    click.echo(
+        f"Found {len(duplicate_groups)} group(s) of duplicates "
+        f"({total_files} files to deduplicate)\n",
+    )
+
+    if verbose:
+        for file_hash, files in duplicate_groups.items():
+            click.echo(f"Hash: {file_hash}\n")
+            for f in files:
+                click.echo(f"  - {f}\n")
+
+    # Replace duplicates with symlinks
+    click.echo("Processing duplicates...\n")
+    num_replaced, space_saved = replace_with_symlinks(duplicate_groups, dry_run=dry_run)
+
+    # Summary
+    click.echo(
+        f"{'Would replace' if dry_run else 'Replaced'} "
+        f"{num_replaced} duplicate file(s)\n",
+    )
+    if not dry_run:
+        click.echo(f"Space saved: {humanize.naturalsize(space_saved, binary=True)}")
+
+
+if __name__ == "__main__":
+    deduplicate()

--- a/docker/rootfs/usr/local/bin/deduplicate.py
+++ b/docker/rootfs/usr/local/bin/deduplicate.py
@@ -21,7 +21,7 @@ def calculate_sha256(filepath: Path) -> str | None:
                 sha256_hash.update(chunk)
         return sha256_hash.hexdigest()
     except OSError as e:
-        click.echo(f"Error reading {filepath}: {e}\n", err=True)
+        click.echo(f"Error reading {filepath}: {e}", err=True)
         return None
 
 
@@ -66,7 +66,7 @@ def replace_with_symlinks(
         original_file = file_list[0]
         duplicates = file_list[1:]
 
-        click.echo(f"Found {len(duplicates)} duplicate(s) of: {original_file}\n")
+        click.echo(f"Found {len(duplicates)} duplicate(s) of: {original_file}")
 
         for duplicate in duplicates:
             try:
@@ -74,7 +74,7 @@ def replace_with_symlinks(
                 file_size = duplicate.stat().st_size
 
                 if dry_run:
-                    click.echo(f"  [DRY RUN] Would replace: {duplicate}\n")
+                    click.echo(f"  [DRY RUN] Would replace: {duplicate}")
                 else:
                     # Remove the duplicate file
                     duplicate.unlink()
@@ -84,18 +84,18 @@ def replace_with_symlinks(
                         # Try to create a relative symlink
                         rel_path = original_file.relative_to(duplicate.parent)
                         duplicate.symlink_to(rel_path)
-                        click.echo(f"  Replaced: {duplicate} -> {rel_path}\n")
+                        click.echo(f"  Replaced: {duplicate} -> {rel_path}")
                     except ValueError:
                         # Fall back to absolute path
                         duplicate.symlink_to(original_file.resolve())
-                        click.echo(f"  Replaced: {duplicate} -> {original_file}\n")
+                        click.echo(f"  Replaced: {duplicate} -> {original_file}")
 
                     space_saved += file_size
 
                 total_duplicates += 1
 
             except OSError as e:
-                click.echo(f"  Error replacing {duplicate}: {e}\n", err=True)
+                click.echo(f"  Error replacing {duplicate}: {e}", err=True)
 
     return total_duplicates, space_saved
 
@@ -128,36 +128,36 @@ def deduplicate(directory: Path, *, dry_run: bool, verbose: bool) -> None:
 
     click.echo(f"Scanning directory: {directory}")
     if dry_run:
-        click.echo("Running in DRY RUN mode - no changes will be made\n")
+        click.echo("Running in DRY RUN mode - no changes will be made")
 
     # Find all duplicate files
-    click.echo("Calculating file hashes...\n")
+    click.echo("Calculating file hashes...")
     duplicate_groups = find_duplicate_files(directory)
 
     if not duplicate_groups:
-        click.echo("No duplicate files found!\n")
+        click.echo("No duplicate files found!")
         return
 
     total_files = sum(len(files) - 1 for files in duplicate_groups.values())
     click.echo(
         f"Found {len(duplicate_groups)} group(s) of duplicates "
-        f"({total_files} files to deduplicate)\n",
+        f"({total_files} files to deduplicate)",
     )
 
     if verbose:
         for file_hash, files in duplicate_groups.items():
-            click.echo(f"Hash: {file_hash}\n")
+            click.echo(f"Hash: {file_hash}")
             for f in files:
-                click.echo(f"  - {f}\n")
+                click.echo(f"  - {f}")
 
     # Replace duplicates with symlinks
-    click.echo("Processing duplicates...\n")
+    click.echo("Processing duplicates...")
     num_replaced, space_saved = replace_with_symlinks(duplicate_groups, dry_run=dry_run)
 
     # Summary
     click.echo(
         f"{'Would replace' if dry_run else 'Replaced'} "
-        f"{num_replaced} duplicate file(s)\n",
+        f"{num_replaced} duplicate file(s)",
     )
     if not dry_run:
         click.echo(f"Space saved: {humanize.naturalsize(space_saved, binary=True)}")


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

With a quick Python script, finds exact duplicates in our static files and replaces them with symlinks to some chosen "first file".  I don't think this affects the release package, as it pulls from the location the frontend files are put, right?

It's a [small savings](https://github.com/paperless-ngx/paperless-ngx/actions/runs/19544443060/job/55960863243#step:12:8486) but seems worth it for a few kbs of text.

No issues viewing PDFs, admin pages or anything.

```bash
$  docker image ls
                                                                                                                                                                                                    i Info →   U  In Use
IMAGE                                                           ID             DISK USAGE   CONTENT SIZE   EXTRA
ghcr.io/paperless-ngx/paperless-ngx:dev                         d8928b6fc4ed       1.42GB             0B        
ghcr.io/paperless-ngx/paperless-ngx:feature-remove-duplicates   50334a93ba3b       1.38GB             0B    
```

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
