### PR TITLE
Add user parameter to MariaDB connection check

### DIFF
--- a/docker/rootfs/etc/s6-overlay/s6-rc.d/init-wait-for-db/run
+++ b/docker/rootfs/etc/s6-overlay/s6-rc.d/init-wait-for-db/run
@@ -50,8 +50,9 @@ wait_for_mariadb() {
 
 	local -r host="${PAPERLESS_DBHOST:-localhost}"
 	local -r port="${PAPERLESS_DBPORT:-3306}"
+	local -r user="${PAPERLESS_DBUSER:-paperless}"
 
-	while ! mariadb-admin --host="$host" --port="$port" ping --silent >/dev/null 2>&1; do
+	while ! mariadb-admin --host="${host}" --port="${port}" --user="${user}" ping --silent >/dev/null 2>&1; do
 		delay_next_attempt
 	done
 	echo "${LOG_PREFIX} Connected to MariaDB"


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change
* Add user parameter to MariaDB connection check 
  When pinging MariaDB, the server checks both, username and host.
* Add curly brackets around variable names.

Postgres connection check has both of these already implemented.
No AI tools used.
<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

<!--
⚠️ Important: Pull requests that implement a new feature or enhancement *should almost always target an existing feature request* with evidence of community interest and discussion. This is in order to balance the work of implementing and maintaining new features / enhancements. If that is not currently the case, please open a feature request instead of this PR to gather feedback from both users and the project maintainers.
-->

Closes #(issue or discussion)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [X] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [X] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [X] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [X] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [X] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [X] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [X] I have made corresponding changes to the documentation as needed.
- [X] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
