### PR TITLE
Enhancement: add basic group management cli commands

### DIFF
--- a/src/documents/management/commands/group_create.py
+++ b/src/documents/management/commands/group_create.py
@@ -1,0 +1,71 @@
+from django.contrib import auth
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+from django.contrib.auth.models import Permission
+from django.core.management import BaseCommand
+from django.db import transaction
+
+from documents.management.commands.mixins import ProgressBarMixin
+
+
+class Command(ProgressBarMixin, BaseCommand):
+    help = "Create a group"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "name",
+            help="Name of the group",
+        )
+
+        # Named (optional) arguments
+        parser.add_argument(
+            "-p",
+            "--permission",
+            action="append",
+            help="Permissions to add to the created group",
+        )
+        # Named (optional) arguments
+        parser.add_argument(
+            "-a",
+            "--all-permissions",
+            action="store_true",
+            help="Give this group all available permissions",
+        )
+        self.add_argument_progress_bar_mixin(parser)
+
+    def handle(self, *args, **options):
+        self.handle_progress_bar_mixin(**options)
+        with transaction.atomic():
+            name = options["name"]
+            permissions = options["permission"]
+            setAllPermissions = options["all_permissions"]
+
+            if setAllPermissions:
+                permissions = set()
+                # We create (but not persist) a temporary superuser and use it to game the
+                # system and pull all permissions easily.
+                tmp_superuser = get_user_model()(
+                    is_active=True,
+                    is_superuser=True,
+                )
+                for backend in auth.get_backends():
+                    if hasattr(backend, "get_all_permissions"):
+                        permissions.update(backend.get_all_permissions(tmp_superuser))
+
+                # Output unique list of permissions sorted by permission name.
+                permissions = sorted(list(permissions))
+
+            new_group, created = Group.objects.get_or_create(name=name)
+            if created:
+                self.stdout.write(f"Created group: {new_group.name}\n")
+            else:
+                self.stdout.write(f"Group already exists: {new_group.name}\n")
+
+            for permission in permissions:
+                [module, codename] = permission.split(".")
+                permission = Permission.objects.get(
+                    content_type__app_label=module,
+                    codename=codename,
+                )
+                new_group.permissions.add(permission)
+                self.stdout.write(f"Added permission: {permission}\n")

--- a/src/documents/management/commands/group_delete.py
+++ b/src/documents/management/commands/group_delete.py
@@ -1,0 +1,24 @@
+from django.contrib.auth.models import Group
+from django.core.management import BaseCommand
+from django.db import transaction
+
+from documents.management.commands.mixins import ProgressBarMixin
+
+
+class Command(ProgressBarMixin, BaseCommand):
+    help = "Delete a group"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "name",
+            help="Name of the group",
+        )
+
+        self.add_argument_progress_bar_mixin(parser)
+
+    def handle(self, *args, **options):
+        self.handle_progress_bar_mixin(**options)
+
+        with transaction.atomic():
+            name = options["name"]
+            Group.objects.filter(name=name).delete()

--- a/src/documents/management/commands/group_list.py
+++ b/src/documents/management/commands/group_list.py
@@ -1,0 +1,13 @@
+from django.contrib.auth.models import Group
+from django.core.management import BaseCommand
+
+from documents.management.commands.mixins import ProgressBarMixin
+
+
+class Command(ProgressBarMixin, BaseCommand):
+    help = "List all groups"
+
+    def handle(self, *args, **options):
+        groups = Group.objects.all()
+        for group in groups:
+            self.stdout.write(f"{group.name}\n")

--- a/src/documents/management/commands/permission_list.py
+++ b/src/documents/management/commands/permission_list.py
@@ -1,0 +1,26 @@
+# Code taken from https://github.com/timonweb/django-debug-permissions
+# Licensed under BSD-3-Clause license
+
+from django.contrib import auth
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    help = "Get a list of all permissions available in the system"
+
+    def handle(self, *args, **options):
+        permissions = set()
+        # We create (but not persist) a temporary superuser and use it to game the
+        # system and pull all permissions easily.
+        tmp_superuser = get_user_model()(
+            is_active=True,
+            is_superuser=True,
+        )
+        for backend in auth.get_backends():
+            if hasattr(backend, "get_all_permissions"):
+                permissions.update(backend.get_all_permissions(tmp_superuser))
+
+        # Output unique list of permissions sorted by permission name.
+        sorted_list_of_permissions = sorted(list(permissions))
+        self.stdout.write("\n".join(sorted_list_of_permissions))


### PR DESCRIPTION
## Proposed change

This commit adds four commands, all intended to make working with groups from the cli easier:

* `group_create` creates groups and assigns intended permissions
* `group_delete` deletes a group
* `group_list` lists the names of all groups
* `permission_list` lists the names of all permissions

Closes https://github.com/paperless-ngx/paperless-ngx/discussions/11486

## Type of change

- [ ] Bug fix: non-breaking change which fixes an issue.
- [x] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
