### PR TITLE
Chore: add some output of social login errors

### DIFF
--- a/src/paperless/adapter.py
+++ b/src/paperless/adapter.py
@@ -137,3 +137,25 @@ class CustomSocialAccountAdapter(DefaultSocialAccountAdapter):
             user.save()
         handle_social_account_updated(None, request, sociallogin)
         return user
+
+    def on_authentication_error(
+        self,
+        request,
+        provider,
+        error=None,
+        exception=None,
+        extra_context=None,
+    ):
+        """
+        Just log errors and pass them along.
+        """
+        logger.warning(
+            f"Social authentication error for provider `{provider!s}`: {error!s} ({exception!s})",
+        )
+        return super().on_authentication_error(
+            request,
+            provider,
+            error,
+            exception,
+            extra_context,
+        )

--- a/src/paperless/tests/test_adapter.py
+++ b/src/paperless/tests/test_adapter.py
@@ -167,3 +167,17 @@ class TestCustomSocialAccountAdapter(TestCase):
         self.assertEqual(user.groups.count(), 1)
         self.assertTrue(user.groups.filter(name="group1").exists())
         self.assertFalse(user.groups.filter(name="group2").exists())
+
+    def test_error_logged_on_authentication_error(self):
+        adapter = get_social_adapter()
+        request = HttpRequest()
+        with self.assertLogs("paperless.auth", level="INFO") as log_cm:
+            adapter.on_authentication_error(
+                request,
+                provider="test-provider",
+                error="Error",
+                exception="Test authentication error",
+            )
+        self.assertTrue(
+            any("Test authentication error" in message for message in log_cm.output),
+        )


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

See https://github.com/paperless-ngx/paperless-ngx/discussions/11524#discussioncomment-15140194

```
[2025-12-03 08:36:08,680] [WARNING] [paperless.auth] Social authentication error for provider `GitHub`: unknown (Error retrieving access token: b'error=incorrect_client_credentials&error_description=The+client_id+and%2For+client_secret+passed+are+incorrect.&error_uri=https%3A%2F%2Fdocs.github.com%2Fapps%2Fmanaging-oauth-apps%2Ftroubleshooting-oauth-app-access-token-request-errors%2F%23incorrect-client-credentials')
```

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
