### PR TITLE
Fix: pass additional arguments to TagSerializer for permissions

### DIFF
--- a/src/documents/serialisers.py
+++ b/src/documents/serialisers.py
@@ -585,6 +585,9 @@ class TagSerializer(MatchingModelSerializer, OwnedObjectSerializer):
             .select_related("owner")
             .annotate(document_count=Count("documents", filter=filter_q)),
             many=True,
+            user=self.user,
+            full_perms=self.full_perms,
+            all_fields=self.all_fields,
             context=self.context,
         )
         return serializer.data


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Happy to add a test for this if desired, but suffice to say it works, the issue is that the TagSerializer isnt getting `full_perms` (among other things):

<img width="519" height="979" alt="Screenshot 2025-12-10 at 7 06 53 AM" src="https://github.com/user-attachments/assets/bc1bcf7c-b479-45f7-b2c8-699a463aa9e9" />


Closes #11572

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
