### PR TITLE
Fix: use request.stream instead of request.content

### DIFF
--- a/src/documents/workflows/webhooks.py
+++ b/src/documents/workflows/webhooks.py
@@ -62,7 +62,7 @@ class WebhookTransport(httpx.HTTPTransport):
             method=request.method,
             url=new_url,
             headers=new_headers,
-            content=request.content,
+            content=request.stream,
             extensions=request.extensions,
         )
         request.extensions["sni_hostname"] = hostname


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Fixes

```
[2025-12-12 11:34:40,059] [ERROR] [celery.app.trace] Task documents.workflows.webhooks.send_webhook[e04488c4-1f55-477c-a87b-95909d1d04e7] raised unexpected: StreamError('Attempted to access streaming request content, without having called `read()`.')
Traceback (most recent call last):
  File "/.venv/lib/python3.10/site-packages/celery/app/trace.py", line 453, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/.venv/lib/python3.10/site-packages/celery/app/trace.py", line 736, in __protected_call__
    return self.run(*args, **kwargs)
  File "/.venv/lib/python3.10/site-packages/celery/app/autoretry.py", line 38, in run
    return task._orig_run(*args, **kwargs)
  File "/src/documents/workflows/webhooks.py", line 169, in send_webhook
    raise e
  File "/src/documents/workflows/webhooks.py", line 159, in send_webhook
    client.post(
  File "/.venv/lib/python3.10/site-packages/httpx/_client.py", line 1144, in post
    return self.request(
  File "/.venv/lib/python3.10/site-packages/httpx/_client.py", line 825, in request
    return self.send(request, auth=auth, follow_redirects=follow_redirects)
  File "/.venv/lib/python3.10/site-packages/httpx/_client.py", line 914, in send
    response = self._send_handling_auth(
  File "/.venv/lib/python3.10/site-packages/httpx/_client.py", line 942, in _send_handling_auth
    response = self._send_handling_redirects(
  File "/.venv/lib/python3.10/site-packages/httpx/_client.py", line 979, in _send_handling_redirects
    response = self._send_single_request(request)
  File "/.venv/lib/python3.10/site-packages/httpx/_client.py", line 1014, in _send_single_request
    response = transport.handle_request(request)
  File "/src/documents/workflows/webhooks.py", line 65, in handle_request
    content=request.content,
  File "/.venv/lib/python3.10/site-packages/httpx/_models.py", line 465, in content
    raise RequestNotRead()
httpx.StreamError: Attempted to access streaming request content, without having called `read()`.
```
-->

```
[2025-12-12 11:36:48,488] [INFO] [httpx] HTTP Request: POST https://webhook.site/9c995c25-c26e-4797-8f0e-896511d22329 "HTTP/1.1 200 OK"
[2025-12-12 11:36:48,488] [INFO] [paperless.workflows.webhooks] Webhook sent to https://webhook.site/9c995c25-c26e-4797-8f0e-896511d22329
```

Closes #(issue or discussion)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
