### PR TITLE
Enhancement: Add support for XML files (as text)

### DIFF
--- a/src/paperless_text/signals.py
+++ b/src/paperless_text/signals.py
@@ -11,6 +11,7 @@ def text_consumer_declaration(sender, **kwargs):
         "mime_types": {
             "text/plain": ".txt",
             "text/csv": ".csv",
+            "text/xml": ".xml",
             "application/csv": ".csv",
         },
     }


### PR DESCRIPTION
## Proposed change

As of today Paperless does not support XML file and refuses to import them.
As discussed in https://github.com/paperless-ngx/paperless-ngx/discussions/6823 many European countries are moving towards e-invoicing. Some countries are already enforcing it and more will follow.

This PR does not aim at supporting a specific e-invoicing format as https://github.com/paperless-ngx/paperless-ngx/pull/8488 tried to. The code was refused as it was very specific to the German e-invoicing format. I myself am from Belgium and B2B must use Peppol as of 1 Jan 2026. While the community continues to explore how e-invoices could be supported further within Paperless, this PR at least allows importing them as text.

## Type of change

- [ ] Bug fix: non-breaking change which fixes an issue.
- [x] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
