### PR TITLE
Chore: Fix hanging gpg-agent processes in test suite

### DIFF
--- a/src/paperless_mail/tests/test_preprocessor.py
+++ b/src/paperless_mail/tests/test_preprocessor.py
@@ -1,5 +1,7 @@
 import email
 import email.contentmanager
+import shutil
+import subprocess
 import tempfile
 from email.message import Message
 from email.mime.application import MIMEApplication
@@ -33,6 +35,30 @@ class MessageEncryptor:
             no_protection=True,
         )
         self.gpg.gen_key(input_data)
+
+    def cleanup(self) -> None:
+        """
+        Kill the gpg-agent process and clean up the temporary GPG home directory.
+
+        This uses gpgconf to properly terminate the agent, which is the officially
+        recommended cleanup method from the GnuPG project. python-gnupg does not
+        provide built-in cleanup methods as it's only a wrapper around the gpg CLI.
+        """
+        # Kill the gpg-agent using the official GnuPG cleanup tool
+        try:
+            subprocess.run(
+                ["gpgconf", "--kill", "gpg-agent"],
+                env={"GNUPGHOME": self.gpg_home},
+                check=False,
+                capture_output=True,
+                timeout=5,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            # gpgconf not found or hung - agent will timeout eventually
+            pass
+
+        # Clean up the temporary directory
+        shutil.rmtree(self.gpg_home, ignore_errors=True)
 
     @staticmethod
     def get_email_body_without_headers(email_message: Message) -> bytes:
@@ -85,8 +111,20 @@ class MessageEncryptor:
 
 
 class TestMailMessageGpgDecryptor(TestMail):
+    @classmethod
+    def setUpClass(cls):
+        """Create GPG encryptor once for all tests in this class."""
+        super().setUpClass()
+        cls.messageEncryptor = MessageEncryptor()
+
+    @classmethod
+    def tearDownClass(cls):
+        """Clean up GPG resources after all tests complete."""
+        if hasattr(cls, "messageEncryptor"):
+            cls.messageEncryptor.cleanup()
+        super().tearDownClass()
+
     def setUp(self):
-        self.messageEncryptor = MessageEncryptor()
         with override_settings(
             EMAIL_GNUPG_HOME=self.messageEncryptor.gpg_home,
             EMAIL_ENABLE_GPG_DECRYPTOR=True,
@@ -138,13 +176,28 @@ class TestMailMessageGpgDecryptor(TestMail):
 
     def test_decrypt_fails(self):
         encrypted_message, _ = self.create_encrypted_unencrypted_message_pair()
+        # This test creates its own empty GPG home to test decryption failure
         empty_gpg_home = tempfile.mkdtemp()
-        with override_settings(
-            EMAIL_ENABLE_GPG_DECRYPTOR=True,
-            EMAIL_GNUPG_HOME=empty_gpg_home,
-        ):
-            message_decryptor = MailMessageDecryptor()
-            self.assertRaises(Exception, message_decryptor.run, encrypted_message)
+        try:
+            with override_settings(
+                EMAIL_ENABLE_GPG_DECRYPTOR=True,
+                EMAIL_GNUPG_HOME=empty_gpg_home,
+            ):
+                message_decryptor = MailMessageDecryptor()
+                self.assertRaises(Exception, message_decryptor.run, encrypted_message)
+        finally:
+            # Clean up the temporary GPG home used only by this test
+            try:
+                subprocess.run(
+                    ["gpgconf", "--kill", "gpg-agent"],
+                    env={"GNUPGHOME": empty_gpg_home},
+                    check=False,
+                    capture_output=True,
+                    timeout=5,
+                )
+            except (FileNotFoundError, subprocess.TimeoutExpired):
+                pass
+            shutil.rmtree(empty_gpg_home, ignore_errors=True)
 
     def test_decrypt_encrypted_mail(self):
         """


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Test suite was leaving `gpg-agent` processes running after tests completed, preventing proper cleanup of temporary directories and file descriptors.  I was seeing ~40 processes per test run and quickly running out of descriptors.

- Added `cleanup()` method to `MessageEncryptor` that uses `gpgconf --kill gpg-agent` (the official GnuPG cleanup method) to terminate agents and remove temp directories
- Moved GPG key generation to class-level `setUpClass()`/`tearDownClass()` instead of per-test setup/teardown
- Added proper cleanup for `test_decrypt_fails()` which creates its own temporary GPG home

I let Claude handle the changes, seems good still to me.

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
