### PR TITLE
Fix sidebar scrollbar theming in dark mode

### DIFF
--- a/src-ui/src/app/components/app-frame/app-frame.component.scss
+++ b/src-ui/src/app/components/app-frame/app-frame.component.scss
@@ -13,6 +13,8 @@
   --pngx-sidebar-width: 100%;
   max-width: var(--pngx-sidebar-width);
   transition: all .2s ease;
+  scrollbar-color: var(--pngx-scrollbar-thumb) var(--pngx-scrollbar-track);
+  scrollbar-width: thin;
 
   .sidebar-heading .spinner-border {
     width: 0.8em;
@@ -146,11 +148,34 @@ main {
   overflow-x: hidden;
   overflow-y: auto; /* Scrollable contents if viewport is shorter than content. */
   min-height: min-content;
+  scrollbar-color: var(--pngx-scrollbar-thumb) var(--pngx-scrollbar-track);
+  scrollbar-width: thin;
 }
 @supports ((position: -webkit-sticky) or (position: sticky)) {
   .sidebar-sticky {
     position: -webkit-sticky;
     position: sticky;
+  }
+}
+
+.sidebar,
+.sidebar-sticky {
+  &::-webkit-scrollbar {
+    width: 10px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background-color: var(--pngx-scrollbar-track);
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background-color: var(--pngx-scrollbar-thumb);
+    border-radius: 999px;
+    border: 2px solid var(--pngx-scrollbar-track);
+  }
+
+  &::-webkit-scrollbar-thumb:hover {
+    background-color: var(--pngx-scrollbar-thumb-hover);
   }
 }
 

--- a/src-ui/src/theme.scss
+++ b/src-ui/src/theme.scss
@@ -24,6 +24,9 @@
   --pngx-bg-alt2: var(--bs-gray-200); // #e9ecef
   --pngx-bg-disabled: #f7f7f7;
   --pngx-focus-alpha: 0.3;
+  --pngx-scrollbar-track: var(--bs-gray-100);
+  --pngx-scrollbar-thumb: var(--bs-gray-400);
+  --pngx-scrollbar-thumb-hover: var(--bs-gray-500);
   --pngx-toast-max-width: 340px;
   --bs-info: var(--pngx-bg-alt2);
   --bs-info-rgb: 233, 236, 239;
@@ -95,6 +98,9 @@ $form-check-radio-checked-bg-image-dark: url("data:image/svg+xml,<svg xmlns='htt
   --bs-tertiary-bg: var(--pngx-bg-darker);
   --bs-dark-border-subtle: var(--pngx-bg-darker);
   --bs-border-color-translucent: rgba(0, 0, 0, .175); // override bs
+  --pngx-scrollbar-track: var(--pngx-bg-darker);
+  --pngx-scrollbar-thumb: #3b3f45;
+  --pngx-scrollbar-thumb-hover: #4a4f57;
 
   .text-dark, .text-light {
     color: var(--bs-body-color) !important;


### PR DESCRIPTION
## Proposed change

Adjust the sidebar scrollbar styling to follow the active theme variables so the scrollbar track/thumb match dark mode in Edge/Windows.

I asked Codex to make a quick fix for this. It worked on my end. Manually (visually) tested on Edge on Windows 11 and Edge on macOS.

Pls kindly review. :)

Testing:
- Not run (UI-only change).

Screenshots before and after this change, taken on Edge on Windows 11:

<img height="450" alt="1-before" src="https://github.com/user-attachments/assets/5f222975-e56e-4b40-8aed-edbd3a8eee6a" />
<img height="450" alt="2-after" src="https://github.com/user-attachments/assets/12eaaabb-2c11-4c96-8a3e-f8669009ca4e" />

Closes #N/A

## Type of change

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
