### PR TITLE
Fix: Running management scripts under rootless could fail

### DIFF
--- a/docker/management_script.sh
+++ b/docker/management_script.sh
@@ -5,10 +5,8 @@ set -e
 
 cd "${PAPERLESS_SRC_DIR}"
 
-if [[ $(id -u) == 0 ]]; then
-	s6-setuidgid paperless python3 manage.py management_command "$@"
-elif [[ $(id -un) == "paperless" ]]; then
+if [[ -n "${USER_IS_NON_ROOT}" ]]; then
 	python3 manage.py management_command "$@"
-else
-	echo "Unknown user."
+elif [[ $(id -un) == "paperless" ]]; then
+	s6-setuidgid paperless python3 manage.py management_command "$@"
 fi

--- a/docker/rootfs/usr/local/bin/convert_mariadb_uuid
+++ b/docker/rootfs/usr/local/bin/convert_mariadb_uuid
@@ -5,10 +5,8 @@ set -e
 
 cd "${PAPERLESS_SRC_DIR}"
 
-if [[ $(id -u) == 0 ]]; then
-	s6-setuidgid paperless python3 manage.py convert_mariadb_uuid "$@"
+if [[ -n "${USER_IS_NON_ROOT}" ]]; then
+		python3 manage.py convert_mariadb_uuid "$@"
 elif [[ $(id -un) == "paperless" ]]; then
-	python3 manage.py convert_mariadb_uuid "$@"
-else
-	echo "Unknown user."
+	s6-setuidgid paperless python3 manage.py convert_mariadb_uuid "$@"
 fi

--- a/docker/rootfs/usr/local/bin/createsuperuser
+++ b/docker/rootfs/usr/local/bin/createsuperuser
@@ -5,10 +5,8 @@ set -e
 
 cd "${PAPERLESS_SRC_DIR}"
 
-if [[ $(id -u) == 0 ]]; then
-	s6-setuidgid paperless python3 manage.py createsuperuser "$@"
+if [[ -n "${USER_IS_NON_ROOT}" ]]; then
+		python3 manage.py createsuperuser "$@"
 elif [[ $(id -un) == "paperless" ]]; then
-	python3 manage.py createsuperuser "$@"
-else
-	echo "Unknown user."
+	s6-setuidgid paperless python3 manage.py createsuperuser "$@"
 fi

--- a/docker/rootfs/usr/local/bin/decrypt_documents
+++ b/docker/rootfs/usr/local/bin/decrypt_documents
@@ -5,10 +5,8 @@ set -e
 
 cd "${PAPERLESS_SRC_DIR}"
 
-if [[ $(id -u) == 0 ]]; then
-	s6-setuidgid paperless python3 manage.py decrypt_documents "$@"
+if [[ -n "${USER_IS_NON_ROOT}" ]]; then
+		python3 manage.py decrypt_documents "$@"
 elif [[ $(id -un) == "paperless" ]]; then
-	python3 manage.py decrypt_documents "$@"
-else
-	echo "Unknown user."
+	s6-setuidgid paperless python3 manage.py decrypt_documents "$@"
 fi

--- a/docker/rootfs/usr/local/bin/document_archiver
+++ b/docker/rootfs/usr/local/bin/document_archiver
@@ -5,10 +5,8 @@ set -e
 
 cd "${PAPERLESS_SRC_DIR}"
 
-if [[ $(id -u) == 0 ]]; then
-	s6-setuidgid paperless python3 manage.py document_archiver "$@"
+if [[ -n "${USER_IS_NON_ROOT}" ]]; then
+		python3 manage.py document_archiver "$@"
 elif [[ $(id -un) == "paperless" ]]; then
-	python3 manage.py document_archiver "$@"
-else
-	echo "Unknown user."
+	s6-setuidgid paperless python3 manage.py document_archiver "$@"
 fi

--- a/docker/rootfs/usr/local/bin/document_create_classifier
+++ b/docker/rootfs/usr/local/bin/document_create_classifier
@@ -5,10 +5,8 @@ set -e
 
 cd "${PAPERLESS_SRC_DIR}"
 
-if [[ $(id -u) == 0 ]]; then
-	s6-setuidgid paperless python3 manage.py document_create_classifier "$@"
+if [[ -n "${USER_IS_NON_ROOT}" ]]; then
+		python3 manage.py document_create_classifier "$@"
 elif [[ $(id -un) == "paperless" ]]; then
-	python3 manage.py document_create_classifier "$@"
-else
-	echo "Unknown user."
+	s6-setuidgid paperless python3 manage.py document_create_classifier "$@"
 fi

--- a/docker/rootfs/usr/local/bin/document_exporter
+++ b/docker/rootfs/usr/local/bin/document_exporter
@@ -5,10 +5,8 @@ set -e
 
 cd "${PAPERLESS_SRC_DIR}"
 
-if [[ $(id -u) == 0 ]]; then
-	s6-setuidgid paperless python3 manage.py document_exporter "$@"
+if [[ -n "${USER_IS_NON_ROOT}" ]]; then
+		python3 manage.py document_exporter "$@"
 elif [[ $(id -un) == "paperless" ]]; then
-	python3 manage.py document_exporter "$@"
-else
-	echo "Unknown user."
+	s6-setuidgid paperless python3 manage.py document_exporter "$@"
 fi

--- a/docker/rootfs/usr/local/bin/document_fuzzy_match
+++ b/docker/rootfs/usr/local/bin/document_fuzzy_match
@@ -5,10 +5,8 @@ set -e
 
 cd "${PAPERLESS_SRC_DIR}"
 
-if [[ $(id -u) == 0 ]]; then
-	s6-setuidgid paperless python3 manage.py document_fuzzy_match "$@"
+if [[ -n "${USER_IS_NON_ROOT}" ]]; then
+		python3 manage.py document_fuzzy_match "$@"
 elif [[ $(id -un) == "paperless" ]]; then
-	python3 manage.py document_fuzzy_match "$@"
-else
-	echo "Unknown user."
+	s6-setuidgid paperless python3 manage.py document_fuzzy_match "$@"
 fi

--- a/docker/rootfs/usr/local/bin/document_importer
+++ b/docker/rootfs/usr/local/bin/document_importer
@@ -5,10 +5,8 @@ set -e
 
 cd "${PAPERLESS_SRC_DIR}"
 
-if [[ $(id -u) == 0 ]]; then
-	s6-setuidgid paperless python3 manage.py document_importer "$@"
+if [[ -n "${USER_IS_NON_ROOT}" ]]; then
+		python3 manage.py document_importer "$@"
 elif [[ $(id -un) == "paperless" ]]; then
-	python3 manage.py document_importer "$@"
-else
-	echo "Unknown user."
+	s6-setuidgid paperless python3 manage.py document_importer "$@"
 fi

--- a/docker/rootfs/usr/local/bin/document_index
+++ b/docker/rootfs/usr/local/bin/document_index
@@ -5,10 +5,8 @@ set -e
 
 cd "${PAPERLESS_SRC_DIR}"
 
-if [[ $(id -u) == 0 ]]; then
-	s6-setuidgid paperless python3 manage.py document_index "$@"
+if [[ -n "${USER_IS_NON_ROOT}" ]]; then
+		python3 manage.py document_index "$@"
 elif [[ $(id -un) == "paperless" ]]; then
-	python3 manage.py document_index "$@"
-else
-	echo "Unknown user."
+	s6-setuidgid paperless python3 manage.py document_index "$@"
 fi

--- a/docker/rootfs/usr/local/bin/document_renamer
+++ b/docker/rootfs/usr/local/bin/document_renamer
@@ -5,10 +5,8 @@ set -e
 
 cd "${PAPERLESS_SRC_DIR}"
 
-if [[ $(id -u) == 0 ]]; then
-	s6-setuidgid paperless python3 manage.py document_renamer "$@"
+if [[ -n "${USER_IS_NON_ROOT}" ]]; then
+		python3 manage.py document_renamer "$@"
 elif [[ $(id -un) == "paperless" ]]; then
-	python3 manage.py document_renamer "$@"
-else
-	echo "Unknown user."
+	s6-setuidgid paperless python3 manage.py document_renamer "$@"
 fi

--- a/docker/rootfs/usr/local/bin/document_retagger
+++ b/docker/rootfs/usr/local/bin/document_retagger
@@ -5,10 +5,8 @@ set -e
 
 cd "${PAPERLESS_SRC_DIR}"
 
-if [[ $(id -u) == 0 ]]; then
-	s6-setuidgid paperless python3 manage.py document_retagger "$@"
+if [[ -n "${USER_IS_NON_ROOT}" ]]; then
+		python3 manage.py document_retagger "$@"
 elif [[ $(id -un) == "paperless" ]]; then
-	python3 manage.py document_retagger "$@"
-else
-	echo "Unknown user."
+	s6-setuidgid paperless python3 manage.py document_retagger "$@"
 fi

--- a/docker/rootfs/usr/local/bin/document_sanity_checker
+++ b/docker/rootfs/usr/local/bin/document_sanity_checker
@@ -5,10 +5,8 @@ set -e
 
 cd "${PAPERLESS_SRC_DIR}"
 
-if [[ $(id -u) == 0 ]]; then
-	s6-setuidgid paperless python3 manage.py document_sanity_checker "$@"
+if [[ -n "${USER_IS_NON_ROOT}" ]]; then
+		python3 manage.py document_sanity_checker "$@"
 elif [[ $(id -un) == "paperless" ]]; then
-	python3 manage.py document_sanity_checker "$@"
-else
-	echo "Unknown user."
+	s6-setuidgid paperless python3 manage.py document_sanity_checker "$@"
 fi

--- a/docker/rootfs/usr/local/bin/document_thumbnails
+++ b/docker/rootfs/usr/local/bin/document_thumbnails
@@ -5,10 +5,8 @@ set -e
 
 cd "${PAPERLESS_SRC_DIR}"
 
-if [[ $(id -u) == 0 ]]; then
-	s6-setuidgid paperless python3 manage.py document_thumbnails "$@"
+if [[ -n "${USER_IS_NON_ROOT}" ]]; then
+		python3 manage.py document_thumbnails "$@"
 elif [[ $(id -un) == "paperless" ]]; then
-	python3 manage.py document_thumbnails "$@"
-else
-	echo "Unknown user."
+	s6-setuidgid paperless python3 manage.py document_thumbnails "$@"
 fi

--- a/docker/rootfs/usr/local/bin/mail_fetcher
+++ b/docker/rootfs/usr/local/bin/mail_fetcher
@@ -5,10 +5,8 @@ set -e
 
 cd "${PAPERLESS_SRC_DIR}"
 
-if [[ $(id -u) == 0 ]]; then
-	s6-setuidgid paperless python3 manage.py mail_fetcher "$@"
+if [[ -n "${USER_IS_NON_ROOT}" ]]; then
+		python3 manage.py mail_fetcher "$@"
 elif [[ $(id -un) == "paperless" ]]; then
-	python3 manage.py mail_fetcher "$@"
-else
-	echo "Unknown user."
+	s6-setuidgid paperless python3 manage.py mail_fetcher "$@"
 fi

--- a/docker/rootfs/usr/local/bin/manage_superuser
+++ b/docker/rootfs/usr/local/bin/manage_superuser
@@ -5,10 +5,8 @@ set -e
 
 cd "${PAPERLESS_SRC_DIR}"
 
-if [[ $(id -u) == 0 ]]; then
-	s6-setuidgid paperless python3 manage.py manage_superuser "$@"
+if [[ -n "${USER_IS_NON_ROOT}" ]]; then
+		python3 manage.py manage_superuser "$@"
 elif [[ $(id -un) == "paperless" ]]; then
-	python3 manage.py manage_superuser "$@"
-else
-	echo "Unknown user."
+	s6-setuidgid paperless python3 manage.py manage_superuser "$@"
 fi

--- a/docker/rootfs/usr/local/bin/prune_audit_logs
+++ b/docker/rootfs/usr/local/bin/prune_audit_logs
@@ -5,10 +5,8 @@ set -e
 
 cd "${PAPERLESS_SRC_DIR}"
 
-if [[ $(id -u) == 0 ]]; then
-	s6-setuidgid paperless python3 manage.py prune_audit_logs "$@"
+if [[ -n "${USER_IS_NON_ROOT}" ]]; then
+		python3 manage.py prune_audit_logs "$@"
 elif [[ $(id -un) == "paperless" ]]; then
-	python3 manage.py prune_audit_logs "$@"
-else
-	echo "Unknown user."
+	s6-setuidgid paperless python3 manage.py prune_audit_logs "$@"
 fi


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

<!--
⚠️ Important: Pull requests that implement a new feature or enhancement *should almost always target an existing feature request* with evidence of community interest and discussion. This is in order to balance the work of implementing and maintaining new features / enhancements. If that is not currently the case, please open a feature request instead of this PR to gather feedback from both users and the project maintainers.
-->

`elif [[ $(id -un) == "paperless" ]]; then`

That line checks the name of the user against `/etc/passwd`.  But if a user sets some other `user: ` in the YAML, such as `user 999:999`, that user ID doesn't exist in `/etc/passwd`, so it ended up not running the script at all.  We already check and set a flag at startup, so we instead re-use that.

As I told the user, they might be the only person using this functionality.

Closes #11867 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
