### PR TITLE
Enhancement: improve relative dates in date filter

### DIFF
--- a/src-ui/src/app/components/common/dates-dropdown/dates-dropdown.component.html
+++ b/src-ui/src/app/components/common/dates-dropdown/dates-dropdown.component.html
@@ -164,9 +164,11 @@
     {{ item.name }}
     <span class="ms-auto text-muted small">
       @if (item.dateEnd) {
-        {{ item.date | customDate:'MMM d' }} &ndash; {{ item.dateEnd | customDate:'mediumDate' }}
+        {{ item.date | customDate:'mediumDate' }} &ndash; {{ item.dateEnd | customDate:'mediumDate' }}
+      } @else if (item.dateTilNow) {
+        {{ item.dateTilNow | customDate:'mediumDate' }} &ndash; <ng-container i18n>now</ng-container>
       } @else {
-        {{ item.date | customDate:'mediumDate' }} &ndash; <ng-container i18n>now</ng-container>
+        {{ item.date | customDate:'mediumDate' }}
       }
     </span>
   </div>

--- a/src-ui/src/app/components/common/dates-dropdown/dates-dropdown.component.ts
+++ b/src-ui/src/app/components/common/dates-dropdown/dates-dropdown.component.ts
@@ -79,32 +79,34 @@ export class DatesDropdownComponent implements OnInit, OnDestroy {
     {
       id: RelativeDate.WITHIN_1_WEEK,
       name: $localize`Within 1 week`,
-      date: new Date().setDate(new Date().getDate() - 7),
+      dateTilNow: new Date().setDate(new Date().getDate() - 7),
     },
     {
       id: RelativeDate.WITHIN_1_MONTH,
       name: $localize`Within 1 month`,
-      date: new Date().setMonth(new Date().getMonth() - 1),
+      dateTilNow: new Date().setMonth(new Date().getMonth() - 1),
     },
     {
       id: RelativeDate.WITHIN_3_MONTHS,
       name: $localize`Within 3 months`,
-      date: new Date().setMonth(new Date().getMonth() - 3),
+      dateTilNow: new Date().setMonth(new Date().getMonth() - 3),
     },
     {
       id: RelativeDate.WITHIN_1_YEAR,
       name: $localize`Within 1 year`,
-      date: new Date().setFullYear(new Date().getFullYear() - 1),
+      dateTilNow: new Date().setFullYear(new Date().getFullYear() - 1),
     },
     {
       id: RelativeDate.THIS_YEAR,
       name: $localize`This year`,
       date: new Date('1/1/' + new Date().getFullYear()),
+      dateEnd: new Date('12/31/' + new Date().getFullYear()),
     },
     {
       id: RelativeDate.THIS_MONTH,
       name: $localize`This month`,
       date: new Date().setDate(1),
+      dateEnd: new Date(new Date().getFullYear(), new Date().getMonth() + 1, 0),
     },
     {
       id: RelativeDate.TODAY,


### PR DESCRIPTION
The date ranges in the date filter seem a bit inconsistent.

- Date range was hard coded with `MMM d` on the left hand side, which weird in some localizations (date and month switch in the from and to part)
- Yesterday and today are ranges that ends in `- now` (especially weird for yesterday)

This addresses these issues and uses the same date format on both sides. Also for single days it is not displayed as range anymore.

| | iso | german | danish |
| - | - | - | - |
| Before | <img width="70%" alt="image" src="https://github.com/user-attachments/assets/64bb1d0f-a2cb-4cc0-9a43-ff3aa4dbca41" /> | <img width="70%" alt="image" src="https://github.com/user-attachments/assets/2dfdb74b-f02f-4451-8f93-ed9697948273" /> | <img width="70%" alt="image" src="https://github.com/user-attachments/assets/baa3d083-2a0c-4521-a3d1-6a6fdf4028c0" /> |
| After | <img width="70%" alt="image" src="https://github.com/user-attachments/assets/86202ee3-f828-4863-87e8-35d935196c0b" /> | <img width="70%" alt="image" src="https://github.com/user-attachments/assets/309ab63b-86ed-4306-8bd6-0ff7a621143d" /> | <img width="70%" alt="image" src="https://github.com/user-attachments/assets/3998baf4-b749-42a1-98aa-a12a9d653d71" /> |

(Ignore the wrong end date in 'This month', i fixed it bit don't want to retake the screenshots)

It may also make sense to replace `now` with `today` as we only display days not time.

Relates to #11881

No AI was used.

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [x] Other. Please explain: Enhancement

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
