### PR TITLE
Chore: Resolve more flaky tests

### DIFF
--- a/src/documents/tests/test_management_consumer.py
+++ b/src/documents/tests/test_management_consumer.py
@@ -748,7 +748,7 @@ def start_consumer(
         thread = ConsumerThread(consumption_dir, scratch_dir, **kwargs)
         threads.append(thread)
         thread.start()
-        sleep(0.5)  # Give thread time to start
+        sleep(1.0)  # Give thread time to start
         return thread
 
     try:

--- a/src/documents/tests/test_management_consumer.py
+++ b/src/documents/tests/test_management_consumer.py
@@ -894,10 +894,10 @@ class TestCommandWatch:
         assert not thread.is_alive()
 
 
+@pytest.mark.django_db
 class TestCommandWatchPolling:
     """Tests for polling mode."""
 
-    @pytest.mark.django_db
     def test_polling_mode_works(
         self,
         consumption_dir: Path,
@@ -926,6 +926,7 @@ class TestCommandWatchPolling:
         mock_consume_file_delay.delay.assert_called()
 
 
+@pytest.mark.django_db
 class TestCommandWatchRecursive:
     """Tests for recursive watching."""
 

--- a/src/documents/tests/test_management_consumer.py
+++ b/src/documents/tests/test_management_consumer.py
@@ -748,7 +748,7 @@ def start_consumer(
         thread = ConsumerThread(consumption_dir, scratch_dir, **kwargs)
         threads.append(thread)
         thread.start()
-        sleep(1.0)  # Give thread time to start
+        sleep(2.0)  # Give thread time to start
         return thread
 
     try:
@@ -812,6 +812,8 @@ class TestCommandWatch:
         shutil.copy(sample_pdf, temp_location)
 
         thread = start_consumer()
+
+        sleep(0.5)
 
         target = consumption_dir / "document.pdf"
         shutil.move(temp_location, target)


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

<!--
⚠️ Important: Pull requests that implement a new feature or enhancement *should almost always target an existing feature request* with evidence of community interest and discussion. This is in order to balance the work of implementing and maintaining new features / enhancements. If that is not currently the case, please open a feature request instead of this PR to gather feedback from both users and the project maintainers.
-->

Further cleaning up flaky tests we've seen recently.  It's hard to say for sure what worked, but it seems the biggest and best change was giving the consumer thread more time to start.  Without that, it isn't watching by the time the test thread moves a file or writes to a file.  There remains flaky tests in the `test_filters` in the mail.  That might be my next area.  It was the only failure I saw across 4 runs at this commit.  (Now that I've said that, what it fail on the PR run...)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
