### PR TITLE
Enhancement: Add setting for default PDF Editor mode

### DIFF
--- a/src-ui/src/app/components/admin/settings/settings.component.html
+++ b/src-ui/src/app/components/admin/settings/settings.component.html
@@ -274,6 +274,19 @@
                 <pngx-input-check i18n-title title="Enable notes" formControlName="notesEnabled"></pngx-input-check>
               </div>
             </div>
+
+            <h5 class="mt-3" i18n>PDF Editor</h5>
+            <div class="row">
+              <div class="col-md-3 col-form-label pt-0">
+                <span i18n>Default editing mode</span>
+              </div>
+              <div class="col">
+                <select class="form-select" formControlName="pdfEditorDefaultEditMode">
+                  <option [ngValue]="PdfEditorEditMode.Create" i18n>Create new document(s)</option>
+                  <option [ngValue]="PdfEditorEditMode.Update" i18n>Update existing document</option>
+                </select>
+              </div>
+            </div>
           </div>
         </div>
       </ng-template>

--- a/src-ui/src/app/components/admin/settings/settings.component.html
+++ b/src-ui/src/app/components/admin/settings/settings.component.html
@@ -259,19 +259,13 @@
               </div>
             </div>
           </div>
+
           <div class="col-xl-6 ps-xl-5">
             <h5 class="mt-3" i18n>Bulk editing</h5>
             <div class="row mb-3">
               <div class="col">
                 <pngx-input-check i18n-title title="Show confirmation dialogs" formControlName="bulkEditConfirmationDialogs"></pngx-input-check>
                 <pngx-input-check i18n-title title="Apply on close" formControlName="bulkEditApplyOnClose"></pngx-input-check>
-              </div>
-            </div>
-
-            <h5 class="mt-3" i18n>Notes</h5>
-            <div class="row mb-3">
-              <div class="col">
-                <pngx-input-check i18n-title title="Enable notes" formControlName="notesEnabled"></pngx-input-check>
               </div>
             </div>
 
@@ -285,6 +279,13 @@
                   <option [ngValue]="PdfEditorEditMode.Create" i18n>Create new document(s)</option>
                   <option [ngValue]="PdfEditorEditMode.Update" i18n>Update existing document</option>
                 </select>
+              </div>
+            </div>
+
+            <h5 class="mt-3" i18n>Notes</h5>
+            <div class="row mb-3">
+              <div class="col">
+                <pngx-input-check i18n-title title="Enable notes" formControlName="notesEnabled"></pngx-input-check>
               </div>
             </div>
           </div>

--- a/src-ui/src/app/components/admin/settings/settings.component.spec.ts
+++ b/src-ui/src/app/components/admin/settings/settings.component.spec.ts
@@ -251,7 +251,7 @@ describe('SettingsComponent', () => {
     expect(toastErrorSpy).toHaveBeenCalled()
     expect(storeSpy).toHaveBeenCalled()
     expect(appearanceSettingsSpy).not.toHaveBeenCalled()
-    expect(setSpy).toHaveBeenCalledTimes(31)
+    expect(setSpy).toHaveBeenCalledTimes(32)
 
     // succeed
     storeSpy.mockReturnValueOnce(of(true))

--- a/src-ui/src/app/components/admin/settings/settings.component.ts
+++ b/src-ui/src/app/components/admin/settings/settings.component.ts
@@ -64,6 +64,7 @@ import { PermissionsGroupComponent } from '../../common/input/permissions/permis
 import { PermissionsUserComponent } from '../../common/input/permissions/permissions-user/permissions-user.component'
 import { SelectComponent } from '../../common/input/select/select.component'
 import { PageHeaderComponent } from '../../common/page-header/page-header.component'
+import { PdfEditorEditMode } from '../../common/pdf-editor/pdf-editor.component'
 import { SystemStatusDialogComponent } from '../../common/system-status-dialog/system-status-dialog.component'
 import { ZoomSetting } from '../../document-detail/document-detail.component'
 import { ComponentWithPermissions } from '../../with-permissions/with-permissions.component'
@@ -163,6 +164,7 @@ export class SettingsComponent
     defaultPermsEditGroups: new FormControl(null),
     useNativePdfViewer: new FormControl(null),
     pdfViewerDefaultZoom: new FormControl(null),
+    pdfEditorDefaultEditMode: new FormControl(null),
     documentEditingRemoveInboxTags: new FormControl(null),
     documentEditingOverlayThumbnail: new FormControl(null),
     documentDetailsHiddenFields: new FormControl([]),
@@ -195,6 +197,8 @@ export class SettingsComponent
   public readonly GlobalSearchType = GlobalSearchType
 
   public readonly ZoomSetting = ZoomSetting
+
+  public readonly PdfEditorEditMode = PdfEditorEditMode
 
   public readonly documentDetailFieldOptions = documentDetailFieldOptions
 
@@ -313,6 +317,9 @@ export class SettingsComponent
       ),
       pdfViewerDefaultZoom: this.settings.get(
         SETTINGS_KEYS.PDF_VIEWER_ZOOM_SETTING
+      ),
+      pdfEditorDefaultEditMode: this.settings.get(
+        SETTINGS_KEYS.PDF_EDITOR_DEFAULT_EDIT_MODE
       ),
       displayLanguage: this.settings.getLanguage(),
       dateLocale: this.settings.get(SETTINGS_KEYS.DATE_LOCALE),
@@ -482,6 +489,10 @@ export class SettingsComponent
     this.settings.set(
       SETTINGS_KEYS.PDF_VIEWER_ZOOM_SETTING,
       this.settingsForm.value.pdfViewerDefaultZoom
+    )
+    this.settings.set(
+      SETTINGS_KEYS.PDF_EDITOR_DEFAULT_EDIT_MODE,
+      this.settingsForm.value.pdfEditorDefaultEditMode
     )
     this.settings.set(
       SETTINGS_KEYS.DATE_LOCALE,

--- a/src-ui/src/app/components/common/pdf-editor/pdf-editor.component.ts
+++ b/src-ui/src/app/components/common/pdf-editor/pdf-editor.component.ts
@@ -47,11 +47,9 @@ export class PDFEditorComponent extends ConfirmDialogComponent {
   documentID: number
   pages: PageOperation[] = []
   totalPages = 0
-  editMode: PdfEditorEditMode =
-    this.settingsService.get(SETTINGS_KEYS.PDF_EDITOR_DEFAULT_EDIT_MODE) ===
-    PdfEditorEditMode.Update
-      ? PdfEditorEditMode.Update
-      : PdfEditorEditMode.Create
+  editMode: PdfEditorEditMode = this.settingsService.get(
+    SETTINGS_KEYS.PDF_EDITOR_DEFAULT_EDIT_MODE
+  )
   deleteOriginal: boolean = false
   includeMetadata: boolean = true
 

--- a/src-ui/src/app/components/common/pdf-editor/pdf-editor.component.ts
+++ b/src-ui/src/app/components/common/pdf-editor/pdf-editor.component.ts
@@ -41,7 +41,7 @@ export class PDFEditorComponent extends ConfirmDialogComponent {
   public PdfEditorEditMode = PdfEditorEditMode
 
   private documentService = inject(DocumentService)
-  private settingsService = inject(SettingsService)
+  private readonly settingsService = inject(SettingsService)
   activeModal: NgbActiveModal = inject(NgbActiveModal)
 
   documentID: number

--- a/src-ui/src/app/components/common/pdf-editor/pdf-editor.component.ts
+++ b/src-ui/src/app/components/common/pdf-editor/pdf-editor.component.ts
@@ -8,7 +8,9 @@ import { FormsModule } from '@angular/forms'
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap'
 import { PDFDocumentProxy, PdfViewerModule } from 'ng2-pdf-viewer'
 import { NgxBootstrapIconsModule } from 'ngx-bootstrap-icons'
+import { SETTINGS_KEYS } from 'src/app/data/ui-settings'
 import { DocumentService } from 'src/app/services/rest/document.service'
+import { SettingsService } from 'src/app/services/settings.service'
 import { ConfirmDialogComponent } from '../confirm-dialog/confirm-dialog.component'
 
 interface PageOperation {
@@ -39,12 +41,17 @@ export class PDFEditorComponent extends ConfirmDialogComponent {
   public PdfEditorEditMode = PdfEditorEditMode
 
   private documentService = inject(DocumentService)
+  private settingsService = inject(SettingsService)
   activeModal: NgbActiveModal = inject(NgbActiveModal)
 
   documentID: number
   pages: PageOperation[] = []
   totalPages = 0
-  editMode: PdfEditorEditMode = PdfEditorEditMode.Create
+  editMode: PdfEditorEditMode =
+    this.settingsService.get(SETTINGS_KEYS.PDF_EDITOR_DEFAULT_EDIT_MODE) ===
+    PdfEditorEditMode.Update
+      ? PdfEditorEditMode.Update
+      : PdfEditorEditMode.Create
   deleteOriginal: boolean = false
   includeMetadata: boolean = true
 

--- a/src-ui/src/app/data/ui-settings.ts
+++ b/src-ui/src/app/data/ui-settings.ts
@@ -1,4 +1,3 @@
-import { PdfEditorEditMode } from '../components/common/pdf-editor/pdf-editor.component'
 import { User } from './user'
 
 export interface UiSettings {
@@ -308,6 +307,6 @@ export const SETTINGS: UiSetting[] = [
   {
     key: SETTINGS_KEYS.PDF_EDITOR_DEFAULT_EDIT_MODE,
     type: 'string',
-    default: PdfEditorEditMode.Create,
+    default: 'create', // PdfEditorEditMode.Create from 'pdf-editor.component'
   },
 ]

--- a/src-ui/src/app/data/ui-settings.ts
+++ b/src-ui/src/app/data/ui-settings.ts
@@ -1,3 +1,4 @@
+import { PdfEditorEditMode } from '../components/common/pdf-editor/pdf-editor.component'
 import { User } from './user'
 
 export interface UiSettings {
@@ -74,12 +75,13 @@ export const SETTINGS_KEYS = {
     'general-settings:document-details:hidden-fields',
   SEARCH_DB_ONLY: 'general-settings:search:db-only',
   SEARCH_FULL_TYPE: 'general-settings:search:more-link',
+  PDF_EDITOR_DEFAULT_EDIT_MODE:
+    'general-settings:document-editing:default-edit-mode',
   EMPTY_TRASH_DELAY: 'trash_delay',
   GMAIL_OAUTH_URL: 'gmail_oauth_url',
   OUTLOOK_OAUTH_URL: 'outlook_oauth_url',
   EMAIL_ENABLED: 'email_enabled',
   AI_ENABLED: 'ai_enabled',
-  PDF_EDITOR_DEFAULT_EDIT_MODE: 'general-settings:pdf-editor:default-edit-mode',
 }
 
 export const SETTINGS: UiSetting[] = [
@@ -306,6 +308,6 @@ export const SETTINGS: UiSetting[] = [
   {
     key: SETTINGS_KEYS.PDF_EDITOR_DEFAULT_EDIT_MODE,
     type: 'string',
-    default: 'create', // PdfEditorEditMode.Create from 'pdf-editor.component'
+    default: PdfEditorEditMode.Create,
   },
 ]

--- a/src-ui/src/app/data/ui-settings.ts
+++ b/src-ui/src/app/data/ui-settings.ts
@@ -79,6 +79,7 @@ export const SETTINGS_KEYS = {
   OUTLOOK_OAUTH_URL: 'outlook_oauth_url',
   EMAIL_ENABLED: 'email_enabled',
   AI_ENABLED: 'ai_enabled',
+  PDF_EDITOR_DEFAULT_EDIT_MODE: 'general-settings:pdf-editor:default-edit-mode',
 }
 
 export const SETTINGS: UiSetting[] = [
@@ -301,5 +302,10 @@ export const SETTINGS: UiSetting[] = [
     key: SETTINGS_KEYS.AI_ENABLED,
     type: 'boolean',
     default: false,
+  },
+  {
+    key: SETTINGS_KEYS.PDF_EDITOR_DEFAULT_EDIT_MODE,
+    type: 'string',
+    default: 'create', // PdfEditorEditMode.Create from 'pdf-editor.component'
   },
 ]


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

This adds a setting that allows selecting the default edit mode of the PDF Editor. The default value of the setting is "Create new Document(s)".

It only changes the initial selection when opening the PDF Editor. All other behavior (e.g. automatically changing back to "Create" when splitting a document) is unchanged.

<img width="1217" height="720" alt="image" src="https://github.com/user-attachments/assets/f6fc55ba-a4c8-4dbd-853d-7a742fb57cda" />

I used Claude Code.

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

<!--
⚠️ Important: Pull requests that implement a new feature or enhancement *should almost always target an existing feature request* with evidence of community interest and discussion. This is in order to balance the work of implementing and maintaining new features / enhancements. If that is not currently the case, please open a feature request instead of this PR to gather feedback from both users and the project maintainers.
-->

Closes #10608

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [x] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
