### PR TITLE
Enhancement: per-type object page sizing

### DIFF
--- a/src-ui/src/app/components/common/page-header/page-header.component.html
+++ b/src-ui/src/app/components/common/page-header/page-header.component.html
@@ -15,7 +15,7 @@
         <span class="h6 mb-0 mt-1 d-block d-md-inline fw-normal ms-md-3 text-truncate" style="line-height: 1.4">{{subTitle}}</span>
       }
       @if (info) {
-        <button class="btn btn-sm btn-link text-muted me-auto p-0 p-md-2" title="What's this?" i18n-title type="button" [ngbPopover]="infoPopover" [autoClose]="true">
+        <button class="btn btn-sm btn-link text-muted p-0 p-md-2" title="What's this?" i18n-title type="button" [ngbPopover]="infoPopover" [autoClose]="true">
           <i-bs name="question-circle"></i-bs>
         </button>
         <ng-template #infoPopover>
@@ -25,6 +25,9 @@
             <i-bs class="ms-1" width=".8em" height=".8em" name="box-arrow-up-right"></i-bs>
           }
         </ng-template>
+      }
+      @if (loading) {
+        <output class="spinner-border spinner-border-sm fs-6 fw-normal" aria-hidden="true"><span class="visually-hidden" i18n>Loading...</span></output>
       }
     </h3>
   </div>

--- a/src-ui/src/app/components/common/page-header/page-header.component.ts
+++ b/src-ui/src/app/components/common/page-header/page-header.component.ts
@@ -42,6 +42,9 @@ export class PageHeaderComponent {
   @Input()
   infoLink: string
 
+  @Input()
+  loading: boolean = false
+
   public copyID() {
     this.copied = this.clipboard.copy(this.id.toString())
     clearTimeout(this.copyTimeout)

--- a/src-ui/src/app/components/manage/management-list/management-list.component.html
+++ b/src-ui/src/app/components/manage/management-list/management-list.component.html
@@ -1,4 +1,4 @@
-<pngx-page-header title="{{ typeNamePlural | titlecase }}" info="View, add, edit and delete {{ typeNamePlural }}." infoLink="usage/#terms-and-definitions">
+<pngx-page-header title="{{ typeNamePlural | titlecase }}" info="View, add, edit and delete {{ typeNamePlural }}." infoLink="usage/#terms-and-definitions" [loading]="loading">
 
   <div ngbDropdown class="btn-group flex-fill d-sm-none">
     <button class="btn btn-sm btn-outline-primary" id="dropdownSelectMobile" ngbDropdownToggle>
@@ -92,7 +92,7 @@
       </tr>
     </thead>
     <tbody>
-      @if (loading) {
+      @if (loading && data.length === 0) {
         <tr>
           <td colspan="5">
             <div class="spinner-border spinner-border-sm me-2" role="status"></div>
@@ -107,7 +107,7 @@
   </table>
 </div>
 
-@if (!loading) {
+@if (!loading || data.length > 0) {
   <div class="d-flex mb-2">
     @if (collectionSize > 0) {
       <div>

--- a/src-ui/src/app/components/manage/management-list/management-list.component.html
+++ b/src-ui/src/app/components/manage/management-list/management-list.component.html
@@ -59,7 +59,7 @@
         <span class="input-group-text border-0" i18n>Show:</span>
       </div>
       <div class="input-group input-group-sm w-auto me-3">
-        <select class="form-select form-select-sm" [(ngModel)]="pageSize">
+        <select class="form-select form-select-sm small" [(ngModel)]="pageSize">
           <option [ngValue]="25">25</option>
           <option [ngValue]="50">50</option>
           <option [ngValue]="100">100</option>

--- a/src-ui/src/app/components/manage/management-list/management-list.component.html
+++ b/src-ui/src/app/components/manage/management-list/management-list.component.html
@@ -46,14 +46,30 @@
 </pngx-page-header>
 
 <div class="row mb-3">
-  <div class="col-md mb-2 mb-xl-0">
+  <div class="col mb-2 mb-xl-0">
     <div class="form-inline d-flex align-items-center">
       <label class="text-muted me-2 mb-0" i18n>Filter by:</label>
       <input class="form-control form-control-sm flex-fill w-auto" type="text" autofocus [(ngModel)]="nameFilter" (keyup)="onNameFilterKeyUp($event)" placeholder="Name" i18n-placeholder>
     </div>
   </div>
 
-  <ngb-pagination class="col-auto" [pageSize]="25" [collectionSize]="collectionSize" [(page)]="page" [maxSize]="5" (pageChange)="reloadData()" size="sm" aria-label="Pagination"></ngb-pagination>
+  <div class="col-auto mb-2 mb-xl-0">
+    <div class="form-inline d-flex align-items-center">
+      <div class="input-group input-group-sm w-auto d-none d-md-flex">
+        <span class="input-group-text border-0" i18n>Show:</span>
+      </div>
+      <div class="input-group input-group-sm w-auto me-3">
+        <select class="form-select form-select-sm" [(ngModel)]="pageSize">
+          <option [ngValue]="25">25</option>
+          <option [ngValue]="50">50</option>
+          <option [ngValue]="100">100</option>
+        </select>
+        <span class="input-group-text text-muted d-none d-md-flex" i18n>per page</span>
+      </div>
+      <ngb-pagination [pageSize]="pageSize" [collectionSize]="collectionSize" [(page)]="page" [maxSize]="5" (pageChange)="reloadData()" size="sm" aria-label="Pagination"></ngb-pagination>
+    </div>
+  </div>
+
 </div>
 
 <div class="card border table-responsive mb-3">
@@ -102,7 +118,7 @@
       </div>
     }
     @if (collectionSize > 20) {
-      <ngb-pagination class="ms-auto" [pageSize]="25" [collectionSize]="collectionSize" [(page)]="page" [maxSize]="5" (pageChange)="reloadData()" size="sm" aria-label="Pagination"></ngb-pagination>
+      <ngb-pagination class="ms-auto" [pageSize]="pageSize" [collectionSize]="collectionSize" [(page)]="page" [maxSize]="5" (pageChange)="reloadData()" size="sm" aria-label="Pagination"></ngb-pagination>
     }
   </div>
 }

--- a/src-ui/src/app/components/manage/management-list/management-list.component.scss
+++ b/src-ui/src/app/components/manage/management-list/management-list.component.scss
@@ -24,3 +24,7 @@ td.name-cell {
         margin-left: .5rem;
     }
 }
+
+select.small {
+    font-size: 0.875rem !important; // 14px
+}

--- a/src-ui/src/app/components/manage/management-list/management-list.component.ts
+++ b/src-ui/src/app/components/manage/management-list/management-list.component.ts
@@ -82,7 +82,7 @@ export abstract class ManagementListComponent<T extends MatchingModel>
   public permissionType: PermissionType
   public extraColumns: ManagementListColumn[]
 
-  private settingsService = inject(SettingsService)
+  private readonly settingsService = inject(SettingsService)
 
   @ViewChildren(SortableDirective) headers: QueryList<SortableDirective>
 

--- a/src-ui/src/app/components/manage/management-list/management-list.component.ts
+++ b/src-ui/src/app/components/manage/management-list/management-list.component.ts
@@ -23,6 +23,7 @@ import {
   MatchingModel,
 } from 'src/app/data/matching-model'
 import { ObjectWithPermissions } from 'src/app/data/object-with-permissions'
+import { SETTINGS_KEYS } from 'src/app/data/ui-settings'
 import {
   SortableDirective,
   SortEvent,
@@ -37,6 +38,7 @@ import {
   AbstractNameFilterService,
   BulkEditObjectOperation,
 } from 'src/app/services/rest/abstract-name-filter-service'
+import { SettingsService } from 'src/app/services/settings.service'
 import { ToastService } from 'src/app/services/toast.service'
 import { ConfirmDialogComponent } from '../../common/confirm-dialog/confirm-dialog.component'
 import { EditDialogMode } from '../../common/edit-dialog/edit-dialog.component'
@@ -79,6 +81,8 @@ export abstract class ManagementListComponent<T extends MatchingModel>
   public typeNamePlural: string
   public permissionType: PermissionType
   public extraColumns: ManagementListColumn[]
+
+  private settingsService = inject(SettingsService)
 
   @ViewChildren(SortableDirective) headers: QueryList<SortableDirective>
 
@@ -160,7 +164,7 @@ export abstract class ManagementListComponent<T extends MatchingModel>
     this.service
       .listFiltered(
         this.page,
-        null,
+        this.pageSize,
         this.sortField,
         this.sortReverse,
         this._nameFilter,
@@ -278,6 +282,30 @@ export abstract class ManagementListComponent<T extends MatchingModel>
 
   onNameFilterKeyUp(event: KeyboardEvent) {
     if (event.code == 'Escape') this.nameFilterDebounce.next(null)
+  }
+
+  public get pageSize(): number {
+    return (
+      this.settingsService.get(SETTINGS_KEYS.OBJECT_LIST_SIZES)[
+        this.typeNamePlural
+      ] || 25
+    )
+  }
+
+  public set pageSize(newPageSize: number) {
+    this.settingsService.set(SETTINGS_KEYS.OBJECT_LIST_SIZES, {
+      ...this.settingsService.get(SETTINGS_KEYS.OBJECT_LIST_SIZES),
+      [this.typeNamePlural]: newPageSize,
+    })
+    this.settingsService.storeSettings().subscribe({
+      next: () => {
+        this.page = 1
+        this.reloadData()
+      },
+      error: (error) => {
+        this.toastService.showError($localize`Error saving settings`, error)
+      },
+    })
   }
 
   userCanDelete(object: ObjectWithPermissions): boolean {

--- a/src-ui/src/app/components/manage/tag-list/tag-list.component.spec.ts
+++ b/src-ui/src/app/components/manage/tag-list/tag-list.component.spec.ts
@@ -101,7 +101,7 @@ describe('TagListComponent', () => {
   it('should request only parent tags when no name filter is applied', () => {
     expect(tagService.listFiltered).toHaveBeenCalledWith(
       1,
-      null,
+      25,
       undefined,
       undefined,
       undefined,
@@ -116,7 +116,7 @@ describe('TagListComponent', () => {
     component.reloadData()
     expect(tagService.listFiltered).toHaveBeenCalledWith(
       1,
-      null,
+      25,
       undefined,
       undefined,
       'Tag',

--- a/src-ui/src/app/data/ui-settings.ts
+++ b/src-ui/src/app/data/ui-settings.ts
@@ -63,6 +63,7 @@ export const SETTINGS_KEYS = {
   SIDEBAR_VIEWS_SHOW_COUNT:
     'general-settings:saved-views:sidebar-views-show-count',
   TOUR_COMPLETE: 'general-settings:tour-complete',
+  OBJECT_LIST_SIZES: 'general-settings:object-list-sizes',
   DEFAULT_PERMS_OWNER: 'general-settings:permissions:default-owner',
   DEFAULT_PERMS_VIEW_USERS: 'general-settings:permissions:default-view-users',
   DEFAULT_PERMS_VIEW_GROUPS: 'general-settings:permissions:default-view-groups',
@@ -200,6 +201,16 @@ export const SETTINGS: UiSetting[] = [
     key: SETTINGS_KEYS.TOUR_COMPLETE,
     type: 'boolean',
     default: false,
+  },
+  {
+    key: SETTINGS_KEYS.OBJECT_LIST_SIZES,
+    type: 'object',
+    default: {
+      correspondents: 25,
+      document_types: 25,
+      tags: 25,
+      storage_paths: 25,
+    },
   },
   {
     key: SETTINGS_KEYS.DEFAULT_PERMS_OWNER,


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

As a reminder, the (now moved) setting has only ever applied to documents. Will likely replicate this on the document list at some point but real estate is much tighter there.

<img width="2044" height="1162" alt="Screenshot 2026-02-02 at 8 51 08 AM" src="https://github.com/user-attachments/assets/f734fefe-614b-4970-8470-2a8de7c7c800" />

Closes #11829
Closes #9501
(others, I think)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [x] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
