### PR TITLE
Enhancement: add confidence threshold for correspondent auto-classification

### DIFF
--- a/src/documents/classifier.py
+++ b/src/documents/classifier.py
@@ -494,6 +494,14 @@ class DocumentClassifier:
     def predict_correspondent(self, content: str) -> int | None:
         if self.correspondent_classifier:
             X = self._vectorize(content)
+            threshold = settings.CLASSIFIER_CONFIDENCE_THRESHOLD
+            if threshold > 0.0:
+                proba = self.correspondent_classifier.predict_proba(X)[0]
+                max_idx = proba.argmax()
+                predicted_class = int(self.correspondent_classifier.classes_[max_idx])
+                if predicted_class != -1 and float(proba[max_idx]) >= threshold:
+                    return predicted_class
+                return None
             correspondent_id = self.correspondent_classifier.predict(X)
             if correspondent_id != -1:
                 return correspondent_id

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -311,6 +311,10 @@ MODEL_FILE = __get_path(
     "PAPERLESS_MODEL_FILE",
     DATA_DIR / "classification_model.pickle",
 )
+CLASSIFIER_CONFIDENCE_THRESHOLD: Final[float] = __get_float(
+    "PAPERLESS_CLASSIFIER_CONFIDENCE_THRESHOLD",
+    0.0,
+)
 LLM_INDEX_DIR = DATA_DIR / "llm_index"
 
 LOGGING_DIR = __get_path("PAPERLESS_LOGGING_DIR", DATA_DIR / "log")


### PR DESCRIPTION
## Summary

The ML classifier always assigns a correspondent regardless of prediction confidence, leading to frequent misclassifications with small training datasets.

This adds `PAPERLESS_CLASSIFIER_CONFIDENCE_THRESHOLD` (0.0–1.0) which uses `predict_proba()` to only accept correspondent predictions above the configured confidence. Default is 0.0 (disabled, original behavior).

## Changes

- **`src/documents/classifier.py`**: Update `predict_correspondent` to use `predict_proba()` when threshold is set
- **`src/paperless/settings.py`**: Add `CLASSIFIER_CONFIDENCE_THRESHOLD` setting
- **`src/documents/tests/test_classifier.py`**: Add tests for threshold behavior

## Usage

```env
PAPERLESS_CLASSIFIER_CONFIDENCE_THRESHOLD=0.85
```