### PR TITLE
Fix: Handle an OOM kill of celery workers in the task handler

### DIFF
--- a/src/documents/parsers.py
+++ b/src/documents/parsers.py
@@ -150,7 +150,15 @@ def run_convert(
 ) -> None:
     environment = os.environ.copy()
     if settings.CONVERT_MEMORY_LIMIT:
+        # MAGICK_MEMORY_LIMIT sets the maximum amount of RAM the pixel cache can use.
+        # MAGICK_MAP_LIMIT sets the maximum amount of memory-mapped I/O allowed.
+        #
+        # For large-format documents  ImageMagick will hit the RAM limit and
+        # immediately try to "map" the remaining data. If MAGICK_MAP_LIMIT isn't
+        # also set, the process may trigger an OOM kill because the default
+        # system/policy map limit is often too restrictive for these massive bitmaps.
         environment["MAGICK_MEMORY_LIMIT"] = settings.CONVERT_MEMORY_LIMIT
+        environment["MAGICK_MAP_LIMIT"] = settings.CONVERT_MEMORY_LIMIT
     if settings.CONVERT_TMPDIR:
         environment["MAGICK_TMPDIR"] = settings.CONVERT_TMPDIR
 

--- a/src/documents/signals/handlers.py
+++ b/src/documents/signals/handlers.py
@@ -936,7 +936,7 @@ def task_postrun_handler(
         task_instance = PaperlessTask.objects.filter(task_id=task_id).first()
 
         if task_instance is not None:
-            task_instance.status = state
+            task_instance.status = state or states.FAILURE
             task_instance.result = retval
             task_instance.date_done = timezone.now()
             task_instance.save()


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

<!--
⚠️ Important: Pull requests that implement a new feature or enhancement *should almost always target an existing feature request* with evidence of community interest and discussion. This is in order to balance the work of implementing and maintaining new features / enhancements. If that is not currently the case, please open a feature request instead of this PR to gather feedback from both users and the project maintainers.
-->

It seems when the OOM killer or other external source kills a worker, the provided state is `None`.  So assume it failed so we don't crash.

Per an LLM suggestion too, set `MAGICK_MAP_LIMIT` to match the convert memory limit, which in theory also helps with convert's memory usage.

Closes #12037 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
