### PR TITLE
Fix: consistent elements in user dropdown

### DIFF
--- a/src-ui/src/app/components/app-frame/app-frame.component.html
+++ b/src-ui/src/app/components/app-frame/app-frame.component.html
@@ -46,9 +46,9 @@
           <p class="small mb-0 px-3 text-muted" i18n>Logged in as {{this.settingsService.displayName}}</p>
           <div class="dropdown-divider"></div>
         </div>
-        <button ngbDropdownItem class="nav-link" (click)="editProfile()">
+        <a ngbDropdownItem class="nav-link" (click)="editProfile()">
           <i-bs class="me-2" name="person"></i-bs><ng-container i18n>My Profile</ng-container>
-        </button>
+        </a>
         <a ngbDropdownItem class="nav-link" routerLink="settings" (click)="closeMenu()"
           *pngxIfPermissions="{ action: PermissionAction.Change, type: PermissionType.UISettings }">
           <i-bs class="me-2" name="gear"></i-bs><ng-container i18n>Settings</ng-container>


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

<!--
⚠️ Important: Pull requests that implement a new feature or enhancement *should almost always target an existing feature request* with evidence of community interest and discussion. This is in order to balance the work of implementing and maintaining new features / enhancements. If that is not currently the case, please open a feature request instead of this PR to gather feedback from both users and the project maintainers.
-->

I was wondering why the gear icon on the left sidebar is black, while the one in the user dropdown is grey:
<img width="173" height="141" alt="image" src="https://github.com/user-attachments/assets/0a949878-656b-4ac3-b862-576cfb5db719" /> <img width="187" height="239" alt="image" src="https://github.com/user-attachments/assets/eb8dd433-2624-454f-ac0d-2a0ae4ab2274" />
Then I realized, that the icons within the same user dropdown don't even share the same color.
The profile icon is black, while the other three are grey.

When looking at the code, the first is a button element, and the others are link elements.
I can only assume this has grown and diverged over time when more options got added, and is not there for a reason - hence matching all options again within the user dropdown.
This would also explain why the extra space was there for the first option (linking #7963) but not the others.
The [sidebar uses link elements too](https://github.com/paperless-ngx/paperless-ngx/blob/56d1b5677a2ebbe13bdfbb02fb0836e233ccb4dd/src-ui/src/app/components/app-frame/app-frame.component.html#L273-L277), but the context there is different which is likely the reason that icons are black there vs. grey in the dropdown. Did not look further into that.

With this proposed change, the code is uniform and all icons in the dropdown look the same again. They would still be grey vs. black in the sidebar.

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [x] Other. Please explain: Cleanup

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
