### PR TITLE
Enhancement: add Apple iWork file support via Tika

### DIFF
--- a/src/paperless_tika/signals.py
+++ b/src/paperless_tika/signals.py
@@ -21,5 +21,8 @@ def tika_consumer_declaration(sender, **kwargs):
             "application/vnd.oasis.opendocument.text": ".odt",
             "application/vnd.oasis.opendocument.graphics": ".odg",
             "text/rtf": ".rtf",
+            "application/vnd.apple.pages": ".pages",
+            "application/vnd.apple.numbers": ".numbers",
+            "application/vnd.apple.keynote": ".key",
         },
     }


### PR DESCRIPTION
## Proposed change

Add support for Apple iWork files (Pages, Numbers, Keynote) to the Tika integration by registering
three MIME types in the `tika_consumer_declaration` signal handler:

| MIME type | Extension | Application |
|---|---|---|
| `application/vnd.apple.pages` | `.pages` | Pages (word processing) |
| `application/vnd.apple.numbers` | `.numbers` | Numbers (spreadsheets) |
| `application/vnd.apple.keynote` | `.key` | Keynote (presentations) |

No new parser code is needed — Apache Tika already handles these formats via its
[IWorkPackageParser](https://tika.apache.org/2.9.2/api/org/apache/tika/parser/iwork/IWorkPackageParser.html),
and Gotenberg converts them to PDF. This change simply makes paperless-ngx aware of the file types
so they are picked up by the consumer.

Closes https://github.com/paperless-ngx/paperless-ngx/discussions/8074
Closes https://github.com/paperless-ngx/paperless-ngx/discussions/10610

## Type of change

- [x] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.

**AI disclosure:** This PR was prepared with the assistance of Claude Code (Anthropic). The change itself is a three-line addition to a dictionary literal.