### PR TITLE
Documentation: clarify behaviour around document splitting

### DIFF
--- a/docs/advanced_usage.md
+++ b/docs/advanced_usage.md
@@ -784,9 +784,17 @@ below.
 
 ### Document Splitting {#document-splitting}
 
-When enabled, Paperless will look for a barcode with the configured value and create a new document
-starting from the next page. The page with the barcode on it will _not_ be retained. It
-is expected to be a page existing only for triggering the split.
+There are multiple configuration options resulting in a consumed document being split.
+By default, no document splitting is enabled. When enabled, Paperless will look for a barcode
+with the configured value and create a new document starting from the next page. 
+The page with the barcode on it will _not_ be retained. It is expected to be a page existing
+only for triggering the split.
+
+This behaviour can be altered by configuring Paperless to retain the page containing the 
+separation barcode. In this case, Paperless will start a new document whenever a page
+containing the barcode with the configured value is detected. In other words, it
+is expected for the first page of each document to contain the barcode, similar to the ASN
+based document splitting explained below.
 
 ### Archive Serial Number Assignment
 
@@ -795,8 +803,10 @@ archive serial number, allowing quick reference back to the original, paper docu
 
 If document splitting via barcode is also enabled, documents will be split when an ASN
 barcode is located. However, differing from the splitting, the page with the
-barcode _will_ be retained. This allows application of a barcode to any page, including
-one which holds data to keep in the document.
+barcode _will_ be retained. Each time a ASN barcode is detected, Paperless will split
+the document and create a new document starting with the page containing the barcode.
+This allows application of a barcode to any page, including one which holds data to
+keep in the document.
 
 ### Tag Assignment
 

--- a/docs/advanced_usage.md
+++ b/docs/advanced_usage.md
@@ -784,17 +784,17 @@ below.
 
 ### Document Splitting {#document-splitting}
 
-There are multiple configuration options resulting in a consumed document being split.
-By default, no document splitting is enabled. When enabled, Paperless will look for a barcode
-with the configured value and create a new document starting from the next page.
-The page with the barcode on it will _not_ be retained. It is expected to be a page existing
-only for triggering the split.
+If document splitting is enabled, Paperless splits *after* a separator barcode by default.
+This means:
 
-This behaviour can be altered by configuring Paperless to retain the page containing the
-separation barcode. In this case, Paperless will start a new document whenever a page
-containing the barcode with the configured value is detected. In other words, it
-is expected for the first page of each document to contain the barcode, similar to the ASN
-based document splitting explained below.
+-   any page containing the configured separator barcode starts a new document, starting with the **next** page
+-   pages containing the separator barcode are discarded
+
+This is intended for dedicated separator sheets such as PATCH-T pages.
+
+If [`PAPERLESS_CONSUMER_BARCODE_RETAIN_SPLIT_PAGES`](configuration.md#PAPERLESS_CONSUMER_BARCODE_RETAIN_SPLIT_PAGES)
+is enabled, the page containing the separator barcode is retained instead. In this mode,
+each page containing the separator barcode becomes the **first** page of a new document.
 
 ### Archive Serial Number Assignment
 
@@ -803,10 +803,9 @@ archive serial number, allowing quick reference back to the original, paper docu
 
 If document splitting via barcode is also enabled, documents will be split when an ASN
 barcode is located. However, differing from the splitting, the page with the
-barcode _will_ be retained. Each time a ASN barcode is detected, Paperless will split
-the document and create a new document starting with the page containing the barcode.
-This allows application of a barcode to any page, including one which holds data to
-keep in the document.
+barcode _will_ be retained. Each detected ASN barcode starts a new document *starting with
+that page*. This allows placing ASN barcodes on content pages that should remain part of
+the document.
 
 ### Tag Assignment
 

--- a/docs/advanced_usage.md
+++ b/docs/advanced_usage.md
@@ -786,11 +786,11 @@ below.
 
 There are multiple configuration options resulting in a consumed document being split.
 By default, no document splitting is enabled. When enabled, Paperless will look for a barcode
-with the configured value and create a new document starting from the next page. 
+with the configured value and create a new document starting from the next page.
 The page with the barcode on it will _not_ be retained. It is expected to be a page existing
 only for triggering the split.
 
-This behaviour can be altered by configuring Paperless to retain the page containing the 
+This behaviour can be altered by configuring Paperless to retain the page containing the
 separation barcode. In this case, Paperless will start a new document whenever a page
 containing the barcode with the configured value is detected. In other words, it
 is expected for the first page of each document to contain the barcode, similar to the ASN

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1441,6 +1441,10 @@ change this.
 #### [`PAPERLESS_CONSUMER_BARCODE_RETAIN_SPLIT_PAGES=<bool>`](#PAPERLESS_CONSUMER_BARCODE_RETAIN_SPLIT_PAGES) {#PAPERLESS_CONSUMER_BARCODE_RETAIN_SPLIT_PAGES}
 
 : If set to true, all pages that are split by a barcode (such as PATCHT) will be kept.
+  
+    Note that this setting will alter default splitting behaviour - please refer
+    to the [advanced usage documentation - barcode section](advanced_usage.md#barcodes)
+    for more details.
 
     Defaults to false.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1441,7 +1441,7 @@ change this.
 #### [`PAPERLESS_CONSUMER_BARCODE_RETAIN_SPLIT_PAGES=<bool>`](#PAPERLESS_CONSUMER_BARCODE_RETAIN_SPLIT_PAGES) {#PAPERLESS_CONSUMER_BARCODE_RETAIN_SPLIT_PAGES}
 
 : If set to true, all pages that are split by a barcode (such as PATCHT) will be kept.
-  
+
     Note that this setting will alter default splitting behaviour - please refer
     to the [advanced usage documentation - barcode section](advanced_usage.md#barcodes)
     for more details.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1442,10 +1442,6 @@ change this.
 
 : If set to true, all pages that are split by a barcode (such as PATCHT) will be kept.
 
-    Note that this setting will alter default splitting behaviour - please refer
-    to the [advanced usage documentation - barcode section](advanced_usage.md#barcodes)
-    for more details.
-
     Defaults to false.
 
 #### [`PAPERLESS_CONSUMER_ENABLE_ASN_BARCODE=<bool>`](#PAPERLESS_CONSUMER_ENABLE_ASN_BARCODE) {#PAPERLESS_CONSUMER_ENABLE_ASN_BARCODE}


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

This PR aims to enhance the documentation by providing more clarify about document splitting behavior in various scenarios. #7912 for example has introduced the ability to retain barcode split pages, but this rendered the documentation to no longer be accurate.

Previous split pages were removed, starting a new document being created **after** this page. When setting `PAPERLESS_CONSUMER_BARCODE_RETAIN_SPLIT_PAGES` to `true`, this behavior is changed, PATCH-T Barcodes no behave similar to ASN codes, creating a new document with the page containing the QR code as the first page (so split happens **before** the page containing the code).

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

<!--
⚠️ Important: Pull requests that implement a new feature or enhancement *should almost always target an existing feature request* with evidence of community interest and discussion. This is in order to balance the work of implementing and maintaining new features / enhancements. If that is not currently the case, please open a feature request instead of this PR to gather feedback from both users and the project maintainers.
-->

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [X] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [X] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [X] I have made corresponding changes to the documentation as needed.
- [ ] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
