### PR TITLE
Enhancement: prevent duplicate mail processing across rules

### DIFF
--- a/.mypy-baseline.txt
+++ b/.mypy-baseline.txt
@@ -2118,7 +2118,6 @@ src/paperless_mail/mail.py:0: error: Function is missing a return type annotatio
 src/paperless_mail/mail.py:0: error: Function is missing a return type annotation  [no-untyped-def]
 src/paperless_mail/mail.py:0: error: Function is missing a return type annotation  [no-untyped-def]
 src/paperless_mail/mail.py:0: error: Function is missing a return type annotation  [no-untyped-def]
-src/paperless_mail/mail.py:0: error: Function is missing a return type annotation  [no-untyped-def]
 src/paperless_mail/mail.py:0: error: Function is missing a type annotation for one or more arguments  [no-untyped-def]
 src/paperless_mail/mail.py:0: error: Function is missing a type annotation for one or more arguments  [no-untyped-def]
 src/paperless_mail/mail.py:0: error: Function is missing a type annotation for one or more arguments  [no-untyped-def]

--- a/src/paperless_mail/mail.py
+++ b/src/paperless_mail/mail.py
@@ -536,7 +536,7 @@ class MailAccountHandler(LoggingMixin):
         self.log.debug(f"Processing mail account {account}")
 
         total_processed_files = 0
-        consumed_messages: set[tuple[str, str]] = set()
+        consumed_messages: set[tuple[str, str | None]] = set()
         try:
             with get_mailbox(
                 account.imap_server,
@@ -607,8 +607,8 @@ class MailAccountHandler(LoggingMixin):
         rule: MailRule,
         *,
         supports_gmail_labels: bool,
-        consumed_messages: set[tuple[str, str]],
-    ):
+        consumed_messages: set[tuple[str, str | None]],
+    ) -> int:
         folders = [rule.folder]
         # In case of MOVE, make sure also the destination exists
         if rule.action == MailRule.MailAction.MOVE:
@@ -655,7 +655,7 @@ class MailAccountHandler(LoggingMixin):
 
         mails_processed = 0
         total_processed_files = 0
-        rule_seen_messages: set[tuple[str, str]] = set()
+        rule_seen_messages: set[tuple[str, str | None]] = set()
 
         for message in messages:
             if TYPE_CHECKING:

--- a/src/paperless_mail/mail.py
+++ b/src/paperless_mail/mail.py
@@ -536,6 +536,7 @@ class MailAccountHandler(LoggingMixin):
         self.log.debug(f"Processing mail account {account}")
 
         total_processed_files = 0
+        consumed_messages: set[tuple[str, str]] = set()
         try:
             with get_mailbox(
                 account.imap_server,
@@ -574,6 +575,7 @@ class MailAccountHandler(LoggingMixin):
                             M,
                             rule,
                             supports_gmail_labels=supports_gmail_labels,
+                            consumed_messages=consumed_messages,
                         )
                         if total_processed_files > 0 and rule.stop_processing:
                             self.log.debug(
@@ -605,6 +607,7 @@ class MailAccountHandler(LoggingMixin):
         rule: MailRule,
         *,
         supports_gmail_labels: bool,
+        consumed_messages: set[tuple[str, str]],
     ):
         folders = [rule.folder]
         # In case of MOVE, make sure also the destination exists
@@ -652,10 +655,25 @@ class MailAccountHandler(LoggingMixin):
 
         mails_processed = 0
         total_processed_files = 0
+        rule_seen_messages: set[tuple[str, str]] = set()
 
         for message in messages:
             if TYPE_CHECKING:
                 assert isinstance(message, MailMessage)
+
+            message_key = (rule.folder, message.uid)
+            if message_key in rule_seen_messages:
+                self.log.debug(
+                    f"Skipping duplicate fetched mail '{message.uid}' subject '{message.subject}' from '{message.from_}'.",
+                )
+                continue
+            rule_seen_messages.add(message_key)
+
+            if message_key in consumed_messages:
+                self.log.debug(
+                    f"Skipping mail '{message.uid}' subject '{message.subject}' from '{message.from_}', already queued by a previous rule in this run.",
+                )
+                continue
 
             if ProcessedMail.objects.filter(
                 rule=rule,
@@ -669,6 +687,8 @@ class MailAccountHandler(LoggingMixin):
 
             try:
                 processed_files = self._handle_message(message, rule)
+                if processed_files > 0:
+                    consumed_messages.add(message_key)
 
                 total_processed_files += processed_files
                 mails_processed += 1

--- a/src/paperless_mail/tests/test_mail.py
+++ b/src/paperless_mail/tests/test_mail.py
@@ -863,7 +863,7 @@ class TestMail(
 
         self.assertEqual(len(self.mailMocker.bogus_mailbox.messages), 0)
 
-    def test_handle_mail_account_overlapping_rules_only_first_consumes(self):
+    def test_handle_mail_account_overlapping_rules_only_first_consumes(self) -> None:
         account = MailAccount.objects.create(
             name="test",
             imap_server="",
@@ -895,7 +895,7 @@ class TestMail(
         ]
         self.assertEqual(queued_rule.id, first_rule.id)
 
-    def test_handle_mail_account_skip_duplicate_uids_from_fetch(self):
+    def test_handle_mail_account_skip_duplicate_uids_from_fetch(self) -> None:
         account = MailAccount.objects.create(
             name="test",
             imap_server="",

--- a/src/paperless_mail/tests/test_mail.py
+++ b/src/paperless_mail/tests/test_mail.py
@@ -864,6 +864,14 @@ class TestMail(
         self.assertEqual(len(self.mailMocker.bogus_mailbox.messages), 0)
 
     def test_handle_mail_account_overlapping_rules_only_first_consumes(self) -> None:
+        """
+        GIVEN:
+            - Multiple rules that match the same mail
+        WHEN:
+            - Mail account is processed
+        THEN:
+            - Only the first rule should be applied
+        """
         account = MailAccount.objects.create(
             name="test",
             imap_server="",
@@ -896,6 +904,14 @@ class TestMail(
         self.assertEqual(queued_rule.id, first_rule.id)
 
     def test_handle_mail_account_skip_duplicate_uids_from_fetch(self) -> None:
+        """
+        GIVEN:
+            - Multiple mails with the same UID returned from the mailbox fetch method
+        WHEN:
+            - Mail account is processed
+        THEN:
+            - Only one of the mails should be processed, to avoid duplicate processing due to fetch issues
+        """
         account = MailAccount.objects.create(
             name="test",
             imap_server="",


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

I think there is a little improvement to be made here, it's not the first time it's come up. "Fixhancement" kinda thing, I do see how the current is a little unexpected.

1. Add `consumed_messages` to `MailAccountHandler.handle_mail_account`:
     - if a message was already queued by an earlier rule in this run, later rules skip it
2. Add `rule_seen_messages` `_handle_mail_rule`:
    - skips duplicate messages from fetch() (dunno if this one actually happened in the linked thread, at first I thought so but ultimately I think _not_, but easy to prevent). Happy to remove this one if preferred
3. Only mark a message as "consumed in this run" when `_handle_message` queues at least one document (`processed_files > 0`)

Closes #(issue or discussion)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
