### PR TITLE
[BREAKING] Remove API v1 compatability

### DIFF
--- a/src/documents/serialisers.py
+++ b/src/documents/serialisers.py
@@ -549,28 +549,6 @@ class ColorField(serializers.Field):
         return 1
 
 
-class TagSerializerVersion1(MatchingModelSerializer, OwnedObjectSerializer):
-    colour = ColorField(source="color", default="#a6cee3")
-
-    class Meta:
-        model = Tag
-        fields = (
-            "id",
-            "slug",
-            "name",
-            "colour",
-            "match",
-            "matching_algorithm",
-            "is_insensitive",
-            "is_inbox_tag",
-            "document_count",
-            "owner",
-            "permissions",
-            "user_can_change",
-            "set_permissions",
-        )
-
-
 class TagSerializer(MatchingModelSerializer, OwnedObjectSerializer):
     def get_text_color(self, obj) -> str:
         try:

--- a/src/documents/tests/test_api_documents.py
+++ b/src/documents/tests/test_api_documents.py
@@ -2419,57 +2419,6 @@ class TestDocumentApi(DirectoriesMixin, DocumentConsumeDelayMixin, APITestCase):
             )
             self.assertEqual(response.status_code, status.HTTP_201_CREATED, endpoint)
 
-    def test_tag_color_default(self) -> None:
-        response = self.client.post("/api/tags/", {"name": "tag"}, format="json")
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(Tag.objects.get(id=response.data["id"]).color, "#a6cee3")
-        self.assertEqual(
-            self.client.get(
-                f"/api/tags/{response.data['id']}/",
-                headers={"Accept": "application/json; version=1"},
-                format="json",
-            ).data["colour"],
-            1,
-        )
-
-    def test_tag_color(self) -> None:
-        response = self.client.post(
-            "/api/tags/",
-            data={"name": "tag", "colour": 3},
-            headers={"Accept": "application/json; version=1"},
-            format="json",
-        )
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(Tag.objects.get(id=response.data["id"]).color, "#b2df8a")
-        self.assertEqual(
-            self.client.get(
-                f"/api/tags/{response.data['id']}/",
-                headers={"Accept": "application/json; version=1"},
-                format="json",
-            ).data["colour"],
-            3,
-        )
-
-    def test_tag_color_invalid(self) -> None:
-        response = self.client.post(
-            "/api/tags/",
-            data={"name": "tag", "colour": 34},
-            headers={"Accept": "application/json; version=1"},
-            format="json",
-        )
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-
-    def test_tag_color_custom(self) -> None:
-        tag = Tag.objects.create(name="test", color="#abcdef")
-        self.assertEqual(
-            self.client.get(
-                f"/api/tags/{tag.id}/",
-                headers={"Accept": "application/json; version=1"},
-                format="json",
-            ).data["colour"],
-            1,
-        )
-
     def test_get_existing_notes(self) -> None:
         """
         GIVEN:

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -181,7 +181,6 @@ from documents.serialisers import ShareLinkSerializer
 from documents.serialisers import StoragePathSerializer
 from documents.serialisers import StoragePathTestSerializer
 from documents.serialisers import TagSerializer
-from documents.serialisers import TagSerializerVersion1
 from documents.serialisers import TasksViewSerializer
 from documents.serialisers import TrashSerializer
 from documents.serialisers import UiSettingsViewSerializer
@@ -472,18 +471,13 @@ class CorrespondentViewSet(PermissionsAwareDocumentCountMixin, ModelViewSet):
 @extend_schema_view(**generate_object_with_permissions_schema(TagSerializer))
 class TagViewSet(PermissionsAwareDocumentCountMixin, ModelViewSet):
     model = Tag
+    serializer_class = TagSerializer
     document_count_through = Document.tags.through
     document_count_source_field = "tag_id"
 
     queryset = Tag.objects.select_related("owner").order_by(
         Lower("name"),
     )
-
-    def get_serializer_class(self, *args, **kwargs):
-        if int(self.request.version) == 1:
-            return TagSerializerVersion1
-        else:
-            return TagSerializer
 
     pagination_class = StandardPagination
     permission_classes = (IsAuthenticated, PaperlessObjectPermissions)

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -377,7 +377,7 @@ REST_FRAMEWORK = {
     "DEFAULT_VERSION": "9",  # match src-ui/src/environments/environment.prod.ts
     # Make sure these are ordered and that the most recent version appears
     # last. See api.md#api-versioning when adding new versions.
-    "ALLOWED_VERSIONS": ["1", "2", "3", "4", "5", "6", "7", "8", "9"],
+    "ALLOWED_VERSIONS": ["2", "3", "4", "5", "6", "7", "8", "9"],
     # DRF Spectacular default schema
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
 }


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

<!--
⚠️ Important: Pull requests that implement a new feature or enhancement *should almost always target an existing feature request* with evidence of community interest and discussion. This is in order to balance the work of implementing and maintaining new features / enhancements. If that is not currently the case, please open a feature request instead of this PR to gather feedback from both users and the project maintainers.
-->

I mean, technically breaking, but not really.  It's been in there for 5 years and many other API versions.

Are there other things we could cleanup?  I didn't see a lot of usages of `request.version`

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [x] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
