### PR TITLE
Fix: correct page count by separating display vs collection sizes for tags

### DIFF
--- a/src-ui/src/app/components/manage/management-list/management-list.component.html
+++ b/src-ui/src/app/components/manage/management-list/management-list.component.html
@@ -62,9 +62,9 @@
 
 @if (!loading) {
   <div class="d-flex mb-2">
-    @if (collectionSize > 0) {
+    @if (displayCollectionSize > 0) {
       <div>
-        <ng-container i18n>{collectionSize, plural, =1 {One {{typeName}}} other {{{collectionSize || 0}} total {{typeNamePlural}}}}</ng-container>
+        <ng-container i18n>{displayCollectionSize, plural, =1 {One {{typeName}}} other {{{displayCollectionSize || 0}} total {{typeNamePlural}}}}</ng-container>
         @if (selectedObjects.size > 0) {
           &nbsp;({{selectedObjects.size}} selected)
         }

--- a/src-ui/src/app/components/manage/management-list/management-list.component.spec.ts
+++ b/src-ui/src/app/components/manage/management-list/management-list.component.spec.ts
@@ -229,7 +229,7 @@ describe('ManagementListComponent', () => {
     expect(reloadSpy).toHaveBeenCalled()
   })
 
-  it('should use the all list length for collection size when provided', fakeAsync(() => {
+  it('should use API count for pagination and all ids for displayed total', fakeAsync(() => {
     jest.spyOn(tagService, 'listFiltered').mockReturnValueOnce(
       of({
         count: 1,
@@ -241,7 +241,8 @@ describe('ManagementListComponent', () => {
     component.reloadData()
     tick(100)
 
-    expect(component.collectionSize).toBe(3)
+    expect(component.collectionSize).toBe(1)
+    expect(component.displayCollectionSize).toBe(3)
   }))
 
   it('should support quick filter for objects', () => {

--- a/src-ui/src/app/components/manage/management-list/management-list.component.ts
+++ b/src-ui/src/app/components/manage/management-list/management-list.component.ts
@@ -23,6 +23,7 @@ import {
   MatchingModel,
 } from 'src/app/data/matching-model'
 import { ObjectWithPermissions } from 'src/app/data/object-with-permissions'
+import { Results } from 'src/app/data/results'
 import {
   SortableDirective,
   SortEvent,
@@ -88,6 +89,7 @@ export abstract class ManagementListComponent<T extends MatchingModel>
   public page = 1
 
   public collectionSize = 0
+  public displayCollectionSize = 0
 
   public sortField: string
   public sortReverse: boolean
@@ -141,6 +143,14 @@ export abstract class ManagementListComponent<T extends MatchingModel>
     return data
   }
 
+  protected getCollectionSize(results: Results<T>): number {
+    return results.all?.length ?? results.count
+  }
+
+  protected getDisplayCollectionSize(results: Results<T>): number {
+    return this.getCollectionSize(results)
+  }
+
   getDocumentCount(object: MatchingModel): number {
     return (
       object.document_count ??
@@ -171,7 +181,8 @@ export abstract class ManagementListComponent<T extends MatchingModel>
         tap((c) => {
           this.unfilteredData = c.results
           this.data = this.filterData(c.results)
-          this.collectionSize = c.all?.length ?? c.count
+          this.collectionSize = this.getCollectionSize(c)
+          this.displayCollectionSize = this.getDisplayCollectionSize(c)
         }),
         delay(100)
       )

--- a/src-ui/src/app/components/manage/tag-list/tag-list.component.ts
+++ b/src-ui/src/app/components/manage/tag-list/tag-list.component.ts
@@ -7,6 +7,7 @@ import {
 } from '@ng-bootstrap/ng-bootstrap'
 import { NgxBootstrapIconsModule } from 'ngx-bootstrap-icons'
 import { FILTER_HAS_TAGS_ALL } from 'src/app/data/filter-rule-type'
+import { Results } from 'src/app/data/results'
 import { Tag } from 'src/app/data/tag'
 import { IfPermissionsDirective } from 'src/app/directives/if-permissions.directive'
 import { SortableDirective } from 'src/app/directives/sortable.directive'
@@ -75,6 +76,16 @@ export class TagListComponent extends ManagementListComponent<Tag> {
     // When filtering by name, exclude children if their parent is also present
     const availableIds = new Set(data.map((tag) => tag.id))
     return data.filter((tag) => !tag.parent || !availableIds.has(tag.parent))
+  }
+
+  protected override getCollectionSize(results: Results<Tag>): number {
+    // Tag list pages are requested with is_root=true (when unfiltered), so
+    // pagination must follow root count even though `all` includes descendants
+    return results.count
+  }
+
+  protected override getDisplayCollectionSize(results: Results<Tag>): number {
+    return super.getCollectionSize(results)
   }
 
   protected override getSelectableIDs(tags: Tag[]): number[] {


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

This was an unintended side-effect of #11888, which correctly fixed the extracting all part but then caused this. The issue is that the frontend stuffs children into the root, which is what a user expects, but that means the paging should use only roots, not the actual total. 🙃

Closes #12168 ( #12167 )

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
