### PR TITLE
fix(frontend): fetch unknown IDs from API instead of displaying 'Private'

### DIFF
--- a/src-ui/src/app/components/common/input/select/select.component.ts
+++ b/src-ui/src/app/components/common/input/select/select.component.ts
@@ -13,6 +13,8 @@ import {
 import { RouterModule } from '@angular/router'
 import { NgSelectModule } from '@ng-select/ng-select'
 import { NgxBootstrapIconsModule } from 'ngx-bootstrap-icons'
+import { Observable } from 'rxjs'
+import { ObjectWithId } from 'src/app/data/object-with-id'
 import { AbstractInputComponent } from '../abstract-input'
 
 @Component({
@@ -64,13 +66,31 @@ export class SelectComponent extends AbstractInputComponent<number> {
     }
   }
 
-  checkForPrivateItem(id) {
-    if (this._items.find((i) => i.id === id) === undefined) {
-      this._items.push({
-        id: id,
-        name: $localize`Private`,
-        private: true,
+  checkForPrivateItem(id: number) {
+    if (this._items.find((i) => i.id === id) !== undefined) return
+    if (this._pendingIds.has(id)) return
+
+    if (this.fetchItem) {
+      this._pendingIds.add(id)
+      this._items.push({ id, name: '…', private: false })
+
+      this.fetchItem(id).subscribe({
+        next: (item) => {
+          this._pendingIds.delete(id)
+          const idx = this._items.findIndex((i) => i.id === id)
+          if (idx !== -1) this._items[idx] = item
+          this.items = [...this._items]
+        },
+        error: () => {
+          this._pendingIds.delete(id)
+          const idx = this._items.findIndex((i) => i.id === id)
+          if (idx !== -1)
+            this._items[idx] = { id, name: $localize`Private`, private: true }
+          this.items = [...this._items]
+        },
       })
+    } else {
+      this._items.push({ id, name: $localize`Private`, private: true })
     }
   }
 
@@ -111,6 +131,9 @@ export class SelectComponent extends AbstractInputComponent<number> {
   @Input()
   hideAddButton: boolean = false
 
+  @Input()
+  fetchItem: (id: number) => Observable<ObjectWithId>
+
   @Output()
   createNew = new EventEmitter<string>()
 
@@ -120,6 +143,8 @@ export class SelectComponent extends AbstractInputComponent<number> {
   public addItemRef: (name) => void
 
   private _lastSearchTerm: string
+
+  private _pendingIds = new Set<number>()
 
   get allowCreateNew(): boolean {
     return !this.disableCreateNew && this.createNew.observers.length > 0

--- a/src-ui/src/app/components/common/input/tags/tags.component.ts
+++ b/src-ui/src/app/components/common/input/tags/tags.component.ts
@@ -59,6 +59,7 @@ export class TagsComponent implements OnInit, ControlValueAccessor {
 
   writeValue(newValue: number[]): void {
     this.value = newValue
+    if (this.tags) this.fetchMissingTags()
   }
   registerOnChange(fn: any): void {
     this.onChange = fn
@@ -73,7 +74,36 @@ export class TagsComponent implements OnInit, ControlValueAccessor {
   ngOnInit(): void {
     this.tagService.listAll().subscribe((result) => {
       this.tags = result.results
+      this._fetchedIds.clear()
+      this.fetchMissingTags()
     })
+  }
+
+  private fetchMissingTags() {
+    if (!this.value?.length) return
+    this.value
+      .filter(
+        (id) => !this.tags.find((t) => t.id === id) && !this._fetchedIds.has(id)
+      )
+      .forEach((id) => {
+        this._fetchedIds.add(id)
+        this.tags = [
+          ...this.tags,
+          {
+            id,
+            name: '…',
+            is_inbox_tag: false,
+            color: '#a6cee3',
+            text_color: '#000000',
+          } as Tag,
+        ]
+        this.tagService.get(id).subscribe({
+          next: (tag) => {
+            this.tags = this.tags.map((t) => (t.id === id ? tag : t))
+          },
+          error: () => {},
+        })
+      })
   }
 
   @Input()
@@ -111,6 +141,8 @@ export class TagsComponent implements OnInit, ControlValueAccessor {
   value: number[] = []
 
   tags: Tag[] = []
+
+  private _fetchedIds = new Set<number>()
 
   public createTagRef: (name) => void
 

--- a/src-ui/src/app/components/document-detail/document-detail.component.html
+++ b/src-ui/src/app/components/document-detail/document-detail.component.html
@@ -168,15 +168,15 @@
               [error]="error?.created"></pngx-input-date>
               @if (!isFieldHidden(DocumentDetailFieldID.Correspondent)) {
                 <pngx-input-select [items]="correspondents" i18n-title title="Correspondent" formControlName="correspondent" [allowNull]="true" [showFilter]="true" [horizontal]="true" (filterDocuments)="filterDocuments($event, DataType.Correspondent)"
-                (createNew)="createCorrespondent($event)" [hideAddButton]="createDisabled(DataType.Correspondent)" [suggestions]="suggestions?.correspondents" *pngxIfPermissions="{ action: PermissionAction.View, type: PermissionType.Correspondent }"></pngx-input-select>
+                (createNew)="createCorrespondent($event)" [hideAddButton]="createDisabled(DataType.Correspondent)" [suggestions]="suggestions?.correspondents" [fetchItem]="fetchCorrespondent" *pngxIfPermissions="{ action: PermissionAction.View, type: PermissionType.Correspondent }"></pngx-input-select>
               }
               @if (!isFieldHidden(DocumentDetailFieldID.DocumentType)) {
                 <pngx-input-select [items]="documentTypes" i18n-title title="Document type" formControlName="document_type" [allowNull]="true" [showFilter]="true" [horizontal]="true" (filterDocuments)="filterDocuments($event, DataType.DocumentType)"
-                (createNew)="createDocumentType($event)" [hideAddButton]="createDisabled(DataType.DocumentType)" [suggestions]="suggestions?.document_types" *pngxIfPermissions="{ action: PermissionAction.View, type: PermissionType.DocumentType }"></pngx-input-select>
+                (createNew)="createDocumentType($event)" [hideAddButton]="createDisabled(DataType.DocumentType)" [suggestions]="suggestions?.document_types" [fetchItem]="fetchDocumentType" *pngxIfPermissions="{ action: PermissionAction.View, type: PermissionType.DocumentType }"></pngx-input-select>
               }
               @if (!isFieldHidden(DocumentDetailFieldID.StoragePath)) {
                 <pngx-input-select [items]="storagePaths" i18n-title title="Storage path" formControlName="storage_path" [allowNull]="true" [showFilter]="true" [horizontal]="true" (filterDocuments)="filterDocuments($event, DataType.StoragePath)"
-                (createNew)="createStoragePath($event)" [hideAddButton]="createDisabled(DataType.StoragePath)" [suggestions]="suggestions?.storage_paths" i18n-placeholder placeholder="Default" *pngxIfPermissions="{ action: PermissionAction.View, type: PermissionType.StoragePath }"></pngx-input-select>
+                (createNew)="createStoragePath($event)" [hideAddButton]="createDisabled(DataType.StoragePath)" [suggestions]="suggestions?.storage_paths" i18n-placeholder placeholder="Default" [fetchItem]="fetchStoragePath" *pngxIfPermissions="{ action: PermissionAction.View, type: PermissionType.StoragePath }"></pngx-input-select>
               }
               @if (!isFieldHidden(DocumentDetailFieldID.Tags)) {
                 <pngx-input-tags #tagsInput formControlName="tags" [suggestions]="suggestions?.tags" [showFilter]="true" [horizontal]="true" (filterDocuments)="filterDocuments($event, DataType.Tag)" [hideAddButton]="createDisabled(DataType.Tag)" *pngxIfPermissions="{ action: PermissionAction.View, type: PermissionType.Tag }"></pngx-input-tags>

--- a/src-ui/src/app/components/document-detail/document-detail.component.ts
+++ b/src-ui/src/app/components/document-detail/document-detail.component.ts
@@ -245,6 +245,10 @@ export class DocumentDetailComponent
   documentTypes: DocumentType[]
   storagePaths: StoragePath[]
 
+  fetchCorrespondent = (id: number) => this.correspondentService.get(id)
+  fetchDocumentType = (id: number) => this.documentTypeService.get(id)
+  fetchStoragePath = (id: number) => this.storagePathService.get(id)
+
   documentForm: FormGroup = new FormGroup({
     title: new FormControl(''),
     content: new FormControl(''),

--- a/src-ui/src/app/pipes/object-name.pipe.spec.ts
+++ b/src-ui/src/app/pipes/object-name.pipe.spec.ts
@@ -34,16 +34,10 @@ describe('ObjectNamePipe', () => {
   })
 
   it('should return object name if user has permission', (done) => {
-    const mockObjects = {
-      results: [
-        { id: 1, name: 'Object 1' },
-        { id: 2, name: 'Object 2' },
-      ],
-      count: 2,
-      all: [1, 2],
-    }
     jest.spyOn(permissionsService, 'currentUserCan').mockReturnValue(true)
-    jest.spyOn(objectService, 'listAll').mockReturnValue(of(mockObjects))
+    jest
+      .spyOn(objectService, 'getCached')
+      .mockReturnValue(of({ id: 1, name: 'Object 1' } as MatchingModel))
 
     pipe.transform(1).subscribe((result) => {
       expect(result).toBe('Object 1')
@@ -52,13 +46,8 @@ describe('ObjectNamePipe', () => {
   })
 
   it('should return Private string if object not found', (done) => {
-    const mockObjects = {
-      results: [{ id: 2, name: 'Object 2' }],
-      count: 1,
-      all: [2],
-    }
     jest.spyOn(permissionsService, 'currentUserCan').mockReturnValue(true)
-    jest.spyOn(objectService, 'listAll').mockReturnValue(of(mockObjects))
+    jest.spyOn(objectService, 'getCached').mockReturnValue(of(undefined))
 
     pipe.transform(1).subscribe((result) => {
       expect(result).toBe('Private')
@@ -78,7 +67,7 @@ describe('ObjectNamePipe', () => {
   it('should handle error and return empty string', (done) => {
     jest.spyOn(permissionsService, 'currentUserCan').mockReturnValue(true)
     jest
-      .spyOn(objectService, 'listAll')
+      .spyOn(objectService, 'getCached')
       .mockReturnValueOnce(throwError(() => new Error('Error getting objects')))
 
     pipe.transform(1).subscribe((result) => {

--- a/src-ui/src/app/pipes/object-name.pipe.ts
+++ b/src-ui/src/app/pipes/object-name.pipe.ts
@@ -32,14 +32,8 @@ export abstract class ObjectNamePipe implements PipeTransform {
         this.permissionType
       )
     ) {
-      return this.objectService.listAll().pipe(
-        map((objects) => {
-          this.objects = objects.results
-          return (
-            this.objects.find((o) => o.id === obejctId)?.name ||
-            $localize`Private`
-          )
-        }),
+      return this.objectService.getCached(obejctId).pipe(
+        map((o) => o?.name ?? $localize`Private`),
         catchError(() => of(''))
       )
     } else {


### PR DESCRIPTION
## Proposed change

When `PAPERLESS_CONSUMER_SUBDIRS_AS_TAGS=true` is enabled, objects created by the consumer (tags, correspondents, document types, storage paths) are not yet in the `listAll()` cache when a document is opened. In this case the UI displays \"Private\" instead of the real name — both in the document list and the detail view.

**Root cause:** `getCached()` in `AbstractPaperlessService` returns `undefined` for any ID not present in the `listAll()` cache. Callers such as `TagComponent` and `ObjectNamePipe` treat `undefined` as a permission-restricted (\"Private\") object, which is incorrect for objects the user created themselves.

**Fix:**
- `getCached()` now falls back to `get(id)` when an ID is missing from the `listAll()` cache. Results are stored in a per-ID `shareReplay` cache to prevent duplicate requests when the same unknown ID appears multiple times on a page.
- `clearCache()` also clears the per-ID cache.
- `ObjectNamePipe` simplified to delegate entirely to `getCached()`.
- `TagsComponent`: fetches missing tag IDs after `listAll()` resolves; inserts a placeholder immediately so the template never receives `undefined`.
- `SelectComponent`: new optional `fetchItem` input; when an ID is not in the local items list, `fetchItem` is called instead of immediately marking the item as Private.
- `DocumentDetailComponent`: binds `fetchItem` for correspondent, document type and storage path.

**How to reproduce:**
1. Enable `PAPERLESS_CONSUMER_SUBDIRS_AS_TAGS=true`
2. Place a file in `consume/NewFolder/document.pdf` where "NewFolder" is not yet a tag
3. Wait for the consumer to process
4. Open the document **without** a page reload → tag shows as "Private"
5. After this fix → tag shows correctly

Fixes the root cause behind #4807 (closed as browser cache issue, but still reproducible)
Related: #8675, #11356

## Type of change

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR. *(Claude was used as a coding assistant; the bug was diagnosed and the fix understood independently by the PR author.)*