### PR TITLE
Development: improve test portability

### DIFF
--- a/src/documents/tests/test_api_uisettings.py
+++ b/src/documents/tests/test_api_uisettings.py
@@ -21,6 +21,16 @@ class TestApiUiSettings(DirectoriesMixin, APITestCase):
         self.test_user.save()
         self.client.force_authenticate(user=self.test_user)
 
+    @override_settings(
+        APP_TITLE=None,
+        APP_LOGO=None,
+        AUDIT_LOG_ENABLED=True,
+        EMPTY_TRASH_DELAY=30,
+        ENABLE_UPDATE_CHECK="default",
+        EMAIL_ENABLED=False,
+        GMAIL_OAUTH_ENABLED=False,
+        OUTLOOK_OAUTH_ENABLED=False,
+    )
     def test_api_get_ui_settings(self) -> None:
         response = self.client.get(self.ENDPOINT, format="json")
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/src/documents/tests/test_barcodes.py
+++ b/src/documents/tests/test_barcodes.py
@@ -919,6 +919,7 @@ class TestTagBarcode(DirectoriesMixin, SampleDirMixin, GetReaderPluginMixin, Tes
     @override_settings(
         CONSUMER_ENABLE_TAG_BARCODE=True,
         CONSUMER_TAG_BARCODE_MAPPING={"ASN(.*)": "\\g<1>"},
+        CONSUMER_ENABLE_ASN_BARCODE=False,
     )
     def test_scan_file_for_many_custom_tags(self) -> None:
         """

--- a/src/documents/tests/test_file_handling.py
+++ b/src/documents/tests/test_file_handling.py
@@ -329,14 +329,14 @@ class TestFileHandling(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
         FILENAME_FORMAT="{added_year}-{added_month}-{added_day}",
     )
     def test_added_year_month_day(self) -> None:
-        d1 = timezone.make_aware(datetime.datetime(232, 1, 9, 1, 1, 1))
+        d1 = timezone.make_aware(datetime.datetime(1232, 1, 9, 1, 1, 1))
         doc1 = Document.objects.create(
             title="doc1",
             mime_type="application/pdf",
             added=d1,
         )
 
-        self.assertEqual(generate_filename(doc1), Path("232-01-09.pdf"))
+        self.assertEqual(generate_filename(doc1), Path("1232-01-09.pdf"))
 
         doc1.added = timezone.make_aware(datetime.datetime(2020, 11, 16, 1, 1, 1))
 

--- a/src/documents/tests/test_management_fuzzy.py
+++ b/src/documents/tests/test_management_fuzzy.py
@@ -140,7 +140,7 @@ class TestFuzzyMatchCommand(TestCase):
             mime_type="application/pdf",
             filename="final_test.pdf",
         )
-        stdout, _ = self.call_command("--no-progress-bar")
+        stdout, _ = self.call_command("--no-progress-bar", "--processes", "1")
         lines = [x.strip() for x in stdout.splitlines() if x.strip()]
         self.assertEqual(len(lines), 3)
         for line in lines:
@@ -183,7 +183,12 @@ class TestFuzzyMatchCommand(TestCase):
 
         self.assertEqual(Document.objects.count(), 3)
 
-        stdout, _ = self.call_command("--delete", "--no-progress-bar")
+        stdout, _ = self.call_command(
+            "--delete",
+            "--no-progress-bar",
+            "--processes",
+            "1",
+        )
 
         self.assertIn(
             "The command is configured to delete documents.  Use with caution",

--- a/src/documents/tests/utils.py
+++ b/src/documents/tests/utils.py
@@ -33,11 +33,11 @@ from documents.plugins.helpers import ProgressStatusOptions
 def setup_directories():
     dirs = namedtuple("Dirs", ())
 
-    dirs.data_dir = Path(tempfile.mkdtemp())
-    dirs.scratch_dir = Path(tempfile.mkdtemp())
-    dirs.media_dir = Path(tempfile.mkdtemp())
-    dirs.consumption_dir = Path(tempfile.mkdtemp())
-    dirs.static_dir = Path(tempfile.mkdtemp())
+    dirs.data_dir = Path(tempfile.mkdtemp()).resolve()
+    dirs.scratch_dir = Path(tempfile.mkdtemp()).resolve()
+    dirs.media_dir = Path(tempfile.mkdtemp()).resolve()
+    dirs.consumption_dir = Path(tempfile.mkdtemp()).resolve()
+    dirs.static_dir = Path(tempfile.mkdtemp()).resolve()
     dirs.index_dir = dirs.data_dir / "index"
     dirs.originals_dir = dirs.media_dir / "documents" / "originals"
     dirs.thumbnail_dir = dirs.media_dir / "documents" / "thumbnails"

--- a/src/paperless/tests/test_adapter.py
+++ b/src/paperless/tests/test_adapter.py
@@ -78,11 +78,15 @@ class TestCustomAccountAdapter(TestCase):
             adapter = get_adapter()
 
             # Test when PAPERLESS_URL is None
-            expected_url = f"https://foo.org{reverse('account_reset_password_from_key', kwargs={'uidb36': 'UID', 'key': 'KEY'})}"
-            self.assertEqual(
-                adapter.get_reset_password_from_key_url("UID-KEY"),
-                expected_url,
-            )
+            with override_settings(
+                PAPERLESS_URL=None,
+                ACCOUNT_DEFAULT_HTTP_PROTOCOL="https",
+            ):
+                expected_url = f"https://foo.org{reverse('account_reset_password_from_key', kwargs={'uidb36': 'UID', 'key': 'KEY'})}"
+                self.assertEqual(
+                    adapter.get_reset_password_from_key_url("UID-KEY"),
+                    expected_url,
+                )
 
             # Test when PAPERLESS_URL is not None
             with override_settings(PAPERLESS_URL="https://bar.com"):

--- a/src/paperless/tests/test_views.py
+++ b/src/paperless/tests/test_views.py
@@ -1,7 +1,7 @@
 import tempfile
 from pathlib import Path
 
-from django.conf import settings
+from django.test import override_settings
 
 
 def test_favicon_view(client):
@@ -11,15 +11,14 @@ def test_favicon_view(client):
         favicon_path.parent.mkdir(parents=True, exist_ok=True)
         favicon_path.write_bytes(b"FAKE ICON DATA")
 
-        settings.STATIC_ROOT = static_dir
-
-        response = client.get("/favicon.ico")
-        assert response.status_code == 200
-        assert response["Content-Type"] == "image/x-icon"
-        assert b"".join(response.streaming_content) == b"FAKE ICON DATA"
+        with override_settings(STATIC_ROOT=static_dir):
+            response = client.get("/favicon.ico")
+            assert response.status_code == 200
+            assert response["Content-Type"] == "image/x-icon"
+            assert b"".join(response.streaming_content) == b"FAKE ICON DATA"
 
 
 def test_favicon_view_missing_file(client):
-    settings.STATIC_ROOT = Path(tempfile.mkdtemp())
-    response = client.get("/favicon.ico")
-    assert response.status_code == 404
+    with override_settings(STATIC_ROOT=Path(tempfile.mkdtemp())):
+        response = client.get("/favicon.ico")
+        assert response.status_code == 404

--- a/src/paperless_mail/parsers.py
+++ b/src/paperless_mail/parsers.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from bleach import clean
 from bleach import linkify
 from django.conf import settings
+from django.utils import timezone
 from django.utils.timezone import is_naive
 from django.utils.timezone import make_aware
 from gotenberg_client import GotenbergClient
@@ -332,7 +333,9 @@ class MailDocumentParser(DocumentParser):
         if data["attachments"]:
             data["attachments_label"] = "Attachments"
 
-        data["date"] = clean_html(mail.date.astimezone().strftime("%Y-%m-%d %H:%M"))
+        data["date"] = clean_html(
+            timezone.localtime(mail.date).strftime("%Y-%m-%d %H:%M"),
+        )
         data["content"] = clean_html(mail.text.strip())
 
         from django.template.loader import render_to_string

--- a/src/paperless_mail/tests/test_parsers.py
+++ b/src/paperless_mail/tests/test_parsers.py
@@ -6,6 +6,7 @@ from unittest import mock
 import httpx
 import pytest
 from django.test.html import parse_html
+from django.utils import timezone
 from pytest_django.fixtures import SettingsWrapper
 from pytest_httpx import HTTPXMock
 from pytest_mock import MockerFixture
@@ -634,13 +635,14 @@ class TestParser:
         THEN:
             - Resulting HTML is as expected
         """
-        mail = mail_parser.parse_file_to_message(html_email_file)
-        html_file = mail_parser.mail_to_html(mail)
+        with timezone.override("UTC"):
+            mail = mail_parser.parse_file_to_message(html_email_file)
+            html_file = mail_parser.mail_to_html(mail)
 
-        expected_html = parse_html(html_email_html_file.read_text())
-        actual_html = parse_html(html_file.read_text())
+            expected_html = parse_html(html_email_html_file.read_text())
+            actual_html = parse_html(html_file.read_text())
 
-        assert expected_html == actual_html
+            assert expected_html == actual_html
 
     def test_generate_pdf_from_mail(
         self,

--- a/src/paperless_tesseract/tests/test_parser.py
+++ b/src/paperless_tesseract/tests/test_parser.py
@@ -857,7 +857,9 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
         )
 
         self.assertIn("ةرازو", normalized_text)
-        self.assertIn("الاخليد", normalized_text)
+        self.assertTrue(
+            any(token in normalized_text for token in ("ةیلخادلا", "الاخليد")),
+        )
 
     @mock.patch("ocrmypdf.ocr")
     def test_gs_rendering_error(self, m) -> None:

--- a/src/paperless_tesseract/tests/test_parser.py
+++ b/src/paperless_tesseract/tests/test_parser.py
@@ -1,5 +1,6 @@
 import shutil
 import tempfile
+import unicodedata
 import uuid
 from pathlib import Path
 from unittest import mock
@@ -847,8 +848,16 @@ class TestParser(DirectoriesMixin, FileSystemAssertsMixin, TestCase):
             "application/pdf",
         )
 
-        # Copied from the PDF to here.  Don't even look at it
-        self.assertIn("ةﯾﻠﺧﺎدﻻ ةرازو", parser.get_text())
+        # OCR output for RTL text varies across platforms/versions due to
+        # bidi controls and presentation forms; normalize before assertion.
+        normalized_text = "".join(
+            char
+            for char in unicodedata.normalize("NFKC", parser.get_text())
+            if unicodedata.category(char) != "Cf" and not char.isspace()
+        )
+
+        self.assertIn("ةرازو", normalized_text)
+        self.assertIn("الاخليد", normalized_text)
 
     @mock.patch("ocrmypdf.ocr")
     def test_gs_rendering_error(self, m) -> None:


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

I am mostly developing on MacOS. I have struggled with the back-end, because 20 or so kept failing, even though everything passed in the CI and on my (linux) server. I finally took the time to track down the issue. There is three changes in this PR that make the tests a bit more robust:

- `test_file_handling.py`: On mac `strftime('%Y')` formats the year to four digits, padding with leading zeros. You can reproduce this with `python3 -c "import datetime; print(datetime.datetime(232, 1, 9).strftime('%Y'))"` on python 3.10.19. Adding a digit to the year ensures it matches on both linux and mac. I hope the test is not specifically for pre 11th century documents :P
- `test_management_fuzzy.py`: Other test in the file add the same argument to the execution. Judging from some comments the `--processes 1` case is also specifically for testing. Apparently MacOS handles process forking differently. This avoids forking.
- `utils.py`: On MacOS the `/var` (where the temp files are created) symlinks to `/private/var`. This confuses the path comparison in some tests. The `.resolve()` resolves symlinks, thus making sure the correct path is used as expected value.

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

<!--
⚠️ Important: Pull requests that implement a new feature or enhancement *should almost always target an existing feature request* with evidence of community interest and discussion. This is in order to balance the work of implementing and maintaining new features / enhancements. If that is not currently the case, please open a feature request instead of this PR to gather feedback from both users and the project maintainers.
-->

Closes #(issue or discussion)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [x] Other. Please explain: improve test portability

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
