### PR TITLE
Fix data persistence with PostgreSQL 18 in Docker Compose files

### DIFF
--- a/docker/compose/docker-compose.portainer.yml
+++ b/docker/compose/docker-compose.portainer.yml
@@ -40,6 +40,7 @@ services:
       POSTGRES_DB: paperless
       POSTGRES_USER: paperless
       POSTGRES_PASSWORD: paperless
+      PGDATA: /var/lib/postgresql/18/docker
   webserver:
     image: ghcr.io/paperless-ngx/paperless-ngx:latest
     restart: unless-stopped

--- a/docker/compose/docker-compose.postgres-tika.yml
+++ b/docker/compose/docker-compose.postgres-tika.yml
@@ -43,6 +43,7 @@ services:
       POSTGRES_DB: paperless
       POSTGRES_USER: paperless
       POSTGRES_PASSWORD: paperless
+      PGDATA: /var/lib/postgresql/18/docker
   webserver:
     image: ghcr.io/paperless-ngx/paperless-ngx:latest
     restart: unless-stopped

--- a/docker/compose/docker-compose.postgres.yml
+++ b/docker/compose/docker-compose.postgres.yml
@@ -39,6 +39,7 @@ services:
       POSTGRES_DB: paperless
       POSTGRES_USER: paperless
       POSTGRES_PASSWORD: paperless
+      PGDATA: /var/lib/postgresql/18/docker
   webserver:
     image: ghcr.io/paperless-ngx/paperless-ngx:latest
     restart: unless-stopped


### PR DESCRIPTION
## Summary

- PostgreSQL 18 changed the default data directory behavior in its Docker image: without an explicit `PGDATA`, the container uses an **anonymous volume** instead of the named `pgdata` volume, causing data loss when the container is recreated.
- Added `PGDATA: /var/lib/postgresql/18/docker` to the `db` service environment in all three affected compose files:
  - `docker/compose/docker-compose.postgres.yml`
  - `docker/compose/docker-compose.postgres-tika.yml`
  - `docker/compose/docker-compose.portainer.yml`

## Test plan

- [x] Deploy with `docker-compose.postgres.yml` using `postgres:18`
- [x] Create a document to populate the database
- [x] Run `docker compose down && docker compose up -d`
- [x] Verify data is preserved after recreating the container
- [x] Confirm the named `pgdata` volume is used (not an anonymous volume)
