### PR TITLE
Tweak: Ignore version documents for workflows, trigger updated on root when versions change

### DIFF
--- a/src/documents/consumer.py
+++ b/src/documents/consumer.py
@@ -43,6 +43,7 @@ from documents.plugins.helpers import ProgressManager
 from documents.plugins.helpers import ProgressStatusOptions
 from documents.signals import document_consumption_finished
 from documents.signals import document_consumption_started
+from documents.signals import document_updated
 from documents.signals.handlers import run_workflows
 from documents.templating.workflows import parse_w_workflow_placeholders
 from documents.utils import copy_basic_file_stats
@@ -645,6 +646,12 @@ class ConsumerPlugin(
                 # renaming logic to acquire the lock as well.
                 # This triggers things like file renaming
                 document.save()
+
+                if document.root_document_id:
+                    document_updated.send(
+                        sender=self.__class__,
+                        document=document.root_document,
+                    )
 
                 # Delete the file only if it was successfully consumed
                 self.log.debug(f"Deleting original file {self.input_doc.original_file}")

--- a/src/documents/signals/handlers.py
+++ b/src/documents/signals/handlers.py
@@ -782,6 +782,14 @@ def run_workflows(
     """
 
     use_overrides = overrides is not None
+
+    if isinstance(document, Document) and document.root_document_id is not None:
+        logger.debug(
+            "Skipping workflow execution for version document %s",
+            document.pk,
+        )
+        return None
+
     if original_file is None:
         original_file = (
             document.source_path if not use_overrides else document.original_file

--- a/src/documents/tasks.py
+++ b/src/documents/tasks.py
@@ -452,13 +452,22 @@ def check_scheduled_workflows() -> None:
 
                 match trigger.schedule_date_field:
                     case WorkflowTrigger.ScheduleDateField.ADDED:
-                        documents = Document.objects.filter(added__lte=threshold)
+                        documents = Document.objects.filter(
+                            root_document__isnull=True,
+                            added__lte=threshold,
+                        )
 
                     case WorkflowTrigger.ScheduleDateField.CREATED:
-                        documents = Document.objects.filter(created__lte=threshold)
+                        documents = Document.objects.filter(
+                            root_document__isnull=True,
+                            created__lte=threshold,
+                        )
 
                     case WorkflowTrigger.ScheduleDateField.MODIFIED:
-                        documents = Document.objects.filter(modified__lte=threshold)
+                        documents = Document.objects.filter(
+                            root_document__isnull=True,
+                            modified__lte=threshold,
+                        )
 
                     case WorkflowTrigger.ScheduleDateField.CUSTOM_FIELD:
                         # cap earliest date to avoid massive scans
@@ -496,7 +505,10 @@ def check_scheduled_workflows() -> None:
                             )
                         ]
 
-                        documents = Document.objects.filter(id__in=matched_ids)
+                        documents = Document.objects.filter(
+                            root_document__isnull=True,
+                            id__in=matched_ids,
+                        )
 
                 if documents.count() > 0:
                     documents = prefilter_documents_by_workflowtrigger(

--- a/src/documents/tests/test_workflows.py
+++ b/src/documents/tests/test_workflows.py
@@ -1742,6 +1742,48 @@ class TestWorkflows(
 
         self.assertEqual(doc.title, "Doc {created_year]")
 
+    def test_document_updated_workflow_ignores_version_documents(self) -> None:
+        trigger = WorkflowTrigger.objects.create(
+            type=WorkflowTrigger.WorkflowTriggerType.DOCUMENT_UPDATED,
+        )
+        action = WorkflowAction.objects.create(
+            assign_title="Doc assign owner",
+            assign_owner=self.user2,
+        )
+        workflow = Workflow.objects.create(
+            name="Workflow 1",
+            order=0,
+        )
+        workflow.triggers.add(trigger)
+        workflow.actions.add(action)
+
+        root_doc = Document.objects.create(
+            title="root",
+            correspondent=self.c,
+            original_filename="root.pdf",
+        )
+        version_doc = Document.objects.create(
+            title="version",
+            correspondent=self.c,
+            original_filename="version.pdf",
+            root_document=root_doc,
+        )
+
+        run_workflows(WorkflowTrigger.WorkflowTriggerType.DOCUMENT_UPDATED, version_doc)
+
+        root_doc.refresh_from_db()
+        version_doc.refresh_from_db()
+
+        self.assertIsNone(root_doc.owner)
+        self.assertIsNone(version_doc.owner)
+        self.assertFalse(
+            WorkflowRun.objects.filter(
+                workflow=workflow,
+                type=WorkflowTrigger.WorkflowTriggerType.DOCUMENT_UPDATED,
+                document=version_doc,
+            ).exists(),
+        )
+
     def test_document_updated_workflow(self) -> None:
         trigger = WorkflowTrigger.objects.create(
             type=WorkflowTrigger.WorkflowTriggerType.DOCUMENT_UPDATED,
@@ -2009,6 +2051,60 @@ class TestWorkflows(
 
         doc.refresh_from_db()
         self.assertEqual(doc.owner, self.user2)
+
+    def test_workflow_scheduled_trigger_ignores_version_documents(self) -> None:
+        trigger = WorkflowTrigger.objects.create(
+            type=WorkflowTrigger.WorkflowTriggerType.SCHEDULED,
+            schedule_offset_days=1,
+            schedule_date_field=WorkflowTrigger.ScheduleDateField.ADDED,
+        )
+        action = WorkflowAction.objects.create(
+            assign_title="Doc assign owner",
+            assign_owner=self.user2,
+        )
+        workflow = Workflow.objects.create(
+            name="Workflow 1",
+            order=0,
+        )
+        workflow.triggers.add(trigger)
+        workflow.actions.add(action)
+
+        root_doc = Document.objects.create(
+            title="root",
+            correspondent=self.c,
+            original_filename="root.pdf",
+            added=timezone.now() - timedelta(days=10),
+        )
+        version_doc = Document.objects.create(
+            title="version",
+            correspondent=self.c,
+            original_filename="version.pdf",
+            root_document=root_doc,
+            added=timezone.now() - timedelta(days=10),
+        )
+
+        tasks.check_scheduled_workflows()
+
+        root_doc.refresh_from_db()
+        version_doc.refresh_from_db()
+
+        self.assertEqual(root_doc.owner, self.user2)
+        self.assertIsNone(version_doc.owner)
+        self.assertEqual(
+            WorkflowRun.objects.filter(
+                workflow=workflow,
+                type=WorkflowTrigger.WorkflowTriggerType.SCHEDULED,
+                document=root_doc,
+            ).count(),
+            1,
+        )
+        self.assertFalse(
+            WorkflowRun.objects.filter(
+                workflow=workflow,
+                type=WorkflowTrigger.WorkflowTriggerType.SCHEDULED,
+                document=version_doc,
+            ).exists(),
+        )
 
     @mock.patch("documents.models.Document.objects.filter", autospec=True)
     def test_workflow_scheduled_trigger_modified(self, mock_filter) -> None:

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -1758,6 +1758,11 @@ class DocumentViewSet(
             .order_by("-id")
             .first()
         )
+
+        document_updated.send(
+            sender=self.__class__,
+            document=root_doc,
+        )
         return Response(
             {
                 "result": "OK",
@@ -1826,6 +1831,11 @@ class DocumentViewSet(
                     "version_id": version_doc.id,
                 },
             )
+
+        document_updated.send(
+            sender=self.__class__,
+            document=root_doc,
+        )
 
         return Response(
             {


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

As noted in https://github.com/paperless-ngx/paperless-ngx/pull/12185#issuecomment-3982857954 and sorry for missing including this in the original PR, I think we should exclude version docs from workflows. Rationale:

1. 'Root' doc is really what users consider **the document**, versions are just a detail of this. The fact that underlying they are document rows shouldnt really be confused with being a full document. Indeed they dont have any of the metadata like title, etc. so they really just dont make sense to run workflows against.
2. In particular running scheduled against versions would be total chaos, create duplications etc.
3. This is analogous to what the API does, we never show versions as separate documents.
4. In a separate PR, we can perhaps implement something like a `VERSION_ADDED` trigger. That would allow users to "opt-in". That's a little tricky so I still need to think about that one (and happy to discuss) but I still think this makes sense either way.

This also makes sure 'updated' triggers (on the root doc) for version changes, which seems expected.

Closes #(issue or discussion)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
