### PR TITLE
Change: use explicit create instead of cloning for versions

### DIFF
--- a/src/documents/consumer.py
+++ b/src/documents/consumer.py
@@ -170,7 +170,7 @@ class ConsumerPlugin(
 ):
     logging_name = LOGGING_NAME
 
-    def _clone_root_into_version(
+    def _create_version_from_root(
         self,
         root_doc: Document,
         *,
@@ -188,30 +188,29 @@ class ConsumerPlugin(
             )["max_index"]
             or 0
         )
-        version_doc = Document.objects.get(pk=root_doc_frozen.pk)
-        setattr(version_doc, "pk", None)
-        version_doc.root_document = root_doc_frozen
-        version_doc.version_index = next_version_index + 1
         file_for_checksum = (
             self.unmodified_original
             if self.unmodified_original is not None
             else self.working_copy
         )
-        version_doc.checksum = hashlib.md5(
-            file_for_checksum.read_bytes(),
-        ).hexdigest()
-        version_doc.content = text or ""
-        version_doc.page_count = page_count
-        version_doc.mime_type = mime_type
-        version_doc.original_filename = self.filename
-        # Clear unique file path fields so they can be generated uniquely later
-        version_doc.filename = None
-        version_doc.archive_filename = None
-        version_doc.archive_checksum = None
+        version_doc = Document(
+            root_document=root_doc_frozen,
+            version_index=next_version_index + 1,
+            checksum=hashlib.md5(
+                file_for_checksum.read_bytes(),
+            ).hexdigest(),
+            content=text or "",
+            page_count=page_count,
+            mime_type=mime_type,
+            original_filename=self.filename,
+            owner_id=root_doc_frozen.owner_id,
+            created=root_doc_frozen.created,
+            title=root_doc_frozen.title,
+            added=timezone.now(),
+            modified=timezone.now(),
+        )
         if self.metadata.version_label is not None:
             version_doc.version_label = self.metadata.version_label
-        version_doc.added = timezone.now()
-        version_doc.modified = timezone.now()
         return version_doc
 
     def run_pre_consume_script(self) -> None:
@@ -537,7 +536,7 @@ class ConsumerPlugin(
                     root_doc = Document.objects.get(
                         pk=self.input_doc.root_document_id,
                     )
-                    original_document = self._clone_root_into_version(
+                    original_document = self._create_version_from_root(
                         root_doc,
                         text=text,
                         page_count=page_count,

--- a/src/documents/tests/test_consumer.py
+++ b/src/documents/tests/test_consumer.py
@@ -731,6 +731,7 @@ class TestConsumer(
             path="root/{{title}}",
         )
         root_doc.storage_path = root_storage_path
+        root_doc.archive_serial_number = 42
         root_doc.save()
 
         actor = User.objects.create_user(
@@ -781,6 +782,7 @@ class TestConsumer(
         assert version.original_filename is not None
         self.assertEqual(version.version_index, 1)
         self.assertEqual(version.version_label, "v2")
+        self.assertIsNone(version.archive_serial_number)
         self.assertEqual(version.original_filename, version_file.name)
         self.assertTrue(bool(version.content))
 


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

I think this should be the last structural change around versioning, pending #12223 

tl;dr, I dont think theres an advantage to 'cloning', and in fact, its cleaner not to, basically want to keep these version rows minimal. This does bring back up the question about a separate versions model, but on balance I dont think thats worth it:

- duplicate file/thumbnail/archive/checksum/search/index/permissions behavior
- duplicate API/serializer/filter/query paths
- etc

I think this is the cleaner plan:
- same model, strict invariants
- explicit version creation (not cloning)
- root-based filename/path context
- version_index constraints + assignment

Closes #(issue or discussion)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
