### PR TITLE
Fix: enforce path limit for db filename fields

### DIFF
--- a/src/documents/consumer.py
+++ b/src/documents/consumer.py
@@ -50,8 +50,6 @@ from documents.utils import copy_file_with_basic_stats
 from documents.utils import run_subprocess
 from paperless_mail.parsers import MailDocumentParser
 
-MAX_STORED_FILENAME_LENGTH = 1024
-
 
 class WorkflowTriggerPlugin(
     NoCleanupPluginMixin,
@@ -497,7 +495,10 @@ class ConsumerPlugin(
                 # place. If this fails, we'll also rollback the transaction.
                 with FileLock(settings.MEDIA_LOCK):
                     generated_filename = generate_unique_filename(document)
-                    if len(str(generated_filename)) > MAX_STORED_FILENAME_LENGTH:
+                    if (
+                        len(str(generated_filename))
+                        > Document.MAX_STORED_FILENAME_LENGTH
+                    ):
                         self.log.warning(
                             "Generated source filename exceeds db path limit, falling back to default naming",
                         )
@@ -529,7 +530,7 @@ class ConsumerPlugin(
                         )
                         if (
                             len(str(generated_archive_filename))
-                            > MAX_STORED_FILENAME_LENGTH
+                            > Document.MAX_STORED_FILENAME_LENGTH
                         ):
                             self.log.warning(
                                 "Generated archive filename exceeds db path limit, falling back to default naming",

--- a/src/documents/consumer.py
+++ b/src/documents/consumer.py
@@ -19,6 +19,7 @@ from documents.classifier import load_classifier
 from documents.data_models import ConsumableDocument
 from documents.data_models import DocumentMetadataOverrides
 from documents.file_handling import create_source_path_directory
+from documents.file_handling import generate_filename
 from documents.file_handling import generate_unique_filename
 from documents.loggers import LoggingMixin
 from documents.models import Correspondent
@@ -48,6 +49,8 @@ from documents.utils import copy_basic_file_stats
 from documents.utils import copy_file_with_basic_stats
 from documents.utils import run_subprocess
 from paperless_mail.parsers import MailDocumentParser
+
+MAX_STORED_FILENAME_LENGTH = 1024
 
 
 class WorkflowTriggerPlugin(
@@ -493,7 +496,16 @@ class ConsumerPlugin(
                 # After everything is in the database, copy the files into
                 # place. If this fails, we'll also rollback the transaction.
                 with FileLock(settings.MEDIA_LOCK):
-                    document.filename = generate_unique_filename(document)
+                    generated_filename = generate_unique_filename(document)
+                    if len(str(generated_filename)) > MAX_STORED_FILENAME_LENGTH:
+                        self.log.warning(
+                            "Generated source filename exceeds db path limit, falling back to default naming",
+                        )
+                        generated_filename = generate_filename(
+                            document,
+                            use_format=False,
+                        )
+                    document.filename = generated_filename
                     create_source_path_directory(document.source_path)
 
                     self._write(
@@ -511,10 +523,23 @@ class ConsumerPlugin(
                     )
 
                     if archive_path and Path(archive_path).is_file():
-                        document.archive_filename = generate_unique_filename(
+                        generated_archive_filename = generate_unique_filename(
                             document,
                             archive_filename=True,
                         )
+                        if (
+                            len(str(generated_archive_filename))
+                            > MAX_STORED_FILENAME_LENGTH
+                        ):
+                            self.log.warning(
+                                "Generated archive filename exceeds db path limit, falling back to default naming",
+                            )
+                            generated_archive_filename = generate_filename(
+                                document,
+                                archive_filename=True,
+                                use_format=False,
+                            )
+                        document.archive_filename = generated_archive_filename
                         create_source_path_directory(document.archive_path)
                         self._write(
                             document.storage_type,

--- a/src/documents/file_handling.py
+++ b/src/documents/file_handling.py
@@ -128,17 +128,21 @@ def generate_filename(
     counter=0,
     append_gpg=True,
     archive_filename=False,
+    use_format=True,
 ) -> Path:
     base_path: Path | None = None
 
     # Determine the source of the format string
-    if doc.storage_path is not None:
-        filename_format = doc.storage_path.path
-    elif settings.FILENAME_FORMAT is not None:
-        # Maybe convert old to new style
-        filename_format = convert_format_str_to_template_format(
-            settings.FILENAME_FORMAT,
-        )
+    if use_format:
+        if doc.storage_path is not None:
+            filename_format = doc.storage_path.path
+        elif settings.FILENAME_FORMAT is not None:
+            # Maybe convert old to new style
+            filename_format = convert_format_str_to_template_format(
+                settings.FILENAME_FORMAT,
+            )
+        else:
+            filename_format = None
     else:
         filename_format = None
 

--- a/src/documents/models.py
+++ b/src/documents/models.py
@@ -160,6 +160,7 @@ class Document(SoftDeleteModel, ModelWithOwner):
         (STORAGE_TYPE_UNENCRYPTED, _("Unencrypted")),
         (STORAGE_TYPE_GPG, _("Encrypted with GNU Privacy Guard")),
     )
+    MAX_STORED_FILENAME_LENGTH: Final[int] = 1024
 
     correspondent = models.ForeignKey(
         Correspondent,
@@ -267,7 +268,7 @@ class Document(SoftDeleteModel, ModelWithOwner):
 
     filename = models.FilePathField(
         _("filename"),
-        max_length=1024,
+        max_length=MAX_STORED_FILENAME_LENGTH,
         editable=False,
         default=None,
         unique=True,
@@ -277,7 +278,7 @@ class Document(SoftDeleteModel, ModelWithOwner):
 
     archive_filename = models.FilePathField(
         _("archive filename"),
-        max_length=1024,
+        max_length=MAX_STORED_FILENAME_LENGTH,
         editable=False,
         default=None,
         unique=True,
@@ -287,7 +288,7 @@ class Document(SoftDeleteModel, ModelWithOwner):
 
     original_filename = models.CharField(
         _("original filename"),
-        max_length=1024,
+        max_length=MAX_STORED_FILENAME_LENGTH,
         editable=False,
         default=None,
         unique=False,

--- a/src/documents/signals/handlers.py
+++ b/src/documents/signals/handlers.py
@@ -59,7 +59,6 @@ if TYPE_CHECKING:
     from documents.data_models import DocumentMetadataOverrides
 
 logger = logging.getLogger("paperless.handlers")
-MAX_STORED_FILENAME_LENGTH = 1024
 
 
 def add_inbox_tags(sender, document: Document, logging_group=None, **kwargs):
@@ -464,11 +463,11 @@ def update_filename_and_move_files(
             move_original = False
 
             candidate_filename = generate_filename(instance)
-            if len(str(candidate_filename)) > MAX_STORED_FILENAME_LENGTH:
+            if len(str(candidate_filename)) > Document.MAX_STORED_FILENAME_LENGTH:
                 msg = (
                     f"Document {instance!s}: Generated filename exceeds db path "
                     f"limit ({len(str(candidate_filename))} > "
-                    f"{MAX_STORED_FILENAME_LENGTH}): {candidate_filename!s}"
+                    f"{Document.MAX_STORED_FILENAME_LENGTH}): {candidate_filename!s}"
                 )
                 logger.warning(msg)
                 raise CannotMoveFilesException(msg)
@@ -497,11 +496,11 @@ def update_filename_and_move_files(
 
             if instance.has_archive_version:
                 archive_candidate = generate_filename(instance, archive_filename=True)
-                if len(str(archive_candidate)) > MAX_STORED_FILENAME_LENGTH:
+                if len(str(archive_candidate)) > Document.MAX_STORED_FILENAME_LENGTH:
                     msg = (
                         f"Document {instance!s}: Generated archive filename exceeds "
                         f"db path limit ({len(str(archive_candidate))} > "
-                        f"{MAX_STORED_FILENAME_LENGTH}): {archive_candidate!s}"
+                        f"{Document.MAX_STORED_FILENAME_LENGTH}): {archive_candidate!s}"
                     )
                     logger.warning(msg)
                     raise CannotMoveFilesException(msg)

--- a/src/documents/signals/handlers.py
+++ b/src/documents/signals/handlers.py
@@ -59,6 +59,7 @@ if TYPE_CHECKING:
     from documents.data_models import DocumentMetadataOverrides
 
 logger = logging.getLogger("paperless.handlers")
+MAX_STORED_FILENAME_LENGTH = 1024
 
 
 def add_inbox_tags(sender, document: Document, logging_group=None, **kwargs):
@@ -460,8 +461,18 @@ def update_filename_and_move_files(
 
             old_filename = instance.filename
             old_source_path = instance.source_path
+            move_original = False
 
             candidate_filename = generate_filename(instance)
+            if len(str(candidate_filename)) > MAX_STORED_FILENAME_LENGTH:
+                msg = (
+                    f"Document {instance!s}: Generated filename exceeds db path "
+                    f"limit ({len(str(candidate_filename))} > "
+                    f"{MAX_STORED_FILENAME_LENGTH}): {candidate_filename!s}"
+                )
+                logger.warning(msg)
+                raise CannotMoveFilesException(msg)
+
             candidate_source_path = (
                 settings.ORIGINALS_DIR / candidate_filename
             ).resolve()
@@ -482,9 +493,18 @@ def update_filename_and_move_files(
 
             old_archive_filename = instance.archive_filename
             old_archive_path = instance.archive_path
+            move_archive = False
 
             if instance.has_archive_version:
                 archive_candidate = generate_filename(instance, archive_filename=True)
+                if len(str(archive_candidate)) > MAX_STORED_FILENAME_LENGTH:
+                    msg = (
+                        f"Document {instance!s}: Generated archive filename exceeds "
+                        f"db path limit ({len(str(archive_candidate))} > "
+                        f"{MAX_STORED_FILENAME_LENGTH}): {archive_candidate!s}"
+                    )
+                    logger.warning(msg)
+                    raise CannotMoveFilesException(msg)
                 archive_candidate_path = (
                     settings.ARCHIVE_DIR / archive_candidate
                 ).resolve()

--- a/src/documents/signals/handlers.py
+++ b/src/documents/signals/handlers.py
@@ -462,6 +462,10 @@ def update_filename_and_move_files(
             old_source_path = instance.source_path
             move_original = False
 
+            old_archive_filename = instance.archive_filename
+            old_archive_path = instance.archive_path
+            move_archive = False
+
             candidate_filename = generate_filename(instance)
             if len(str(candidate_filename)) > Document.MAX_STORED_FILENAME_LENGTH:
                 msg = (
@@ -489,10 +493,6 @@ def update_filename_and_move_files(
             # Need to convert to string to be able to save it to the db
             instance.filename = str(new_filename)
             move_original = old_filename != instance.filename
-
-            old_archive_filename = instance.archive_filename
-            old_archive_path = instance.archive_path
-            move_archive = False
 
             if instance.has_archive_version:
                 archive_candidate = generate_filename(instance, archive_filename=True)

--- a/src/documents/tests/test_consumer.py
+++ b/src/documents/tests/test_consumer.py
@@ -633,8 +633,12 @@ class TestConsumer(
 
         self._assert_first_last_send_progress()
 
-    @override_settings(FILENAME_FORMAT="a" * 1100)
-    def testFilenameHandlingFallsBackWhenGeneratedPathExceedsDbLimit(self):
+    @mock.patch("documents.consumer.generate_unique_filename")
+    def testFilenameHandlingFallsBackWhenGeneratedPathExceedsDbLimit(self, m):
+        m.side_effect = lambda doc, archive_filename=False: Path(
+            ("a" * 1100 + ".pdf") if not archive_filename else ("b" * 1100 + ".pdf"),
+        )
+
         with self.get_consumer(
             self.get_test_file(),
             DocumentMetadataOverrides(title="new docs"),

--- a/src/documents/tests/test_consumer.py
+++ b/src/documents/tests/test_consumer.py
@@ -633,6 +633,29 @@ class TestConsumer(
 
         self._assert_first_last_send_progress()
 
+    @override_settings(FILENAME_FORMAT="a" * 1100)
+    def testFilenameHandlingFallsBackWhenGeneratedPathExceedsDbLimit(self):
+        with self.get_consumer(
+            self.get_test_file(),
+            DocumentMetadataOverrides(title="new docs"),
+        ) as consumer:
+            consumer.run()
+
+        document = Document.objects.first()
+        self.assertIsNotNone(document)
+        assert document is not None
+
+        self.assertEqual(document.filename, f"{document.pk:07d}.pdf")
+        self.assertLessEqual(len(document.filename), 1024)
+        self.assertLessEqual(
+            len(document.archive_filename),
+            1024,
+        )
+        self.assertIsFile(document.source_path)
+        self.assertIsFile(document.archive_path)
+
+        self._assert_first_last_send_progress()
+
     @override_settings(FILENAME_FORMAT="{correspondent}/{title}")
     @mock.patch("documents.signals.handlers.generate_unique_filename")
     def testFilenameHandlingUnstableFormat(self, m):

--- a/src/documents/tests/test_file_handling.py
+++ b/src/documents/tests/test_file_handling.py
@@ -1699,6 +1699,21 @@ class TestCustomFieldFilenameUpdates(
         self.assertTrue(Path(self.doc.source_path).is_file())
         self.assertLessEqual(m.call_count, 1)
 
+    @override_settings(FILENAME_FORMAT=None)
+    def test_overlong_storage_path_keeps_existing_filename(self):
+        initial_filename = generate_filename(self.doc)
+        Document.objects.filter(pk=self.doc.pk).update(filename=str(initial_filename))
+        self.doc.refresh_from_db()
+        Path(self.doc.source_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(self.doc.source_path).touch()
+
+        self.doc.storage_path = StoragePath.objects.create(path="a" * 1100)
+        self.doc.save()
+
+        self.doc.refresh_from_db()
+        self.assertEqual(Path(self.doc.filename), initial_filename)
+        self.assertTrue(Path(self.doc.source_path).is_file())
+
 
 class TestPathDateLocalization:
     """


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Tried to keep this tight, I think should sort it though

Closes #12227 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
