### PR TITLE
Fix: use maxsplit=1 in Redis URL parsing to handle URLs with multiple colons

### DIFF
--- a/src/paperless/settings/__init__.py
+++ b/src/paperless/settings/__init__.py
@@ -130,7 +130,7 @@ def _parse_redis_url(env_redis: str | None) -> tuple[str, str]:
     if "unix" in env_redis.lower():
         # channels_redis socket format, looks like:
         # "unix:///path/to/redis.sock"
-        _, path = env_redis.split(":")
+        _, path = env_redis.split(":", 1)
         # Optionally setting a db number
         if "?db=" in env_redis:
             path, number = path.split("?db=")
@@ -141,7 +141,7 @@ def _parse_redis_url(env_redis: str | None) -> tuple[str, str]:
     elif "+socket" in env_redis.lower():
         # celery socket style, looks like:
         # "redis+socket:///path/to/redis.sock"
-        _, path = env_redis.split(":")
+        _, path = env_redis.split(":", 1)
         if "?virtual_host=" in env_redis:
             # Virtual host (aka db number)
             path, number = path.split("?virtual_host=")


### PR DESCRIPTION
## Proposed change

URLs like `unix://user:password@/path/to/redis.sock` contain more than one colon, causing the bare `split(":")` to return 3+ values and raising a ValueError when unpacking into two variables.


```
Mar 04 07:54:35 antares.milli.ways python3[304990]: Traceback (most recent call last):
Mar 04 07:54:35 antares.milli.ways python3[304990]:   File "/usr/src/paperless/manage.py", line 10, in <module>
Mar 04 07:54:35 antares.milli.ways python3[304990]:     execute_from_command_line(sys.argv)
Mar 04 07:54:35 antares.milli.ways python3[304990]:     ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
Mar 04 07:54:35 antares.milli.ways python3[304990]:   File "/usr/lib/python3.13/site-packages/django/core/management/__init__.py", line 443, in execute_from_command_line
Mar 04 07:54:35 antares.milli.ways python3[304990]:     utility.execute()
Mar 04 07:54:35 antares.milli.ways python3[304990]:     ~~~~~~~~~~~~~~~^^
Mar 04 07:54:35 antares.milli.ways python3[304990]:   File "/usr/lib/python3.13/site-packages/django/core/management/__init__.py", line 383, in execute
Mar 04 07:54:35 antares.milli.ways python3[304990]:     settings.INSTALLED_APPS
Mar 04 07:54:35 antares.milli.ways python3[304990]:   File "/usr/lib/python3.13/site-packages/django/conf/__init__.py", line 75, in __getattr__
Mar 04 07:54:35 antares.milli.ways python3[304990]:     self._setup(name)
Mar 04 07:54:35 antares.milli.ways python3[304990]:     ~~~~~~~~~~~^^^^^^
Mar 04 07:54:35 antares.milli.ways python3[304990]:   File "/usr/lib/python3.13/site-packages/django/conf/__init__.py", line 62, in _setup
Mar 04 07:54:35 antares.milli.ways python3[304990]:     self._wrapped = Settings(settings_module)
Mar 04 07:54:35 antares.milli.ways python3[304990]:                     ~~~~~~~~^^^^^^^^^^^^^^^^^
Mar 04 07:54:35 antares.milli.ways python3[304990]:   File "/usr/lib/python3.13/site-packages/django/conf/__init__.py", line 162, in __init__
Mar 04 07:54:35 antares.milli.ways python3[304990]:     mod = importlib.import_module(self.SETTINGS_MODULE)
Mar 04 07:54:35 antares.milli.ways python3[304990]:   File "/usr/lib64/python3.13/importlib/__init__.py", line 88, in import_module
Mar 04 07:54:35 antares.milli.ways python3[304990]:     return _bootstrap._gcd_import(name[level:], package, level)
Mar 04 07:54:35 antares.milli.ways python3[304990]:            ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Mar 04 07:54:35 antares.milli.ways python3[304990]:   File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
Mar 04 07:54:35 antares.milli.ways python3[304990]:   File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
Mar 04 07:54:35 antares.milli.ways python3[304990]:   File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
Mar 04 07:54:35 antares.milli.ways python3[304990]:   File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
Mar 04 07:54:35 antares.milli.ways python3[304990]:   File "<frozen importlib._bootstrap_external>", line 1023, in exec_module
Mar 04 07:54:35 antares.milli.ways python3[304990]:   File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
Mar 04 07:54:35 antares.milli.ways python3[304990]:   File "/usr/src/paperless/paperless/settings.py", line 437, in <module>
Mar 04 07:54:35 antares.milli.ways python3[304990]:     _CELERY_REDIS_URL, _CHANNELS_REDIS_URL = _parse_redis_url(
Mar 04 07:54:35 antares.milli.ways python3[304990]:                                              ~~~~~~~~~~~~~~~~^
Mar 04 07:54:35 antares.milli.ways python3[304990]:         os.getenv("PAPERLESS_REDIS", None),
Mar 04 07:54:35 antares.milli.ways python3[304990]:         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Mar 04 07:54:35 antares.milli.ways python3[304990]:     )
Mar 04 07:54:35 antares.milli.ways python3[304990]:     ^
Mar 04 07:54:35 antares.milli.ways python3[304990]:   File "/usr/src/paperless/paperless/settings.py", line 142, in _parse_redis_url
Mar 04 07:54:35 antares.milli.ways python3[304990]:     _, path = env_redis.split(":")
Mar 04 07:54:35 antares.milli.ways python3[304990]:     ^^^^^^^
Mar 04 07:54:35 antares.milli.ways python3[304990]: ValueError: too many values to unpack (expected 2)
```

## Type of change

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
