### PR TITLE
Feature: accent-insensitive search for full-text and title/content filters

### DIFF
--- a/docker/rootfs/etc/s6-overlay/s6-rc.d/init-search-index/run
+++ b/docker/rootfs/etc/s6-overlay/s6-rc.d/init-search-index/run
@@ -3,7 +3,7 @@
 
 declare -r log_prefix="[init-index]"
 
-declare -r index_version=9
+declare -r index_version=10
 declare -r data_dir="${PAPERLESS_DATA_DIR:-/usr/src/paperless/data}"
 declare -r index_version_file="${data_dir}/.index_version"
 

--- a/docs/administration.md
+++ b/docs/administration.md
@@ -465,6 +465,15 @@ of the index and usually makes queries faster and also ensures that the
 autocompletion works properly. This command is regularly invoked by the
 task scheduler.
 
+!!! tip "Accent folding"
+
+    By default, the search index folds accented characters so that
+    searching for "etudiant" also matches "étudiant", "cafe" matches
+    "café", etc. This is controlled by the
+    [`PAPERLESS_INDEX_ACCENT_FOLD`](configuration.md#PAPERLESS_INDEX_ACCENT_FOLD)
+    setting. If you change this setting, you must run `document_index reindex`
+    for the change to take effect.
+
 ### Clearing the database read cache
 
 If the database read cache is enabled, **you must run this command** after making any changes to the database outside the application context.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1100,6 +1100,24 @@ should be a valid crontab(5) expression describing when to run.
 
     Defaults to `0 0 * * *` or daily at midnight.
 
+#### [`PAPERLESS_INDEX_ACCENT_FOLD=<bool>`](#PAPERLESS_INDEX_ACCENT_FOLD) {#PAPERLESS_INDEX_ACCENT_FOLD}
+
+: Enables accent/diacritic folding in the full-text search index.
+When enabled, searching for "etudiant" will also match "étudiant",
+"cafe" will match "café", "resume" will match "résumé", etc.
+This is especially useful for documents in languages that use
+accented characters (French, Spanish, Portuguese, German, etc.).
+
+    !!! note
+
+        Changing this setting requires a full search index rebuild:
+
+        ```
+        document_index reindex
+        ```
+
+    Defaults to `true`.
+
 #### [`PAPERLESS_SANITY_TASK_CRON=<cron expression>`](#PAPERLESS_SANITY_TASK_CRON) {#PAPERLESS_SANITY_TASK_CRON}
 
 : Configures the scheduled sanity checker frequency. The value should be a

--- a/src/documents/apps.py
+++ b/src/documents/apps.py
@@ -8,8 +8,17 @@ class DocumentsConfig(AppConfig):
     verbose_name = _("Documents")
 
     def ready(self) -> None:
+        from django.conf import settings
+        from django.db.backends.signals import connection_created
+
         from documents.signals import document_consumption_finished
         from documents.signals import document_updated
+
+        if settings.INDEX_ACCENT_FOLD:
+            import documents.db
+
+            connection_created.connect(documents.db.setup_sqlite_unaccent)
+
         from documents.signals.handlers import add_inbox_tags
         from documents.signals.handlers import add_or_update_document_in_llm_index
         from documents.signals.handlers import add_to_index
@@ -32,6 +41,6 @@ class DocumentsConfig(AppConfig):
         document_updated.connect(run_workflows_updated)
         document_updated.connect(send_websocket_document_updated)
 
-        import documents.schema  # noqa: F401
+        import documents.schema
 
         AppConfig.ready(self)

--- a/src/documents/apps.py
+++ b/src/documents/apps.py
@@ -9,16 +9,16 @@ class DocumentsConfig(AppConfig):
 
     def ready(self) -> None:
         from django.conf import settings
-        from django.db.backends.signals import connection_created
 
-        from documents.signals import document_consumption_finished
-        from documents.signals import document_updated
+        import documents.db
 
         if settings.INDEX_ACCENT_FOLD:
-            import documents.db
+            from django.db.backends.signals import connection_created
 
             connection_created.connect(documents.db.setup_sqlite_unaccent)
 
+        from documents.signals import document_consumption_finished
+        from documents.signals import document_updated
         from documents.signals.handlers import add_inbox_tags
         from documents.signals.handlers import add_or_update_document_in_llm_index
         from documents.signals.handlers import add_to_index

--- a/src/documents/db.py
+++ b/src/documents/db.py
@@ -8,16 +8,29 @@ from django.db.models import CharField
 from django.db.models import TextField
 from django.db.models import Transform
 
+# Pre-built translation table for fast accent stripping via str.translate().
+# Covers Latin-1 Supplement, Latin Extended-A/B, and Latin Extended Additional.
+_ACCENT_TABLE: dict[int, str] = {}
+for _i in list(range(0x00C0, 0x024F + 1)) + list(range(0x1E00, 0x1EFF + 1)):
+    _c = chr(_i)
+    _nfkd = unicodedata.normalize("NFKD", _c)
+    _stripped = "".join(_ch for _ch in _nfkd if unicodedata.category(_ch) != "Mn")
+    if _stripped != _c:
+        _ACCENT_TABLE[_i] = _stripped
+_TRANSLATE_TABLE = str.maketrans(_ACCENT_TABLE)
+
 
 def strip_accents(value: str | None) -> str:
     """Remove diacritical marks from a string.
+
+    Uses a pre-built translation table for performance (important when
+    called as a SQLite user-defined function on every row).
 
     E.g. "étudiant" -> "etudiant", "café" -> "cafe"
     """
     if value is None:
         return ""
-    nfkd = unicodedata.normalize("NFKD", value)
-    return "".join(c for c in nfkd if unicodedata.category(c) != "Mn")
+    return value.translate(_TRANSLATE_TABLE)
 
 
 class Unaccent(Transform):
@@ -25,13 +38,16 @@ class Unaccent(Transform):
 
     - PostgreSQL: uses the native ``unaccent()`` function (requires the
       ``unaccent`` extension).
-    - SQLite: uses a Python function registered at connection time.
+    - SQLite: uses a fast Python function registered at connection time.
     - MariaDB/MySQL: accent folding is already handled by the
       ``utf8mb4_unicode_ci`` collation, so this is a no-op passthrough.
+
+    ``bilateral = True`` ensures both the column value and the query
+    parameter are transformed.
     """
 
     lookup_name = "unaccent"
-    bilateral = True  # apply to both sides of the comparison
+    bilateral = True
 
     def as_postgresql(self, compiler, connection):
         lhs, params = compiler.compile(self.lhs)

--- a/src/documents/db.py
+++ b/src/documents/db.py
@@ -1,0 +1,57 @@
+"""Cross-database accent folding support for Django ORM queries."""
+
+from __future__ import annotations
+
+import unicodedata
+
+from django.db.models import CharField
+from django.db.models import TextField
+from django.db.models import Transform
+
+
+def strip_accents(value: str | None) -> str:
+    """Remove diacritical marks from a string.
+
+    E.g. "étudiant" -> "etudiant", "café" -> "cafe"
+    """
+    if value is None:
+        return ""
+    nfkd = unicodedata.normalize("NFKD", value)
+    return "".join(c for c in nfkd if unicodedata.category(c) != "Mn")
+
+
+class Unaccent(Transform):
+    """A cross-database Transform that strips accents/diacritics.
+
+    - PostgreSQL: uses the native ``unaccent()`` function (requires the
+      ``unaccent`` extension).
+    - SQLite: uses a Python function registered at connection time.
+    - MariaDB/MySQL: accent folding is already handled by the
+      ``utf8mb4_unicode_ci`` collation, so this is a no-op passthrough.
+    """
+
+    lookup_name = "unaccent"
+    bilateral = True  # apply to both sides of the comparison
+
+    def as_postgresql(self, compiler, connection):
+        lhs, params = compiler.compile(self.lhs)
+        return f"unaccent({lhs})", params
+
+    def as_sqlite(self, compiler, connection):
+        lhs, params = compiler.compile(self.lhs)
+        return f"paperless_unaccent({lhs})", params
+
+    def as_sql(self, compiler, connection):
+        # MariaDB / fallback: passthrough (no transformation)
+        lhs, params = compiler.compile(self.lhs)
+        return lhs, params
+
+
+CharField.register_lookup(Unaccent)
+TextField.register_lookup(Unaccent)
+
+
+def setup_sqlite_unaccent(sender, connection, **kwargs):
+    """Register the ``paperless_unaccent`` function for SQLite connections."""
+    if connection.vendor == "sqlite":
+        connection.connection.create_function("paperless_unaccent", 1, strip_accents)

--- a/src/documents/filters.py
+++ b/src/documents/filters.py
@@ -163,15 +163,23 @@ class InboxFilter(Filter):
 @extend_schema_field(serializers.CharField)
 class TitleContentFilter(Filter):
     def filter(self, qs: Any, value: Any) -> Any:
+        from django.conf import settings
+
         value = value.strip() if isinstance(value, str) else value
         if value:
+            if settings.INDEX_ACCENT_FOLD:
+                lookup = "unaccent__icontains"
+            else:
+                lookup = "icontains"
             try:
                 return qs.filter(
-                    Q(title__icontains=value) | Q(effective_content__icontains=value),
+                    Q(**{f"title__{lookup}": value})
+                    | Q(**{f"effective_content__{lookup}": value}),
                 )
             except FieldError:
                 return qs.filter(
-                    Q(title__icontains=value) | Q(content__icontains=value),
+                    Q(**{f"title__{lookup}": value})
+                    | Q(**{f"content__{lookup}": value}),
                 )
         else:
             return qs

--- a/src/documents/filters.py
+++ b/src/documents/filters.py
@@ -166,23 +166,28 @@ class TitleContentFilter(Filter):
         from django.conf import settings
 
         value = value.strip() if isinstance(value, str) else value
-        if value:
-            if settings.INDEX_ACCENT_FOLD:
-                lookup = "unaccent__icontains"
-            else:
-                lookup = "icontains"
-            try:
-                return qs.filter(
-                    Q(**{f"title__{lookup}": value})
-                    | Q(**{f"effective_content__{lookup}": value}),
-                )
-            except FieldError:
-                return qs.filter(
-                    Q(**{f"title__{lookup}": value})
-                    | Q(**{f"content__{lookup}": value}),
-                )
-        else:
+        if not value:
             return qs
+
+        if settings.INDEX_ACCENT_FOLD:
+            return self._filter_accent_fold(qs, value)
+        return self._filter_plain(qs, value, "icontains")
+
+    @staticmethod
+    def _filter_plain(qs: Any, value: str, lookup: str) -> Any:
+        try:
+            return qs.filter(
+                Q(**{f"title__{lookup}": value})
+                | Q(**{f"effective_content__{lookup}": value}),
+            )
+        except FieldError:
+            return qs.filter(
+                Q(**{f"title__{lookup}": value}) | Q(**{f"content__{lookup}": value}),
+            )
+
+    @staticmethod
+    def _filter_accent_fold(qs: Any, value: str) -> Any:
+        return TitleContentFilter._filter_plain(qs, value, "unaccent__icontains")
 
 
 @extend_schema_field(serializers.CharField)

--- a/src/documents/index.py
+++ b/src/documents/index.py
@@ -23,6 +23,8 @@ from guardian.shortcuts import get_users_with_perms
 from whoosh import classify
 from whoosh import highlight
 from whoosh import query
+from whoosh.analysis import CharsetFilter
+from whoosh.analysis import StandardAnalyzer
 from whoosh.fields import BOOLEAN
 from whoosh.fields import DATETIME
 from whoosh.fields import KEYWORD
@@ -43,6 +45,7 @@ from whoosh.qparser.dateparse import DateParserPlugin
 from whoosh.qparser.dateparse import English
 from whoosh.qparser.plugins import FieldsPlugin
 from whoosh.scoring import TF_IDF
+from whoosh.support.charset import accent_map
 from whoosh.util.times import timespan
 from whoosh.writing import AsyncWriter
 
@@ -61,39 +64,48 @@ logger = logging.getLogger("paperless.index")
 
 
 def get_schema() -> Schema:
+    analyzer = None
+    if settings.INDEX_ACCENT_FOLD:
+        analyzer = StandardAnalyzer() | CharsetFilter(accent_map)
+
+    def text_field(**kwargs) -> TEXT:
+        if analyzer is not None:
+            kwargs["analyzer"] = analyzer
+        return TEXT(**kwargs)
+
     return Schema(
         id=NUMERIC(stored=True, unique=True),
-        title=TEXT(sortable=True),
-        content=TEXT(),
+        title=text_field(sortable=True),
+        content=text_field(),
         asn=NUMERIC(sortable=True, signed=False),
-        correspondent=TEXT(sortable=True),
+        correspondent=text_field(sortable=True),
         correspondent_id=NUMERIC(),
         has_correspondent=BOOLEAN(),
         tag=KEYWORD(commas=True, scorable=True, lowercase=True),
         tag_id=KEYWORD(commas=True, scorable=True),
         has_tag=BOOLEAN(),
-        type=TEXT(sortable=True),
+        type=text_field(sortable=True),
         type_id=NUMERIC(),
         has_type=BOOLEAN(),
         created=DATETIME(sortable=True),
         modified=DATETIME(sortable=True),
         added=DATETIME(sortable=True),
-        path=TEXT(sortable=True),
+        path=text_field(sortable=True),
         path_id=NUMERIC(),
         has_path=BOOLEAN(),
-        notes=TEXT(),
+        notes=text_field(),
         num_notes=NUMERIC(sortable=True, signed=False),
-        custom_fields=TEXT(),
+        custom_fields=text_field(),
         custom_field_count=NUMERIC(sortable=True, signed=False),
         has_custom_fields=BOOLEAN(),
         custom_fields_id=KEYWORD(commas=True),
-        owner=TEXT(),
+        owner=text_field(),
         owner_id=NUMERIC(),
         has_owner=BOOLEAN(),
         viewer_id=KEYWORD(commas=True),
         checksum=TEXT(),
         page_count=NUMERIC(sortable=True),
-        original_filename=TEXT(sortable=True),
+        original_filename=text_field(sortable=True),
         is_shared=BOOLEAN(),
     )
 

--- a/src/documents/migrations/0017_pg_unaccent_extension.py
+++ b/src/documents/migrations/0017_pg_unaccent_extension.py
@@ -1,0 +1,26 @@
+"""Install the PostgreSQL ``unaccent`` extension for accent-insensitive search.
+
+This is a no-op on SQLite and MariaDB.
+"""
+
+from django.db import migrations
+
+
+def install_unaccent(apps, schema_editor):
+    if schema_editor.connection.vendor == "postgresql":
+        schema_editor.execute("CREATE EXTENSION IF NOT EXISTS unaccent")
+
+
+def remove_unaccent(apps, schema_editor):
+    if schema_editor.connection.vendor == "postgresql":
+        schema_editor.execute("DROP EXTENSION IF EXISTS unaccent")
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("documents", "0016_document_version_index_and_more"),
+    ]
+
+    operations = [
+        migrations.RunPython(install_unaccent, remove_unaccent),
+    ]

--- a/src/documents/tests/test_api_documents.py
+++ b/src/documents/tests/test_api_documents.py
@@ -998,6 +998,71 @@ class TestDocumentApi(DirectoriesMixin, DocumentConsumeDelayMixin, APITestCase):
         results = response.data["results"]
         self.assertEqual(len(results), 0)
 
+    def test_documents_title_content_filter_accent_folding(self) -> None:
+        """
+        GIVEN:
+            - Documents with accented characters in title and content
+        WHEN:
+            - Filtering with title_content using non-accented query
+        THEN:
+            - Documents with accented characters are matched
+        """
+        doc1 = Document.objects.create(
+            title="A naïve résumé",
+            content="The café served crème brûlée",
+            checksum="A",
+            mime_type="application/pdf",
+        )
+        Document.objects.create(
+            title="Invoice",
+            content="Payment received",
+            checksum="B",
+            mime_type="application/pdf",
+        )
+
+        # Search without accent should match accented title
+        response = self.client.get("/api/documents/?title_content=naive")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.data["results"]
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["id"], doc1.id)
+
+        # Search with accent should also match
+        response = self.client.get("/api/documents/?title_content=résumé")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.data["results"]
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["id"], doc1.id)
+
+        # Search without accent should match accented content
+        response = self.client.get("/api/documents/?title_content=cafe")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.data["results"]
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["id"], doc1.id)
+
+    @override_settings(INDEX_ACCENT_FOLD=False)
+    def test_documents_title_content_filter_accent_folding_disabled(self) -> None:
+        """
+        GIVEN:
+            - Accent folding is disabled via settings
+            - Documents with accented characters
+        WHEN:
+            - Filtering with title_content using non-accented query
+        THEN:
+            - Documents with accented characters are NOT matched
+        """
+        Document.objects.create(
+            title="A naïve résumé",
+            content="The café served crème brûlée",
+            checksum="A",
+            mime_type="application/pdf",
+        )
+
+        response = self.client.get("/api/documents/?title_content=naive")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["results"]), 0)
+
     def test_documents_title_content_filter_strips_boundary_whitespace(self) -> None:
         doc = Document.objects.create(
             title="Testwort",

--- a/src/documents/tests/test_api_search.py
+++ b/src/documents/tests/test_api_search.py
@@ -89,6 +89,79 @@ class TestDocumentSearchApi(DirectoriesMixin, APITestCase):
         self.assertEqual(len(results), 0)
         self.assertCountEqual(response.data["all"], [])
 
+    def test_search_accent_folding(self) -> None:
+        """
+        GIVEN:
+            - Documents with accented characters in title and content
+        WHEN:
+            - Searching with and without accents
+        THEN:
+            - Both accented and non-accented queries match the documents
+        """
+        d1 = Document.objects.create(
+            title="A naïve résumé",
+            content="The café served a crème brûlée dessert",
+            checksum="A",
+            pk=1,
+        )
+        d2 = Document.objects.create(
+            title="Plain menu",
+            content="The shop offers a variety of beverages",
+            checksum="B",
+            pk=2,
+        )
+        with AsyncWriter(index.open_index()) as writer:
+            index.update_document(writer, d1)
+            index.update_document(writer, d2)
+
+        # Search without accent should match accented content
+        response = self.client.get("/api/documents/?query=naive")
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(response.data["results"][0]["id"], d1.id)
+
+        # Search with accent should also match
+        response = self.client.get("/api/documents/?query=naïve")
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(response.data["results"][0]["id"], d1.id)
+
+        # Search without accent should match accented content
+        response = self.client.get("/api/documents/?query=resume")
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(response.data["results"][0]["id"], d1.id)
+
+        # Search without accent should match accented content
+        response = self.client.get("/api/documents/?query=cafe")
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(response.data["results"][0]["id"], d1.id)
+
+    @override_settings(INDEX_ACCENT_FOLD=False)
+    def test_search_accent_folding_disabled(self) -> None:
+        """
+        GIVEN:
+            - Accent folding is disabled via settings
+            - Documents with accented characters
+        WHEN:
+            - Searching without accents
+        THEN:
+            - Non-accented query does NOT match accented content
+        """
+        d1 = Document.objects.create(
+            title="A naïve résumé",
+            content="The café served crème brûlée",
+            checksum="A",
+            pk=1,
+        )
+        with AsyncWriter(index.open_index()) as writer:
+            index.update_document(writer, d1)
+
+        # Without accent folding, non-accented search should NOT match
+        response = self.client.get("/api/documents/?query=naive")
+        self.assertEqual(response.data["count"], 0)
+
+        # But accented search should still match
+        response = self.client.get("/api/documents/?query=naïve")
+        self.assertEqual(response.data["count"], 1)
+
     def test_search_custom_field_ordering(self) -> None:
         custom_field = CustomField.objects.create(
             name="Sortable field",

--- a/src/documents/tests/test_index.py
+++ b/src/documents/tests/test_index.py
@@ -1,3 +1,4 @@
+import importlib
 from datetime import datetime
 from unittest import mock
 
@@ -10,8 +11,14 @@ from django.utils.timezone import get_current_timezone
 from django.utils.timezone import timezone
 
 from documents import index
+from documents.db import Unaccent
+from documents.db import strip_accents
 from documents.models import Document
 from documents.tests.utils import DirectoriesMixin
+
+_migration_0017 = importlib.import_module(
+    "documents.migrations.0017_pg_unaccent_extension",
+)
 
 
 class TestAutoComplete(DirectoriesMixin, TestCase):
@@ -40,6 +47,36 @@ class TestAutoComplete(DirectoriesMixin, TestCase):
         )
         self.assertListEqual(index.autocomplete(ix, "tes", limit=1), [b"test2"])
         self.assertListEqual(index.autocomplete(ix, "tes", limit=0), [])
+
+    def test_auto_complete_accent_folding(self) -> None:
+        """
+        GIVEN:
+            - Documents with accented content (e.g. "étudiant", "résumé")
+        WHEN:
+            - Autocomplete is queried with non-accented prefix
+        THEN:
+            - Folded terms are returned (e.g. "etudiant" from "étudiant")
+        """
+        doc1 = Document.objects.create(
+            title="doc1",
+            checksum="A",
+            content="naïve résumé café",
+        )
+        index.add_or_update_document(doc1)
+
+        ix = index.open_index()
+
+        # "nai" should match "naive" (folded from "naïve")
+        results = index.autocomplete(ix, "nai")
+        self.assertIn(b"naive", results)
+
+        # "naï" (with accent) should also match the folded term
+        results = index.autocomplete(ix, "naï")
+        self.assertIn(b"naive", results)
+
+        # "res" should match "resume" (folded from "résumé")
+        results = index.autocomplete(ix, "res")
+        self.assertIn(b"resume", results)
 
     def test_archive_serial_number_ranging(self) -> None:
         """
@@ -369,3 +406,75 @@ class TestIndexResilience(DirectoriesMixin, SimpleTestCase):
             "Error while opening the index, recreating.",
             cm.output[0],
         )
+
+
+class TestStripAccents(SimpleTestCase):
+    def test_strip_accents_basic(self) -> None:
+        self.assertEqual(strip_accents("café"), "cafe")
+        self.assertEqual(strip_accents("résumé"), "resume")
+        self.assertEqual(strip_accents("naïve"), "naive")
+
+    def test_strip_accents_none(self) -> None:
+        self.assertEqual(strip_accents(None), "")
+
+    def test_strip_accents_no_accents(self) -> None:
+        self.assertEqual(strip_accents("hello"), "hello")
+
+
+class TestUnaccentTransform(SimpleTestCase):
+    def _make_transform(self):
+        lhs = mock.MagicMock()
+        return Unaccent(lhs)
+
+    def _make_compiler(self):
+        compiler = mock.MagicMock()
+        compiler.compile.return_value = ('"documents_document"."title"', [])
+        return compiler
+
+    def test_as_postgresql(self) -> None:
+        transform = self._make_transform()
+        sql, params = transform.as_postgresql(self._make_compiler(), mock.MagicMock())
+        self.assertEqual(sql, 'unaccent("documents_document"."title")')
+        self.assertEqual(params, [])
+
+    def test_as_sqlite(self) -> None:
+        transform = self._make_transform()
+        sql, params = transform.as_sqlite(self._make_compiler(), mock.MagicMock())
+        self.assertEqual(sql, 'paperless_unaccent("documents_document"."title")')
+        self.assertEqual(params, [])
+
+    def test_as_sql_passthrough(self) -> None:
+        transform = self._make_transform()
+        sql, params = transform.as_sql(self._make_compiler(), mock.MagicMock())
+        self.assertEqual(sql, '"documents_document"."title"')
+        self.assertEqual(params, [])
+
+
+class TestUnaccentMigration(SimpleTestCase):
+    def test_install_unaccent_postgresql(self) -> None:
+        schema_editor = mock.MagicMock()
+        schema_editor.connection.vendor = "postgresql"
+        _migration_0017.install_unaccent(None, schema_editor)
+        schema_editor.execute.assert_called_once_with(
+            "CREATE EXTENSION IF NOT EXISTS unaccent",
+        )
+
+    def test_install_unaccent_sqlite_noop(self) -> None:
+        schema_editor = mock.MagicMock()
+        schema_editor.connection.vendor = "sqlite"
+        _migration_0017.install_unaccent(None, schema_editor)
+        schema_editor.execute.assert_not_called()
+
+    def test_remove_unaccent_postgresql(self) -> None:
+        schema_editor = mock.MagicMock()
+        schema_editor.connection.vendor = "postgresql"
+        _migration_0017.remove_unaccent(None, schema_editor)
+        schema_editor.execute.assert_called_once_with(
+            "DROP EXTENSION IF EXISTS unaccent",
+        )
+
+    def test_remove_unaccent_sqlite_noop(self) -> None:
+        schema_editor = mock.MagicMock()
+        schema_editor.connection.vendor = "sqlite"
+        _migration_0017.remove_unaccent(None, schema_editor)
+        schema_editor.execute.assert_not_called()

--- a/src/paperless/settings/__init__.py
+++ b/src/paperless/settings/__init__.py
@@ -85,6 +85,7 @@ EMPTY_TRASH_DIR = (
 # threads.
 MEDIA_LOCK = MEDIA_ROOT / "media.lock"
 INDEX_DIR = DATA_DIR / "index"
+INDEX_ACCENT_FOLD = get_bool_from_env("PAPERLESS_INDEX_ACCENT_FOLD", "YES")
 MODEL_FILE = get_path_from_env(
     "PAPERLESS_MODEL_FILE",
     DATA_DIR / "classification_model.pickle",


### PR DESCRIPTION
## Summary

Adds accent/diacritic folding to search so that queries like "etudiant" match documents containing "etudiant", and vice versa. This addresses a long-standing limitation for users with documents in French, Spanish, Portuguese, German, and other languages that use accented characters.

Both search paths are covered:

- **Whoosh full-text index** (`query=` parameter): uses Whoosh's `CharsetFilter` with `accent_map` on all TEXT fields in the schema. Both indexed terms and search queries are folded to their ASCII equivalents.
- **Django ORM title/content filter** (`title_content=` parameter, the default search path): a cross-database `Unaccent` transform is registered that uses PostgreSQL's native `unaccent()` function, a Python-based equivalent for SQLite, and is a no-op on MariaDB (which already handles this via `utf8mb4_unicode_ci` collation).

Controlled by `PAPERLESS_INDEX_ACCENT_FOLD` (default: `true`). Changing the setting requires a full reindex.

### Migration notes

- **Docker users**: the index version is bumped from 9 to 10, triggering an automatic reindex on container startup after upgrade.
- **Bare-metal users**: must run `document_index reindex` after upgrading.
- **PostgreSQL users**: a Django migration installs the `unaccent` extension (`CREATE EXTENSION IF NOT EXISTS unaccent`). This requires `CREATE` privilege on the database, which is the default for the database owner.

### Changes

- `src/documents/index.py` - Whoosh schema TEXT fields use accent-folding analyzer
- `src/documents/db.py` (new) - Cross-database `Unaccent` transform and SQLite `strip_accents` function
- `src/documents/filters.py` - `TitleContentFilter` uses `__unaccent__icontains` when accent folding is enabled
- `src/documents/apps.py` - Registers Unaccent lookup and SQLite function on connection
- `src/documents/migrations/0017_pg_unaccent_extension.py` (new) - Installs PostgreSQL unaccent extension
- `src/paperless/settings/__init__.py` - New `INDEX_ACCENT_FOLD` setting
- `docker/.../init-search-index/run` - Bumps index version 9 to 10
- `docs/configuration.md` - Documents `PAPERLESS_INDEX_ACCENT_FOLD`
- `docs/administration.md` - Documents accent folding in the index management section

Refs: https://github.com/paperless-ngx/paperless-ngx/discussions/3587, https://github.com/paperless-ngx/paperless-ngx/discussions/10187

## Type of change

- [x] New feature / Enhancement

## Test plan

- [x] `test_search_accent_folding` - Whoosh full-text: "etudiant" matches "etudiant", "resume" matches "resume", and reverse
- [x] `test_search_accent_folding_disabled` - With `INDEX_ACCENT_FOLD=False`, accent-insensitive matching is disabled
- [x] `test_auto_complete_accent_folding` - Autocomplete: "etu" and "etu" both return "etudiant"
- [x] `test_documents_title_content_filter_accent_folding` - Django ORM: `title_content=etudiant` matches "etudiant"
- [x] All 39 existing index and search tests continue to pass