### PR TITLE
Enhancement: Show more document details in merge dialog

### DIFF
--- a/src-ui/src/app/components/common/confirm-dialog/merge-confirm-dialog/merge-confirm-dialog.component.html
+++ b/src-ui/src/app/components/common/confirm-dialog/merge-confirm-dialog/merge-confirm-dialog.component.html
@@ -11,12 +11,21 @@
             cdkDropList
             (cdkDropListDropped)="onDrop($event)">
             @for (document of documents; track document.id) {
-                <li class="list-group-item" cdkDrag>
+                <li class="list-group-item d-flex align-items-center" cdkDrag>
                     <i-bs name="grip-vertical" class="me-2"></i-bs>
-                    @if (document.correspondent) {
-                      <b>{{document.correspondent | correspondentName | async}}:</b>
-                    }
-                    {{document.title}}
+                    <div class="d-flex flex-column">
+                        <div>
+                          @if (document.correspondent) {
+                            <b>{{document.correspondent | correspondentName | async}}: </b>
+                          }{{document.title}}
+                        </div>
+                        <small class="text-muted">
+                          {{document.created | customDate:'mediumDate'}}
+                          @if (document.page_count) {
+                            | {document.page_count, plural, =1 {One page} other {{{document.page_count}} pages}}
+                          }
+                        </small>
+                    </div>
                 </li>
             }
         </ul>

--- a/src-ui/src/app/components/common/confirm-dialog/merge-confirm-dialog/merge-confirm-dialog.component.html
+++ b/src-ui/src/app/components/common/confirm-dialog/merge-confirm-dialog/merge-confirm-dialog.component.html
@@ -10,10 +10,13 @@
         <ul class="list-group"
             cdkDropList
             (cdkDropListDropped)="onDrop($event)">
-            @for (documentID of documentIDs; track documentID) {
+            @for (document of documents; track document.id) {
                 <li class="list-group-item" cdkDrag>
                     <i-bs name="grip-vertical" class="me-2"></i-bs>
-                    {{getDocument(documentID)?.title}}
+                    @if (document.correspondent) {
+                      <b>{{document.correspondent | correspondentName | async}}:</b>
+                    }
+                    {{document.title}}
                 </li>
             }
         </ul>

--- a/src-ui/src/app/components/common/confirm-dialog/merge-confirm-dialog/merge-confirm-dialog.component.ts
+++ b/src-ui/src/app/components/common/confirm-dialog/merge-confirm-dialog/merge-confirm-dialog.component.ts
@@ -10,6 +10,7 @@ import { NgxBootstrapIconsModule } from 'ngx-bootstrap-icons'
 import { takeUntil } from 'rxjs'
 import { Document } from 'src/app/data/document'
 import { CorrespondentNamePipe } from 'src/app/pipes/correspondent-name.pipe'
+import { CustomDatePipe } from 'src/app/pipes/custom-date.pipe'
 import { PermissionsService } from 'src/app/services/permissions.service'
 import { DocumentService } from 'src/app/services/rest/document.service'
 import { ConfirmDialogComponent } from '../confirm-dialog.component'
@@ -21,6 +22,7 @@ import { ConfirmDialogComponent } from '../confirm-dialog.component'
   imports: [
     AsyncPipe,
     CorrespondentNamePipe,
+    CustomDatePipe,
     DragDropModule,
     FormsModule,
     ReactiveFormsModule,

--- a/src-ui/src/app/components/common/confirm-dialog/merge-confirm-dialog/merge-confirm-dialog.component.ts
+++ b/src-ui/src/app/components/common/confirm-dialog/merge-confirm-dialog/merge-confirm-dialog.component.ts
@@ -3,11 +3,13 @@ import {
   DragDropModule,
   moveItemInArray,
 } from '@angular/cdk/drag-drop'
+import { AsyncPipe } from '@angular/common'
 import { Component, OnInit, inject } from '@angular/core'
 import { FormsModule, ReactiveFormsModule } from '@angular/forms'
 import { NgxBootstrapIconsModule } from 'ngx-bootstrap-icons'
 import { takeUntil } from 'rxjs'
 import { Document } from 'src/app/data/document'
+import { CorrespondentNamePipe } from 'src/app/pipes/correspondent-name.pipe'
 import { PermissionsService } from 'src/app/services/permissions.service'
 import { DocumentService } from 'src/app/services/rest/document.service'
 import { ConfirmDialogComponent } from '../confirm-dialog.component'
@@ -17,6 +19,8 @@ import { ConfirmDialogComponent } from '../confirm-dialog.component'
   templateUrl: './merge-confirm-dialog.component.html',
   styleUrl: './merge-confirm-dialog.component.scss',
   imports: [
+    AsyncPipe,
+    CorrespondentNamePipe,
     DragDropModule,
     FormsModule,
     ReactiveFormsModule,


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

As proposed in #12152, I want to change the merge document dialog from this:
<img width="619" height="651" alt="image" src="https://github.com/user-attachments/assets/9915b630-9911-4001-aeb5-626b91e90a6b" />
to this:
<img width="623" height="652" alt="image" src="https://github.com/user-attachments/assets/2ee36ae3-0cf1-4e90-a71f-08ecfd763132" />

I have a lot of similarly named documents and I want to make this dialog more effective for me. Currently, I have to have two windows open and cross-reference document titles so that I know which is which. For the screenshot I only used my test instance's two documents to illustrate the change. However, imagine it with tons of very similarly named documents.

First contribution to paperless-ngx (which I absolutely love! Thanks so much for this project!) and I'm not a frontend dev so be gentle. I do hope the change is small enough and that it makes sense.

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

<!--
⚠️ Important: Pull requests that implement a new feature or enhancement *should almost always target an existing feature request* with evidence of community interest and discussion. This is in order to balance the work of implementing and maintaining new features / enhancements. If that is not currently the case, please open a feature request instead of this PR to gather feedback from both users and the project maintainers.
-->

Closes #12152

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [x] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
