### PR TITLE
Set a timeout on views HTTP calls

### DIFF
--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -3368,6 +3368,7 @@ class RemoteVersionView(GenericAPIView):
                 resp = httpx.get(
                     "https://api.github.com/repos/paperless-ngx/paperless-ngx/releases/latest",
                     headers={"Accept": "application/json"},
+                    timeout=10.0,
                 )
                 resp.raise_for_status()
                 data = resp.json()


### PR DESCRIPTION
Introduced a timeout in src/documents/views.py to avoid indefinite worker hangs.

Reason: Network calls without a timeout can hang a worker indefinitely.

Validation: `/Users/tejasattarde/Desktop/gh-patchbot/.venv/bin/python -m py_compile src/documents/views.py`.

Context: py-http-timeout at src/documents/views.py:3368.