### PR TITLE
Enhancement: Sort custom field names and Select field values wherever shown

### DIFF
--- a/src-ui/src/app/components/common/custom-fields-dropdown/custom-fields-dropdown.component.spec.ts
+++ b/src-ui/src/app/components/common/custom-fields-dropdown/custom-fields-dropdown.component.spec.ts
@@ -80,6 +80,27 @@ describe('CustomFieldsDropdownComponent', () => {
     fixture.detectChanges()
   })
 
+  it('should display fields sorted by name', () => {
+    const unsortedFields: CustomField[] = [
+      { id: 2, name: 'Release Date', data_type: CustomFieldDataType.Date },
+      { id: 3, name: 'Film Title', data_type: CustomFieldDataType.Integer },
+    ]
+    jest.spyOn(customFieldService, 'listAll').mockReturnValue(
+      of({
+        count: unsortedFields.length,
+        all: unsortedFields.map((f) => f.id),
+        results: unsortedFields,
+      })
+    )
+    fixture = TestBed.createComponent(CustomFieldsDropdownComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+    expect(component.filteredFields).toEqual([
+      { id: 3, name: 'Film Title', data_type: CustomFieldDataType.Integer },
+      { id: 2, name: 'Release Date', data_type: CustomFieldDataType.Date },
+    ])
+  })
+
   it('should support add field', () => {
     let addedField
     component.added.subscribe((f) => (addedField = f))

--- a/src-ui/src/app/components/common/custom-fields-dropdown/custom-fields-dropdown.component.ts
+++ b/src-ui/src/app/components/common/custom-fields-dropdown/custom-fields-dropdown.component.ts
@@ -95,6 +95,8 @@ export class CustomFieldsDropdownComponent extends LoadingComponentWithPermissio
       .pipe(first(), takeUntil(this.unsubscribeNotifier))
       .subscribe((result) => {
         this.customFields = result.results
+          .slice()
+          .sort((a, b) => a.name.localeCompare(b.name))
         this.updateUnusedFields()
       })
   }

--- a/src-ui/src/app/components/common/custom-fields-query-dropdown/custom-fields-query-dropdown.component.spec.ts
+++ b/src-ui/src/app/components/common/custom-fields-query-dropdown/custom-fields-query-dropdown.component.spec.ts
@@ -37,12 +37,12 @@ const customFields = [
   },
   {
     id: 2,
-    name: 'Test Select Field',
+    name: 'Earlier Alphabetically Sorted Field',
     data_type: CustomFieldDataType.Select,
     extra_data: {
       select_options: [
-        { label: 'Option 1', id: 'abc-123' },
-        { label: 'Option 2', id: 'def-456' },
+        { label: 'Millennium Falcon', id: 'thx-1138' },
+        { label: 'Aluminum Falcon', id: 'aa-23' },
       ],
     },
   },
@@ -83,8 +83,11 @@ describe('CustomFieldsQueryDropdownComponent', () => {
     fixture.detectChanges()
   })
 
-  it('should initialize custom fields on creation', () => {
-    expect(component.customFields).toEqual(customFields)
+  it('should initialize custom fields on creation, sorted by name', () => {
+    expect(component.customFields).toEqual([
+      customFields[1], // Test Field
+      customFields[0], // Earlier Alphabetically Sorted Field
+    ])
   })
 
   it('should add an expression when opened if queries are empty', () => {
@@ -123,7 +126,7 @@ describe('CustomFieldsQueryDropdownComponent', () => {
     )
 
     // Fallback to basic operators if field is not found
-    const operators2 = component.getOperatorsForField(2)
+    const operators2 = component.getOperatorsForField(3)
     expect(operators2.length).toEqual(
       CUSTOM_FIELD_QUERY_OPERATORS_BY_GROUP[
         CustomFieldQueryOperatorGroups.Basic
@@ -131,27 +134,15 @@ describe('CustomFieldsQueryDropdownComponent', () => {
     )
   })
 
-  it('should get select options for a field', () => {
-    const field: CustomField = {
-      id: 1,
-      name: 'Test Field',
-      data_type: CustomFieldDataType.Select,
-      extra_data: {
-        select_options: [
-          { label: 'Option 1', id: 'abc-123' },
-          { label: 'Option 2', id: 'def-456' },
-        ],
-      },
-    }
-    component.customFields = [field]
-    const options = component.getSelectOptionsForField(1)
+  it('should get select options for a field, sorted by label', () => {
+    const options = component.getSelectOptionsForField(2)
     expect(options).toEqual([
-      { label: 'Option 1', id: 'abc-123' },
-      { label: 'Option 2', id: 'def-456' },
+      { label: 'Aluminum Falcon', id: 'aa-23' },
+      { label: 'Millennium Falcon', id: 'thx-1138' },
     ])
 
     // Fallback to empty array if field is not found
-    const options2 = component.getSelectOptionsForField(2)
+    const options2 = component.getSelectOptionsForField(99)
     expect(options2).toEqual([])
   })
 
@@ -202,7 +193,10 @@ describe('CustomFieldsQueryDropdownComponent', () => {
   })
 
   it('should support getting a custom field by ID', () => {
-    expect(component.getCustomFieldByID(1)).toEqual(customFields[0])
+    expect(component.getCustomFieldByID(1)?.name).toEqual('Test Field')
+    expect(component.getCustomFieldByID(2)?.name).toEqual(
+      'Earlier Alphabetically Sorted Field'
+    )
   })
 
   it('should sanitize name from title', () => {

--- a/src-ui/src/app/components/common/custom-fields-query-dropdown/custom-fields-query-dropdown.component.ts
+++ b/src-ui/src/app/components/common/custom-fields-query-dropdown/custom-fields-query-dropdown.component.ts
@@ -317,6 +317,13 @@ export class CustomFieldsQueryDropdownComponent extends LoadingComponentWithPerm
       .pipe(first(), takeUntil(this.unsubscribeNotifier))
       .subscribe((result) => {
         this.customFields = result.results
+          .slice()
+          .sort((a, b) => a.name.localeCompare(b.name))
+        for (const field of this.customFields) {
+          field.extra_data?.['select_options']?.sort((a, b) =>
+            a.label.localeCompare(b.label)
+          )
+        }
       })
   }
 

--- a/src-ui/src/app/components/common/edit-dialog/custom-field-edit-dialog/custom-field-edit-dialog.component.spec.ts
+++ b/src-ui/src/app/components/common/edit-dialog/custom-field-edit-dialog/custom-field-edit-dialog.component.spec.ts
@@ -69,6 +69,58 @@ describe('CustomFieldEditDialogComponent', () => {
     expect(component.objectForm.get('data_type').disabled).toBeTruthy()
   })
 
+  it('should sort existing select options by label on edit', () => {
+    component.dialogMode = EditDialogMode.EDIT
+    component.object = {
+      id: 1,
+      name: 'Starship Model',
+      data_type: CustomFieldDataType.Select,
+      extra_data: {
+        select_options: [
+          { label: 'X-Wing', id: 'x-id' },
+          { label: 'B-Wing', id: 'b-id' },
+          { label: 'Y-Wing', id: 'y-id' },
+          { label: 'A-Wing', id: 'a-id' },
+        ],
+      },
+    }
+    fixture.detectChanges()
+    component.ngOnInit()
+    expect(component.allSelectOptions).toEqual([
+      { label: 'A-Wing', id: 'a-id' },
+      { label: 'B-Wing', id: 'b-id' },
+      { label: 'X-Wing', id: 'x-id' },
+      { label: 'Y-Wing', id: 'y-id' },
+    ])
+  })
+
+  it('should append new select options at the end without sorting', () => {
+    component.dialogMode = EditDialogMode.EDIT
+    component.object = {
+      id: 1,
+      name: 'Starship Model',
+      data_type: CustomFieldDataType.Select,
+      extra_data: {
+        select_options: [
+          { label: 'A-Wing', id: 'a-id' },
+          { label: 'B-Wing', id: 'b-id' },
+          { label: 'X-Wing', id: 'x-id' },
+          { label: 'Y-Wing', id: 'y-id' },
+        ],
+      },
+    }
+    fixture.detectChanges()
+    component.ngOnInit()
+    component.addSelectOption()
+    expect(component.allSelectOptions).toEqual([
+      { label: 'A-Wing', id: 'a-id' },
+      { label: 'B-Wing', id: 'b-id' },
+      { label: 'X-Wing', id: 'x-id' },
+      { label: 'Y-Wing', id: 'y-id' },
+      { label: null, id: null },
+    ])
+  })
+
   it('should initialize select options on edit', () => {
     component.dialogMode = EditDialogMode.EDIT
     component.object = {
@@ -139,6 +191,7 @@ describe('CustomFieldEditDialogComponent', () => {
     }
     fixture.detectChanges()
     component.ngOnInit()
+    // modify first item on page 2, after sort this is "Option 17"
     component.selectOptionsPage = 2
     fixture.detectChanges()
     component.objectForm
@@ -146,19 +199,21 @@ describe('CustomFieldEditDialogComponent', () => {
       .get('select_options')
       .get('0')
       .get('label')
-      .setValue('Updated Option 9')
+      .setValue('Edited Option 17')
+    // navigate beyond page 2
+    component.selectOptionsPage = 3
     const formValues = (component as any).getFormValues()
     // first item unchanged
     expect(formValues.extra_data.select_options[0]).toEqual({
       label: 'Option 1',
       id: '1-xyz',
     })
-    // page 2 first item updated
+    // page 2 first item updated with initial option sort
     expect(
       formValues.extra_data.select_options[component.SELECT_OPTION_PAGE_SIZE]
     ).toEqual({
-      label: 'Updated Option 9',
-      id: '9-xyz',
+      label: 'Edited Option 17',
+      id: '17-xyz',
     })
   })
 })

--- a/src-ui/src/app/components/common/edit-dialog/custom-field-edit-dialog/custom-field-edit-dialog.component.ts
+++ b/src-ui/src/app/components/common/edit-dialog/custom-field-edit-dialog/custom-field-edit-dialog.component.ts
@@ -88,7 +88,7 @@ export class CustomFieldEditDialogComponent
     if (this.object?.data_type === CustomFieldDataType.Select) {
       this._allSelectOptions = [
         ...(this.object.extra_data.select_options ?? []),
-      ]
+      ].sort((a, b) => a.label.localeCompare(b.label))
       this.selectOptionsPage = 1
     }
   }
@@ -139,7 +139,10 @@ export class CustomFieldEditDialogComponent
       this.objectForm.get('data_type')?.value === CustomFieldDataType.Select
     ) {
       // Make sure we send all select options, with updated values
-      formValues.extra_data.select_options = this._allSelectOptions
+      // Filter out any options with empty labels (e.g. added but not filled in)
+      formValues.extra_data.select_options = this._allSelectOptions.filter(
+        (o) => o.label
+      )
     }
     return formValues
   }

--- a/src-ui/src/app/components/common/edit-dialog/workflow-edit-dialog/workflow-edit-dialog.component.spec.ts
+++ b/src-ui/src/app/components/common/edit-dialog/workflow-edit-dialog/workflow-edit-dialog.component.spec.ts
@@ -168,12 +168,22 @@ describe('WorkflowEditDialogComponent', () => {
                 results: [
                   {
                     id: 1,
-                    name: 'cf1',
+                    name: 'Planet',
                     data_type: CustomFieldDataType.String,
                   },
                   {
                     id: 2,
-                    name: 'cf2',
+                    name: 'Starship',
+                    data_type: CustomFieldDataType.String,
+                  },
+                  {
+                    id: 3,
+                    name: 'Credits',
+                    data_type: CustomFieldDataType.Integer,
+                  },
+                  {
+                    id: 4,
+                    name: 'Release Date',
                     data_type: CustomFieldDataType.Date,
                   },
                 ],
@@ -994,6 +1004,15 @@ describe('WorkflowEditDialogComponent', () => {
 
     component.removeSelectedCustomField(3, formGroup)
     expect(formGroup.get('assign_custom_fields').value).toEqual([])
+  })
+
+  it('should sort custom fields by name on load', () => {
+    expect(component.customFields.map((f) => f.name)).toEqual([
+      'Credits',
+      'Planet',
+      'Release Date',
+      'Starship',
+    ])
   })
 
   it('should handle parsing of passwords from array to string and back on save', () => {

--- a/src-ui/src/app/components/common/edit-dialog/workflow-edit-dialog/workflow-edit-dialog.component.ts
+++ b/src-ui/src/app/components/common/edit-dialog/workflow-edit-dialog/workflow-edit-dialog.component.ts
@@ -529,6 +529,8 @@ export class WorkflowEditDialogComponent
       .pipe(first())
       .subscribe((result) => {
         this.customFields = result.results
+          .slice()
+          .sort((a, b) => a.name.localeCompare(b.name))
         this.dateCustomFields = this.customFields?.filter(
           (f) => f.data_type === CustomFieldDataType.Date
         )

--- a/src-ui/src/app/components/document-detail/document-detail.component.spec.ts
+++ b/src-ui/src/app/components/document-detail/document-detail.component.spec.ts
@@ -1362,34 +1362,35 @@ describe('DocumentDetailComponent', () => {
         created: new Date(),
       },
     ]
-    const docWithMultipleFields = Object.assign({}, doc, {
-      custom_fields: [
-        {
-          field: docCustomFields[0].id, // 'Field 1'
-          document: doc.id,
-          created: new Date(),
-          value: 'Test value',
-        },
-        {
-          field: docCustomFields[1].id, // 'Custom Field 2'
-          document: doc.id,
-          created: new Date(),
-          value: 'More test value',
-        },
-        {
-          field: docCustomFields[2].id, // 'Even More Custom Field'
-          document: doc.id,
-          created: new Date(),
-          value: 'Yet another test value',
-        },
-      ],
-    })
+    const docCustomFieldValues = [
+      {
+        field: docCustomFields[0].id, // 'Field 1'
+        document: doc.id,
+        created: new Date(),
+        value: 'Test value',
+      },
+      {
+        field: docCustomFields[1].id, // 'Custom Field 2'
+        document: doc.id,
+        created: new Date(),
+        value: 'More test value',
+      },
+      {
+        field: docCustomFields[2].id, // 'Even More Custom Field'
+        document: doc.id,
+        created: new Date(),
+        value: 'Yet another test value',
+      },
+    ]
+    const docWithMultipleFields = of(
+      Object.assign({}, doc, {
+        custom_fields: docCustomFieldValues.map((cf) => ({ ...cf })),
+      })
+    )
     jest
       .spyOn(activatedRoute, 'paramMap', 'get')
       .mockReturnValue(of(convertToParamMap({ id: 3, section: 'details' })))
-    jest
-      .spyOn(documentService, 'get')
-      .mockReturnValue(of(Object.assign({}, docWithMultipleFields)))
+    jest.spyOn(documentService, 'get').mockReturnValue(docWithMultipleFields)
     jest.spyOn(openDocumentsService, 'getOpenDocument').mockReturnValue(null)
     jest
       .spyOn(openDocumentsService, 'openDocument')
@@ -1412,10 +1413,21 @@ describe('DocumentDetailComponent', () => {
       { id: 2, name: 'Even More Custom Field' },
       { id: 0, name: 'Field 1' },
     ])
+    expect(
+      component.customFieldFormFields.controls.map((c) => c.get('field').value)
+    ).toEqual([
+      docCustomFields[1].id, // 'Custom Field 2'
+      docCustomFields[2].id, // 'Even More Custom Field'
+      docCustomFields[0].id, // 'Field 1'
+    ])
     // After save, fields should remain sorted
-    jest
-      .spyOn(documentService, 'patch')
-      .mockReturnValue(of(Object.assign({}, docWithMultipleFields)))
+    jest.spyOn(documentService, 'patch').mockReturnValue(
+      of(
+        Object.assign({}, doc, {
+          custom_fields: docCustomFieldValues.map((cf) => ({ ...cf })),
+        })
+      )
+    )
     component.save(true)
     expect(
       component.document.custom_fields
@@ -1425,6 +1437,13 @@ describe('DocumentDetailComponent', () => {
       { id: 1, name: 'Custom Field 2' },
       { id: 2, name: 'Even More Custom Field' },
       { id: 0, name: 'Field 1' },
+    ])
+    expect(
+      component.customFieldFormFields.controls.map((c) => c.get('field').value)
+    ).toEqual([
+      docCustomFields[1].id, // 'Custom Field 2'
+      docCustomFields[2].id, // 'Even More Custom Field'
+      docCustomFields[0].id, // 'Field 1'
     ])
   })
 

--- a/src-ui/src/app/components/document-detail/document-detail.component.spec.ts
+++ b/src-ui/src/app/components/document-detail/document-detail.component.spec.ts
@@ -1320,7 +1320,11 @@ describe('DocumentDetailComponent', () => {
     const patchSpy = jest.spyOn(documentService, 'patch')
     component.save(true)
     expect(patchSpy.mock.lastCall[0].custom_fields).toHaveLength(2)
-    expect(patchSpy.mock.lastCall[0].custom_fields[1]).toEqual({
+    expect(
+      patchSpy.mock.lastCall[0].custom_fields.find(
+        (cf) => cf.field === customFields[1].id
+      )
+    ).toEqual({
       field: customFields[1].id,
       value: null,
     })
@@ -1330,7 +1334,11 @@ describe('DocumentDetailComponent', () => {
     initNormally()
     const initialLength = doc.custom_fields.length
     expect(component.customFieldFormFields).toHaveLength(initialLength)
-    component.removeField(doc.custom_fields[0])
+    component.removeField(
+      component.document.custom_fields.find(
+        (cf) => cf.field === customFields[0].id
+      )
+    )
     fixture.detectChanges()
     expect(component.document.custom_fields).toHaveLength(initialLength - 1)
     expect(component.customFieldFormFields).toHaveLength(initialLength - 1)
@@ -1342,6 +1350,82 @@ describe('DocumentDetailComponent', () => {
     expect(patchSpy.mock.lastCall[0].custom_fields).toHaveLength(
       initialLength - 1
     )
+  })
+
+  it('should sort custom fields by name on load and after save', () => {
+    var docCustomFields = [
+      ...customFields,
+      {
+        id: 2,
+        name: 'Even More Custom Field',
+        data_type: CustomFieldDataType.String,
+        created: new Date(),
+      },
+    ]
+    const docWithMultipleFields = Object.assign({}, doc, {
+      custom_fields: [
+        {
+          field: docCustomFields[0].id, // 'Field 1'
+          document: doc.id,
+          created: new Date(),
+          value: 'Test value',
+        },
+        {
+          field: docCustomFields[1].id, // 'Custom Field 2'
+          document: doc.id,
+          created: new Date(),
+          value: 'More test value',
+        },
+        {
+          field: docCustomFields[2].id, // 'Even More Custom Field'
+          document: doc.id,
+          created: new Date(),
+          value: 'Yet another test value',
+        },
+      ],
+    })
+    jest
+      .spyOn(activatedRoute, 'paramMap', 'get')
+      .mockReturnValue(of(convertToParamMap({ id: 3, section: 'details' })))
+    jest
+      .spyOn(documentService, 'get')
+      .mockReturnValue(of(Object.assign({}, docWithMultipleFields)))
+    jest.spyOn(openDocumentsService, 'getOpenDocument').mockReturnValue(null)
+    jest
+      .spyOn(openDocumentsService, 'openDocument')
+      .mockReturnValueOnce(of(true))
+    jest.spyOn(customFieldsService, 'listAll').mockReturnValue(
+      of({
+        count: docCustomFields.length,
+        all: docCustomFields.map((f) => f.id),
+        results: docCustomFields,
+      })
+    )
+    fixture.detectChanges()
+    // After load, fields should be sorted
+    expect(
+      component.document.custom_fields
+        .map((cf) => component.getCustomFieldFromInstance(cf))
+        .map((cf) => ({ id: cf.id, name: cf.name }))
+    ).toEqual([
+      { id: 1, name: 'Custom Field 2' },
+      { id: 2, name: 'Even More Custom Field' },
+      { id: 0, name: 'Field 1' },
+    ])
+    // After save, fields should remain sorted
+    jest
+      .spyOn(documentService, 'patch')
+      .mockReturnValue(of(Object.assign({}, docWithMultipleFields)))
+    component.save(true)
+    expect(
+      component.document.custom_fields
+        .map((cf) => component.getCustomFieldFromInstance(cf))
+        .map((cf) => ({ id: cf.id, name: cf.name }))
+    ).toEqual([
+      { id: 1, name: 'Custom Field 2' },
+      { id: 2, name: 'Even More Custom Field' },
+      { id: 0, name: 'Field 1' },
+    ])
   })
 
   it('should correctly determine changed fields', () => {

--- a/src-ui/src/app/components/document-detail/document-detail.component.spec.ts
+++ b/src-ui/src/app/components/document-detail/document-detail.component.spec.ts
@@ -1261,6 +1261,51 @@ describe('DocumentDetailComponent', () => {
     )
   })
 
+  it('should sort custom field select options by label on load', () => {
+    const selectField = {
+      id: 2,
+      name: 'Starship Type',
+      data_type: CustomFieldDataType.Select,
+      created: new Date(),
+      extra_data: {
+        select_options: [
+          { label: 'Y-Wing', id: 'y' },
+          { label: 'A-Wing', id: 'a' },
+          { label: 'X-Wing', id: 'x' },
+          { label: 'B-Wing', id: 'b' },
+        ],
+      },
+    }
+    const allFields = [...customFields, selectField]
+    jest
+      .spyOn(activatedRoute, 'paramMap', 'get')
+      .mockReturnValue(of(convertToParamMap({ id: 3, section: 'details' })))
+    jest.spyOn(documentService, 'get').mockReturnValueOnce(of(doc))
+    jest.spyOn(openDocumentsService, 'getOpenDocument').mockReturnValue(null)
+    jest
+      .spyOn(openDocumentsService, 'openDocument')
+      .mockReturnValueOnce(of(true))
+    jest.spyOn(customFieldsService, 'listAll').mockReturnValue(
+      of({
+        count: allFields.length,
+        all: allFields.map((f) => f.id),
+        results: allFields,
+      })
+    )
+    fixture.detectChanges()
+    const loadedField = component.getCustomFieldFromInstance({
+      created: new Date(),
+      document: 3,
+      field: 2,
+    })
+    expect(loadedField.extra_data.select_options).toEqual([
+      { label: 'A-Wing', id: 'a' },
+      { label: 'B-Wing', id: 'b' },
+      { label: 'X-Wing', id: 'x' },
+      { label: 'Y-Wing', id: 'y' },
+    ])
+  })
+
   it('should support add custom field, correctly send via post', () => {
     initNormally()
     const initialLength = doc.custom_fields.length

--- a/src-ui/src/app/components/document-detail/document-detail.component.ts
+++ b/src-ui/src/app/components/document-detail/document-detail.component.ts
@@ -1201,10 +1201,11 @@ export class DocumentDetailComponent
           this.closeIncomingUpdateModal()
           this.lastLocalSaveModified = docValues.modified ?? null
           // in case data changed while saving eg removing inbox_tags
+          this.document.custom_fields = docValues.custom_fields
+          this.updateFormForCustomFields()
           this.documentForm.patchValue(docValues)
-          const newValues = Object.assign({}, this.documentForm.value)
+          const newValues = Object.assign({}, this.documentForm.getRawValue())
           newValues.tags = [...docValues.tags]
-          newValues.custom_fields = [...docValues.custom_fields]
           this.store.next(newValues)
           this.openDocumentService.setDirty(this.document, false)
           this.openDocumentService.save()

--- a/src-ui/src/app/components/document-detail/document-detail.component.ts
+++ b/src-ui/src/app/components/document-detail/document-detail.component.ts
@@ -1694,7 +1694,14 @@ export class DocumentDetailComponent
     this.customFieldsService
       .listAll()
       .pipe(first(), takeUntil(this.unsubscribeNotifier))
-      .subscribe((result) => (this.customFields = result.results))
+      .subscribe((result) => {
+        this.customFields = result.results
+        for (const field of this.customFields) {
+          field.extra_data?.select_options?.sort((a, b) =>
+            a.label.localeCompare(b.label)
+          )
+        }
+      })
   }
 
   public refreshCustomFields() {

--- a/src-ui/src/app/components/document-detail/document-detail.component.ts
+++ b/src-ui/src/app/components/document-detail/document-detail.component.ts
@@ -1722,6 +1722,11 @@ export class DocumentDetailComponent
 
   private updateFormForCustomFields(emitEvent: boolean = false) {
     this.customFieldFormFields.clear({ emitEvent: false })
+    this.document.custom_fields?.sort((a, b) =>
+      (this.getCustomFieldFromInstance(a)?.name ?? '').localeCompare(
+        this.getCustomFieldFromInstance(b)?.name ?? ''
+      )
+    )
     this.document.custom_fields?.forEach((fieldInstance) => {
       this.customFieldFormFields.push(
         new FormGroup({

--- a/src-ui/src/app/components/manage/document-attributes/custom-fields/custom-fields.component.spec.ts
+++ b/src-ui/src/app/components/manage/document-attributes/custom-fields/custom-fields.component.spec.ts
@@ -103,6 +103,30 @@ describe('CustomFieldsComponent', () => {
     jest.advanceTimersByTime(100)
   })
 
+  it('should display fields sorted by name', () => {
+    const unsortedFields: CustomField[] = [
+      { id: 23, name: 'Cell Block', data_type: CustomFieldDataType.String },
+      { id: 1138, name: 'THX', data_type: CustomFieldDataType.Boolean },
+      { id: 1977, name: 'Release Date', data_type: CustomFieldDataType.Date },
+      { id: 2187, name: 'Credits', data_type: CustomFieldDataType.Monetary },
+    ]
+    jest.spyOn(customFieldsService, 'listAll').mockReturnValue(
+      of({
+        count: unsortedFields.length,
+        all: unsortedFields.map((f) => f.id),
+        results: unsortedFields,
+      })
+    )
+    component.reload()
+    jest.advanceTimersByTime(100)
+    expect(component.fields.map((f) => f.name)).toEqual([
+      'Cell Block',
+      'Credits',
+      'Release Date',
+      'THX',
+    ])
+  })
+
   it('should support create, show notification on error / success', () => {
     let modal: NgbModalRef
     modalService.activeInstances.subscribe((m) => (modal = m[m.length - 1]))

--- a/src-ui/src/app/components/manage/document-attributes/custom-fields/custom-fields.component.ts
+++ b/src-ui/src/app/components/manage/document-attributes/custom-fields/custom-fields.component.ts
@@ -64,6 +64,8 @@ export class CustomFieldsComponent
         takeUntil(this.unsubscribeNotifier),
         tap((r) => {
           this.fields = r.results
+            .slice()
+            .sort((a, b) => a.name.localeCompare(b.name))
         }),
         delay(100)
       )

--- a/src/documents/serialisers.py
+++ b/src/documents/serialisers.py
@@ -752,7 +752,7 @@ class CustomFieldSerializer(serializers.ModelSerializer):
                 or not isinstance(attrs["extra_data"]["select_options"], list)
                 or len(attrs["extra_data"]["select_options"]) == 0
                 or not all(
-                    len(option.get("label", "")) > 0
+                    len(option.get("label") or "") > 0
                     for option in attrs["extra_data"]["select_options"]
                 )
             ):

--- a/src/documents/tests/test_api_custom_fields.py
+++ b/src/documents/tests/test_api_custom_fields.py
@@ -150,6 +150,38 @@ class TestCustomFieldsAPI(DirectoriesMixin, APITestCase):
         )
         self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
 
+        # Option with null label
+        resp = self.client.post(
+            self.ENDPOINT,
+            json.dumps(
+                {
+                    "data_type": "select",
+                    "name": "Select Field",
+                    "extra_data": {
+                        "select_options": [{"label": None, "id": None}],
+                    },
+                },
+            ),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+
+        # Option with empty label
+        resp = self.client.post(
+            self.ENDPOINT,
+            json.dumps(
+                {
+                    "data_type": "select",
+                    "name": "Select Field",
+                    "extra_data": {
+                        "select_options": [{"label": "", "id": None}],
+                    },
+                },
+            ),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+
     def test_custom_field_select_unique_ids(self) -> None:
         """
         GIVEN:


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Background

Custom fields are both fantastic and essential for organizing my documents. I have several Select-type custom fields with a large number of predefined choices; my top example is an "Account" field where I have a choice for every bank account/credit card/loan/etc account. This allows me to both assign and retrieve documents for a particular account easily.

Custom fields, and configured choices for Select custom field values, are displayed without any sort order. Therefore they default to primary-key ordering, e.g. they are listed in their creation order. This makes options and values sometimes difficult to locate.

### Screenshots of existing behavior

<img width="673" height="595" alt="1-settings-crop" src="https://github.com/user-attachments/assets/30092f06-07c3-477f-af9a-b949c6fd46c2" />

<img width="519" height="765" alt="2-settings-select-options-crop" src="https://github.com/user-attachments/assets/736e2cb0-1500-41e7-be2e-a8b0722bee22" />

## Proposed change

This change sorts custom field names and Select custom field type values alphabetically in each UI component I've found where custom fields are used.

This branch is organized into one commit per component change. These could be broken out into individual pull requests if desired.

## Additional notes

I used Claude Code to help author this PR. I guided it extensively while working on one component at a time. I ensured the finished tests actually test the desired functionality. In many cases the LLM's implementation was wrong and I corrected it. Front-end development is not my strongest experience area, so LLM assistance was very helpful.

In the selection option editor within the custom field editor, in some cases I received errors when saving fields due to empty option values being passed to the API. That commit (14c9c2604d4051c001cd2a521352a599e3a8867b) includes a small non-API-breaking backend change to discard options with empty or null labels in the request data.

For development, I used Creative Commons (CC-BY-SA-4.0) licensed sample PDFs from https://github.com/py-pdf/sample-files. These appear in some screenshots below.

## Screenshots of new behavior

### Custom fields attributes page

<img width="673" height="595" alt="1-settings-crop" src="https://github.com/user-attachments/assets/97098879-bc00-4503-a1e3-841fedaf5f01" />

### Select option editor within custom field editor

<img width="519" height="765" alt="2-settings-select-options-crop" src="https://github.com/user-attachments/assets/b0b94d61-fe11-490c-b155-ac166af0c251" />

### Documents query filter

#### Field names

<img width="618" height="388" alt="3-query-filter-fields-crop" src="https://github.com/user-attachments/assets/35a1fa3c-2fa2-456d-9471-6c42b1a3d64f" />

#### Select field type values

<img width="618" height="388" alt="4-query-filter-select-values-crop" src="https://github.com/user-attachments/assets/3440600c-7dd2-4aad-995e-44628cebc44e" />

### Workflow triggers editor

#### Field names

<img width="1170" height="411" alt="5-workflow-triggers-fields-crop" src="https://github.com/user-attachments/assets/580ed160-9bd1-4462-98cc-dd4e58b70418" />

#### Select field type values

<img width="1170" height="411" alt="6-workflow-triggers-select-values-crop" src="https://github.com/user-attachments/assets/808c7574-92e1-4e02-b36a-f2ab55b76292" />

### Workflow actions editor

#### Field names

<img width="686" height="521" alt="7-workflow-action-field-selector-crop" src="https://github.com/user-attachments/assets/33d1756d-50ee-4018-b6a3-1d94db94ca6a" />

#### Select field type values

<img width="686" height="521" alt="8-workflow-action-fields-crop" src="https://github.com/user-attachments/assets/598ad141-666a-480f-99ec-219aacdcac73" />

### Document details page

#### Add custom field dropdown

<img width="614" height="316" alt="9-document-details-add-fields-crop" src="https://github.com/user-attachments/assets/1cbb7ff2-6664-472d-a2b6-d8ec4911e786" />

#### Custom field value inputs -- both input fields and dropdown values are now sorted

<img width="559" height="568" alt="10-document-details-field-select-values-2-crop" src="https://github.com/user-attachments/assets/016c2d2f-8aa0-4e89-8271-1e510664d550" />

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

<!--
⚠️ Important: Pull requests that implement a new feature or enhancement *should almost always target an existing feature request* with evidence of community interest and discussion. This is in order to balance the work of implementing and maintaining new features / enhancements. If that is not currently the case, please open a feature request instead of this PR to gather feedback from both users and the project maintainers.
-->

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [x] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] ~~I have made corresponding changes to the documentation as needed.~~
- [x] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
