### PR TITLE
Fix: merge() consume task never dispatched when delete_originals=False

### DIFF
--- a/src/documents/bulk_edit.py
+++ b/src/documents/bulk_edit.py
@@ -576,8 +576,8 @@ def merge(
         except Exception:
             restore_archive_serial_numbers(backup)
             raise
-        else:
-            consume_task.delay()
+    else:
+        consume_task.delay()
 
     return "OK"
 

--- a/src/documents/tests/test_bulk_edit.py
+++ b/src/documents/tests/test_bulk_edit.py
@@ -643,6 +643,8 @@ class TestPDFActions(DirectoriesMixin, TestCase):
         )
 
         mock_consume_file.assert_called()
+        consume_sig = mock_consume_file.return_value
+        consume_sig.delay.assert_called_once()
         consume_file_args, _ = mock_consume_file.call_args
         self.assertEqual(
             Path(consume_file_args[0].original_file).name,
@@ -722,6 +724,7 @@ class TestPDFActions(DirectoriesMixin, TestCase):
         mock_delete_documents.assert_called()
         consume_sig = mock_consume_file.return_value
         consume_sig.apply_async.assert_called_once()
+        consume_sig.delay.assert_not_called()
 
         consume_file_args, _ = mock_consume_file.call_args
         self.assertEqual(


### PR DESCRIPTION
## Summary

Fixes an indentation bug in `bulk_edit.merge()` where the `else` clause was attached to the `try` block instead of the `if delete_originals` block:

- **`delete_originals=False`**: The merged PDF was written to disk and a Celery signature created, but `delay()` was never called — the merged document silently disappeared.
- **`delete_originals=True`**: After `apply_async()` succeeded, the `try/else` also ran `consume_task.delay()`, consuming the merged document twice (once with the delete callback, once without).

The fix moves the `else` one indentation level out so it belongs to the `if`, matching the pattern already used by `split()` and `edit_pdf()` in the same file.

## Changes

- `src/documents/bulk_edit.py`: Dedent `else: consume_task.delay()` from `try/else` to `if/else`
- `src/documents/tests/test_bulk_edit.py`: Add assertions that `delay()` is called in the non-delete path and not called in the delete path

Closes #12359

## Test plan

- [x] `test_merge` now verifies `consume_sig.delay.assert_called_once()`
- [x] `test_merge_and_delete_originals` now verifies `consume_sig.delay.assert_not_called()`
- [ ] Existing test suite passes

Note: This PR includes AI-assisted code, as per the project's contribution guidelines.