### PR TITLE
Fix: fix file button hover color in dark mode

### DIFF
--- a/src-ui/src/theme.scss
+++ b/src-ui/src/theme.scss
@@ -153,6 +153,11 @@ $form-check-radio-checked-bg-image-dark: url("data:image/svg+xml,<svg xmlns='htt
     --bs-list-group-action-active-color: var(--bs-body-color);
     --bs-list-group-action-active-bg: var(--pngx-bg-darker);
   }
+
+  .form-control:hover::file-selector-button {
+    background-color:var(--pngx-bg-dark) !important
+  }
+
   .search-container {
     input, input:focus, i-bs[name="search"] , ::placeholder {
       color: var(--pngx-primary-text-contrast) !important;


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

I know, crazy.

<img width="171" height="146" alt="Screenshot 2026-03-17 at 9 24 32 AM" src="https://github.com/user-attachments/assets/3467c020-eecd-4605-9b5c-b945c2dfa0da" />

(as opposed to):
<img width="509" height="366" alt="Screenshot 2026-03-12 at 2 09 00 PM" src="https://github.com/user-attachments/assets/865f2e36-18cd-46c6-a7e2-8b6b92e035cd" />


Closes #(issue or discussion)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
