### PR TITLE
Fix: Respect workflow change_groups during consumption

### DIFF
--- a/src/documents/consumer.py
+++ b/src/documents/consumer.py
@@ -1,6 +1,7 @@
 import datetime
 import hashlib
 import os
+import shutil
 import tempfile
 from enum import StrEnum
 from pathlib import Path
@@ -833,7 +834,7 @@ class ConsumerPlugin(
             self.metadata.view_users is not None
             or self.metadata.view_groups is not None
             or self.metadata.change_users is not None
-            or self.metadata.change_users is not None
+            or self.metadata.change_groups is not None
         ):
             permissions = {
                 "view": {
@@ -866,7 +867,7 @@ class ConsumerPlugin(
             Path(source).open("rb") as read_file,
             Path(target).open("wb") as write_file,
         ):
-            write_file.write(read_file.read())
+            shutil.copyfileobj(read_file, write_file)
 
         # Attempt to copy file's original stats, but it's ok if we can't
         try:

--- a/src/documents/tasks.py
+++ b/src/documents/tasks.py
@@ -53,8 +53,8 @@ from documents.models import Tag
 from documents.models import WorkflowRun
 from documents.models import WorkflowTrigger
 from documents.plugins.base import ConsumeTaskPlugin
-from documents.plugins.base import ProgressManager
 from documents.plugins.base import StopConsumeTaskError
+from documents.plugins.helpers import ProgressManager
 from documents.plugins.helpers import ProgressStatusOptions
 from documents.sanity_checker import SanityCheckFailedException
 from documents.signals import document_updated
@@ -533,13 +533,13 @@ def check_scheduled_workflows() -> None:
                             id__in=matched_ids,
                         )
 
-                if documents.count() > 0:
+                if documents.exists():
                     documents = prefilter_documents_by_workflowtrigger(
                         documents,
                         trigger,
                     )
 
-                if documents.count() > 0:
+                if documents.exists():
                     logger.debug(
                         f"Found {documents.count()} documents for trigger {trigger}",
                     )


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

<!--
⚠️ Important: Pull requests that implement a new feature or enhancement *should almost always target an existing feature request* with evidence of community interest and discussion. This is in order to balance the work of implementing and maintaining new features / enhancements. If that is not currently the case, please open a feature request instead of this PR to gather feedback from both users and the project maintainers.
-->

We had a copy and paste here, so anyone using `change_groups` wouldn't have seen those applied.  I guess no one noticed.  Furthermore, a couple other small changes to other things, for a minor efficient upgrade.  `exists` is a little quicker query than forcing a count.  and [`copyfileobj`](https://docs.python.org/3/library/shutil.html#shutil.copyfileobj) reads a file in chunks to another file, instead of loading everything into memory.

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
