### PR TITLE
Tests: add regression test for redis URL with empty username

### DIFF
--- a/src/paperless/tests/settings/test_custom_parsers.py
+++ b/src/paperless/tests/settings/test_custom_parsers.py
@@ -80,7 +80,6 @@ class TestRedisSocketConversion:
                 id="celery_style_socket_with_credentials",
             ),
             # Empty username, password only: unix://:SECRET@/path.sock
-            # Regression test for https://github.com/paperless-ngx/paperless-ngx/pull/12239
             pytest.param(
                 "unix://:SECRET@/run/redis/paperless.sock",
                 (

--- a/src/paperless/tests/settings/test_custom_parsers.py
+++ b/src/paperless/tests/settings/test_custom_parsers.py
@@ -79,6 +79,16 @@ class TestRedisSocketConversion:
                 ),
                 id="celery_style_socket_with_credentials",
             ),
+            # Empty username, password only: unix://:SECRET@/path.sock
+            # Regression test for https://github.com/paperless-ngx/paperless-ngx/pull/12239
+            pytest.param(
+                "unix://:SECRET@/run/redis/paperless.sock",
+                (
+                    "redis+socket://:SECRET@/run/redis/paperless.sock",
+                    "unix://:SECRET@/run/redis/paperless.sock",
+                ),
+                id="redis_py_style_socket_with_password_only",
+            ),
         ],
     )
     def test_redis_socket_parsing(


### PR DESCRIPTION
Covers the unix://:SECRET@/path.sock format (empty username, password only), which was missing from the existing test cases for PR #12239.

<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

add regression test for redis URL with empty username and password only

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

<!--
⚠️ Important: Pull requests that implement a new feature or enhancement *should almost always target an existing feature request* with evidence of community interest and discussion. This is in order to balance the work of implementing and maintaining new features / enhancements. If that is not currently the case, please open a feature request instead of this PR to gather feedback from both users and the project maintainers.
-->

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [x] Other. Please explain: Add regression test

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
