### PR TITLE
Add backup_db management command for PostgreSQL

### DIFF
--- a/src/documents/management/commands/backup_db.py
+++ b/src/documents/management/commands/backup_db.py
@@ -1,0 +1,157 @@
+"""Logical PostgreSQL backup to disk (pull-by-path producer contract).
+
+Writes ``paperless-YYYY-MM-DD.dump`` (custom format) and ``paperless-YYYY-MM-DD.version``
+under a configurable directory. See sibling extension docs / operator BACKUP-INTERFACE.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from datetime import timedelta
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from django.core.management.base import CommandError
+from django.utils import timezone
+
+from paperless import version
+
+if TYPE_CHECKING:
+    from django.core.management.base import CommandParser
+
+
+class Command(BaseCommand):
+    help = (
+        "Create a PostgreSQL database dump (pg_dump -Fc) for disaster recovery. "
+        "Outputs paperless-YYYY-MM-DD.dump and .version under the backup directory."
+    )
+
+    def add_arguments(self, parser: CommandParser) -> None:
+        parser.add_argument(
+            "--output-dir",
+            type=Path,
+            default=None,
+            help=(
+                "Directory for dump files. "
+                "Default: PAPERLESS_BACKUP_DIR if set, else DATA_DIR/backups."
+            ),
+        )
+        parser.add_argument(
+            "--retention-days",
+            type=int,
+            default=None,
+            help=(
+                "Delete backup pairs (*.dump + *.version) older than this many days "
+                "in the output directory. Default: no retention cleanup."
+            ),
+        )
+        parser.add_argument(
+            "--skip-validation",
+            action="store_true",
+            help="Skip pg_restore --list check (not recommended for automation).",
+        )
+
+    def handle(self, *args, **options) -> None:
+        db = settings.DATABASES["default"]
+        engine = db["ENGINE"]
+        if engine != "django.db.backends.postgresql":
+            raise CommandError(
+                "backup_db supports only PostgreSQL in this version; "
+                f"configured engine is {engine!r}.",
+            )
+
+        out_dir: Path = options["output_dir"]
+        if out_dir is None:
+            env_dir = os.getenv("PAPERLESS_BACKUP_DIR")
+            out_dir = Path(env_dir) if env_dir else Path(settings.DATA_DIR) / "backups"
+        out_dir = out_dir.expanduser().resolve()
+        out_dir.mkdir(parents=True, exist_ok=True)
+
+        date_str = timezone.localdate().isoformat()
+        dump_path = out_dir / f"paperless-{date_str}.dump"
+        version_path = out_dir / f"paperless-{date_str}.version"
+
+        name = str(db["NAME"])
+        user = str(db["USER"])
+        password = str(db.get("PASSWORD") or "")
+        host = db.get("HOST") or ""
+        port = db.get("PORT")
+        if port is not None and port != "":
+            port = str(port)
+
+        env = os.environ.copy()
+        env["PGPASSWORD"] = password
+
+        cmd: list[str] = ["pg_dump", "-U", user]
+        if host:
+            cmd.extend(["-h", host])
+        if port:
+            cmd.extend(["-p", port])
+        cmd.extend(["-Fc", "-f", str(dump_path), name])
+
+        self.stdout.write(f"Creating dump {dump_path} ...")
+        try:
+            completed = subprocess.run(
+                cmd,
+                env=env,
+                check=False,
+                capture_output=True,
+            )
+        except OSError as exc:  # e.g. pg_dump not found
+            dump_path.unlink(missing_ok=True)
+            raise CommandError(f"Could not run pg_dump: {exc}") from exc
+
+        if completed.returncode != 0:
+            dump_path.unlink(missing_ok=True)
+            err = (completed.stderr or b"").decode(errors="replace")
+            raise CommandError(f"pg_dump failed (exit {completed.returncode}): {err}")
+
+        version_path.write_text(
+            f"{version.__full_version_str__}\n",
+            encoding="utf-8",
+        )
+
+        if not options["skip_validation"]:
+            vcmd = ["pg_restore", "--list", str(dump_path)]
+            try:
+                vcompleted = subprocess.run(
+                    vcmd,
+                    check=False,
+                    capture_output=True,
+                )
+            except OSError as exc:
+                dump_path.unlink(missing_ok=True)
+                version_path.unlink(missing_ok=True)
+                raise CommandError(f"Could not run pg_restore: {exc}") from exc
+
+            if vcompleted.returncode != 0:
+                err = (vcompleted.stderr or b"").decode(errors="replace")
+                dump_path.unlink(missing_ok=True)
+                version_path.unlink(missing_ok=True)
+                raise CommandError(f"Dump validation failed: {err}")
+
+        self.stdout.write(self.style.SUCCESS(f"Backup complete: {dump_path.name}"))
+
+        retention: int | None = options["retention_days"]
+        if retention is not None and retention > 0:
+            self._apply_retention(out_dir, retention)
+
+    def _apply_retention(self, out_dir: Path, retention_days: int) -> None:
+        cutoff_ts = (timezone.now() - timedelta(days=retention_days)).timestamp()
+        removed = 0
+        for dump in sorted(out_dir.glob("paperless-*.dump")):
+            try:
+                if dump.stat().st_mtime >= cutoff_ts:
+                    continue
+            except OSError:
+                continue
+            dump.unlink(missing_ok=True)
+            ver = dump.with_name(f"{dump.stem}.version")
+            ver.unlink(missing_ok=True)
+            removed += 1
+        if removed:
+            self.stdout.write(f"Retention removed {removed} backup pair(s).")
+

--- a/src/documents/tests/test_management_backup_db.py
+++ b/src/documents/tests/test_management_backup_db.py
@@ -1,0 +1,120 @@
+import shutil
+import tempfile
+from io import StringIO
+from pathlib import Path
+from subprocess import CompletedProcess
+from unittest import mock
+
+import pytest
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import TestCase
+from django.test import override_settings
+
+from documents.tests.utils import DirectoriesMixin
+
+
+@pytest.mark.management
+class TestBackupDb(DirectoriesMixin, TestCase):
+    @override_settings(
+        DATABASES={
+            "default": {
+                "ENGINE": "django.db.backends.sqlite3",
+                "NAME": ":memory:",
+            },
+        },
+    )
+    def test_rejects_non_postgresql(self) -> None:
+        with self.assertRaises(CommandError) as cm:
+            call_command("backup_db", skip_checks=True)
+        self.assertIn("backup_db supports only PostgreSQL", str(cm.exception))
+
+    @override_settings(
+        DATABASES={
+            "default": {
+                "ENGINE": "django.db.backends.postgresql",
+                "NAME": "paperless",
+                "USER": "paperless",
+                "PASSWORD": "secret",
+                "HOST": "db",
+                "PORT": "5432",
+            },
+        },
+    )
+    def test_happy_path_invokes_pg_dump_and_pg_restore(self) -> None:
+        tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: shutil.rmtree(tmp, ignore_errors=True))
+        backup_root = tmp / "backups"
+
+        def fake_run(cmd: list[str], **kwargs):  # noqa: ANN003
+            binary = cmd[0]
+            if binary == "pg_dump":
+                out = Path(cmd[cmd.index("-f") + 1])
+                out.parent.mkdir(parents=True, exist_ok=True)
+                out.write_bytes(b"fake-dump")
+                return CompletedProcess(cmd, 0, b"", b"")
+            if binary == "pg_restore":
+                return CompletedProcess(cmd, 0, b"", b"")
+            return CompletedProcess(cmd, 1, b"", b"unknown")
+
+        out = StringIO()
+        with mock.patch("documents.management.commands.backup_db.subprocess.run", fake_run):
+            with mock.patch(
+                "documents.management.commands.backup_db.timezone.localdate",
+                return_value=__import__("datetime").date(2099, 1, 1),
+            ):
+                call_command(
+                    "backup_db",
+                    "--output-dir",
+                    str(backup_root),
+                    stdout=out,
+                    stderr=StringIO(),
+                    skip_checks=True,
+                )
+
+        written = backup_root / "paperless-2099-01-01.dump"
+        ver = backup_root / "paperless-2099-01-01.version"
+        self.assertTrue(written.is_file())
+        self.assertTrue(ver.is_file())
+        self.assertIn("Backup complete", out.getvalue())
+
+    @override_settings(
+        DATABASES={
+            "default": {
+                "ENGINE": "django.db.backends.postgresql",
+                "NAME": "paperless",
+                "USER": "u",
+                "PASSWORD": "p",
+                "HOST": "",
+                "PORT": "",
+            },
+        },
+    )
+    def test_pg_dump_failure_removes_partial(self) -> None:
+        def fake_run(cmd: list[str], **kwargs):  # noqa: ANN003
+            if cmd[0] == "pg_dump":
+                out = Path(cmd[cmd.index("-f") + 1])
+                out.parent.mkdir(parents=True, exist_ok=True)
+                out.write_bytes(b"partial")
+                return CompletedProcess(cmd, 1, b"", b"pg_dump: error")
+            return CompletedProcess(cmd, 0, b"", b"")
+
+        tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: shutil.rmtree(tmp, ignore_errors=True))
+        backup_root = tmp / "bk"
+        with mock.patch("documents.management.commands.backup_db.subprocess.run", fake_run):
+            with mock.patch(
+                "documents.management.commands.backup_db.timezone.localdate",
+                return_value=__import__("datetime").date(2099, 6, 15),
+            ):
+                with self.assertRaises(CommandError):
+                    call_command(
+                        "backup_db",
+                        "--output-dir",
+                        str(backup_root),
+                        stdout=StringIO(),
+                        stderr=StringIO(),
+                        skip_checks=True,
+                    )
+
+        self.assertEqual(list(backup_root.glob("paperless-*.dump")), [])


### PR DESCRIPTION
This PR implements the PostgreSQL piece discussed in [Discussion #9904](https://github.com/paperless-ngx/paperless-ngx/discussions/9904) (CLI backup / pull-by-path).

It adds a Django management command backup_db that creates a PostgreSQL logical backup using pg_dump (custom format -Fc), writes companion paperless-YYYY-MM-DD.dump and paperless-YYYY-MM-DD.version under a configurable directory (env PAPERLESS_BACKUP_DIR, --output-dir, or default under DATA_DIR/backups), optionally validates the dump with pg_restore --list, and supports retention via --retention-days.

Scope: PostgreSQL only for this first step; other engines are out of scope here.

Tests: src/documents/tests/test_management_backup_db.py