### PR TITLE
Fix: only set tags in workflow action when needed

### DIFF
--- a/src/documents/signals/handlers.py
+++ b/src/documents/signals/handlers.py
@@ -813,6 +813,7 @@ def run_workflows(
     workflows = get_workflows_for_trigger(trigger_type, workflow_to_run)
 
     for workflow in workflows:
+        tags_modified = False
         if not use_overrides:
             # This can be called from bulk_update_documents, which may be running multiple times
             # Refresh this so the matching data is fresh and instance fields are re-freshed
@@ -833,6 +834,7 @@ def run_workflows(
                     if use_overrides and overrides:
                         apply_assignment_to_overrides(action, overrides)
                     else:
+                        tags_modified = tags_modified or action.has_assign_tags
                         apply_assignment_to_document(
                             action,
                             document,
@@ -843,6 +845,9 @@ def run_workflows(
                     if use_overrides and overrides:
                         apply_removal_to_overrides(action, overrides)
                     else:
+                        tags_modified = tags_modified or (
+                            action.remove_all_tags or action.remove_tags.exists()
+                        )
                         apply_removal_to_document(action, document, doc_tag_ids)
                 elif action.type == WorkflowAction.WorkflowActionType.EMAIL:
                     context = build_workflow_action_context(document, overrides)
@@ -886,7 +891,8 @@ def run_workflows(
                         "modified",
                     ],
                 )
-                document.tags.set(doc_tag_ids)
+                if tags_modified:
+                    document.tags.set(doc_tag_ids)
 
             WorkflowRun.objects.create(
                 workflow=workflow,

--- a/src/documents/tests/test_workflows.py
+++ b/src/documents/tests/test_workflows.py
@@ -3512,6 +3512,60 @@ class TestWorkflows(
             as_json=False,
         )
 
+    @mock.patch("documents.signals.handlers.execute_webhook_action")
+    def test_workflow_webhook_action_does_not_overwrite_concurrent_tags(
+        self,
+        mock_execute_webhook_action,
+    ):
+        """
+        GIVEN:
+            - A document updated workflow with only a webhook action
+            - A tag update that happens after run_workflows
+        WHEN:
+            - The workflow runs
+        THEN:
+            - The concurrent tag update is preserved
+        """
+        trigger = WorkflowTrigger.objects.create(
+            type=WorkflowTrigger.WorkflowTriggerType.DOCUMENT_UPDATED,
+        )
+        webhook_action = WorkflowActionWebhook.objects.create(
+            use_params=False,
+            body="Test message: {{doc_url}}",
+            url="http://paperless-ngx.com",
+            include_document=False,
+        )
+        action = WorkflowAction.objects.create(
+            type=WorkflowAction.WorkflowActionType.WEBHOOK,
+            webhook=webhook_action,
+        )
+        w = Workflow.objects.create(
+            name="Webhook workflow",
+            order=0,
+        )
+        w.triggers.add(trigger)
+        w.actions.add(action)
+        w.save()
+
+        inbox_tag = Tag.objects.create(name="inbox")
+        error_tag = Tag.objects.create(name="error")
+        doc = Document.objects.create(
+            title="sample test",
+            correspondent=self.c,
+            original_filename="sample.pdf",
+        )
+        doc.tags.add(inbox_tag)
+
+        def add_error_tag(*args, **kwargs):
+            Document.objects.get(pk=doc.pk).tags.add(error_tag)
+
+        mock_execute_webhook_action.side_effect = add_error_tag
+
+        run_workflows(WorkflowTrigger.WorkflowTriggerType.DOCUMENT_UPDATED, doc)
+
+        doc.refresh_from_db()
+        self.assertCountEqual(doc.tags.all(), [inbox_tag, error_tag])
+
     @override_settings(
         PAPERLESS_URL="http://localhost:8000",
     )


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

This is a bit tricky as my first instinct was to just somehow 'refresh' tags again but I think that would effectively reverse https://github.com/paperless-ngx/paperless-ngx/pull/7711 so instead this is just a bit of a guard against the (admittedly probably rare) situation where tags are getting modified outside the workflow loop: tl;dr we only update them if the workflow action explicitly changes them. Without the change here, the test fails as expected, I *think* reproducing the issue in the discussion:

```
=================================== FAILURES ===================================
_ TestWorkflows.test_workflow_webhook_action_does_not_overwrite_concurrent_tags _

self = <documents.tests.test_workflows.TestWorkflows testMethod=test_workflow_webhook_action_does_not_overwrite_concurrent_tags>
mock_execute_webhook_action = <MagicMock name='execute_webhook_action' id='4850263648'>

    @mock.patch("documents.signals.handlers.execute_webhook_action")
    def test_workflow_webhook_action_does_not_overwrite_concurrent_tags(
        self,
        mock_execute_webhook_action,
    ):
        """
        GIVEN:
            - A document updated workflow with only a webhook action
            - A tag update that happens after run_workflows
        WHEN:
            - The workflow runs
        THEN:
            - The concurrent tag update is preserved
        """
        trigger = WorkflowTrigger.objects.create(
            type=WorkflowTrigger.WorkflowTriggerType.DOCUMENT_UPDATED,
        )
        webhook_action = WorkflowActionWebhook.objects.create(
            use_params=False,
            body="Test message: {{doc_url}}",
            url="http://paperless-ngx.com",
            include_document=False,
        )
        action = WorkflowAction.objects.create(
            type=WorkflowAction.WorkflowActionType.WEBHOOK,
            webhook=webhook_action,
        )
        w = Workflow.objects.create(
            name="Webhook workflow",
            order=0,
        )
        w.triggers.add(trigger)
        w.actions.add(action)
        w.save()
    
        inbox_tag = Tag.objects.create(name="inbox")
        error_tag = Tag.objects.create(name="error")
        doc = Document.objects.create(
            title="sample test",
            correspondent=self.c,
            original_filename="sample.pdf",
        )
        doc.tags.add(inbox_tag)
    
        def add_error_tag(*args, **kwargs):
            Document.objects.get(pk=doc.pk).tags.add(error_tag)
    
        mock_execute_webhook_action.side_effect = add_error_tag
    
        run_workflows(WorkflowTrigger.WorkflowTriggerType.DOCUMENT_UPDATED, doc)
    
        doc.refresh_from_db()
>       self.assertCountEqual(doc.tags.all(), [inbox_tag, error_tag])
E       AssertionError: Element counts were not equal:
E       First has 0, Second has 1:  <Tag: error>

documents/tests/test_workflows.py:3567: AssertionError

----------------------------- Captured stderr call -----------------------------
[2026-03-31 08:52:35,973] [INFO] [paperless.matching] Document matched WorkflowTrigger 1 from Workflow: Webhook workflow
[2026-03-31 08:52:35,980] [INFO] [paperless.handlers] Applying WorkflowAction 1 from Workflow: Webhook workflow
```

Closes #(issue or discussion)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
