### PR TITLE
Fix: dont defer tag change application in workflows

### DIFF
--- a/src/documents/signals/handlers.py
+++ b/src/documents/signals/handlers.py
@@ -818,7 +818,6 @@ def run_workflows(
             # Refresh this so the matching data is fresh and instance fields are re-freshed
             # Otherwise, this instance might be behind and overwrite the work another process did
             document.refresh_from_db()
-            doc_tag_ids = list(document.tags.values_list("pk", flat=True))
 
         if matching.document_matches_workflow(document, workflow, trigger_type):
             action: WorkflowAction
@@ -836,14 +835,13 @@ def run_workflows(
                         apply_assignment_to_document(
                             action,
                             document,
-                            doc_tag_ids,
                             logging_group,
                         )
                 elif action.type == WorkflowAction.WorkflowActionType.REMOVAL:
                     if use_overrides and overrides:
                         apply_removal_to_overrides(action, overrides)
                     else:
-                        apply_removal_to_document(action, document, doc_tag_ids)
+                        apply_removal_to_document(action, document)
                 elif action.type == WorkflowAction.WorkflowActionType.EMAIL:
                     context = build_workflow_action_context(document, overrides)
                     execute_email_action(
@@ -886,7 +884,6 @@ def run_workflows(
                         "modified",
                     ],
                 )
-                document.tags.set(doc_tag_ids)
 
             WorkflowRun.objects.create(
                 workflow=workflow,

--- a/src/documents/tests/test_workflows.py
+++ b/src/documents/tests/test_workflows.py
@@ -3512,6 +3512,124 @@ class TestWorkflows(
             as_json=False,
         )
 
+    @mock.patch("documents.signals.handlers.execute_webhook_action")
+    def test_workflow_webhook_action_does_not_overwrite_concurrent_tags(
+        self,
+        mock_execute_webhook_action,
+    ):
+        """
+        GIVEN:
+            - A document updated workflow with only a webhook action
+            - A tag update that happens after run_workflows
+        WHEN:
+            - The workflow runs
+        THEN:
+            - The concurrent tag update is preserved
+        """
+        trigger = WorkflowTrigger.objects.create(
+            type=WorkflowTrigger.WorkflowTriggerType.DOCUMENT_UPDATED,
+        )
+        webhook_action = WorkflowActionWebhook.objects.create(
+            use_params=False,
+            body="Test message: {{doc_url}}",
+            url="http://paperless-ngx.com",
+            include_document=False,
+        )
+        action = WorkflowAction.objects.create(
+            type=WorkflowAction.WorkflowActionType.WEBHOOK,
+            webhook=webhook_action,
+        )
+        w = Workflow.objects.create(
+            name="Webhook workflow",
+            order=0,
+        )
+        w.triggers.add(trigger)
+        w.actions.add(action)
+        w.save()
+
+        inbox_tag = Tag.objects.create(name="inbox")
+        error_tag = Tag.objects.create(name="error")
+        doc = Document.objects.create(
+            title="sample test",
+            correspondent=self.c,
+            original_filename="sample.pdf",
+        )
+        doc.tags.add(inbox_tag)
+
+        def add_error_tag(*args, **kwargs):
+            Document.objects.get(pk=doc.pk).tags.add(error_tag)
+
+        mock_execute_webhook_action.side_effect = add_error_tag
+
+        run_workflows(WorkflowTrigger.WorkflowTriggerType.DOCUMENT_UPDATED, doc)
+
+        doc.refresh_from_db()
+        self.assertCountEqual(doc.tags.all(), [inbox_tag, error_tag])
+
+    @mock.patch("documents.signals.handlers.execute_webhook_action")
+    def test_workflow_tag_actions_do_not_overwrite_concurrent_tags(
+        self,
+        mock_execute_webhook_action,
+    ):
+        """
+        GIVEN:
+            - A document updated workflow that clears tags and assigns an inbox tag
+            - A later tag update that happens before the workflow finishes
+        WHEN:
+            - The workflow runs
+        THEN:
+            - The later tag update is preserved
+        """
+        trigger = WorkflowTrigger.objects.create(
+            type=WorkflowTrigger.WorkflowTriggerType.DOCUMENT_UPDATED,
+        )
+        removal_action = WorkflowAction.objects.create(
+            type=WorkflowAction.WorkflowActionType.REMOVAL,
+            remove_all_tags=True,
+        )
+        assign_action = WorkflowAction.objects.create(
+            assign_owner=self.user2,
+        )
+        assign_action.assign_tags.add(self.t1)
+        webhook_action = WorkflowActionWebhook.objects.create(
+            use_params=False,
+            body="Test message: {{doc_url}}",
+            url="http://paperless-ngx.com",
+            include_document=False,
+        )
+        notify_action = WorkflowAction.objects.create(
+            type=WorkflowAction.WorkflowActionType.WEBHOOK,
+            webhook=webhook_action,
+        )
+        w = Workflow.objects.create(
+            name="Workflow tag race",
+            order=0,
+        )
+        w.triggers.add(trigger)
+        w.actions.add(removal_action)
+        w.actions.add(assign_action)
+        w.actions.add(notify_action)
+        w.save()
+
+        doc = Document.objects.create(
+            title="sample test",
+            correspondent=self.c,
+            original_filename="sample.pdf",
+            owner=self.user3,
+        )
+        doc.tags.add(self.t2, self.t3)
+
+        def add_error_tag(*args, **kwargs):
+            Document.objects.get(pk=doc.pk).tags.add(self.t2)
+
+        mock_execute_webhook_action.side_effect = add_error_tag
+
+        run_workflows(WorkflowTrigger.WorkflowTriggerType.DOCUMENT_UPDATED, doc)
+
+        doc.refresh_from_db()
+        self.assertEqual(doc.owner, self.user2)
+        self.assertCountEqual(doc.tags.all(), [self.t1, self.t2])
+
     @override_settings(
         PAPERLESS_URL="http://localhost:8000",
     )

--- a/src/documents/workflows/mutations.py
+++ b/src/documents/workflows/mutations.py
@@ -16,7 +16,6 @@ logger = logging.getLogger("paperless.workflows.mutations")
 def apply_assignment_to_document(
     action: WorkflowAction,
     document: Document,
-    doc_tag_ids: list[int],
     logging_group,
 ):
     """
@@ -25,12 +24,7 @@ def apply_assignment_to_document(
     action: WorkflowAction, annotated with 'has_assign_*' boolean fields
     """
     if action.has_assign_tags:
-        tag_ids_to_add: set[int] = set()
-        for tag in action.assign_tags.all():
-            tag_ids_to_add.add(tag.pk)
-            tag_ids_to_add.update(int(pk) for pk in tag.get_ancestors_pks())
-
-        doc_tag_ids[:] = list(set(doc_tag_ids) | tag_ids_to_add)
+        document.add_nested_tags(action.assign_tags.all())
 
     if action.assign_correspondent:
         document.correspondent = action.assign_correspondent
@@ -197,7 +191,6 @@ def apply_assignment_to_overrides(
 def apply_removal_to_document(
     action: WorkflowAction,
     document: Document,
-    doc_tag_ids: list[int],
 ):
     """
     Apply removal actions to a Document instance.
@@ -206,14 +199,15 @@ def apply_removal_to_document(
     """
 
     if action.remove_all_tags:
-        doc_tag_ids.clear()
+        document.tags.clear()
     else:
         tag_ids_to_remove: set[int] = set()
         for tag in action.remove_tags.all():
             tag_ids_to_remove.add(tag.pk)
             tag_ids_to_remove.update(int(pk) for pk in tag.get_descendants_pks())
 
-        doc_tag_ids[:] = [t for t in doc_tag_ids if t not in tag_ids_to_remove]
+        if tag_ids_to_remove:
+            document.tags.remove(*tag_ids_to_remove)
 
     if action.remove_all_correspondents or (
         document.correspondent


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Sheesh, this stuff isnt always obvious. I think the [other PR](https://github.com/paperless-ngx/paperless-ngx/pull/12477) was too narrow because the workflow in the support request _did_ change tags. So this is hopefully a bit more correct, if a bit broader: instead of deferring tag updates until the end, we apply them as we go (like we used to). At first this looks like a potential regression of https://github.com/paperless-ngx/paperless-ngx/pull/7711 but that test is still passing, and we no longer use `document.save()` (https://github.com/paperless-ngx/paperless-ngx/pull/12390 changed it to only update specific fields), so I think it is reasonable to conclude this is not a regression.

Of course, appreciate any thoughts in case Im missing something but to try and be more certain (if there is such a thing), I asked ChatGPT to generate a few more tests around this, all of which still pass (but I didnt include them in the PR):

```py
    def test_workflow_tag_assignment_then_owner_keeps_both_changes(self):
        """
        GIVEN:
            - A document updated workflow with ordered tag and owner assignments
        WHEN:
            - The document is updated through the API
        THEN:
            - The assigned tag and owner both persist
        """
        trigger = WorkflowTrigger.objects.create(
            type=WorkflowTrigger.WorkflowTriggerType.DOCUMENT_UPDATED,
        )
        assign_tag = WorkflowAction.objects.create()
        assign_tag.assign_tags.add(self.t1)
        assign_owner = WorkflowAction.objects.create(
            assign_owner=self.user2,
        )
        w = Workflow.objects.create(
            name="Workflow Add Tag Then Owner",
            order=0,
        )
        w.triggers.add(trigger)
        w.actions.add(assign_tag)
        w.actions.add(assign_owner)
        w.save()

        doc = Document.objects.create(
            title="sample test",
            correspondent=self.c,
            original_filename="sample.pdf",
        )

        superuser = User.objects.create_superuser("superuser")
        self.client.force_authenticate(user=superuser)

        self.client.patch(
            f"/api/documents/{doc.id}/",
            {"title": "new title"},
            format="json",
        )

        doc.refresh_from_db()
        self.assertEqual(doc.owner, self.user2)
        self.assertCountEqual(doc.tags.all(), [self.t1])

    def test_workflow_tag_assignment_with_custom_field_keeps_all_changes(self):
        """
        GIVEN:
            - A document updated workflow with tag assignment and custom field assignment
        WHEN:
            - The workflow runs
        THEN:
            - Tag, custom field, and scalar changes all persist together
        """
        trigger = WorkflowTrigger.objects.create(
            type=WorkflowTrigger.WorkflowTriggerType.DOCUMENT_UPDATED,
        )
        assign_tag = WorkflowAction.objects.create()
        assign_tag.assign_tags.add(self.t1)
        assign_custom_field = WorkflowAction.objects.create(
            assign_custom_fields_values={self.cf1.pk: "cars"},
        )
        assign_custom_field.assign_custom_fields.add(self.cf1)
        assign_owner = WorkflowAction.objects.create(
            assign_owner=self.user2,
        )
        w = Workflow.objects.create(
            name="Workflow Add Tag Custom Field Owner",
            order=0,
        )
        w.triggers.add(trigger)
        w.actions.add(assign_tag)
        w.actions.add(assign_custom_field)
        w.actions.add(assign_owner)
        w.save()

        doc = Document.objects.create(
            title="sample test",
            correspondent=self.c,
            original_filename="sample.pdf",
        )

        run_workflows(WorkflowTrigger.WorkflowTriggerType.DOCUMENT_UPDATED, doc)

        doc.refresh_from_db()
        self.assertEqual(doc.owner, self.user2)
        self.assertCountEqual(doc.tags.all(), [self.t1])
        self.assertEqual(
            doc.custom_fields.get(field=self.cf1).value,
            "cars",
        )

    def test_workflow_multiple_tag_actions_then_owner_respect_order(self):
        """
        GIVEN:
            - A document updated workflow with ordered tag removal, tag assignment, and owner assignment
        WHEN:
            - The document is updated through the API
        THEN:
            - Tag action order and scalar changes are both preserved
        """
        trigger = WorkflowTrigger.objects.create(
            type=WorkflowTrigger.WorkflowTriggerType.DOCUMENT_UPDATED,
        )
        trigger.filter_has_tags.add(self.t1)
        remove_tag = WorkflowAction.objects.create(
            type=WorkflowAction.WorkflowActionType.REMOVAL,
        )
        remove_tag.remove_tags.add(self.t1)
        assign_tag = WorkflowAction.objects.create()
        assign_tag.assign_tags.add(self.t3)
        assign_owner = WorkflowAction.objects.create(
            assign_owner=self.user2,
        )
        w = Workflow.objects.create(
            name="Workflow Remove Add Tag Then Owner",
            order=0,
        )
        w.triggers.add(trigger)
        w.actions.add(remove_tag)
        w.actions.add(assign_tag)
        w.actions.add(assign_owner)
        w.save()

        doc = Document.objects.create(
            title="sample test",
            correspondent=self.c,
            original_filename="sample.pdf",
        )

        superuser = User.objects.create_superuser("superuser")
        self.client.force_authenticate(user=superuser)

        self.client.patch(
            f"/api/documents/{doc.id}/",
            {"tags": [self.t1.id, self.t2.id]},
            format="json",
        )

        doc.refresh_from_db()
        self.assertEqual(doc.owner, self.user2)
        self.assertCountEqual(doc.tags.all(), [self.t2, self.t3])
```

Closes #12475

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
