### PR TITLE
feat: add email address book and message templates with CC/BCC support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,7 +78,16 @@ virtualenv
 .venv/
 /docker-compose.env
 /docker-compose.yml
+/docker-compose.dev.yml
+/.env
 .ruff_cache/
+
+# Temp reference files
+*.ref.txt
+pr-diff.txt
+test-ref.txt
+frontend-test-ref.txt
+upstream-*.txt
 
 # Used for development
 scripts/import-for-development

--- a/src-ui/src/app/components/common/email-document-dialog/email-document-dialog.component.html
+++ b/src-ui/src/app/components/common/email-document-dialog/email-document-dialog.component.html
@@ -7,33 +7,129 @@
     <button type="button" class="btn-close" aria-label="Close" (click)="close()"></button>
 </div>
 <div class="modal-body">
-    <div class="mb-1">
-        <label for="email" class="form-label" i18n>Email address(es)</label>
-        <input type="email" class="form-control" id="email" [(ngModel)]="emailAddress">
+    <!-- To -->
+    <div class="mb-2">
+        <label for="toInput" class="form-label" i18n="@@email-to-label">Recipient(s)</label>
+        <div class="recipient-field">
+            @for (addr of toRecipients; track addr; let i = $index) {
+                <span class="badge bg-primary recipient-chip">
+                    {{ addr }}
+                    <button type="button" class="btn-close btn-close-white btn-close-sm ms-1" (click)="removeRecipient('to', i)"></button>
+                </span>
+            }
+            <input type="text" class="form-control recipient-input" id="toInput"
+                   name="recipient-search"
+                   autocomplete="off"
+                   #toTypeahead="ngbTypeahead"
+                   [(ngModel)]="toInput"
+                   [ngbTypeahead]="searchContacts"
+                   [resultFormatter]="contactFormatter"
+                   [inputFormatter]="contactInputFormatter"
+                   (selectItem)="addRecipient('to', $event)"
+                   (keydown)="onInputKeydown('to', $event)"
+                   (focus)="onFocus($event)"
+                   [focusFirst]="false"
+                   placeholder="Search contacts or enter email" i18n-placeholder="@@email-search-contacts">
+        </div>
     </div>
-    <div class="mb-1">
-        <label for="email" class="form-label" i18n>Subject</label>
-        <input type="email" class="form-control" id="subject" [(ngModel)]="emailSubject">
+
+    <!-- CC / BCC toggle -->
+    @if (!showCcBcc) {
+        <div class="mb-2">
+            <button type="button" class="btn btn-link btn-sm p-0" (click)="showCcBcc = true" i18n>Show CC / BCC</button>
+        </div>
+    }
+
+    <!-- CC -->
+    @if (showCcBcc) {
+        <div class="mb-2">
+            <label for="ccInput" class="form-label">CC</label>
+            <div class="recipient-field">
+                @for (addr of ccRecipients; track addr; let i = $index) {
+                    <span class="badge bg-secondary recipient-chip">
+                        {{ addr }}
+                        <button type="button" class="btn-close btn-close-white btn-close-sm ms-1" (click)="removeRecipient('cc', i)"></button>
+                    </span>
+                }
+                <input type="text" class="form-control recipient-input" id="ccInput"
+                       name="cc-search"
+                       autocomplete="off"
+                       #ccTypeahead="ngbTypeahead"
+                       [(ngModel)]="ccInput"
+                       [ngbTypeahead]="searchContacts"
+                       [resultFormatter]="contactFormatter"
+                       [inputFormatter]="contactInputFormatter"
+                       (selectItem)="addRecipient('cc', $event)"
+                       (keydown)="onInputKeydown('cc', $event)"
+                       (focus)="onFocus($event)"
+                       [focusFirst]="false"
+                       placeholder="CC recipients" i18n-placeholder="@@email-cc-placeholder">
+            </div>
+        </div>
+
+        <!-- BCC -->
+        <div class="mb-2">
+            <label for="bccInput" class="form-label">BCC</label>
+            <div class="recipient-field">
+                @for (addr of bccRecipients; track addr; let i = $index) {
+                    <span class="badge bg-secondary recipient-chip">
+                        {{ addr }}
+                        <button type="button" class="btn-close btn-close-white btn-close-sm ms-1" (click)="removeRecipient('bcc', i)"></button>
+                    </span>
+                }
+                <input type="text" class="form-control recipient-input" id="bccInput"
+                       name="bcc-search"
+                       autocomplete="off"
+                       #bccTypeahead="ngbTypeahead"
+                       [(ngModel)]="bccInput"
+                       [ngbTypeahead]="searchContacts"
+                       [resultFormatter]="contactFormatter"
+                       [inputFormatter]="contactInputFormatter"
+                       (selectItem)="addRecipient('bcc', $event)"
+                       (keydown)="onInputKeydown('bcc', $event)"
+                       (focus)="onFocus($event)"
+                       [focusFirst]="false"
+                       placeholder="BCC recipients" i18n-placeholder="@@email-bcc-placeholder">
+            </div>
+        </div>
+    }
+
+    <!-- Template -->
+    <div class="mb-2">
+        <label for="template" class="form-label" i18n>Template</label>
+        <select class="form-select" id="template" (change)="applyTemplate(templates[$any($event.target).value])" [value]="''">
+            <option value="" disabled selected i18n>Select a template...</option>
+            @for (template of templates; track template.id; let i = $index) {
+                <option [value]="i">{{ template.name }}</option>
+            }
+        </select>
     </div>
-    <div>
+    <div class="mb-2">
+        <label for="subject" class="form-label" i18n>Subject</label>
+        <input type="text" class="form-control" id="subject" [(ngModel)]="emailSubject">
+    </div>
+    <div class="mb-2">
         <label for="message" class="form-label" i18n>Message</label>
-        <textarea class="form-control" id="message" rows="3" [(ngModel)]="emailMessage"></textarea>
+        <textarea class="form-control" id="message" rows="6" [(ngModel)]="emailMessage"></textarea>
     </div>
 </div>
-<div class="modal-footer">
+<div class="modal-footer flex-column align-items-stretch">
     <div class="input-group">
         <div class="input-group-text flex-grow-1">
             <input class="form-check-input mt-0 me-2" type="checkbox" role="switch" id="useArchiveVersion" [disabled]="!hasArchiveVersion" [(ngModel)]="useArchiveVersion">
             <label class="form-check-label w-100 text-start" for="useArchiveVersion" i18n>Use archive version</label>
         </div>
-        <button type="submit" class="btn btn-outline-primary" (click)="emailDocuments()" [disabled]="loading || emailAddress.length === 0 || emailMessage.length === 0 || emailSubject.length === 0">
+        <button type="submit" class="btn btn-outline-primary" (click)="emailDocuments()" [disabled]="!canSend">
             @if (loading) {
                 <div class="spinner-border spinner-border-sm me-2" role="status"></div>
             }
             <ng-container i18n>Send email</ng-container>
         </button>
     </div>
-    <div class="text-light fst-italic small mt-2">
+    <div class="text-muted fst-italic small mt-2">
         <ng-container i18n>Some email servers may reject messages with large attachments.</ng-container>
+    </div>
+    <div class="text-muted small mt-1">
+        <ng-container i18n="@@email-admin-hint">Manage contacts and templates via <a href="/admin/" target="_blank">Django Admin</a>.</ng-container>
     </div>
 </div>

--- a/src-ui/src/app/components/common/email-document-dialog/email-document-dialog.component.scss
+++ b/src-ui/src/app/components/common/email-document-dialog/email-document-dialog.component.scss
@@ -1,0 +1,47 @@
+.recipient-field {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  padding: 0.25rem;
+  border: 1px solid var(--bs-border-color);
+  border-radius: var(--bs-border-radius);
+  background: var(--bs-body-bg);
+  min-height: 2.5rem;
+  align-items: center;
+  cursor: text;
+
+  &:focus-within {
+    border-color: var(--bs-primary);
+    box-shadow: 0 0 0 0.2rem rgba(var(--bs-primary-rgb), 0.25);
+  }
+}
+
+.recipient-input {
+  border: none;
+  outline: none;
+  box-shadow: none !important;
+  flex: 1 1 120px;
+  min-width: 120px;
+  padding: 0.15rem 0.35rem;
+  background: transparent;
+}
+
+.recipient-chip {
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.85rem;
+  font-weight: normal;
+  padding: 0.25rem 0.5rem;
+  border-radius: 1rem;
+
+  .btn-close {
+    font-size: 0.55rem;
+    padding: 0;
+    margin-left: 0.3rem;
+    opacity: 0.8;
+
+    &:hover {
+      opacity: 1;
+    }
+  }
+}

--- a/src-ui/src/app/components/common/email-document-dialog/email-document-dialog.component.spec.ts
+++ b/src-ui/src/app/components/common/email-document-dialog/email-document-dialog.component.spec.ts
@@ -8,6 +8,8 @@ import { of, throwError } from 'rxjs'
 import { IfPermissionsDirective } from 'src/app/directives/if-permissions.directive'
 import { PermissionsService } from 'src/app/services/permissions.service'
 import { DocumentService } from 'src/app/services/rest/document.service'
+import { EmailContactService } from 'src/app/services/rest/email-contact.service'
+import { EmailTemplateService } from 'src/app/services/rest/email-template.service'
 import { ToastService } from 'src/app/services/toast.service'
 import { EmailDocumentDialogComponent } from './email-document-dialog.component'
 
@@ -29,6 +31,14 @@ describe('EmailDocumentDialogComponent', () => {
         provideHttpClient(withInterceptorsFromDi()),
         provideHttpClientTesting(),
         NgbActiveModal,
+        {
+          provide: EmailContactService,
+          useValue: { listAll: () => of({ results: [] }) },
+        },
+        {
+          provide: EmailTemplateService,
+          useValue: { listAll: () => of({ results: [] }) },
+        },
       ],
     }).compileComponents()
 
@@ -53,7 +63,7 @@ describe('EmailDocumentDialogComponent', () => {
     const toastErrorSpy = jest.spyOn(toastService, 'showError')
     const toastSuccessSpy = jest.spyOn(toastService, 'showInfo')
     component.documentIds = [1]
-    component.emailAddress = 'hello@paperless-ngx.com'
+    component.toRecipients = ['hello@paperless-ngx.com']
     component.emailSubject = 'Hello'
     component.emailMessage = 'World'
     jest
@@ -74,7 +84,7 @@ describe('EmailDocumentDialogComponent', () => {
     const toastErrorSpy = jest.spyOn(toastService, 'showError')
     const toastSuccessSpy = jest.spyOn(toastService, 'showInfo')
     component.documentIds = [1, 2, 3]
-    component.emailAddress = 'hello@paperless-ngx.com'
+    component.toRecipients = ['hello@paperless-ngx.com']
     component.emailSubject = 'Hello'
     component.emailMessage = 'World'
     jest
@@ -89,6 +99,26 @@ describe('EmailDocumentDialogComponent', () => {
     jest.spyOn(documentService, 'emailDocuments').mockReturnValue(of(true))
     component.emailDocuments()
     expect(toastSuccessSpy).toHaveBeenCalledWith('Email sent')
+  })
+
+  it('should add and remove recipients', () => {
+    component.addRecipient('to', {
+      item: { email: 'test@example.com' },
+      preventDefault: () => {},
+    })
+    expect(component.toRecipients).toContain('test@example.com')
+
+    component.removeRecipient('to', 0)
+    expect(component.toRecipients.length).toBe(0)
+  })
+
+  it('should report canSend correctly', () => {
+    expect(component.canSend).toBeFalsy()
+
+    component.toRecipients = ['test@example.com']
+    component.emailSubject = 'Subject'
+    component.emailMessage = 'Body'
+    expect(component.canSend).toBeTruthy()
   })
 
   it('should close the dialog', () => {

--- a/src-ui/src/app/components/common/email-document-dialog/email-document-dialog.component.ts
+++ b/src-ui/src/app/components/common/email-document-dialog/email-document-dialog.component.ts
@@ -1,8 +1,24 @@
 import { Component, Input, inject } from '@angular/core'
 import { FormsModule } from '@angular/forms'
-import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap'
+import { NgbActiveModal, NgbTypeaheadModule } from '@ng-bootstrap/ng-bootstrap'
 import { NgxBootstrapIconsModule } from 'ngx-bootstrap-icons'
+import {
+  Observable,
+  OperatorFunction,
+  debounceTime,
+  forkJoin,
+  of,
+  switchMap,
+} from 'rxjs'
+import { Document } from 'src/app/data/document'
+import { EmailContact } from 'src/app/data/email-contact'
+import { EmailTemplate } from 'src/app/data/email-template'
+import { CorrespondentService } from 'src/app/services/rest/correspondent.service'
+import { DocumentTypeService } from 'src/app/services/rest/document-type.service'
 import { DocumentService } from 'src/app/services/rest/document.service'
+import { EmailContactService } from 'src/app/services/rest/email-contact.service'
+import { EmailTemplateService } from 'src/app/services/rest/email-template.service'
+import { UserService } from 'src/app/services/rest/user.service'
 import { ToastService } from 'src/app/services/toast.service'
 import { LoadingComponentWithPermissions } from '../../loading-component/loading.component'
 
@@ -10,15 +26,36 @@ import { LoadingComponentWithPermissions } from '../../loading-component/loading
   selector: 'pngx-email-document-dialog',
   templateUrl: './email-document-dialog.component.html',
   styleUrl: './email-document-dialog.component.scss',
-  imports: [FormsModule, NgxBootstrapIconsModule],
+  imports: [FormsModule, NgxBootstrapIconsModule, NgbTypeaheadModule],
 })
 export class EmailDocumentDialogComponent extends LoadingComponentWithPermissions {
   private activeModal = inject(NgbActiveModal)
   private documentService = inject(DocumentService)
   private toastService = inject(ToastService)
+  private emailContactService = inject(EmailContactService)
+  private emailTemplateService = inject(EmailTemplateService)
+  private correspondentService = inject(CorrespondentService)
+  private documentTypeService = inject(DocumentTypeService)
+  private userService = inject(UserService)
 
   @Input()
   documentIds: number[]
+
+  private _documents: Document[] = []
+
+  @Input()
+  set documents(value: Document[]) {
+    this._documents = value
+    if (value.length > 0) {
+      this.buildPlaceholderContext(value[0])
+    }
+  }
+
+  get documents(): Document[] {
+    return this._documents
+  }
+
+  private placeholderContext: Record<string, string> = {}
 
   private _hasArchiveVersion: boolean = true
 
@@ -34,31 +71,252 @@ export class EmailDocumentDialogComponent extends LoadingComponentWithPermission
 
   public useArchiveVersion: boolean = true
 
-  public emailAddress: string = ''
+  // Recipient chips for To, CC, BCC
+  public toRecipients: string[] = []
+  public ccRecipients: string[] = []
+  public bccRecipients: string[] = []
+
+  // Input fields for typeahead
+  public toInput: string = ''
+  public ccInput: string = ''
+  public bccInput: string = ''
+
+  public showCcBcc: boolean = false
+
   public emailSubject: string = ''
   public emailMessage: string = ''
+
+  public templates: EmailTemplate[] = []
+  public allContacts: EmailContact[] = []
+  public selectedTemplate: EmailTemplate | null = null
 
   constructor() {
     super()
     this.loading = false
+    this.emailTemplateService
+      .listAll()
+      .subscribe((r) => (this.templates = r.results))
+    this.emailContactService
+      .listAll()
+      .subscribe((r) => (this.allContacts = r.results))
+  }
+
+  private buildPlaceholderContext(doc: Document) {
+    const created = doc.created ? new Date(doc.created) : null
+    const added = doc.added ? new Date(doc.added) : null
+    const ctx: Record<string, string> = {
+      doc_title: doc.title ?? '',
+      original_filename: doc.original_file_name?.replace(/\.[^.]+$/, '') ?? '',
+      filename: doc.original_file_name?.replace(/\.[^.]+$/, '') ?? '',
+      doc_url: doc.id
+        ? `${window.location.origin}/documents/${doc.id}/details`
+        : '',
+      doc_id: doc.id ? String(doc.id) : '',
+    }
+    if (created) {
+      ctx.created = created.toISOString().split('T')[0]
+      ctx.created_year = String(created.getFullYear())
+      ctx.created_year_short = String(created.getFullYear()).slice(-2)
+      ctx.created_month = String(created.getMonth() + 1).padStart(2, '0')
+      ctx.created_month_name = created.toLocaleDateString('en-US', {
+        month: 'long',
+      })
+      ctx.created_month_name_short = created.toLocaleDateString('en-US', {
+        month: 'short',
+      })
+      ctx.created_day = String(created.getDate()).padStart(2, '0')
+      ctx.created_time = `${String(created.getHours()).padStart(2, '0')}:${String(created.getMinutes()).padStart(2, '0')}`
+    }
+    if (added) {
+      ctx.added = added.toISOString()
+      ctx.added_year = String(added.getFullYear())
+      ctx.added_year_short = String(added.getFullYear()).slice(-2)
+      ctx.added_month = String(added.getMonth() + 1).padStart(2, '0')
+      ctx.added_month_name = added.toLocaleDateString('en-US', {
+        month: 'long',
+      })
+      ctx.added_month_name_short = added.toLocaleDateString('en-US', {
+        month: 'short',
+      })
+      ctx.added_day = String(added.getDate()).padStart(2, '0')
+      ctx.added_time = `${String(added.getHours()).padStart(2, '0')}:${String(added.getMinutes()).padStart(2, '0')}`
+    }
+    // Resolve correspondent and document_type names
+    const obs: Record<string, Observable<any>> = {}
+    if (doc.correspondent) {
+      obs['correspondent'] = this.correspondentService.getCached(
+        doc.correspondent
+      )
+    }
+    if (doc.document_type) {
+      obs['document_type'] = this.documentTypeService.getCached(
+        doc.document_type
+      )
+    }
+    if (doc.owner) {
+      obs['owner'] = this.userService.getCached(doc.owner)
+    }
+    if (Object.keys(obs).length > 0) {
+      forkJoin(obs).subscribe((results: any) => {
+        if (results.correspondent)
+          ctx.correspondent = results.correspondent.name ?? ''
+        if (results.document_type)
+          ctx.document_type = results.document_type.name ?? ''
+        if (results.owner) ctx.owner_username = results.owner.username ?? ''
+        this.placeholderContext = ctx
+      })
+    } else {
+      ctx.correspondent = ''
+      ctx.document_type = ''
+      ctx.owner_username = ''
+      this.placeholderContext = ctx
+    }
+  }
+
+  private renderPlaceholders(text: string): string {
+    if (!text) return text
+    return text.replace(/\{\{\s*(\w+)\s*\}\}/g, (match, key) => {
+      return this.placeholderContext[key] ?? match
+    })
+  }
+
+  private get allSelectedEmails(): string[] {
+    return [...this.toRecipients, ...this.ccRecipients, ...this.bccRecipients]
+  }
+
+  public searchContacts: OperatorFunction<string, EmailContact[]> = (
+    text$: Observable<string>
+  ) =>
+    text$.pipe(
+      debounceTime(100),
+      switchMap((term) => {
+        const selected = this.allSelectedEmails
+        const available = this.allContacts.filter(
+          (c) => !selected.includes(c.email)
+        )
+        if (!term || term.length === 0) {
+          return of(available.slice(0, 15))
+        }
+        const filtered = available.filter(
+          (c) =>
+            c.name?.toLowerCase().includes(term.toLowerCase()) ||
+            c.email?.toLowerCase().includes(term.toLowerCase())
+        )
+        return of(filtered.slice(0, 15))
+      })
+    )
+
+  public contactFormatter = (contact: EmailContact) =>
+    `${contact.name} <${contact.email}>`
+
+  public contactInputFormatter = (_contact: EmailContact) => ''
+
+  public addRecipient(field: 'to' | 'cc' | 'bcc', event?: any) {
+    let email: string
+    if (event?.item) {
+      event.preventDefault()
+      email = event.item.email
+    } else {
+      email =
+        field === 'to'
+          ? this.toInput
+          : field === 'cc'
+            ? this.ccInput
+            : this.bccInput
+    }
+    email = email?.trim()
+    if (!email) return
+    const list =
+      field === 'to'
+        ? this.toRecipients
+        : field === 'cc'
+          ? this.ccRecipients
+          : this.bccRecipients
+    if (!list.includes(email)) {
+      list.push(email)
+    }
+    if (field === 'to') this.toInput = ''
+    else if (field === 'cc') this.ccInput = ''
+    else this.bccInput = ''
+    // Re-focus input after selection (like tags closeOnSelect=false)
+    setTimeout(() => {
+      const inputId =
+        field === 'to' ? 'toInput' : field === 'cc' ? 'ccInput' : 'bccInput'
+      const el = document.getElementById(inputId) as HTMLInputElement
+      if (el) {
+        el.focus()
+        el.dispatchEvent(new Event('input'))
+      }
+    })
+  }
+
+  public removeRecipient(field: 'to' | 'cc' | 'bcc', index: number) {
+    const list =
+      field === 'to'
+        ? this.toRecipients
+        : field === 'cc'
+          ? this.ccRecipients
+          : this.bccRecipients
+    list.splice(index, 1)
+  }
+
+  public onInputKeydown(field: 'to' | 'cc' | 'bcc', event: KeyboardEvent) {
+    if (
+      event.key === 'Enter' ||
+      event.key === ',' ||
+      event.key === ';' ||
+      event.key === 'Tab'
+    ) {
+      event.preventDefault()
+      this.addRecipient(field)
+    }
+  }
+
+  public onFocus(event: FocusEvent) {
+    const input = event.target as HTMLInputElement
+    input.dispatchEvent(new Event('input'))
+  }
+
+  public applyTemplate(template: EmailTemplate) {
+    this.selectedTemplate = template
+    this.emailSubject = this.renderPlaceholders(template.subject ?? '')
+    this.emailMessage = this.renderPlaceholders(template.body ?? '')
+    this.toastService.showInfo($localize`Template applied`)
+  }
+
+  public get canSend(): boolean {
+    return (
+      this.toRecipients.length > 0 &&
+      this.emailSubject.length > 0 &&
+      this.emailMessage.length > 0 &&
+      !this.loading
+    )
   }
 
   public emailDocuments() {
     this.loading = true
+    const addresses = this.toRecipients.join(',')
+    const cc = this.ccRecipients.join(',')
+    const bcc = this.bccRecipients.join(',')
     this.documentService
       .emailDocuments(
         this.documentIds,
-        this.emailAddress,
+        addresses,
         this.emailSubject,
         this.emailMessage,
-        this.useArchiveVersion
+        this.useArchiveVersion,
+        cc || undefined,
+        bcc || undefined
       )
       .subscribe({
         next: () => {
           this.loading = false
-          this.emailAddress = ''
+          this.toRecipients = []
+          this.ccRecipients = []
+          this.bccRecipients = []
           this.emailSubject = ''
           this.emailMessage = ''
+          this.selectedTemplate = null
           this.close()
           this.toastService.showInfo($localize`Email sent`)
         },

--- a/src-ui/src/app/components/document-detail/document-detail.component.spec.ts
+++ b/src-ui/src/app/components/document-detail/document-detail.component.spec.ts
@@ -212,6 +212,7 @@ describe('DocumentDetailComponent', () => {
                   },
                 ],
               }),
+            getCached: (id: number) => of({ id: 11, name: 'Correspondent11' }),
           },
         },
         {
@@ -226,6 +227,7 @@ describe('DocumentDetailComponent', () => {
                   },
                 ],
               }),
+            getCached: (id: number) => of({ id: 21, name: 'DocumentType21' }),
           },
         },
         {
@@ -258,6 +260,7 @@ describe('DocumentDetailComponent', () => {
                   },
                 ],
               }),
+            getCached: (id: number) => of({ id: 1, username: 'user1' }),
           },
         },
         CustomFieldsService,

--- a/src-ui/src/app/components/document-detail/document-detail.component.ts
+++ b/src-ui/src/app/components/document-detail/document-detail.component.ts
@@ -1920,8 +1920,10 @@ export class DocumentDetailComponent
   public openEmailDocument() {
     const modal = this.modalService.open(EmailDocumentDialogComponent, {
       backdrop: 'static',
+      size: 'lg',
     })
     modal.componentInstance.documentIds = [this.document.id]
+    modal.componentInstance.documents = [this.document]
     modal.componentInstance.hasArchiveVersion =
       this.metadata?.has_archive_version ?? !!this.document?.archived_file_name
   }

--- a/src-ui/src/app/components/document-list/bulk-editor/bulk-editor.component.ts
+++ b/src-ui/src/app/components/document-list/bulk-editor/bulk-editor.component.ts
@@ -1079,8 +1079,12 @@ export class BulkEditorComponent
 
     const modal = this.modalService.open(EmailDocumentDialogComponent, {
       backdrop: 'static',
+      size: 'lg',
     })
     modal.componentInstance.documentIds = Array.from(this.list.selected)
+    modal.componentInstance.documents = this.list.documents.filter((d) =>
+      this.list.selected.has(d.id)
+    )
     modal.componentInstance.hasArchiveVersion = allHaveArchiveVersion
   }
 }

--- a/src-ui/src/app/data/email-contact.ts
+++ b/src-ui/src/app/data/email-contact.ts
@@ -1,0 +1,7 @@
+import { ObjectWithId } from './object-with-id'
+
+export interface EmailContact extends ObjectWithId {
+  name?: string
+  email?: string
+  owner?: number
+}

--- a/src-ui/src/app/data/email-template.ts
+++ b/src-ui/src/app/data/email-template.ts
@@ -1,0 +1,8 @@
+import { ObjectWithId } from './object-with-id'
+
+export interface EmailTemplate extends ObjectWithId {
+  name?: string
+  subject?: string
+  body?: string
+  owner?: number
+}

--- a/src-ui/src/app/services/rest/document.service.ts
+++ b/src-ui/src/app/services/rest/document.service.ts
@@ -437,14 +437,19 @@ export class DocumentService extends AbstractPaperlessService<Document> {
     addresses: string,
     subject: string,
     message: string,
-    useArchiveVersion: boolean
+    useArchiveVersion: boolean,
+    cc?: string,
+    bcc?: string
   ): Observable<any> {
-    return this.http.post(this.getResourceUrl(null, 'email'), {
+    const body: any = {
       documents: documentIds,
       addresses: addresses,
       subject: subject,
       message: message,
       use_archive_version: useArchiveVersion,
-    })
+    }
+    if (cc) body.cc = cc
+    if (bcc) body.bcc = bcc
+    return this.http.post(this.getResourceUrl(null, 'email'), body)
   }
 }

--- a/src-ui/src/app/services/rest/email-contact.service.ts
+++ b/src-ui/src/app/services/rest/email-contact.service.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@angular/core'
+import { EmailContact } from 'src/app/data/email-contact'
+import { AbstractNameFilterService } from './abstract-name-filter-service'
+
+@Injectable({
+  providedIn: 'root',
+})
+export class EmailContactService extends AbstractNameFilterService<EmailContact> {
+  constructor() {
+    super()
+    this.resourceName = 'email_contacts'
+  }
+}

--- a/src-ui/src/app/services/rest/email-template.service.ts
+++ b/src-ui/src/app/services/rest/email-template.service.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@angular/core'
+import { EmailTemplate } from 'src/app/data/email-template'
+import { AbstractNameFilterService } from './abstract-name-filter-service'
+
+@Injectable({
+  providedIn: 'root',
+})
+export class EmailTemplateService extends AbstractNameFilterService<EmailTemplate> {
+  constructor() {
+    super()
+    this.resourceName = 'email_templates'
+  }
+}

--- a/src/documents/admin.py
+++ b/src/documents/admin.py
@@ -8,6 +8,8 @@ from documents.models import CustomField
 from documents.models import CustomFieldInstance
 from documents.models import Document
 from documents.models import DocumentType
+from documents.models import EmailContact
+from documents.models import EmailTemplate
 from documents.models import Note
 from documents.models import PaperlessTask
 from documents.models import SavedView
@@ -235,6 +237,8 @@ admin.site.register(ShareLink, ShareLinksAdmin)
 admin.site.register(ShareLinkBundle, ShareLinkBundleAdmin)
 admin.site.register(CustomField, CustomFieldsAdmin)
 admin.site.register(CustomFieldInstance, CustomFieldInstancesAdmin)
+admin.site.register(EmailContact)
+admin.site.register(EmailTemplate)
 
 if settings.AUDIT_LOG_ENABLED:
 

--- a/src/documents/filters.py
+++ b/src/documents/filters.py
@@ -39,6 +39,8 @@ from documents.models import CustomField
 from documents.models import CustomFieldInstance
 from documents.models import Document
 from documents.models import DocumentType
+from documents.models import EmailContact
+from documents.models import EmailTemplate
 from documents.models import PaperlessTask
 from documents.models import ShareLink
 from documents.models import ShareLinkBundle
@@ -1031,3 +1033,20 @@ class DocumentsOrderingFilter(OrderingFilter):
             )
 
         return super().filter_queryset(request, queryset, view)
+
+
+class EmailContactFilterSet(FilterSet):
+    class Meta:
+        model = EmailContact
+        fields = {
+            "name": ["istartswith", "icontains"],
+            "email": ["istartswith", "icontains"],
+        }
+
+
+class EmailTemplateFilterSet(FilterSet):
+    class Meta:
+        model = EmailTemplate
+        fields = {
+            "name": ["istartswith", "icontains"],
+        }

--- a/src/documents/mail.py
+++ b/src/documents/mail.py
@@ -21,6 +21,8 @@ def send_email(
     body: str,
     to: list[str],
     attachments: list[EmailAttachment],
+    cc: list[str] | None = None,
+    bcc: list[str] | None = None,
 ) -> int:
     """
     Send an email with attachments.
@@ -30,6 +32,8 @@ def send_email(
         body: Email body text
         to: List of recipient email addresses
         attachments: List of attachments
+        cc: List of CC email addresses
+        bcc: List of BCC email addresses
 
     Returns:
         Number of emails sent
@@ -40,6 +44,8 @@ def send_email(
         subject=subject,
         body=body,
         to=to,
+        cc=cc or [],
+        bcc=bcc or [],
     )
 
     used_filenames: set[str] = set()

--- a/src/documents/migrations/0017_emailcontact_emailtemplate.py
+++ b/src/documents/migrations/0017_emailcontact_emailtemplate.py
@@ -1,0 +1,112 @@
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations
+from django.db import models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ("documents", "0016_sha256_checksums"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="EmailContact",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "name",
+                    models.CharField(
+                        max_length=256,
+                        verbose_name="name",
+                    ),
+                ),
+                (
+                    "email",
+                    models.EmailField(
+                        max_length=254,
+                        verbose_name="email address",
+                    ),
+                ),
+                (
+                    "owner",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="email_contacts",
+                        to=settings.AUTH_USER_MODEL,
+                        verbose_name="owner",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "email contact",
+                "verbose_name_plural": "email contacts",
+                "ordering": ("name",),
+            },
+        ),
+        migrations.CreateModel(
+            name="EmailTemplate",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "name",
+                    models.CharField(
+                        max_length=256,
+                        verbose_name="name",
+                    ),
+                ),
+                (
+                    "subject",
+                    models.CharField(
+                        blank=True,
+                        default="",
+                        max_length=512,
+                        verbose_name="subject",
+                    ),
+                ),
+                (
+                    "body",
+                    models.TextField(
+                        blank=True,
+                        default="",
+                        verbose_name="body",
+                    ),
+                ),
+                (
+                    "owner",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="email_templates",
+                        to=settings.AUTH_USER_MODEL,
+                        verbose_name="owner",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "email template",
+                "verbose_name_plural": "email templates",
+                "ordering": ("name",),
+            },
+        ),
+    ]

--- a/src/documents/models.py
+++ b/src/documents/models.py
@@ -1803,3 +1803,74 @@ class WorkflowRun(SoftDeleteModel):
 
     def __str__(self) -> str:
         return f"WorkflowRun of {self.workflow} at {self.run_at} on {self.document}"
+
+
+class EmailContact(models.Model):
+    name = models.CharField(
+        _("name"),
+        max_length=256,
+    )
+
+    email = models.EmailField(
+        _("email address"),
+    )
+
+    owner = models.ForeignKey(
+        User,
+        blank=True,
+        null=True,
+        on_delete=models.SET_NULL,
+        verbose_name=_("owner"),
+    )
+
+    class Meta:
+        verbose_name = _("email contact")
+        verbose_name_plural = _("email contacts")
+        ordering = ("name",)
+
+    def __str__(self):
+        return f"{self.name} <{self.email}>"
+
+
+class EmailTemplate(models.Model):
+    name = models.CharField(
+        _("name"),
+        max_length=256,
+    )
+
+    subject = models.CharField(
+        _("email subject"),
+        max_length=256,
+        blank=True,
+        default="",
+        help_text=_(
+            "The subject of the email, can include Jinja2 placeholders, "
+            "see documentation.",
+        ),
+    )
+
+    body = models.TextField(
+        _("email body"),
+        blank=True,
+        default="",
+        help_text=_(
+            "The body (message) of the email, can include Jinja2 placeholders, "
+            "see documentation.",
+        ),
+    )
+
+    owner = models.ForeignKey(
+        User,
+        blank=True,
+        null=True,
+        on_delete=models.SET_NULL,
+        verbose_name=_("owner"),
+    )
+
+    class Meta:
+        verbose_name = _("email template")
+        verbose_name_plural = _("email templates")
+        ordering = ("name",)
+
+    def __str__(self):
+        return self.name

--- a/src/documents/serialisers.py
+++ b/src/documents/serialisers.py
@@ -61,6 +61,8 @@ from documents.models import CustomField
 from documents.models import CustomFieldInstance
 from documents.models import Document
 from documents.models import DocumentType
+from documents.models import EmailContact
+from documents.models import EmailTemplate
 from documents.models import MatchingModel
 from documents.models import Note
 from documents.models import PaperlessTask
@@ -2334,6 +2336,20 @@ class EmailSerializer(DocumentListSerializer):
         label="Email message",
     )
 
+    cc = serializers.CharField(
+        required=False,
+        default="",
+        label="CC addresses",
+        help_text="Comma-separated CC email addresses",
+    )
+
+    bcc = serializers.CharField(
+        required=False,
+        default="",
+        label="BCC addresses",
+        help_text="Comma-separated BCC email addresses",
+    )
+
     use_archive_version = serializers.BooleanField(
         default=True,
         label="Use archive version",
@@ -3314,3 +3330,32 @@ class StoragePathTestSerializer(SerializerWithPerms):
                 "documents.view_document",
                 Document,
             )
+
+
+class EmailContactSerializer(OwnedObjectSerializer):
+    class Meta:
+        model = EmailContact
+        fields = (
+            "id",
+            "name",
+            "email",
+            "owner",
+            "permissions",
+            "user_can_change",
+            "set_permissions",
+        )
+
+
+class EmailTemplateSerializer(OwnedObjectSerializer):
+    class Meta:
+        model = EmailTemplate
+        fields = (
+            "id",
+            "name",
+            "subject",
+            "body",
+            "owner",
+            "permissions",
+            "user_can_change",
+            "set_permissions",
+        )

--- a/src/documents/tests/test_api_email.py
+++ b/src/documents/tests/test_api_email.py
@@ -437,3 +437,211 @@ class TestEmail(DirectoriesMixin, SampleDirMixin, APITestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
         self.assertIn("Error emailing documents", response.content.decode())
+
+    @override_settings(
+        EMAIL_ENABLED=True,
+        EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend",
+    )
+    def test_email_cc_bcc(self) -> None:
+        """
+        GIVEN:
+            - Existing documents
+        WHEN:
+            - API request is made with cc and bcc fields
+        THEN:
+            - Email is sent with correct CC and BCC headers
+        """
+        response = self.client.post(
+            self.ENDPOINT,
+            json.dumps(
+                {
+                    "documents": [self.doc1.pk],
+                    "addresses": "to@example.com",
+                    "subject": "CC/BCC Test",
+                    "message": "Test message",
+                    "cc": "cc1@example.com,cc2@example.com",
+                    "bcc": "bcc@example.com",
+                },
+            ),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(mail.outbox), 1)
+
+        email = mail.outbox[0]
+        self.assertEqual(email.to, ["to@example.com"])
+        self.assertEqual(email.cc, ["cc1@example.com", "cc2@example.com"])
+        self.assertEqual(email.bcc, ["bcc@example.com"])
+
+    @override_settings(
+        EMAIL_ENABLED=True,
+        EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend",
+    )
+    def test_email_empty_cc_bcc(self) -> None:
+        """
+        GIVEN:
+            - Existing documents
+        WHEN:
+            - API request is made without cc and bcc fields
+        THEN:
+            - Email is sent without CC and BCC headers
+        """
+        response = self.client.post(
+            self.ENDPOINT,
+            json.dumps(
+                {
+                    "documents": [self.doc1.pk],
+                    "addresses": "to@example.com",
+                    "subject": "No CC/BCC Test",
+                    "message": "Test message",
+                },
+            ),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(mail.outbox), 1)
+
+        email = mail.outbox[0]
+        self.assertEqual(email.to, ["to@example.com"])
+        self.assertEqual(email.cc, [])
+        self.assertEqual(email.bcc, [])
+
+
+class TestEmailContacts(DirectoriesMixin, APITestCase):
+    ENDPOINT = "/api/email_contacts/"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.user = User.objects.create_superuser(username="temp_admin")
+        self.client.force_authenticate(user=self.user)
+
+    def test_create_contact(self) -> None:
+        response = self.client.post(
+            self.ENDPOINT,
+            {"name": "John Doe", "email": "john@example.com"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["name"], "John Doe")
+        self.assertEqual(response.data["email"], "john@example.com")
+
+    def test_list_contacts(self) -> None:
+        from documents.models import EmailContact
+
+        EmailContact.objects.create(
+            name="Alice",
+            email="alice@example.com",
+            owner=self.user,
+        )
+        EmailContact.objects.create(
+            name="Bob",
+            email="bob@example.com",
+            owner=self.user,
+        )
+
+        response = self.client.get(self.ENDPOINT)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 2)
+
+    def test_update_contact(self) -> None:
+        from documents.models import EmailContact
+
+        contact = EmailContact.objects.create(
+            name="Old Name",
+            email="old@example.com",
+            owner=self.user,
+        )
+        response = self.client.patch(
+            f"{self.ENDPOINT}{contact.pk}/",
+            {"name": "New Name"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["name"], "New Name")
+
+    def test_delete_contact(self) -> None:
+        from documents.models import EmailContact
+
+        contact = EmailContact.objects.create(
+            name="Delete Me",
+            email="del@example.com",
+            owner=self.user,
+        )
+        response = self.client.delete(f"{self.ENDPOINT}{contact.pk}/")
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(EmailContact.objects.filter(pk=contact.pk).exists())
+
+
+class TestEmailTemplates(DirectoriesMixin, APITestCase):
+    ENDPOINT = "/api/email_templates/"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.user = User.objects.create_superuser(username="temp_admin")
+        self.client.force_authenticate(user=self.user)
+
+    def test_create_template(self) -> None:
+        response = self.client.post(
+            self.ENDPOINT,
+            {
+                "name": "Welcome",
+                "subject": "Hello {{ doc_title }}",
+                "body": "Please find attached.",
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["name"], "Welcome")
+        self.assertEqual(response.data["subject"], "Hello {{ doc_title }}")
+
+    def test_list_templates(self) -> None:
+        from documents.models import EmailTemplate
+
+        EmailTemplate.objects.create(
+            name="T1",
+            subject="S1",
+            body="B1",
+            owner=self.user,
+        )
+        EmailTemplate.objects.create(
+            name="T2",
+            subject="S2",
+            body="B2",
+            owner=self.user,
+        )
+
+        response = self.client.get(self.ENDPOINT)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 2)
+
+    def test_update_template(self) -> None:
+        from documents.models import EmailTemplate
+
+        template = EmailTemplate.objects.create(
+            name="Old",
+            subject="S",
+            body="B",
+            owner=self.user,
+        )
+        response = self.client.patch(
+            f"{self.ENDPOINT}{template.pk}/",
+            {"name": "Updated"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["name"], "Updated")
+
+    def test_delete_template(self) -> None:
+        from documents.models import EmailTemplate
+
+        template = EmailTemplate.objects.create(
+            name="Del",
+            subject="S",
+            body="B",
+            owner=self.user,
+        )
+        response = self.client.delete(f"{self.ENDPOINT}{template.pk}/")
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(EmailTemplate.objects.filter(pk=template.pk).exists())

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -129,6 +129,8 @@ from documents.filters import CustomFieldFilterSet
 from documents.filters import DocumentFilterSet
 from documents.filters import DocumentsOrderingFilter
 from documents.filters import DocumentTypeFilterSet
+from documents.filters import EmailContactFilterSet
+from documents.filters import EmailTemplateFilterSet
 from documents.filters import ObjectOwnedOrGrantedPermissionsFilter
 from documents.filters import ObjectOwnedPermissionsFilter
 from documents.filters import PaperlessTaskFilterSet
@@ -147,6 +149,8 @@ from documents.models import CustomField
 from documents.models import CustomFieldInstance
 from documents.models import Document
 from documents.models import DocumentType
+from documents.models import EmailContact
+from documents.models import EmailTemplate
 from documents.models import Note
 from documents.models import PaperlessTask
 from documents.models import SavedView
@@ -183,7 +187,9 @@ from documents.serialisers import DocumentTypeSerializer
 from documents.serialisers import DocumentVersionLabelSerializer
 from documents.serialisers import DocumentVersionSerializer
 from documents.serialisers import EditPdfDocumentsSerializer
+from documents.serialisers import EmailContactSerializer
 from documents.serialisers import EmailSerializer
+from documents.serialisers import EmailTemplateSerializer
 from documents.serialisers import MergeDocumentsSerializer
 from documents.serialisers import NotesSerializer
 from documents.serialisers import PostDocumentSerializer
@@ -1638,12 +1644,28 @@ class DocumentViewSet(
         validated_data = serializer.validated_data
         document_ids = validated_data.get("documents")
         addresses = validated_data.get("addresses").split(",")
-        addresses = [addr.strip() for addr in addresses]
+        addresses = [addr.strip() for addr in addresses if addr.strip()]
+        cc_raw = validated_data.get("cc", "")
+        cc = (
+            [addr.strip() for addr in cc_raw.split(",") if addr.strip()]
+            if cc_raw
+            else []
+        )
+        bcc_raw = validated_data.get("bcc", "")
+        bcc = (
+            [addr.strip() for addr in bcc_raw.split(",") if addr.strip()]
+            if bcc_raw
+            else []
+        )
         subject = validated_data.get("subject")
         message = validated_data.get("message")
         use_archive_version = validated_data.get("use_archive_version", True)
 
-        documents = Document.objects.select_related("owner").filter(pk__in=document_ids)
+        documents = Document.objects.select_related(
+            "owner",
+            "correspondent",
+            "document_type",
+        ).filter(pk__in=document_ids)
         for document in documents:
             if request.user is not None and not has_perms_owner_aware(
                 request.user,
@@ -1651,6 +1673,55 @@ class DocumentViewSet(
                 document,
             ):
                 return HttpResponseForbidden("Insufficient permissions")
+
+        # Resolve Jinja2 placeholders using the first document's metadata
+        if documents.exists():
+            first_doc = documents.first()
+            try:
+                from documents.templating.workflows import parse_w_workflow_placeholders
+
+                subject = parse_w_workflow_placeholders(
+                    text=subject,
+                    correspondent_name=(
+                        first_doc.correspondent.name if first_doc.correspondent else ""
+                    ),
+                    doc_type_name=(
+                        first_doc.document_type.name if first_doc.document_type else ""
+                    ),
+                    owner_username=(
+                        first_doc.owner.username if first_doc.owner else ""
+                    ),
+                    local_added=timezone.localtime(first_doc.added),
+                    original_filename=first_doc.original_filename or "",
+                    filename=first_doc.filename or "",
+                    created=first_doc.created,
+                    doc_title=first_doc.title,
+                    doc_url=first_doc.get_public_filename(),
+                    doc_id=first_doc.id,
+                )
+                message = parse_w_workflow_placeholders(
+                    text=message,
+                    correspondent_name=(
+                        first_doc.correspondent.name if first_doc.correspondent else ""
+                    ),
+                    doc_type_name=(
+                        first_doc.document_type.name if first_doc.document_type else ""
+                    ),
+                    owner_username=(
+                        first_doc.owner.username if first_doc.owner else ""
+                    ),
+                    local_added=timezone.localtime(first_doc.added),
+                    original_filename=first_doc.original_filename or "",
+                    filename=first_doc.filename or "",
+                    created=first_doc.created,
+                    doc_title=first_doc.title,
+                    doc_url=first_doc.get_public_filename(),
+                    doc_id=first_doc.id,
+                )
+            except Exception:
+                logger.debug(
+                    "Could not resolve template placeholders, using raw text",
+                )
 
         try:
             attachments: list[EmailAttachment] = []
@@ -1674,6 +1745,8 @@ class DocumentViewSet(
                 subject=subject,
                 body=message,
                 to=addresses,
+                cc=cc,
+                bcc=bcc,
                 attachments=attachments,
             )
 
@@ -4473,3 +4546,37 @@ def serve_logo(request: HttpRequest, filename: str | None = None) -> FileRespons
         filename=app_logo.name,
         as_attachment=True,
     )
+
+
+class EmailContactViewSet(ModelViewSet, PassUserMixin):
+    model = EmailContact
+
+    queryset = EmailContact.objects.select_related("owner").order_by(Lower("name"))
+
+    serializer_class = EmailContactSerializer
+    pagination_class = StandardPagination
+    permission_classes = (IsAuthenticated, PaperlessObjectPermissions)
+    filter_backends = (
+        DjangoFilterBackend,
+        OrderingFilter,
+        ObjectOwnedOrGrantedPermissionsFilter,
+    )
+    filterset_class = EmailContactFilterSet
+    ordering_fields = ("name", "email")
+
+
+class EmailTemplateViewSet(ModelViewSet, PassUserMixin):
+    model = EmailTemplate
+
+    queryset = EmailTemplate.objects.select_related("owner").order_by(Lower("name"))
+
+    serializer_class = EmailTemplateSerializer
+    pagination_class = StandardPagination
+    permission_classes = (IsAuthenticated, PaperlessObjectPermissions)
+    filter_backends = (
+        DjangoFilterBackend,
+        OrderingFilter,
+        ObjectOwnedOrGrantedPermissionsFilter,
+    )
+    filterset_class = EmailTemplateFilterSet
+    ordering_fields = ("name",)

--- a/src/paperless/urls.py
+++ b/src/paperless/urls.py
@@ -24,6 +24,8 @@ from documents.views import CustomFieldViewSet
 from documents.views import DeleteDocumentsView
 from documents.views import DocumentTypeViewSet
 from documents.views import EditPdfDocumentsView
+from documents.views import EmailContactViewSet
+from documents.views import EmailTemplateViewSet
 from documents.views import GlobalSearchView
 from documents.views import IndexView
 from documents.views import LogViewSet
@@ -88,6 +90,8 @@ api_router.register(r"workflows", WorkflowViewSet)
 api_router.register(r"custom_fields", CustomFieldViewSet)
 api_router.register(r"config", ApplicationConfigurationViewSet)
 api_router.register(r"processed_mail", ProcessedMailViewSet)
+api_router.register(r"email_contacts", EmailContactViewSet)
+api_router.register(r"email_templates", EmailTemplateViewSet)
 
 
 urlpatterns = [


### PR DESCRIPTION
## Description

Adds **EmailContact** and **EmailTemplate** models for managing reusable email contacts and message templates when sending documents via email. This feature was highly requested in the community discussions.

### Features

- **Email Address Book**: Store and manage email contacts (name + email) with owner-based permissions
- **Email Templates**: Reusable message templates with Jinja2 placeholder support (`{{ doc_title }}`, `{{ correspondent }}`, `{{ created }}`, etc.) using the existing `parse_w_workflow_placeholders` engine
- **CC / BCC Support**: Optionally add CC and BCC recipients when sending emails
- **Recipient Chips UI**: Typeahead search for saved contacts with chip-based selection (matching the native paperless-ngx tag/doc-type selection pattern)
- **Client-side Template Preview**: Placeholders are resolved in real-time on the frontend before sending, so users see the final email content
- **Django Admin**: Both models are registered in the Django admin for easy management

### Screenshots

#### Default dialog (collapsed CC/BCC)

<img width="727" height="601" alt="Unbenannt" src="https://github.com/user-attachments/assets/4c5aa166-fd55-4526-9aba-0c293fecccac" />

#### Expanded CC/BCC fields
<img width="728" height="716" alt="1" src="https://github.com/user-attachments/assets/a1f338e7-f45e-4f4a-9566-3436c2dbd539" />
<img width="724" height="709" alt="image" src="https://github.com/user-attachments/assets/e1fb851d-a852-447c-83ea-0301eb18847d" />



#### Template applied with placeholder preview
<img width="720" height="824" alt="2" src="https://github.com/user-attachments/assets/90a22dfc-f33c-4de6-aa01-092d602c39a4" />


<img width="878" height="559" alt="image" src="https://github.com/user-attachments/assets/305d2315-327f-4e26-97e8-5855d497204a" />
<img width="545" height="298" alt="image" src="https://github.com/user-attachments/assets/c0507387-4d80-4f2e-b14e-eacd11adea30" />
<img width="506" height="395" alt="image" src="https://github.com/user-attachments/assets/4ca0a93d-105d-4f24-9440-8655e8b44a1e" />
<img width="729" height="703" alt="image" src="https://github.com/user-attachments/assets/1eb80692-6709-42f3-9454-bbf6045ee975" />






### Backend Changes

- New `EmailContact` model (name, email, owner) with full CRUD API + filtering
- New `EmailTemplate` model (name, subject, body, owner) with full CRUD API + filtering
- `send_email()` updated with optional `cc` and `bcc` parameters
- `email_documents()` view extended with CC/BCC parsing and server-side Jinja2 placeholder resolution
- Migration `0017` (depends on `0016_sha256_checksums`)
- Django admin registration for both models
- FilterSets, Serializers, ViewSets, URL routing

### Frontend Changes

- Recipient chips UI with typeahead contact search (To / CC / BCC)
- Email template selector dropdown with client-side placeholder preview
- Larger modal dialog (`size: lg`) with document context
- New data types (`EmailContact`, `EmailTemplate`) and REST services
- `Show CC / BCC` toggle to keep the default view clean

### Tests

- Backend: CC/BCC email sending, EmailContact CRUD, EmailTemplate CRUD
- Frontend: Updated spec for the chips-based recipient API

### How to Test

1. Create contacts via Django Admin (`/admin/documents/emailcontact/`)
2. Create a template with placeholders, e.g. Subject: `Document: {{ doc_title }}` and Body using `{{ correspondent }}`, `{{ created }}`, etc.
3. Open any document > Actions > Email Document
4. Search for contacts in the recipient field, add CC/BCC if needed
5. Select a template and observe placeholder preview
6. Send the email

Closes https://github.com/paperless-ngx/paperless-ngx/discussions/12221
Related: https://github.com/paperless-ngx/paperless-ngx/discussions/10545
