### PR TITLE
Feature: Consumer logging correlation

### DIFF
--- a/src/documents/tasks.py
+++ b/src/documents/tasks.py
@@ -61,6 +61,7 @@ from documents.utils import compute_checksum
 from documents.utils import identity
 from documents.workflows.utils import get_workflows_for_trigger
 from paperless.config import AIConfig
+from paperless.logging import consume_task_id
 from paperless.parsers import ParserContext
 from paperless.parsers.registry import get_parser_registry
 from paperless_ai.indexing import llm_index_add_or_update_document
@@ -147,76 +148,85 @@ def consume_file(
     input_doc: ConsumableDocument,
     overrides: DocumentMetadataOverrides | None = None,
 ):
-    # Default no overrides
-    if overrides is None:
-        overrides = DocumentMetadataOverrides()
+    token = consume_task_id.set((self.request.id or "")[:8])
+    try:
+        # Default no overrides
+        if overrides is None:
+            overrides = DocumentMetadataOverrides()
 
-    plugins: list[type[ConsumeTaskPlugin]] = (
-        [
-            ConsumerPreflightPlugin,
-            ConsumerPlugin,
-        ]
-        if input_doc.root_document_id is not None
-        else [
-            ConsumerPreflightPlugin,
-            AsnCheckPlugin,
-            CollatePlugin,
-            BarcodePlugin,
-            AsnCheckPlugin,  # Re-run ASN check after barcode reading
-            WorkflowTriggerPlugin,
-            ConsumerPlugin,
-        ]
-    )
+        plugins: list[type[ConsumeTaskPlugin]] = (
+            [
+                ConsumerPreflightPlugin,
+                ConsumerPlugin,
+            ]
+            if input_doc.root_document_id is not None
+            else [
+                ConsumerPreflightPlugin,
+                AsnCheckPlugin,
+                CollatePlugin,
+                BarcodePlugin,
+                AsnCheckPlugin,  # Re-run ASN check after barcode reading
+                WorkflowTriggerPlugin,
+                ConsumerPlugin,
+            ]
+        )
 
-    with (
-        ProgressManager(
-            overrides.filename or input_doc.original_file.name,
-            self.request.id,
-        ) as status_mgr,
-        TemporaryDirectory(dir=settings.SCRATCH_DIR) as tmp_dir,
-    ):
-        tmp_dir = Path(tmp_dir)
-        for plugin_class in plugins:
-            plugin_name = plugin_class.NAME
-
-            plugin = plugin_class(
-                input_doc,
-                overrides,
-                status_mgr,
-                tmp_dir,
+        with (
+            ProgressManager(
+                overrides.filename or input_doc.original_file.name,
                 self.request.id,
-            )
+            ) as status_mgr,
+            TemporaryDirectory(dir=settings.SCRATCH_DIR) as tmp_dir,
+        ):
+            tmp_dir = Path(tmp_dir)
+            for plugin_class in plugins:
+                plugin_name = plugin_class.NAME
 
-            if not plugin.able_to_run:
-                logger.debug(f"Skipping plugin {plugin_name}")
-                continue
+                plugin = plugin_class(
+                    input_doc,
+                    overrides,
+                    status_mgr,
+                    tmp_dir,
+                    self.request.id,
+                )
 
-            try:
-                logger.debug(f"Executing plugin {plugin_name}")
-                plugin.setup()
+                if not plugin.able_to_run:
+                    logger.debug(f"Skipping plugin {plugin_name}")
+                    continue
 
-                msg = plugin.run()
+                try:
+                    logger.debug(f"Executing plugin {plugin_name}")
+                    plugin.setup()
 
-                if msg is not None:
-                    logger.info(f"{plugin_name} completed with: {msg}")
-                else:
-                    logger.info(f"{plugin_name} completed with no message")
+                    msg = plugin.run()
 
-                overrides = plugin.metadata
+                    if msg is not None:
+                        logger.info(f"{plugin_name} completed with: {msg}")
+                    else:
+                        logger.info(f"{plugin_name} completed with no message")
 
-            except StopConsumeTaskError as e:
-                logger.info(f"{plugin_name} requested task exit: {e.message}")
-                return e.message
+                    overrides = plugin.metadata
 
-            except Exception as e:
-                logger.exception(f"{plugin_name} failed: {e}")
-                status_mgr.send_progress(ProgressStatusOptions.FAILED, f"{e}", 100, 100)
-                raise
+                except StopConsumeTaskError as e:
+                    logger.info(f"{plugin_name} requested task exit: {e.message}")
+                    return e.message
 
-            finally:
-                plugin.cleanup()
+                except Exception as e:
+                    logger.exception(f"{plugin_name} failed: {e}")
+                    status_mgr.send_progress(
+                        ProgressStatusOptions.FAILED,
+                        f"{e}",
+                        100,
+                        100,
+                    )
+                    raise
 
-    return msg
+                finally:
+                    plugin.cleanup()
+
+        return msg
+    finally:
+        consume_task_id.reset(token)
 
 
 @shared_task

--- a/src/paperless/logging.py
+++ b/src/paperless/logging.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import logging
+from contextvars import ContextVar
+
+consume_task_id: ContextVar[str] = ContextVar("consume_task_id", default="")
+
+
+class ConsumeTaskFormatter(logging.Formatter):
+    """
+    Logging formatter that prepends a short task correlation ID to messages
+    emitted during document consumption.
+
+    The ID is the first 8 characters of the Celery task UUID, set via the
+    ``consume_task_id`` ContextVar at the entry of ``consume_file``.  When
+    the ContextVar is empty (any log outside a consume task) no prefix is
+    added and the output is identical to the standard verbose format.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(
+            fmt="[{asctime}] [{levelname}] [{name}] {task_prefix}{message}",
+            style="{",
+            validate=False,  # {task_prefix} is not a standard LogRecord attribute, so Python's
+            # init-time format-string validation would raise ValueError without
+            # this. Runtime safety comes from format() always setting
+            # record.task_prefix before calling super().format().
+        )
+
+    def format(self, record: logging.LogRecord) -> str:
+        task_id = consume_task_id.get()
+        record.task_prefix = f"[{task_id}] " if task_id else ""
+        return super().format(record)

--- a/src/paperless/settings/__init__.py
+++ b/src/paperless/settings/__init__.py
@@ -592,8 +592,7 @@ LOGGING = {
     "disable_existing_loggers": False,
     "formatters": {
         "verbose": {
-            "format": "[{asctime}] [{levelname}] [{name}] {message}",
-            "style": "{",
+            "()": "paperless.logging.ConsumeTaskFormatter",
         },
         "simple": {
             "format": "{levelname} {message}",

--- a/src/paperless/tests/test_logging.py
+++ b/src/paperless/tests/test_logging.py
@@ -1,0 +1,34 @@
+import logging
+
+from paperless.logging import ConsumeTaskFormatter
+from paperless.logging import consume_task_id
+
+
+def _make_record(msg: str = "Test message") -> logging.LogRecord:
+    return logging.LogRecord(
+        name="paperless.consumer",
+        level=logging.INFO,
+        pathname="",
+        lineno=0,
+        msg=msg,
+        args=(),
+        exc_info=None,
+    )
+
+
+def test_formatter_includes_task_id_when_set():
+    token = consume_task_id.set("a8098c1a")
+    try:
+        formatter = ConsumeTaskFormatter()
+        output = formatter.format(_make_record())
+        assert "[a8098c1a] Test message" in output
+    finally:
+        consume_task_id.reset(token)
+
+
+def test_formatter_omits_prefix_when_no_task_id():
+    # ContextVar default is "" — no task active
+    formatter = ConsumeTaskFormatter()
+    output = formatter.format(_make_record())
+    assert "[] " not in output
+    assert "Test message" in output


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

<!--
⚠️ Important: Pull requests that implement a new feature or enhancement *should almost always target an existing feature request* with evidence of community interest and discussion. This is in order to balance the work of implementing and maintaining new features / enhancements. If that is not currently the case, please open a feature request instead of this PR to gather feedback from both users and the project maintainers.
-->

It's basically impossible to tell current what log lines come from what worker (ie file).  There was some wiring around the logging mixin which could have done this, but it was never really connected up, so it didn't help.

With the PR, for consume tasks, the first 8 characters of the Celery task ID are included in the logging (or not, for non-consume things).

This gives us logging like the following, where 2 workers are going at the same time:

```
[INFO] [paperless.management.consumer] Adding /consume/small-0.pdf to the task queue
[INFO] [paperless.management.consumer] Adding /consume/small-1.pdf to the task queue
[INFO] [paperless.management.consumer] Adding /consume/small-2.pdf to the task queue
[DEBUG] [paperless.tasks] [10c23463] Executing plugin ConsumerPreflightPlugin
[INFO] [paperless.tasks] [10c23463] ConsumerPreflightPlugin completed with no message
[DEBUG] [paperless.tasks] [10c23463] Executing plugin AsnCheckPlugin
[INFO] [paperless.tasks] [10c23463] AsnCheckPlugin completed with no message
[DEBUG] [paperless.tasks] [10c23463] Skipping plugin CollatePlugin
[DEBUG] [paperless.tasks] [10c23463] Skipping plugin BarcodePlugin
[DEBUG] [paperless.tasks] [10c23463] Executing plugin AsnCheckPlugin
[INFO] [paperless.tasks] [10c23463] AsnCheckPlugin completed with no message
[DEBUG] [paperless.tasks] [10c23463] Executing plugin WorkflowTriggerPlugin
[DEBUG] [paperless.tasks] [b076cc33] Executing plugin ConsumerPreflightPlugin
[INFO] [paperless.tasks] [10c23463] WorkflowTriggerPlugin completed with: 
[DEBUG] [paperless.tasks] [10c23463] Executing plugin ConsumeTaskPlugin
[INFO] [paperless.consumer] [10c23463] Consuming small-0.pdf
[INFO] [paperless.tasks] [b076cc33] ConsumerPreflightPlugin completed with no message
[DEBUG] [paperless.tasks] [b076cc33] Executing plugin AsnCheckPlugin
[DEBUG] [paperless.consumer] [10c23463] Detected mime type: application/pdf
[INFO] [paperless.tasks] [b076cc33] AsnCheckPlugin completed with no message
[DEBUG] [paperless.tasks] [b076cc33] Skipping plugin CollatePlugin
[DEBUG] [paperless.tasks] [b076cc33] Skipping plugin BarcodePlugin
[DEBUG] [paperless.tasks] [b076cc33] Executing plugin AsnCheckPlugin
[DEBUG] [paperless.consumer] [10c23463] Parser: Paperless-ngx Tesseract OCR Parser v2.20.13
[INFO] [paperless.tasks] [b076cc33] AsnCheckPlugin completed with no message
[DEBUG] [paperless.tasks] [b076cc33] Executing plugin WorkflowTriggerPlugin
[DEBUG] [paperless.consumer] [10c23463] Parsing small-0.pdf...
[INFO] [paperless.tasks] [b076cc33] WorkflowTriggerPlugin completed with: 
[DEBUG] [paperless.tasks] [b076cc33] Executing plugin ConsumeTaskPlugin
[INFO] [paperless.consumer] [b076cc33] Consuming small-1.pdf
[DEBUG] [paperless.consumer] [b076cc33] Detected mime type: application/pdf
[DEBUG] [paperless.consumer] [b076cc33] Parser: Paperless-ngx Tesseract OCR Parser v2.20.13
[DEBUG] [paperless.consumer] [b076cc33] Parsing small-1.pdf...
[INFO] [paperless.parsing.tesseract] [10c23463] pdftotext exited 0
[INFO] [paperless.parsing.tesseract] [b076cc33] pdftotext exited 0
[DEBUG] [paperless.parsing.tesseract] [10c23463] Calling OCRmyPDF with args: {'input_file_or_options': PosixPath('/tmp/paperless/paperless-ngx3pgta__y/small-0.pdf'), 'output_file': PosixPath('/tmp/paperless/paperless-jpq45t8v/archive.pdf'), 'use_threads': True, 'jobs': 16, 'language': 'eng', 'output_type': 'pdfa', 'progress_bar': False, 'color_conversion_strategy': 'RGB', 'skip_text': True, 'clean': True, 'deskew': True, 'rotate_pages': True, 'rotate_pages_threshold': 12.0, 'sidecar': PosixPath('/tmp/paperless/paperless-jpq45t8v/sidecar.txt')}
[DEBUG] [paperless.parsing.tesseract] [b076cc33] Calling OCRmyPDF with args: {'input_file_or_options': PosixPath('/tmp/paperless/paperless-ngxfx47z9_z/small-1.pdf'), 'output_file': PosixPath('/tmp/paperless/paperless-i4cpog1e/archive.pdf'), 'use_threads': True, 'jobs': 16, 'language': 'eng', 'output_type': 'pdfa', 'progress_bar': False, 'color_conversion_strategy': 'RGB', 'skip_text': True, 'clean': True, 'deskew': True, 'rotate_pages': True, 'rotate_pages_threshold': 12.0, 'sidecar': PosixPath('/tmp/paperless/paperless-i4cpog1e/sidecar.txt')}
[INFO] [ocrmypdf._pipeline] skipping all processing on this page
[INFO] [ocrmypdf._pipelines.ocr] [10c23463] Postprocessing...
[INFO] [ocrmypdf._pipeline] skipping all processing on this page
[INFO] [ocrmypdf._pipelines.ocr] [b076cc33] Postprocessing...
[INFO] [ocrmypdf._pipeline] [b076cc33] Image optimization ratio: 1.00 savings: 0.0%
[INFO] [ocrmypdf._pipeline] [b076cc33] Total file size ratio: 0.03 savings: -3490.5%
[INFO] [ocrmypdf._pipeline] [10c23463] Image optimization ratio: 1.00 savings: 0.0%
[INFO] [ocrmypdf._pipeline] [10c23463] Total file size ratio: 0.03 savings: -3507.0%
[INFO] [ocrmypdf._pipelines._common] [b076cc33] Output file is a PDF/A-2b (as expected)
[INFO] [ocrmypdf._pipelines._common] [10c23463] Output file is a PDF/A-2b (as expected)
[DEBUG] [paperless.parsing.tesseract] [b076cc33] Incomplete sidecar file: discarding.
[DEBUG] [paperless.parsing.tesseract] [10c23463] Incomplete sidecar file: discarding.
[INFO] [paperless.parsing.tesseract] [10c23463] pdftotext exited 0
[DEBUG] [paperless.consumer] [10c23463] Generating thumbnail for small-0.pdf...
[DEBUG] [paperless.parsing] [10c23463] Execute: convert -density 300 -scale 500x5000> -alpha remove -strip -auto-orient -define pdf:use-cropbox=true /tmp/paperless/paperless-jpq45t8v/archive.pdf[0] /tmp/paperless/paperless-jpq45t8v/convert.webp
[INFO] [paperless.parsing.tesseract] [b076cc33] pdftotext exited 0
[DEBUG] [paperless.consumer] [b076cc33] Generating thumbnail for small-1.pdf...
[DEBUG] [paperless.parsing] [b076cc33] Execute: convert -density 300 -scale 500x5000> -alpha remove -strip -auto-orient -define pdf:use-cropbox=true /tmp/paperless/paperless-i4cpog1e/archive.pdf[0] /tmp/paperless/paperless-i4cpog1e/convert.webp
[INFO] [paperless.parsing] [10c23463] convert exited 0
[INFO] [paperless.parsing] [b076cc33] convert exited 0
[DEBUG] [paperless.classifier] [10c23463] Document classification model does not exist (yet), not performing automatic matching.
[DEBUG] [paperless.consumer] [10c23463] Saving record to database
[DEBUG] [paperless.consumer] [10c23463] Creation date from st_mtime: 2025-01-14 08:00:12.688956-08:00
[DEBUG] [paperless.classifier] [b076cc33] Document classification model does not exist (yet), not performing automatic matching.
[DEBUG] [paperless.consumer] [b076cc33] Saving record to database
[DEBUG] [paperless.consumer] [b076cc33] Creation date from st_mtime: 2025-01-14 08:00:12.689956-08:00
[DEBUG] [paperless.consumer] [10c23463] Deleting original file /consume/small-0.pdf
[DEBUG] [paperless.consumer] [10c23463] Deleting working copy /tmp/paperless/paperless-ngx3pgta__y/small-0.pdf
[DEBUG] [paperless.parsing.tesseract] [10c23463] Cleaning up temporary directory /tmp/paperless/paperless-jpq45t8v
[INFO] [paperless.consumer] [10c23463] Document 2025-01-14 small-0 consumption finished
[INFO] [paperless.tasks] [10c23463] ConsumeTaskPlugin completed with: Success. New document id 2 created
[DEBUG] [paperless.consumer] [b076cc33] Deleting original file /consume/small-1.pdf
[DEBUG] [paperless.consumer] [b076cc33] Deleting working copy /tmp/paperless/paperless-ngxfx47z9_z/small-1.pdf
[DEBUG] [paperless.parsing.tesseract] [b076cc33] Cleaning up temporary directory /tmp/paperless/paperless-i4cpog1e
[INFO] [paperless.consumer] [b076cc33] Document 2025-01-14 small-1 consumption finished
[INFO] [paperless.tasks] [b076cc33] ConsumeTaskPlugin completed with: Success. New document id 3 created
[DEBUG] [paperless.tasks] [162c0315] Executing plugin ConsumerPreflightPlugin
[INFO] [paperless.tasks] [162c0315] ConsumerPreflightPlugin completed with no message
[DEBUG] [paperless.tasks] [162c0315] Executing plugin AsnCheckPlugin
[INFO] [paperless.tasks] [162c0315] AsnCheckPlugin completed with no message
[DEBUG] [paperless.tasks] [162c0315] Skipping plugin CollatePlugin
[DEBUG] [paperless.tasks] [162c0315] Skipping plugin BarcodePlugin
[DEBUG] [paperless.tasks] [162c0315] Executing plugin AsnCheckPlugin
[INFO] [paperless.tasks] [162c0315] AsnCheckPlugin completed with no message
[DEBUG] [paperless.tasks] [162c0315] Executing plugin WorkflowTriggerPlugin
[INFO] [paperless.tasks] [162c0315] WorkflowTriggerPlugin completed with: 
[DEBUG] [paperless.tasks] [162c0315] Executing plugin ConsumeTaskPlugin
[INFO] [paperless.consumer] [162c0315] Consuming small-2.pdf
[DEBUG] [paperless.consumer] [162c0315] Detected mime type: application/pdf
[DEBUG] [paperless.consumer] [162c0315] Parser: Paperless-ngx Tesseract OCR Parser v2.20.13
[DEBUG] [paperless.consumer] [162c0315] Parsing small-2.pdf...
[INFO] [paperless.parsing.tesseract] [162c0315] pdftotext exited 0
[DEBUG] [paperless.parsing.tesseract] [162c0315] Calling OCRmyPDF with args: {'input_file_or_options': PosixPath('/tmp/paperless/paperless-ngxshrmlfyw/small-2.pdf'), 'output_file': PosixPath('/tmp/paperless/paperless-6kdd66cl/archive.pdf'), 'use_threads': True, 'jobs': 16, 'language': 'eng', 'output_type': 'pdfa', 'progress_bar': False, 'color_conversion_strategy': 'RGB', 'skip_text': True, 'clean': True, 'deskew': True, 'rotate_pages': True, 'rotate_pages_threshold': 12.0, 'sidecar': PosixPath('/tmp/paperless/paperless-6kdd66cl/sidecar.txt')}
[INFO] [ocrmypdf._pipeline] skipping all processing on this page
[INFO] [ocrmypdf._pipelines.ocr] [162c0315] Postprocessing...
[INFO] [ocrmypdf._pipeline] [162c0315] Image optimization ratio: 1.00 savings: 0.0%
[INFO] [ocrmypdf._pipeline] [162c0315] Total file size ratio: 0.03 savings: -3502.2%
[INFO] [ocrmypdf._pipelines._common] [162c0315] Output file is a PDF/A-2b (as expected)
[DEBUG] [paperless.parsing.tesseract] [162c0315] Incomplete sidecar file: discarding.
[INFO] [paperless.parsing.tesseract] [162c0315] pdftotext exited 0
[DEBUG] [paperless.consumer] [162c0315] Generating thumbnail for small-2.pdf...
[DEBUG] [paperless.parsing] [162c0315] Execute: convert -density 300 -scale 500x5000> -alpha remove -strip -auto-orient -define pdf:use-cropbox=true /tmp/paperless/paperless-6kdd66cl/archive.pdf[0] /tmp/paperless/paperless-6kdd66cl/convert.webp
[INFO] [paperless.parsing] [162c0315] convert exited 0
[DEBUG] [paperless.classifier] [162c0315] Document classification model does not exist (yet), not performing automatic matching.
[DEBUG] [paperless.consumer] [162c0315] Saving record to database
[DEBUG] [paperless.consumer] [162c0315] Creation date from st_mtime: 2025-01-14 08:00:12.690957-08:00
[DEBUG] [paperless.consumer] [162c0315] Deleting original file /consume/small-2.pdf
[DEBUG] [paperless.consumer] [162c0315] Deleting working copy /tmp/paperless/paperless-ngxshrmlfyw/small-2.pdf
[DEBUG] [paperless.parsing.tesseract] [162c0315] Cleaning up temporary directory /tmp/paperless/paperless-6kdd66cl
[INFO] [paperless.consumer] [162c0315] Document 2025-01-14 small-2 consumption finished
[INFO] [paperless.tasks] [162c0315] ConsumeTaskPlugin completed with: Success. New document id 4 created
```

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
