### PR TITLE
Enhancement: implement caching for Tantivy search results

### DIFF
--- a/src/documents/caching.py
+++ b/src/documents/caching.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import logging
 import pickle
 from binascii import hexlify
@@ -19,6 +20,7 @@ if TYPE_CHECKING:
     from django.core.cache.backends.base import BaseCache
 
     from documents.classifier import DocumentClassifier
+    from documents.search._backend import SearchResults
 
 logger = logging.getLogger("paperless.caching")
 
@@ -343,3 +345,92 @@ def clear_document_caches(document_id: int) -> None:
             get_thumbnail_modified_key(document_id),
         ],
     )
+
+
+# ---------------------------------------------------------------------------
+# Tantivy search result cache
+# ---------------------------------------------------------------------------
+# Uses a generation counter stored in read_cache.  Every search result key
+# embeds the current generation.  When the index changes (write commit or
+# rebuild), the generation is bumped and all previous entries become
+# unreachable — they expire naturally at their TTL without needing explicit
+# enumeration or prefix-deletion.
+# ---------------------------------------------------------------------------
+
+SEARCH_GENERATION_KEY: Final[str] = "tantivy_search_generation"
+
+
+def _get_search_generation() -> int:
+    return read_cache.get(SEARCH_GENERATION_KEY, default=0)
+
+
+def bump_search_cache_generation() -> None:
+    """Invalidate all cached search results by advancing the generation counter.
+
+    The generation key is stored without expiration (timeout=None) so it can
+    never silently reset to 0.  If the key expired before this call (e.g. on a
+    freshly flushed cache), incr() raises ValueError and we initialise it to 1
+    with no TTL.  After a successful incr() we explicitly clear the TTL via
+    touch() because the key may have been created with a finite TTL during a
+    previous ValueError path in an older deployment.
+    """
+    try:
+        read_cache.incr(SEARCH_GENERATION_KEY)
+    except ValueError:
+        read_cache.set(SEARCH_GENERATION_KEY, 1, None)
+    else:
+        read_cache.touch(SEARCH_GENERATION_KEY, None)
+
+
+def _search_cache_key(
+    query: str,
+    search_mode: str,
+    user_id: int | None,
+    sort_field: str | None,
+    *,
+    sort_reverse: bool,
+) -> str:
+    generation = _get_search_generation()
+    # Hash the query to keep key length bounded and avoid special-character issues.
+    query_hash = hashlib.sha256(query.encode()).hexdigest()
+    uid = user_id if user_id is not None else "__superuser__"
+    return f"tantivy_search:{generation}:{search_mode}:{uid}:{sort_field}:{sort_reverse}:{query_hash}"
+
+
+def get_search_results_cache(
+    query: str,
+    search_mode: str,
+    user_id: int | None,
+    sort_field: str | None,
+    *,
+    sort_reverse: bool,
+) -> SearchResults | None:
+    """Return cached SearchResults for the given parameters, or None on a miss."""
+    key = _search_cache_key(
+        query,
+        search_mode,
+        user_id,
+        sort_field,
+        sort_reverse=sort_reverse,
+    )
+    return read_cache.get(key)
+
+
+def set_search_results_cache(
+    query: str,
+    search_mode: str,
+    user_id: int | None,
+    sort_field: str | None,
+    *,
+    sort_reverse: bool,
+    results: SearchResults,
+) -> None:
+    """Store SearchResults in the cache."""
+    key = _search_cache_key(
+        query,
+        search_mode,
+        user_id,
+        sort_field,
+        sort_reverse=sort_reverse,
+    )
+    read_cache.set(key, results, settings.CACHALOT_TIMEOUT)

--- a/src/documents/search/_backend.py
+++ b/src/documents/search/_backend.py
@@ -19,11 +19,16 @@ from django.conf import settings
 from django.utils.timezone import get_current_timezone
 from guardian.shortcuts import get_users_with_perms
 
+from documents.caching import bump_search_cache_generation
+from documents.caching import get_search_results_cache
+from documents.caching import set_search_results_cache
 from documents.search._normalize import ascii_fold
 from documents.search._query import build_permission_filter
+from documents.search._query import normalize_query
 from documents.search._query import parse_simple_text_query
 from documents.search._query import parse_simple_title_query
 from documents.search._query import parse_user_query
+from documents.search._query import rewrite_natural_date_keywords
 from documents.search._schema import _write_sentinels
 from documents.search._schema import build_schema
 from documents.search._schema import open_or_rebuild_index
@@ -96,12 +101,12 @@ class SearchResults:
     Attributes:
         hits: List of search results with scores and highlights
         total: Total matching documents across all pages (for pagination)
-        query: Preprocessed query string after date/syntax rewriting
+        query: Raw query string as entered by the user
     """
 
     hits: list[SearchHit]
     total: int  # total matching documents (for pagination)
-    query: str  # preprocessed query string
+    query: str  # raw query string as entered by the user
 
 
 class TantivyRelevanceList:
@@ -172,6 +177,7 @@ class WriteBatch:
             if exc_type is None:
                 self._writer.commit()
                 self._backend._index.reload()
+                bump_search_cache_generation()
             # Explicitly delete writer to release tantivy's internal lock.
             # On exception the uncommitted writer is simply discarded.
             if self._writer is not None:
@@ -459,16 +465,32 @@ class TantivyBackend:
                 plain-text search over title only
 
         Returns:
-            SearchResults with hits, total count, and processed query
+            SearchResults with hits, total count, and the raw query string
         """
         self._ensure_open()
+
+        user_id = user.pk if user is not None else None
         tz = get_current_timezone()
+
         if search_mode is SearchMode.TEXT:
             user_query = parse_simple_text_query(self._index, query)
+            # TEXT/TITLE are plain-text searches — tantivy lowercases tokens, so
+            # "Rechnung" and "rechnung" return identical results.  Lowercase the
+            # key so both map to the same cache entry.
+            effective_query_key = query.lower()
         elif search_mode is SearchMode.TITLE:
             user_query = parse_simple_title_query(self._index, query)
+            effective_query_key = query.lower()
         else:
             user_query = parse_user_query(self._index, query, tz)
+            # QUERY mode rewrites relative date keywords (e.g. "today", "[-7 days to now]")
+            # to absolute ISO 8601 ranges at parse time.  Cache by the rewritten string so
+            # that "created:today" tomorrow does not return yesterday's cached results.
+            # We do not lowercase here because boolean operators (AND, OR, NOT) are
+            # case-sensitive in tantivy's query parser.
+            effective_query_key = normalize_query(
+                rewrite_natural_date_keywords(query, tz),
+            )
 
         # Apply permission filter if user is not None (not superuser)
         if user is not None:
@@ -482,10 +504,72 @@ class TantivyBackend:
         else:
             final_query = user_query
 
-        searcher = self._index.searcher()
-        offset = (page - 1) * page_size
+        full_results = self._fetch_all_hits(
+            query,
+            effective_query_key,
+            search_mode,
+            user_id,
+            final_query,
+            sort_field,
+            sort_reverse=sort_reverse,
+        )
 
-        # Map sort fields
+        # Cache hit path: slice only — zero tantivy calls.
+        offset = (page - 1) * page_size
+        return SearchResults(
+            hits=full_results.hits[offset : offset + page_size],
+            total=full_results.total,
+            query=full_results.query,
+        )
+
+    def _fetch_all_hits(
+        self,
+        query: str,
+        effective_query_key: str,
+        search_mode: str,
+        user_id: int | None,
+        final_query: tantivy.Query,
+        sort_field: str | None,
+        *,
+        sort_reverse: bool,
+    ) -> SearchResults:
+        """Fetch, score, and build all matching hits for a query.
+
+        Results are cached keyed by (effective_query_key, search_mode, user_id,
+        sort_field, sort_reverse) with no pagination parameters — the full hit
+        list including precomputed highlights is stored once and sliced per page
+        by the caller.
+
+        Highlights are generated here, not in ``search()``, because
+        ``SnippetGenerator.create()`` is the expensive step — it loads posting
+        lists for all query terms across every segment regardless of how many
+        docs you ultimately call ``snippet_from_doc()`` on.  Paying that cost
+        once on cache miss and storing the result strings means cache hits are a
+        free list slice with zero tantivy work.
+
+        All stored field types are plain Python (int, float, str, dict) — safely
+        picklable by Redis or any other Django cache backend.
+
+        ``effective_query_key`` ensures QUERY mode date expressions like
+        "created:today" resolve to an absolute ISO range and never return stale
+        results across day boundaries.
+
+        ``total`` is clamped to ``len(all_hits)`` after filtering so pagination
+        stays consistent with the hard ``_MAX_HITS`` cap.
+        """
+        cached: SearchResults | None = get_search_results_cache(
+            effective_query_key,
+            search_mode,
+            user_id,
+            sort_field,
+            sort_reverse=sort_reverse,
+        )
+        if cached is not None:
+            return cached
+
+        searcher = self._index.searcher()
+
+        _MAX_HITS = 10_000
         sort_field_map = {
             "title": "title_sort",
             "correspondent__name": "correspondent_sort",
@@ -498,23 +582,20 @@ class TantivyBackend:
             "num_notes": "num_notes",
         }
 
-        # Perform search
         if sort_field and sort_field in sort_field_map:
             mapped_field = sort_field_map[sort_field]
             results = searcher.search(
                 final_query,
-                limit=offset + page_size,
+                limit=_MAX_HITS,
                 order_by_field=mapped_field,
                 order=tantivy.Order.Desc if sort_reverse else tantivy.Order.Asc,
             )
-            # Field sorting: hits are still (score, DocAddress) tuples; score unused
+            # Field sorting: hits are (score, DocAddress) tuples; score unused
             all_hits = [(hit[1], 0.0) for hit in results.hits]
         else:
             # Score-based search: hits are (score, DocAddress) tuples
-            results = searcher.search(final_query, limit=offset + page_size)
+            results = searcher.search(final_query, limit=_MAX_HITS)
             all_hits = [(hit[1], hit[0]) for hit in results.hits]
-
-        total = results.count
 
         # Normalize scores for score-based searches
         if not sort_field and all_hits:
@@ -526,23 +607,22 @@ class TantivyBackend:
         if threshold is not None and not sort_field:
             all_hits = [hit for hit in all_hits if hit[1] >= threshold]
 
-        # Get the page's hits
-        page_hits = all_hits[offset : offset + page_size]
+        # total is clamped to the number of hits we can actually serve.
+        # results.count may exceed _MAX_HITS; reporting it would produce empty
+        # pages beyond the cap while the UI shows a misleadingly large total.
+        total = len(all_hits)
 
-        # Build result hits with highlights
         hits: list[SearchHit] = []
         snippet_generator = None
         notes_snippet_generator = None
 
-        for rank, (doc_address, score) in enumerate(page_hits, start=offset + 1):
-            # Get the actual document from the searcher using the doc address
+        for rank, (doc_address, score) in enumerate(all_hits, start=1):
             actual_doc = searcher.doc(doc_address)
             doc_dict = actual_doc.to_dict()
             doc_id = doc_dict["id"][0]
 
             highlights: dict[str, str] = {}
 
-            # Generate highlights if score > 0
             if score > 0:
                 try:
                     if snippet_generator is None:
@@ -557,7 +637,6 @@ class TantivyBackend:
                     if content_snippet:
                         highlights["content"] = str(content_snippet)
 
-                    # Try notes highlights
                     if "notes" in doc_dict:
                         if notes_snippet_generator is None:
                             notes_snippet_generator = tantivy.SnippetGenerator.create(
@@ -584,11 +663,16 @@ class TantivyBackend:
                 ),
             )
 
-        return SearchResults(
-            hits=hits,
-            total=total,
-            query=query,
+        full_results = SearchResults(hits=hits, total=total, query=query)
+        set_search_results_cache(
+            effective_query_key,
+            search_mode,
+            user_id,
+            sort_field,
+            sort_reverse=sort_reverse,
+            results=full_results,
         )
+        return full_results
 
     def autocomplete(
         self,
@@ -812,6 +896,7 @@ class TantivyBackend:
                 writer.add_document(doc)
             writer.commit()
             new_index.reload()
+            bump_search_cache_generation()
         except BaseException:  # pragma: no cover
             # Restore old index on failure so the backend remains usable
             self._index = old_index

--- a/src/documents/tests/search/test_cache.py
+++ b/src/documents/tests/search/test_cache.py
@@ -1,0 +1,536 @@
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth.models import User
+
+from documents.caching import bump_search_cache_generation
+from documents.caching import get_search_results_cache
+from documents.caching import set_search_results_cache
+from documents.models import Document
+from documents.search._backend import SearchMode
+from documents.search._backend import SearchResults
+from documents.search._backend import TantivyBackend
+
+pytestmark = [pytest.mark.search, pytest.mark.django_db]
+
+
+def _make_cached(query: str = "test") -> SearchResults:
+    return SearchResults(hits=[], total=0, query=query)
+
+
+class TestSearchCacheFunctions:
+    """Unit tests for the search cache helpers in caching.py."""
+
+    def test_miss_returns_none(self) -> None:
+        result = get_search_results_cache(
+            "missing",
+            "text",
+            1,
+            None,
+            sort_reverse=False,
+        )
+        assert result is None
+
+    def test_set_then_get_returns_results(self) -> None:
+        results = _make_cached("invoice")
+        set_search_results_cache(
+            "invoice",
+            "text",
+            1,
+            None,
+            sort_reverse=False,
+            results=results,
+        )
+        cached = get_search_results_cache(
+            "invoice",
+            "text",
+            1,
+            None,
+            sort_reverse=False,
+        )
+        assert cached == results
+
+    def test_different_query_is_separate_entry(self) -> None:
+        r1 = _make_cached("invoice")
+        r2 = _make_cached("receipt")
+        set_search_results_cache(
+            "invoice",
+            "text",
+            1,
+            None,
+            sort_reverse=False,
+            results=r1,
+        )
+        set_search_results_cache(
+            "receipt",
+            "text",
+            1,
+            None,
+            sort_reverse=False,
+            results=r2,
+        )
+        assert (
+            get_search_results_cache("invoice", "text", 1, None, sort_reverse=False)
+            == r1
+        )
+        assert (
+            get_search_results_cache("receipt", "text", 1, None, sort_reverse=False)
+            == r2
+        )
+
+    def test_different_user_is_separate_entry(self) -> None:
+        r1 = _make_cached()
+        r2 = _make_cached()
+        set_search_results_cache("q", "text", 1, None, sort_reverse=False, results=r1)
+        set_search_results_cache("q", "text", 2, None, sort_reverse=False, results=r2)
+        assert get_search_results_cache("q", "text", 1, None, sort_reverse=False) == r1
+        assert get_search_results_cache("q", "text", 2, None, sort_reverse=False) == r2
+
+    def test_superuser_none_is_separate_from_user(self) -> None:
+        r_super = _make_cached("a")
+        r_user = _make_cached("b")
+        set_search_results_cache(
+            "q",
+            "text",
+            None,
+            None,
+            sort_reverse=False,
+            results=r_super,
+        )
+        set_search_results_cache(
+            "q",
+            "text",
+            1,
+            None,
+            sort_reverse=False,
+            results=r_user,
+        )
+        assert (
+            get_search_results_cache("q", "text", None, None, sort_reverse=False)
+            == r_super
+        )
+        assert (
+            get_search_results_cache("q", "text", 1, None, sort_reverse=False) == r_user
+        )
+
+    def test_different_search_mode_is_separate_entry(self) -> None:
+        r_text = _make_cached()
+        r_title = _make_cached()
+        set_search_results_cache(
+            "q",
+            "text",
+            1,
+            None,
+            sort_reverse=False,
+            results=r_text,
+        )
+        set_search_results_cache(
+            "q",
+            "title",
+            1,
+            None,
+            sort_reverse=False,
+            results=r_title,
+        )
+        assert (
+            get_search_results_cache("q", "text", 1, None, sort_reverse=False) == r_text
+        )
+        assert (
+            get_search_results_cache("q", "title", 1, None, sort_reverse=False)
+            == r_title
+        )
+
+    def test_bump_generation_invalidates_all_entries(self) -> None:
+        results = _make_cached()
+        set_search_results_cache(
+            "q",
+            "text",
+            1,
+            None,
+            sort_reverse=False,
+            results=results,
+        )
+        assert (
+            get_search_results_cache("q", "text", 1, None, sort_reverse=False)
+            is not None
+        )
+
+        bump_search_cache_generation()
+
+        assert (
+            get_search_results_cache("q", "text", 1, None, sort_reverse=False) is None
+        )
+
+    def test_bump_generation_multiple_times(self) -> None:
+        results = _make_cached()
+        set_search_results_cache(
+            "q",
+            "text",
+            1,
+            None,
+            sort_reverse=False,
+            results=results,
+        )
+        bump_search_cache_generation()
+        bump_search_cache_generation()
+        set_search_results_cache(
+            "q",
+            "text",
+            1,
+            None,
+            sort_reverse=False,
+            results=results,
+        )
+        bump_search_cache_generation()
+        assert (
+            get_search_results_cache("q", "text", 1, None, sort_reverse=False) is None
+        )
+
+    def test_generation_key_has_no_expiry(self) -> None:
+        """Generation key must be stored without TTL so it cannot expire and silently
+        reset to 0, which would make stale cache entries reachable again."""
+        from django.core.cache import caches
+
+        from documents.caching import SEARCH_GENERATION_KEY
+        from documents.caching import read_cache
+
+        bump_search_cache_generation()
+
+        # Simulate expiry of the generation key by deleting it directly.
+        read_cache.delete(SEARCH_GENERATION_KEY)
+
+        # After expiry, bump must re-initialise without TTL.
+        bump_search_cache_generation()
+
+        # Verify the key now has no TTL (ttl returns None or -1 depending on backend).
+        # Django's LocMemCache doesn't expose ttl(), so we check via the underlying
+        # _expire_info dict when available; otherwise just confirm the key exists.
+        raw_cache = caches["read-cache"]
+        if hasattr(raw_cache, "_expire_info"):
+            import time
+
+            expire_at = raw_cache._expire_info.get(
+                raw_cache.make_key(SEARCH_GENERATION_KEY),
+            )
+            assert expire_at is None or expire_at > time.time() + 86400 * 3650, (
+                "Generation key must not have a short TTL"
+            )
+        else:
+            # For Redis or other backends, just confirm the key is still present.
+            assert read_cache.get(SEARCH_GENERATION_KEY) is not None
+
+
+class TestSearchCacheIntegration:
+    """Integration tests: cache is populated and invalidated via TantivyBackend."""
+
+    def test_search_result_is_cached(self, backend: TantivyBackend) -> None:
+        doc = Document.objects.create(
+            title="Invoice 2024",
+            content="total due",
+            checksum="C1",
+            pk=1,
+        )
+        backend.add_or_update(doc)
+
+        # First call executes Tantivy and populates the cache.
+        r1 = backend.search(
+            "Invoice",
+            user=None,
+            page=1,
+            page_size=10,
+            sort_field=None,
+            sort_reverse=False,
+        )
+
+        # Cache holds SearchResults — pure Python types, safely picklable.
+        cached = get_search_results_cache(
+            "Invoice",
+            SearchMode.QUERY,
+            None,
+            None,
+            sort_reverse=False,
+        )
+        assert cached is not None
+        assert cached.total == r1.total
+        assert len(cached.hits) == len(r1.hits)  # one doc fits within page_size=10
+
+        # Second call must return the same ordering and totals from cache.
+        r2 = backend.search(
+            "Invoice",
+            user=None,
+            page=1,
+            page_size=10,
+            sort_field=None,
+            sort_reverse=False,
+        )
+        assert r1.total == r2.total
+        assert [h["id"] for h in r1.hits] == [h["id"] for h in r2.hits]
+
+    def test_different_pages_served_from_single_cache_entry(
+        self,
+        backend: TantivyBackend,
+    ) -> None:
+        """All pages of the same query must be served from one cache entry."""
+        for i in range(1, 6):
+            Document.objects.create(
+                title=f"Report {i}",
+                content="quarterly data",
+                checksum=f"RPT{i}",
+                pk=100 + i,
+            )
+            backend.add_or_update(Document.objects.get(pk=100 + i))
+
+        # Page 1 populates cache.
+        p1 = backend.search(
+            "Report",
+            user=None,
+            page=1,
+            page_size=2,
+            sort_field=None,
+            sort_reverse=False,
+        )
+        # Page 2 must be served from the same cache entry.
+        p2 = backend.search(
+            "Report",
+            user=None,
+            page=2,
+            page_size=2,
+            sort_field=None,
+            sort_reverse=False,
+        )
+
+        # Results must be different slices, not the same page repeated.
+        assert p1.total == p2.total == 5
+        assert len(p1.hits) == 2
+        assert len(p2.hits) == 2
+        p1_ids = {h["id"] for h in p1.hits}
+        p2_ids = {h["id"] for h in p2.hits}
+        assert p1_ids.isdisjoint(p2_ids), "page 1 and page 2 must not overlap"
+
+    def test_add_or_update_invalidates_cache(self, backend: TantivyBackend) -> None:
+        doc = Document.objects.create(
+            title="Old Title",
+            content="content",
+            checksum="C2",
+            pk=2,
+        )
+        backend.add_or_update(doc)
+        backend.search(
+            "Old Title",
+            user=None,
+            page=1,
+            page_size=10,
+            sort_field=None,
+            sort_reverse=False,
+        )
+
+        # Mutate the document — this must invalidate the cache.
+        doc.title = "New Title"
+        doc.checksum = "C2b"
+        doc.save(update_fields=["title", "checksum"])
+        backend.add_or_update(doc)
+
+        # The QUERY mode cache entry that was populated above must be gone.
+        assert (
+            get_search_results_cache(
+                "Old Title",
+                SearchMode.QUERY,
+                None,
+                None,
+                sort_reverse=False,
+            )
+            is None
+        )
+
+    def test_remove_invalidates_cache(self, backend: TantivyBackend) -> None:
+        doc = Document.objects.create(
+            title="To Remove",
+            content="bye",
+            checksum="C3",
+            pk=3,
+        )
+        backend.add_or_update(doc)
+        backend.search(
+            "To Remove",
+            user=None,
+            page=1,
+            page_size=10,
+            sort_field=None,
+            sort_reverse=False,
+        )
+
+        backend.remove(doc.pk)
+
+        assert (
+            get_search_results_cache(
+                "To Remove",
+                SearchMode.QUERY,
+                None,
+                None,
+                sort_reverse=False,
+            )
+            is None
+        )
+
+    def test_cache_is_per_user(self, backend: TantivyBackend) -> None:
+        doc = Document.objects.create(
+            title="Shared Doc",
+            content="data",
+            checksum="C4",
+            pk=4,
+        )
+        backend.add_or_update(doc)
+
+        user = User.objects.create_user(username="alice", pk=99)
+        r_super = backend.search(
+            "Shared",
+            user=None,
+            page=1,
+            page_size=10,
+            sort_field=None,
+            sort_reverse=False,
+        )
+        r_user = backend.search(
+            "Shared",
+            user=user,
+            page=1,
+            page_size=10,
+            sort_field=None,
+            sort_reverse=False,
+        )
+
+        # Both should be cached under different keys — one SearchResults per user.
+        cached_super = get_search_results_cache(
+            "Shared",
+            SearchMode.QUERY,
+            None,
+            None,
+            sort_reverse=False,
+        )
+        cached_user = get_search_results_cache(
+            "Shared",
+            SearchMode.QUERY,
+            user.pk,
+            None,
+            sort_reverse=False,
+        )
+        assert cached_super is not None
+        assert cached_user is not None
+        assert cached_super.total == r_super.total
+        assert cached_user.total == r_user.total
+
+    def test_query_mode_uses_rewritten_key_not_raw_query(
+        self,
+        backend: TantivyBackend,
+    ) -> None:
+        """QUERY mode must cache under the date-rewritten key.
+
+        A raw query containing a relative date keyword ("today") is rewritten
+        to an absolute ISO 8601 range at parse time.  The cache must use the
+        rewritten key so that tomorrow's "created:today" request does not
+        return today's cached results.
+
+        We verify this by checking that the raw query string is NOT a cache key
+        while the rewritten key IS present after a search.
+        """
+        from django.utils.timezone import get_current_timezone
+
+        from documents.search._query import normalize_query
+        from documents.search._query import rewrite_natural_date_keywords
+
+        doc = Document.objects.create(
+            title="Daily Report",
+            content="today's figures",
+            checksum="DR1",
+            pk=5,
+        )
+        backend.add_or_update(doc)
+
+        raw_query = "created:today"
+        tz = get_current_timezone()
+        effective_key = normalize_query(rewrite_natural_date_keywords(raw_query, tz))
+
+        backend.search(
+            raw_query,
+            user=None,
+            page=1,
+            page_size=10,
+            sort_field=None,
+            sort_reverse=False,
+        )
+
+        # Raw query must NOT be in the cache (it was rewritten).
+        assert (
+            get_search_results_cache(
+                raw_query,
+                SearchMode.QUERY,
+                None,
+                None,
+                sort_reverse=False,
+            )
+            is None
+        )
+        # The rewritten key must be in the cache.
+        assert (
+            get_search_results_cache(
+                effective_key,
+                SearchMode.QUERY,
+                None,
+                None,
+                sort_reverse=False,
+            )
+            is not None
+        )
+
+    @pytest.mark.parametrize("mode", [SearchMode.TEXT, SearchMode.TITLE])
+    def test_text_and_title_search_cache_is_case_insensitive(
+        self,
+        backend: TantivyBackend,
+        mode: SearchMode,
+    ) -> None:
+        """TEXT and TITLE searches differing only in case must share one cache entry.
+
+        Tantivy lowercases tokens at index and query time, so 'Rechnung' and
+        'rechnung' return identical results.  The cache key must be lowercased
+        so both map to the same entry and the second request is a cache hit.
+        """
+        doc = Document.objects.create(
+            title="Rechnung 2024",
+            content="Betrag fällig",
+            checksum="DE1",
+            pk=6,
+        )
+        backend.add_or_update(doc)
+
+        r1 = backend.search(
+            "Rechnung",
+            user=None,
+            page=1,
+            page_size=10,
+            sort_field=None,
+            sort_reverse=False,
+            search_mode=mode,
+        )
+        # Second search with different casing must be a cache hit returning the same results.
+        r2 = backend.search(
+            "rechnung",
+            user=None,
+            page=1,
+            page_size=10,
+            sort_field=None,
+            sort_reverse=False,
+            search_mode=mode,
+        )
+        assert r1.total == r2.total
+        assert [h["id"] for h in r1.hits] == [h["id"] for h in r2.hits]
+
+        # Both queries must map to the same lowercased cache key.
+        cached = get_search_results_cache(
+            "rechnung",
+            mode,
+            None,
+            None,
+            sort_reverse=False,
+        )
+        assert cached is not None
+        assert cached.total == r1.total


### PR DESCRIPTION
## Proposed change
Adds a Tantivy full-text search result cache that reduces TTFB on repeated searches (~3s → ~500ms after first request) and speeds up page changes in a result set (before Tantivy was queried on each page change, on big result sets, page change took 2-5s each time.)
Basically replicating what Cachalot did for the ORM search.
I did not add any memory cap, redis handling should be sufficient.

How:
- Cache key: generation + search_mode + user_id + sort_field + sort_reverse + hash(effective_query_key)
- Cache miss: full tantivy search + highlight generation for all matching docs → stored as SearchResults (pure Python types, Redis-safe)
- Cache hit: list slice only — zero tantivy calls
- Invalidation: generation counter bumped atomically on every index write/rebuild; old entries expire naturally at their TTL

(Code Changes were mostly done by AI, I went through several iterations of review and fixed manually what I would have done diffrently.)

Key design decisions:
- QUERY mode uses date-rewritten, normalized key so created:today never serves yesterday's results
- TEXT/TITLE mode keys are lowercased so Rechnung and rechnung share one entry
- SnippetGenerator.create() is the expensive operation (loads posting lists), so highlights are generated once on cache miss and stored — not regenerated per page
- Generation key has no TTL so it can never silently reset and make stale entries reachable

A pre-built image is available for testing:
docker pull kevinfischer99/paperless-ngx:search-cache

Building on PR #12485 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [x] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
