### PR TITLE
Fix: prevent duplicate parent tag IDs

### DIFF
--- a/src-ui/src/app/components/common/input/tags/tags.component.spec.ts
+++ b/src-ui/src/app/components/common/input/tags/tags.component.spec.ts
@@ -205,6 +205,20 @@ describe('TagsComponent', () => {
     expect(component.value).toEqual([2, 1])
   })
 
+  it('should not duplicate parents when adding sibling nested tags', () => {
+    const root: Tag = { id: 1, name: 'root' }
+    const parent: Tag = { id: 2, name: 'parent', parent: 1 }
+    const leafA: Tag = { id: 3, name: 'leaf-a', parent: 2 }
+    const leafB: Tag = { id: 4, name: 'leaf-b', parent: 2 }
+    component.tags = [root, parent, leafA, leafB]
+
+    component.value = []
+    component.addTag(3)
+    component.addTag(4)
+
+    expect(component.value).toEqual([3, 2, 1, 4])
+  })
+
   it('should return ancestors from root to parent using getParentChain', () => {
     const root: Tag = { id: 1, name: 'root' }
     const mid: Tag = { id: 2, name: 'mid', parent: 1 }

--- a/src-ui/src/app/components/common/input/tags/tags.component.ts
+++ b/src-ui/src/app/components/common/input/tags/tags.component.ts
@@ -153,11 +153,13 @@ export class TagsComponent implements OnInit, ControlValueAccessor {
   }
 
   public onAdd(tag: Tag) {
-    if (tag.parent) {
+    if (tag?.parent) {
       // add all parents recursively
       const parent = this.getTag(tag.parent)
-      this.value = [...this.value, parent.id]
-      this.onAdd(parent)
+      if (parent && !this.value.includes(parent.id)) {
+        this.value = [...this.value, parent.id]
+        this.onAdd(parent)
+      }
     }
   }
 


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Adding sibling nested tags can add duplicate parent IDs which seems to trip up the angular form state so the fix is just to prevent the tags input from adding the same parent tag multiple times. 

Closes #12519

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
