### PR TITLE
Fix: serve PWA manifest dynamically with correct app title

### DIFF
--- a/src/documents/templates/paperless-ngx/base.html
+++ b/src/documents/templates/paperless-ngx/base.html
@@ -12,6 +12,7 @@
             {% block head_title %}
             {% endblock head_title %}
         </title>
+        <link rel="manifest" href="/manifest.webmanifest">
         <link href="{% static 'bootstrap.min.css' %}" rel="stylesheet">
         <link href="{% static 'base.css' %}" rel="stylesheet">
     </head>

--- a/src/paperless/tests/test_views.py
+++ b/src/paperless/tests/test_views.py
@@ -64,9 +64,10 @@ def test_manifest_view_custom_title_from_settings(
 def test_manifest_view_custom_title_from_db(
     client: Client,
 ) -> None:
-    config = ApplicationConfiguration.objects.first()
-    config.app_title = "DB Custom Title"
-    config.save()
+    ApplicationConfiguration.objects.update_or_create(
+        pk=1,
+        defaults={"app_title": "DB Custom Title"},
+    )
     response = client.get("/manifest.webmanifest")
     data = json.loads(response.content)
     assert data["name"] == "DB Custom Title"

--- a/src/paperless/tests/test_views.py
+++ b/src/paperless/tests/test_views.py
@@ -1,7 +1,11 @@
+import json
 from pathlib import Path
 
+import pytest
 from django.test import Client
 from pytest_django.fixtures import SettingsWrapper
+
+from paperless.models import ApplicationConfiguration
 
 
 def test_favicon_view(
@@ -29,3 +33,50 @@ def test_favicon_view_missing_file(
     settings.STATIC_ROOT = tmp_path
     response = client.get("/favicon.ico")
     assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_manifest_view_default_title(
+    client: Client,
+) -> None:
+    response = client.get("/manifest.webmanifest")
+    assert response.status_code == 200
+    assert response["Content-Type"] == "application/manifest+json"
+    data = json.loads(response.content)
+    assert data["name"] == "Paperless-ngx"
+    assert data["short_name"] == "Paperless-ngx"
+    assert data["display"] == "standalone"
+
+
+@pytest.mark.django_db
+def test_manifest_view_custom_title_from_settings(
+    client: Client,
+    settings: SettingsWrapper,
+) -> None:
+    settings.APP_TITLE = "My Custom App"
+    response = client.get("/manifest.webmanifest")
+    data = json.loads(response.content)
+    assert data["name"] == "My Custom App"
+    assert data["short_name"] == "My Custom App"
+
+
+@pytest.mark.django_db
+def test_manifest_view_custom_title_from_db(
+    client: Client,
+) -> None:
+    config = ApplicationConfiguration.objects.first()
+    config.app_title = "DB Custom Title"
+    config.save()
+    response = client.get("/manifest.webmanifest")
+    data = json.loads(response.content)
+    assert data["name"] == "DB Custom Title"
+    assert data["short_name"] == "DB Custom Title"
+
+
+@pytest.mark.django_db
+def test_manifest_view_locale_prefixed_path(
+    client: Client,
+) -> None:
+    response = client.get("/en-US/manifest.webmanifest")
+    assert response.status_code == 200
+    assert response["Content-Type"] == "application/manifest+json"

--- a/src/paperless/urls.py
+++ b/src/paperless/urls.py
@@ -57,6 +57,7 @@ from paperless.views import DisconnectSocialAccountView
 from paperless.views import FaviconView
 from paperless.views import GenerateAuthTokenView
 from paperless.views import GroupViewSet
+from paperless.views import ManifestView
 from paperless.views import PaperlessObtainAuthTokenView
 from paperless.views import ProfileView
 from paperless.views import SocialAccountProvidersView
@@ -277,6 +278,11 @@ urlpatterns = [
     ),
     re_path(r"share/(?P<slug>\w+)/?$", SharedLinkView.as_view()),
     re_path(r"^favicon.ico$", FaviconView.as_view(), name="favicon"),
+    re_path(
+        r"^(?:.+/)?manifest.webmanifest$",
+        ManifestView.as_view(),
+        name="manifest",
+    ),
     re_path(r"admin/", admin.site.urls),
     re_path(
         r"^fetch/",

--- a/src/paperless/views.py
+++ b/src/paperless/views.py
@@ -18,6 +18,7 @@ from django.http import FileResponse
 from django.http import HttpResponseBadRequest
 from django.http import HttpResponseForbidden
 from django.http import HttpResponseNotFound
+from django.http import JsonResponse
 from django.views.generic import View
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.types import OpenApiTypes
@@ -112,6 +113,32 @@ class FaviconView(View):
             return FileResponse(path.open("rb"), content_type="image/x-icon")
         except FileNotFoundError:
             return HttpResponseNotFound("favicon.ico not found")
+
+
+class ManifestView(View):
+    def get(self, request, *args, **kwargs):
+        from paperless.config import GeneralConfig
+
+        general_config = GeneralConfig()
+
+        app_title = settings.APP_TITLE
+        if general_config.app_title is not None and len(general_config.app_title) > 0:
+            app_title = general_config.app_title
+        app_title = app_title or "Paperless-ngx"
+
+        manifest = {
+            "background_color": "white",
+            "description": "A supercharged version of paperless: scan, index and archive all your physical documents",
+            "display": "standalone",
+            "icons": [
+                {"src": "favicon.ico", "sizes": "256x256"},
+                {"src": "assets/logo-notext.svg", "sizes": "any"},
+            ],
+            "name": app_title,
+            "short_name": app_title,
+            "start_url": "/",
+        }
+        return JsonResponse(manifest, content_type="application/manifest+json")
 
 
 class UserViewSet(ModelViewSet):

--- a/src/paperless/views.py
+++ b/src/paperless/views.py
@@ -116,7 +116,7 @@ class FaviconView(View):
 
 
 class ManifestView(View):
-    def get(self, request, *args, **kwargs):
+    def get(self, _request, *_args, **_kwargs):
         from paperless.config import GeneralConfig
 
         general_config = GeneralConfig()


### PR DESCRIPTION
## Summary
- Add `ManifestView` to serve `manifest.webmanifest` dynamically, using the configured app title from the database (`ApplicationConfiguration`) or the `PAPERLESS_APP_TITLE` environment variable
- Update the URL pattern regex to handle locale-prefixed paths (e.g. `/en-US/manifest.webmanifest`), since Angular's `<base href>` causes the browser to request the manifest under the locale path
- Add `<link rel="manifest">` to the Django base template so the manifest is available on login/account pages

## Test plan
- [ ] Set a custom "Application Title" under `/config`
- [ ] Verify `manifest.webmanifest` returns the custom title
- [ ] Verify the browser's "Install app" prompt shows the custom title
- [ ] Verify it works for different locale prefixes (e.g. `/en-US/`, `/de-DE/`)
- [ ] Verify the manifest is also linked on the login page
