### PR TITLE
Fix: An N+1 query in matching with the version content fetching

### DIFF
--- a/src/documents/consumer.py
+++ b/src/documents/consumer.py
@@ -650,6 +650,10 @@ class ConsumerPlugin(
                         # If we get here, it was successful. Proceed with post-consume
                         # hooks. If they fail, nothing will get changed.
 
+                        document = Document.objects.prefetch_related("versions").get(
+                            pk=document.pk,
+                        )
+
                         document_consumption_finished.send(
                             sender=self.__class__,
                             document=document,

--- a/src/documents/models.py
+++ b/src/documents/models.py
@@ -381,7 +381,10 @@ class Document(SoftDeleteModel, ModelWithOwner):  # type: ignore[django-manager-
             if isinstance(prefetched_cache, dict)
             else None
         )
-        if prefetched_versions:
+        if prefetched_versions is not None:
+            # Empty list means prefetch ran and found no versions — use own content.
+            if not prefetched_versions:
+                return self.content
             latest_prefetched = max(prefetched_versions, key=lambda doc: doc.id)
             return latest_prefetched.content
 

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -1248,7 +1248,10 @@ class DocumentViewSet(
         ),
     )
     def suggestions(self, request, pk=None):
-        doc = get_object_or_404(Document.objects.select_related("owner"), pk=pk)
+        doc = get_object_or_404(
+            Document.objects.select_related("owner").prefetch_related("versions"),
+            pk=pk,
+        )
         if request.user is not None and not has_perms_owner_aware(
             request.user,
             "view_document",


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

<!--
⚠️ Important: Pull requests that implement a new feature or enhancement *should almost always target an existing feature request* with evidence of community interest and discussion. This is in order to balance the work of implementing and maintaining new features / enhancements. If that is not currently the case, please open a feature request instead of this PR to gather feedback from both users and the project maintainers.
-->

Noticed while profiling.  As the matching uses effective content, we can and should fetch the versions.  Also, fixes the versions in `get_effective_content` which would have treated no versions (probably the default most of the time) as needing to fetch the versions again.

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
