### PR TITLE
Fix: reject invalid requests to API notes endpoint

### DIFF
--- a/src/documents/tests/test_api_documents.py
+++ b/src/documents/tests/test_api_documents.py
@@ -3146,6 +3146,56 @@ class TestDocumentApi(DirectoriesMixin, DocumentConsumeDelayMixin, APITestCase):
         # modified was updated to today
         self.assertEqual(doc.modified.day, timezone.now().day)
 
+    def test_delete_note_missing_id(self) -> None:
+        """
+        GIVEN:
+            - Existing document
+        WHEN:
+            - API DELETE request to notes endpoint without an id query param
+            - API DELETE request to notes endpoint with an empty id query param
+        THEN:
+            - HTTP 400 is returned
+        """
+        doc = Document.objects.create(
+            title="test",
+            mime_type="application/pdf",
+            content="this is a document",
+        )
+
+        response = self.client.delete(
+            f"/api/documents/{doc.pk}/notes/",
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        response = self.client.delete(
+            f"/api/documents/{doc.pk}/notes/?id=",
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_delete_note_nonexistent_id(self) -> None:
+        """
+        GIVEN:
+            - Existing document, no notes
+        WHEN:
+            - API DELETE request to notes endpoint with a non-existent note id
+        THEN:
+            - HTTP 404 is returned
+        """
+        doc = Document.objects.create(
+            title="test",
+            mime_type="application/pdf",
+            content="this is a document",
+        )
+
+        response = self.client.delete(
+            f"/api/documents/{doc.pk}/notes/?id=99999",
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
     def test_get_notes_no_doc(self) -> None:
         """
         GIVEN:

--- a/src/documents/tests/test_api_documents.py
+++ b/src/documents/tests/test_api_documents.py
@@ -3174,6 +3174,27 @@ class TestDocumentApi(DirectoriesMixin, DocumentConsumeDelayMixin, APITestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
+    def test_delete_note_invalid_id(self) -> None:
+        """
+        GIVEN:
+            - Existing document
+        WHEN:
+            - API DELETE request to notes endpoint with a non-integer note id
+        THEN:
+            - HTTP 400 is returned
+        """
+        doc = Document.objects.create(
+            title="test",
+            mime_type="application/pdf",
+            content="this is a document",
+        )
+
+        response = self.client.delete(
+            f"/api/documents/{doc.pk}/notes/?id=notaninteger",
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
     def test_delete_note_nonexistent_id(self) -> None:
         """
         GIVEN:

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -1502,7 +1502,13 @@ class DocumentViewSet(
             ):
                 return HttpResponseForbidden("Insufficient permissions to delete notes")
 
-            note = Note.objects.get(id=int(request.GET.get("id")), document=doc)
+            note_id = request.GET.get("id")
+            if not note_id:
+                raise ValidationError({"id": "This field is required."})
+            try:
+                note = Note.objects.get(id=int(note_id), document=doc)
+            except (Note.DoesNotExist, ValueError):
+                raise NotFound(f"Note {note_id} does not exist.")
             if settings.AUDIT_LOG_ENABLED:
                 LogEntry.objects.log_create(
                     instance=doc,

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -1506,9 +1506,10 @@ class DocumentViewSet(
             if not note_id:
                 raise ValidationError({"id": "This field is required."})
             try:
-                note = Note.objects.get(id=int(note_id), document=doc)
-            except (Note.DoesNotExist, ValueError):
-                raise NotFound(f"Note {note_id} does not exist.")
+                note_id_int = int(note_id)
+            except ValueError:
+                raise ValidationError({"id": "A valid integer is required."})
+            note = get_object_or_404(Note, id=note_id_int, document=doc)
             if settings.AUDIT_LOG_ENABLED:
                 LogEntry.objects.log_create(
                     instance=doc,


### PR DESCRIPTION
## Proposed change

Returns HTTP 400 instead of HTTP 500 on DELETE /api/documents/{id}/notes/ with missing or invalid note id

Closes #12581

## Type of change

- [X] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

- [X] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [X] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [X] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [X] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [X] I have made corresponding changes to the documentation as needed.
- [X] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.


Tested only the 2 new added tests
```
uv run pytest documents/tests/test_api_documents.py::TestDocumentApi::test_delete_note_missing_id documents/tests/test_api_documents.py::TestDocumentApi::test_delete_note_nonexistent_id -v -o "addopts="          
Test session starts (platform: linux, Python 3.12.3, pytest 9.0.3, pytest-sugar 1.1.1)
cachedir: .pytest_cache
django: version: 5.2.13, settings: paperless.settings (from ini)
rootdir: /home/ggouzi/Documents/DEV/Perso/paperless-ngx
configfile: pyproject.toml
plugins: rerunfailures-16.1, anyio-4.12.1, time-machine-3.2.0, xdist-3.8.0, env-1.6.0, Faker-40.12.0, httpx-0.36.0, django-4.12.0, mock-3.15.1, sugar-1.1.1, cov-7.1.0
collected 2 items                                                                            

 src/documents/tests/test_api_documents.py::TestDocumentApi.test_delete_note_missing_id ✓50%
 src/documents/tests/test_api_documents.py::TestDocumentApi.test_delete_note_nonexistent_id ✓100%

Results (7.07s):
       2 passed
```

Use of AI assistant to write the 2 unit tests following project guideline.