### PR TITLE
disable csrf on update_version

### DIFF
--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -100,6 +100,7 @@ from rest_framework.viewsets import GenericViewSet
 from rest_framework.viewsets import ModelViewSet
 from rest_framework.viewsets import ReadOnlyModelViewSet
 from rest_framework.viewsets import ViewSet
+from rest_framework.authentication import TokenAuthentication
 
 from documents import bulk_edit
 from documents.bulk_download import ArchiveOnlyStrategy
@@ -1720,7 +1721,8 @@ class DocumentViewSet(
             200: OpenApiTypes.STR,
         },
     )
-    @action(methods=["post"], detail=True, parser_classes=[parsers.MultiPartParser])
+    @action(methods=["post"], detail=True,
+    authentication_classes=[TokenAuthentication], parser_classes=[parsers.MultiPartParser])
     def update_version(self, request, pk=None):
         serializer = DocumentVersionSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -81,6 +81,7 @@ from redis import Redis
 from rest_framework import parsers
 from rest_framework import serializers
 from rest_framework import status
+from rest_framework.authentication import TokenAuthentication
 from rest_framework.decorators import action
 from rest_framework.exceptions import NotFound
 from rest_framework.exceptions import PermissionDenied
@@ -100,7 +101,6 @@ from rest_framework.viewsets import GenericViewSet
 from rest_framework.viewsets import ModelViewSet
 from rest_framework.viewsets import ReadOnlyModelViewSet
 from rest_framework.viewsets import ViewSet
-from rest_framework.authentication import TokenAuthentication
 
 from documents import bulk_edit
 from documents.bulk_download import ArchiveOnlyStrategy

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -1721,8 +1721,12 @@ class DocumentViewSet(
             200: OpenApiTypes.STR,
         },
     )
-    @action(methods=["post"], detail=True,
-    authentication_classes=[TokenAuthentication], parser_classes=[parsers.MultiPartParser])
+    @action(
+        methods=["post"],
+        detail=True,
+        authentication_classes=[TokenAuthentication],
+        parser_classes=[parsers.MultiPartParser],
+    )
     def update_version(self, request, pk=None):
         serializer = DocumentVersionSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)


### PR DESCRIPTION
I am adding support for sync in my document scanner application.
`/api/documents/post_document/` is working fine but `/api/documents/${paperlessDocId}/update_version/` is not and throws a csrf error even if i pass the auth token (exactly like i do for `post_document`).
looking at it it seems the way both APIs are defined is different and `SessionAuthentication` is present on `update_version` while it is not on `post_document`. 
This PR simply removes it from `update_version` and ensure it works exactly like `post_document`. 
Maybe this would need to be added to all APIs using ` @action` but i preferred to limit it to `update_version` for this PR.