### PR TITLE
Enhancement: Handle case to filtering monetary custom fields by numerical value only

### DIFF
--- a/src/documents/filters.py
+++ b/src/documents/filters.py
@@ -6,6 +6,8 @@ import json
 import logging
 import operator
 from contextlib import contextmanager
+from decimal import Decimal
+from decimal import InvalidOperation
 from typing import TYPE_CHECKING
 from typing import Any
 
@@ -519,6 +521,18 @@ class CustomFieldQueryParser:
             and op in self.EXPR_BY_CATEGORY["arithmetic"]
         ):
             value_field_name = "value_monetary_amount"
+        if (
+            custom_field.data_type == CustomField.FieldDataType.MONETARY
+            and op == "exact"
+            and value
+        ):
+            try:
+                value = Decimal(str(value))
+                value_field_name = "value_monetary_amount"
+            except InvalidOperation:
+                # fall back to value_monetary for raw string match (e.g. "EUR10.00")
+                pass
+
         has_field = Q(custom_fields__field=custom_field)
 
         # We need to use an annotation here because different atoms

--- a/src/documents/tests/test_api_filter_by_custom_fields.py
+++ b/src/documents/tests/test_api_filter_by_custom_fields.py
@@ -448,8 +448,8 @@ class TestCustomFieldsSearch(DirectoriesMixin, APITestCase):
                 "monetary_field" in document
                 and document["monetary_field"] is not None
                 and (
-                    document["monetary_field"] == "EUR50.00" # With currency symbol
-                    or document["monetary_field"] == "50.00" # No currency symbol
+                    document["monetary_field"] == "EUR50.00"  # With currency symbol
+                    or document["monetary_field"] == "50.00"  # No currency symbol
                 )
             ),
         )
@@ -460,8 +460,8 @@ class TestCustomFieldsSearch(DirectoriesMixin, APITestCase):
                 "monetary_field" in document
                 and document["monetary_field"] is not None
                 and (
-                    document["monetary_field"] == "EUR101.00" # With currency symbol
-                    or document["monetary_field"] == "101.00" # No currency symbol
+                    document["monetary_field"] == "EUR101.00"  # With currency symbol
+                    or document["monetary_field"] == "101.00"  # No currency symbol
                 )
             ),
         )

--- a/src/documents/tests/test_api_filter_by_custom_fields.py
+++ b/src/documents/tests/test_api_filter_by_custom_fields.py
@@ -440,6 +440,32 @@ class TestCustomFieldsSearch(DirectoriesMixin, APITestCase):
             ),
         )
 
+    def test_exact_monetary(self) -> None:
+        # Users should be able to search for "EUR50.00"
+        self._assert_query_match_predicate(
+            ["monetary_field", "exact", "EUR50.00"],
+            lambda document: (
+                "monetary_field" in document
+                and document["monetary_field"] is not None
+                and (
+                    document["monetary_field"] == "EUR50.00" # With currency symbol
+                    or document["monetary_field"] == "50.00" # No currency symbol
+                )
+            ),
+        )
+        # Also works for values stored without a currency prefix ("50.00")
+        self._assert_query_match_predicate(
+            ["monetary_field", "exact", "101.00"],
+            lambda document: (
+                "monetary_field" in document
+                and document["monetary_field"] is not None
+                and (
+                    document["monetary_field"] == "EUR101.00" # With currency symbol
+                    or document["monetary_field"] == "101.00" # No currency symbol
+                )
+            ),
+        )
+
     def test_gt_monetary(self) -> None:
         self._assert_query_match_predicate(
             ["monetary_field", "gt", "99"],


### PR DESCRIPTION
## Proposed change

Allow filtering by custom monetary fields using the `Equals to` operator with numerical values.
For example, a document with a monetary field set to EUR10.00 can now be found by filtering `exact=10.00`, `exact=10`, etc. (in addition to default behavior `exact=EUR10.00`)

Discussed in #12589

## Type of change

- [ ] Bug fix: non-breaking change which fixes an issue.
- [X] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

- [X] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [X] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [X] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [X] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [X] I have made corresponding changes to the documentation as needed.
- [X] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.