### PR TITLE
Fixhancement: Exact custom field monetary exact searching

### DIFF
--- a/src/documents/filters.py
+++ b/src/documents/filters.py
@@ -6,6 +6,8 @@ import json
 import logging
 import operator
 from contextlib import contextmanager
+from decimal import Decimal
+from decimal import InvalidOperation
 from typing import TYPE_CHECKING
 from typing import Any
 
@@ -289,6 +291,34 @@ class MimeTypeFilter(Filter):
             return qs.filter(mime_type__icontains=value)
         else:
             return qs
+
+
+class MonetaryAmountField(serializers.Field):
+    """
+    Accepts either a plain decimal string ("100", "100.00") or a currency-prefixed
+    string ("USD100.00") and returns the numeric amount as a Decimal.
+
+    Mirrors the logic of the value_monetary_amount generated field: if the value
+    starts with a non-digit, the first 3 characters are treated as a currency code
+    (ISO 4217) and stripped before parsing. This preserves backwards compatibility
+    with saved views that stored a currency-prefixed string as the filter value.
+    """
+
+    default_error_messages = {"invalid": "A valid number is required."}
+
+    def to_internal_value(self, data):
+        if not isinstance(data, str | int | float):
+            self.fail("invalid")
+        value = str(data).strip()
+        if value and not value[0].isdigit() and value[0] != "-":
+            value = value[3:]  # strip 3-char ISO 4217 currency code
+        try:
+            return Decimal(value)
+        except InvalidOperation:
+            self.fail("invalid")
+
+    def to_representation(self, value):
+        return str(value)
 
 
 class SelectField(serializers.CharField):
@@ -630,9 +660,10 @@ class CustomFieldQueryParser:
         elif custom_field.data_type == CustomField.FieldDataType.MONETARY and (
             op in self.EXPR_BY_CATEGORY["arithmetic"] or op in {"exact", "in"}
         ):
-            # These ops compare against value_monetary_amount (a DecimalField), so the
-            # filter value must be numeric, not a currency-prefixed string like "USD100".
-            field = serializers.DecimalField(max_digits=65, decimal_places=2)
+            # These ops compare against value_monetary_amount (a DecimalField).
+            # MonetaryAmountField accepts both "100" and "USD100.00" for backwards
+            # compatibility with saved views that stored currency-prefixed values.
+            field = MonetaryAmountField()
         else:
             # The general case: inferred from the corresponding field in CustomFieldInstance.
             value_field_name = CustomFieldInstance.get_value_field_name(

--- a/src/documents/filters.py
+++ b/src/documents/filters.py
@@ -514,9 +514,8 @@ class CustomFieldQueryParser:
         value_field_name = CustomFieldInstance.get_value_field_name(
             custom_field.data_type,
         )
-        if (
-            custom_field.data_type == CustomField.FieldDataType.MONETARY
-            and op in self.EXPR_BY_CATEGORY["arithmetic"]
+        if custom_field.data_type == CustomField.FieldDataType.MONETARY and (
+            op in self.EXPR_BY_CATEGORY["arithmetic"] or op in {"exact", "in"}
         ):
             value_field_name = "value_monetary_amount"
         has_field = Q(custom_fields__field=custom_field)

--- a/src/documents/filters.py
+++ b/src/documents/filters.py
@@ -627,6 +627,12 @@ class CustomFieldQueryParser:
         elif custom_field.data_type == CustomField.FieldDataType.URL:
             # For URL fields we don't need to be strict about validation (e.g., for istartswith).
             field = serializers.CharField()
+        elif custom_field.data_type == CustomField.FieldDataType.MONETARY and (
+            op in self.EXPR_BY_CATEGORY["arithmetic"] or op in {"exact", "in"}
+        ):
+            # These ops compare against value_monetary_amount (a DecimalField), so the
+            # filter value must be numeric, not a currency-prefixed string like "USD100".
+            field = serializers.DecimalField(max_digits=65, decimal_places=2)
         else:
             # The general case: inferred from the corresponding field in CustomFieldInstance.
             value_field_name = CustomFieldInstance.get_value_field_name(

--- a/src/documents/tests/test_api_filter_by_custom_fields.py
+++ b/src/documents/tests/test_api_filter_by_custom_fields.py
@@ -9,6 +9,8 @@ from rest_framework.test import APITestCase
 
 from documents.models import CustomField
 from documents.models import Document
+from documents.models import SavedView
+from documents.models import SavedViewFilterRule
 from documents.serialisers import DocumentSerializer
 from documents.tests.utils import DirectoriesMixin
 
@@ -479,23 +481,82 @@ class TestCustomFieldsSearch(DirectoriesMixin, APITestCase):
             ),
         )
 
-    def test_exact_monetary_with_currency_prefix_is_invalid(self) -> None:
-        # Providing a currency-prefixed string like "USD100" for an exact/arithmetic
-        # monetary filter should be rejected, since these ops compare against the
-        # extracted numeric amount and cannot accept non-numeric values.
-        self._assert_validation_error(
-            json.dumps(["monetary_field", "exact", "USD100"]),
-            ["custom_field_query", "2"],
-            "valid number",
+    def test_exact_monetary_with_currency_prefix(self) -> None:
+        # Providing a currency-prefixed string like "USD100.00" for an exact monetary
+        # filter should work for backwards compatibility with saved views. The currency
+        # code is stripped and the numeric amount is used for comparison.
+        self._assert_query_match_predicate(
+            ["monetary_field", "exact", "USD100.00"],
+            lambda document: (
+                "monetary_field" in document
+                and document["monetary_field"] == "USD100.00"
+            ),
         )
-        self._assert_validation_error(
-            json.dumps(["monetary_field", "gt", "USD100"]),
-            ["custom_field_query", "2"],
-            "valid number",
+        self._assert_query_match_predicate(
+            ["monetary_field", "in", ["USD100.00", "EUR50.00"]],
+            lambda document: (
+                "monetary_field" in document
+                and document["monetary_field"] in {"USD100.00", "EUR50.00"}
+            ),
         )
+        self._assert_query_match_predicate(
+            ["monetary_field", "gt", "USD99.00"],
+            lambda document: (
+                "monetary_field" in document
+                and document["monetary_field"] is not None
+                and (
+                    document["monetary_field"] == "USD100.00"
+                    or document["monetary_field"] == "101.00"
+                )
+            ),
+        )
+
+    def test_saved_view_with_currency_prefixed_monetary_filter(self) -> None:
+        """
+        A saved view created before the exact-monetary fix stored currency-prefixed
+        values like '["monetary_field", "exact", "USD100.00"]' as the filter rule value
+        (rule_type=42). Those saved views must continue to return correct results.
+        """
+        saved_view = SavedView.objects.create(name="test view", owner=self.user)
+        SavedViewFilterRule.objects.create(
+            saved_view=saved_view,
+            rule_type=42,  # FILTER_CUSTOM_FIELDS_QUERY
+            value=json.dumps(["monetary_field", "exact", "USD100.00"]),
+        )
+        # The frontend translates rule_type=42 to the custom_field_query URL param;
+        # simulate that here using the stored filter rule value directly.
+        rule = saved_view.filter_rules.get(rule_type=42)
+        query_string = quote(rule.value, safe="")
+        response = self.client.get(
+            "/api/documents/?"
+            + "&".join(
+                (
+                    f"custom_field_query={query_string}",
+                    "ordering=archive_serial_number",
+                    "page=1",
+                    f"page_size={len(self.documents)}",
+                    "truncate_content=true",
+                ),
+            ),
+        )
+        self.assertEqual(response.status_code, 200, msg=str(response.json()))
+        result_ids = {doc["id"] for doc in response.json()["results"]}
+        # Should match the single document with monetary_field = "USD100.00"
+        expected_ids = {
+            doc.id
+            for doc in self.documents
+            if doc.custom_fields.filter(
+                field__name="monetary_field",
+                value_monetary="USD100.00",
+            ).exists()
+        }
+        self.assertEqual(result_ids, expected_ids)
+
+    def test_monetary_amount_with_invalid_value(self) -> None:
+        # A value that has a currency prefix but no valid number after it should fail.
         self._assert_validation_error(
-            json.dumps(["monetary_field", "in", ["USD100", "EUR50"]]),
-            ["custom_field_query", "2", "0"],
+            json.dumps(["monetary_field", "exact", "USDnotanumber"]),
+            ["custom_field_query", "2"],
             "valid number",
         )
 

--- a/src/documents/tests/test_api_filter_by_custom_fields.py
+++ b/src/documents/tests/test_api_filter_by_custom_fields.py
@@ -479,6 +479,26 @@ class TestCustomFieldsSearch(DirectoriesMixin, APITestCase):
             ),
         )
 
+    def test_exact_monetary_with_currency_prefix_is_invalid(self) -> None:
+        # Providing a currency-prefixed string like "USD100" for an exact/arithmetic
+        # monetary filter should be rejected, since these ops compare against the
+        # extracted numeric amount and cannot accept non-numeric values.
+        self._assert_validation_error(
+            json.dumps(["monetary_field", "exact", "USD100"]),
+            ["custom_field_query", "2"],
+            "valid number",
+        )
+        self._assert_validation_error(
+            json.dumps(["monetary_field", "gt", "USD100"]),
+            ["custom_field_query", "2"],
+            "valid number",
+        )
+        self._assert_validation_error(
+            json.dumps(["monetary_field", "in", ["USD100", "EUR50"]]),
+            ["custom_field_query", "2", "0"],
+            "valid number",
+        )
+
     # ==========================================================#
     # Subset check (document link field only)                   #
     # ==========================================================#

--- a/src/documents/tests/test_api_filter_by_custom_fields.py
+++ b/src/documents/tests/test_api_filter_by_custom_fields.py
@@ -453,6 +453,32 @@ class TestCustomFieldsSearch(DirectoriesMixin, APITestCase):
             ),
         )
 
+    def test_exact_monetary(self) -> None:
+        # "exact" should match by numeric amount, ignoring currency code prefix.
+        self._assert_query_match_predicate(
+            ["monetary_field", "exact", "100"],
+            lambda document: (
+                "monetary_field" in document
+                and document["monetary_field"] == "USD100.00"
+            ),
+        )
+        self._assert_query_match_predicate(
+            ["monetary_field", "exact", "101"],
+            lambda document: (
+                "monetary_field" in document and document["monetary_field"] == "101.00"
+            ),
+        )
+
+    def test_in_monetary(self) -> None:
+        # "in" should match by numeric amount, ignoring currency code prefix.
+        self._assert_query_match_predicate(
+            ["monetary_field", "in", ["100", "50"]],
+            lambda document: (
+                "monetary_field" in document
+                and document["monetary_field"] in {"USD100.00", "EUR50.00"}
+            ),
+        )
+
     # ==========================================================#
     # Subset check (document link field only)                   #
     # ==========================================================#


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

<!--
⚠️ Important: Pull requests that implement a new feature or enhancement *should almost always target an existing feature request* with evidence of community interest and discussion. This is in order to balance the work of implementing and maintaining new features / enhancements. If that is not currently the case, please open a feature request instead of this PR to gather feedback from both users and the project maintainers.
-->

Doesn't appear to break anything else and the added tests fail without the code change.  Might not work if the monetary value is a decimal, because floating point, but I just though about that right now.

Closes #12589

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
