### PR TITLE
Enhancement: add highlighting to title + content searches

### DIFF
--- a/src/documents/search/_backend.py
+++ b/src/documents/search/_backend.py
@@ -21,7 +21,7 @@ from guardian.shortcuts import get_users_with_perms
 
 from documents.search._normalize import ascii_fold
 from documents.search._query import build_permission_filter
-from documents.search._query import parse_simple_highlight_query
+from documents.search._query import parse_simple_text_highlight_query
 from documents.search._query import parse_simple_text_query
 from documents.search._query import parse_simple_title_query
 from documents.search._query import parse_user_query
@@ -336,17 +336,6 @@ class TantivyBackend:
         else:
             return parse_user_query(self._index, query, tz)
 
-    def _parse_highlight_query(
-        self,
-        query: str,
-        search_mode: SearchMode,
-    ) -> tantivy.Query:
-        if search_mode is SearchMode.TEXT:
-            # title does not supported highlight for now
-            return parse_simple_highlight_query(self._index, query, ["content"])
-        else:
-            return self._parse_query(query, search_mode)
-
     def _apply_permission_filter(
         self,
         query: tantivy.Query,
@@ -561,7 +550,9 @@ class TantivyBackend:
 
         self._ensure_open()
         user_query = self._parse_query(query, search_mode)
-        highlight_query = self._parse_highlight_query(query, search_mode)
+        highlight_query = user_query
+        if search_mode is SearchMode.TEXT:
+            highlight_query = parse_simple_text_highlight_query(self._index, query)
 
         # For notes_text snippet generation, we need a query that targets the
         # notes_text field directly. user_query may contain JSON-field terms

--- a/src/documents/search/_backend.py
+++ b/src/documents/search/_backend.py
@@ -21,6 +21,7 @@ from guardian.shortcuts import get_users_with_perms
 
 from documents.search._normalize import ascii_fold
 from documents.search._query import build_permission_filter
+from documents.search._query import parse_simple_highlight_query
 from documents.search._query import parse_simple_text_query
 from documents.search._query import parse_simple_title_query
 from documents.search._query import parse_user_query
@@ -335,6 +336,17 @@ class TantivyBackend:
         else:
             return parse_user_query(self._index, query, tz)
 
+    def _parse_highlight_query(
+        self,
+        query: str,
+        search_mode: SearchMode,
+    ) -> tantivy.Query:
+        if search_mode is SearchMode.TEXT:
+            # title does not supported highlight for now
+            return parse_simple_highlight_query(self._index, query, ["content"])
+        else:
+            return self._parse_query(query, search_mode)
+
     def _apply_permission_filter(
         self,
         query: tantivy.Query,
@@ -549,6 +561,7 @@ class TantivyBackend:
 
         self._ensure_open()
         user_query = self._parse_query(query, search_mode)
+        highlight_query = self._parse_highlight_query(query, search_mode)
 
         # For notes_text snippet generation, we need a query that targets the
         # notes_text field directly. user_query may contain JSON-field terms
@@ -601,7 +614,7 @@ class TantivyBackend:
                 if snippet_generator is None:
                     snippet_generator = tantivy.SnippetGenerator.create(
                         searcher,
-                        user_query,
+                        highlight_query,
                         self._schema,
                         "content",
                     )
@@ -610,7 +623,7 @@ class TantivyBackend:
                 if content_html:
                     highlights["content"] = content_html
 
-                if "notes_text" in doc_dict:
+                if search_mode is SearchMode.QUERY and "notes_text" in doc_dict:
                     # Use notes_text (plain text) for snippet generation — tantivy's
                     # SnippetGenerator does not support JSON fields.
                     if notes_snippet_generator is None:

--- a/src/documents/search/_query.py
+++ b/src/documents/search/_query.py
@@ -606,26 +606,21 @@ def parse_simple_query(
     return tantivy.Query.boolean_query(field_queries)
 
 
-def parse_simple_highlight_query(
+def parse_simple_text_highlight_query(
     index: tantivy.Index,
     raw_query: str,
-    fields: list[str],
 ) -> tantivy.Query:
-    """Build a snippet-friendly query for simple text/title searches.
+    """Build a snippet-friendly query for simple text searches.
 
     Simple search matching uses regex queries but for compatibility with Tantivy
-    SnippetGenerator we build a plain term query over the actual text fields instead.
+    SnippetGenerator we build a plain term query over the content field instead.
     """
 
     tokens = _simple_query_tokens(raw_query)
     if not tokens:
         return tantivy.Query.empty_query()
 
-    return index.parse_query(
-        " ".join(tokens),
-        fields,
-        field_boosts={field: _FIELD_BOOSTS.get(field, 1.0) for field in fields},
-    )
+    return index.parse_query(" ".join(tokens), ["content"])
 
 
 def parse_simple_text_query(

--- a/src/documents/search/_query.py
+++ b/src/documents/search/_query.py
@@ -490,6 +490,14 @@ _FIELD_BOOSTS = {"title": 2.0}
 _SIMPLE_FIELD_BOOSTS = {"simple_title": 2.0}
 
 
+def _simple_query_tokens(raw_query: str) -> list[str]:
+    tokens = [
+        ascii_fold(token.lower())
+        for token in _SIMPLE_QUERY_TOKEN_RE.findall(raw_query, timeout=_REGEX_TIMEOUT)
+    ]
+    return [token for token in tokens if token]
+
+
 def _build_simple_field_query(
     index: tantivy.Index,
     field: str,
@@ -585,11 +593,7 @@ def parse_simple_query(
 
     Query string is escaped and normalized to be treated as "simple" text query.
     """
-    tokens = [
-        ascii_fold(token.lower())
-        for token in _SIMPLE_QUERY_TOKEN_RE.findall(raw_query, timeout=_REGEX_TIMEOUT)
-    ]
-    tokens = [token for token in tokens if token]
+    tokens = _simple_query_tokens(raw_query)
     if not tokens:
         return tantivy.Query.empty_query()
 
@@ -600,6 +604,28 @@ def parse_simple_query(
     if len(field_queries) == 1:
         return field_queries[0][1]
     return tantivy.Query.boolean_query(field_queries)
+
+
+def parse_simple_highlight_query(
+    index: tantivy.Index,
+    raw_query: str,
+    fields: list[str],
+) -> tantivy.Query:
+    """Build a snippet-friendly query for simple text/title searches.
+
+    Simple search matching uses regex queries but for compatibility with Tantivy
+    SnippetGenerator we build a plain term query over the actual text fields instead.
+    """
+
+    tokens = _simple_query_tokens(raw_query)
+    if not tokens:
+        return tantivy.Query.empty_query()
+
+    return index.parse_query(
+        " ".join(tokens),
+        fields,
+        field_boosts={field: _FIELD_BOOSTS.get(field, 1.0) for field in fields},
+    )
 
 
 def parse_simple_text_query(

--- a/src/documents/tests/search/test_backend.py
+++ b/src/documents/tests/search/test_backend.py
@@ -563,6 +563,26 @@ class TestFieldHandling:
 class TestHighlightHits:
     """Test highlight_hits returns proper HTML strings, not raw Snippet objects."""
 
+    def test_highlights_simple_text_mode_returns_html_string(
+        self,
+        backend: TantivyBackend,
+    ):
+        """Simple text search should still produce content highlights for exact-token hits."""
+        doc = Document.objects.create(
+            title="Highlight Test",
+            content="The quick brown fox jumps over the lazy dog",
+            checksum="HH0",
+            pk=89,
+        )
+        backend.add_or_update(doc)
+
+        hits = backend.highlight_hits("quick", [doc.pk], search_mode=SearchMode.TEXT)
+
+        assert len(hits) == 1
+        highlights = hits[0]["highlights"]
+        assert "content" in highlights
+        assert "<b>" in highlights["content"]
+
     def test_highlights_content_returns_html_string(self, backend: TantivyBackend):
         """highlight_hits must return HTML strings (from Snippet.to_html()), not Snippet objects."""
         doc = Document.objects.create(


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

its a little confusing-ly named, but the highlighting is still just for content but its the "title+content" option on the frontend:

<img width="1930" height="1183" alt="Screenshot 2026-04-17 at 8 14 12 AM" src="https://github.com/user-attachments/assets/f218bb92-04a8-4e9b-ba0c-0bc407898ee1" />

See https://github.com/paperless-ngx/paperless-ngx/pull/12518#issuecomment-4211717738

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
