### PR TITLE
Fix: prevent intermediate change event when CustomFieldQueryAtom operator changes type

### DIFF
--- a/src-ui/src/app/utils/custom-field-query-element.spec.ts
+++ b/src-ui/src/app/utils/custom-field-query-element.spec.ts
@@ -142,6 +142,21 @@ describe('CustomFieldQueryAtom', () => {
     atom.value = [1, 3]
     expect(changeSpy).toHaveBeenCalledTimes(1)
   })
+
+  it('should emit one changed event when operator change coerces value', () => {
+    const atom = new CustomFieldQueryAtom([
+      1,
+      CustomFieldQueryOperator.In,
+      [1, 2],
+    ])
+    const changeSpy = jest.fn()
+    atom.changed.subscribe(changeSpy)
+
+    atom.operator = CustomFieldQueryOperator.Exact
+
+    expect(changeSpy).toHaveBeenCalledTimes(1)
+    expect(atom.serialize()).toEqual([1, CustomFieldQueryOperator.Exact, ''])
+  })
 })
 
 describe('CustomFieldQueryExpression', () => {

--- a/src-ui/src/app/utils/custom-field-query-element.ts
+++ b/src-ui/src/app/utils/custom-field-query-element.ts
@@ -70,29 +70,29 @@ export class CustomFieldQueryAtom extends CustomFieldQueryElement {
     const newTypes: string[] =
       CUSTOM_FIELD_QUERY_VALUE_TYPES_BY_OPERATOR[operator]?.split('|')
     if (!newTypes) {
-      this.value = null
+      this._value = null
     } else {
       if (!newTypes.includes(typeof this.value)) {
         switch (newTypes[0]) {
           case 'string':
-            this.value = ''
+            this._value = ''
             break
           case 'boolean':
-            this.value = 'true'
+            this._value = 'true'
             break
           case 'array':
-            this.value = []
+            this._value = []
             break
           case 'number':
             const num = parseFloat(this.value as string)
-            this.value = isNaN(num) ? null : num.toString()
+            this._value = isNaN(num) ? null : num.toString()
             break
         }
       } else if (
         ['true', 'false'].includes(this.value as string) &&
         newTypes.includes('string')
       ) {
-        this.value = ''
+        this._value = ''
       }
     }
     super.operator = operator


### PR DESCRIPTION
## Proposed change

When changing operator to `in`, the setter first sets `this.value = []`, but atom.operator is still the OLD operator at that point. If the old operator was `exists`, the query `[fieldId, "exists", []]` gets sent to the backend. This returns an HTTP 400 error object, which is then displayed by the frontend.

The goal of this change is that events are fired only once per operator change.
No more intermediate query sent with the old operator + new empty value.

Closes #12596

I'm included recording of behavior before and after the fix.

- Before:

https://github.com/user-attachments/assets/75941e62-f235-439f-879d-8cc0f35fd4df

- After:

https://github.com/user-attachments/assets/b394c10a-4e52-4940-be2f-e72f81fe2bb8

Not sure if dedicated unit tests need to be written for this specific edge case.

## Type of change

- [X] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

- [X] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [X] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [X] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [X] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
