### PR TITLE
Fix: Date filtering issues

### DIFF
--- a/src-ui/src/app/components/common/dates-dropdown/dates-dropdown.component.html
+++ b/src-ui/src/app/components/common/dates-dropdown/dates-dropdown.component.html
@@ -86,7 +86,7 @@
         <div class="selected-icon">
           @if (addedRelativeDate) {
             <a class="text-light focus-variants" href="javascript:void(0)" (click)="clearAddedRelativeDate()">
-              <i-bs width="1em" height="1em" name="check" class="variant-unfocused"></i-bs>
+              <i-bs width="1em" height="1em" name="check" class="variant-unfocused text-dark"></i-bs>
               <i-bs width="1em" height="1em" name="x" class="variant-focused text-primary"></i-bs>
             </a>
           }

--- a/src-ui/src/app/components/document-list/filter-editor/filter-editor.component.spec.ts
+++ b/src-ui/src/app/components/document-list/filter-editor/filter-editor.component.spec.ts
@@ -1837,6 +1837,93 @@ describe('FilterEditorComponent', () => {
     ])
   }))
 
+  it('should emit quoted keyword for non-range relative date created (e.g. this year)', fakeAsync(() => {
+    const dateCreatedDropdown = fixture.debugElement.queryAll(
+      By.directive(DatesDropdownComponent)
+    )[0]
+    component.dateCreatedRelativeDate = RelativeDate.THIS_YEAR
+    dateCreatedDropdown.triggerEventHandler('datesSet')
+    fixture.detectChanges()
+    tick(400)
+    expect(component.filterRules).toEqual([
+      {
+        rule_type: FILTER_FULLTEXT_QUERY,
+        value: 'created:"this_year"',
+      },
+    ])
+  }))
+
+  it('should emit quoted keyword for non-range relative date added (e.g. last month)', fakeAsync(() => {
+    const datesDropdown = fixture.debugElement.query(
+      By.directive(DatesDropdownComponent)
+    )
+    component.dateAddedRelativeDate = RelativeDate.PREVIOUS_MONTH
+    datesDropdown.triggerEventHandler('datesSet')
+    fixture.detectChanges()
+    tick(400)
+    expect(component.filterRules).toEqual([
+      {
+        rule_type: FILTER_FULLTEXT_QUERY,
+        value: 'added:"last_month"',
+      },
+    ])
+  }))
+
+  it('should ingest quoted keyword relative date for created', fakeAsync(() => {
+    expect(component.dateCreatedRelativeDate).toBeNull()
+    component.filterRules = [
+      {
+        rule_type: FILTER_FULLTEXT_QUERY,
+        value: 'created:"this_year"',
+      },
+    ]
+    expect(component.dateCreatedRelativeDate).toEqual(RelativeDate.THIS_YEAR)
+    expect(component.textFilter).toBeNull()
+  }))
+
+  it('should ingest quoted keyword relative date for added', fakeAsync(() => {
+    expect(component.dateAddedRelativeDate).toBeNull()
+    component.filterRules = [
+      {
+        rule_type: FILTER_FULLTEXT_QUERY,
+        value: 'added:"last_month"',
+      },
+    ]
+    expect(component.dateAddedRelativeDate).toEqual(RelativeDate.PREVIOUS_MONTH)
+    expect(component.textFilter).toBeNull()
+  }))
+
+  it('should ingest both created and added relative dates from a single fulltext rule', fakeAsync(() => {
+    expect(component.dateCreatedRelativeDate).toBeNull()
+    expect(component.dateAddedRelativeDate).toBeNull()
+    component.filterRules = [
+      {
+        rule_type: FILTER_FULLTEXT_QUERY,
+        value: 'created:"this_year",added:"last_month"',
+      },
+    ]
+    expect(component.dateCreatedRelativeDate).toEqual(RelativeDate.THIS_YEAR)
+    expect(component.dateAddedRelativeDate).toEqual(RelativeDate.PREVIOUS_MONTH)
+    expect(component.textFilter).toBeNull()
+  }))
+
+  it('should emit both created and added relative dates in a single fulltext rule', fakeAsync(() => {
+    const dateCreatedDropdown = fixture.debugElement.queryAll(
+      By.directive(DatesDropdownComponent)
+    )[0]
+    component.dateCreatedRelativeDate = RelativeDate.THIS_YEAR
+    component.dateAddedRelativeDate = RelativeDate.PREVIOUS_MONTH
+    dateCreatedDropdown.triggerEventHandler('datesSet')
+    fixture.detectChanges()
+    tick(400)
+    expect(component.filterRules).toEqual([
+      {
+        rule_type: FILTER_FULLTEXT_QUERY,
+        value: 'created:"this_year",added:"last_month"',
+      },
+    ])
+  }))
+
   it('should convert user input to correct filter on permissions select my docs', fakeAsync(() => {
     const permissionsDropdown = fixture.debugElement.query(
       By.directive(PermissionsFilterDropdownComponent)

--- a/src-ui/src/app/components/document-list/filter-editor/filter-editor.component.ts
+++ b/src-ui/src/app/components/document-list/filter-editor/filter-editor.component.ts
@@ -158,11 +158,11 @@ const RELATIVE_DATE_QUERYSTRINGS = [
   },
   {
     relativeDate: RelativeDate.THIS_YEAR,
-    dateQuery: 'this year',
+    dateQuery: 'this_year',
   },
   {
     relativeDate: RelativeDate.THIS_MONTH,
-    dateQuery: 'this month',
+    dateQuery: 'this_month',
   },
   {
     relativeDate: RelativeDate.TODAY,
@@ -174,19 +174,19 @@ const RELATIVE_DATE_QUERYSTRINGS = [
   },
   {
     relativeDate: RelativeDate.PREVIOUS_WEEK,
-    dateQuery: 'previous week',
+    dateQuery: 'last_week',
   },
   {
     relativeDate: RelativeDate.PREVIOUS_MONTH,
-    dateQuery: 'previous month',
+    dateQuery: 'last_month',
   },
   {
     relativeDate: RelativeDate.PREVIOUS_QUARTER,
-    dateQuery: 'previous quarter',
+    dateQuery: 'last_quarter',
   },
   {
     relativeDate: RelativeDate.PREVIOUS_YEAR,
-    dateQuery: 'previous year',
+    dateQuery: 'last_year',
   },
 ]
 

--- a/src/documents/search/_query.py
+++ b/src/documents/search/_query.py
@@ -33,13 +33,14 @@ _DATE_KEYWORDS = frozenset(
         "last_week",
         "this_month",
         "last_month",
+        "last_quarter",
         "this_year",
         "last_year",
     },
 )
 
 _FIELD_DATE_RE = regex.compile(
-    r"(\w+):(" + "|".join(_DATE_KEYWORDS) + r")\b",
+    r'(\w+):"?(' + "|".join(_DATE_KEYWORDS) + r')\b"?',
 )
 _COMPACT_DATE_RE = regex.compile(r"\b(\d{14})\b")
 _RELATIVE_RANGE_RE = regex.compile(
@@ -106,6 +107,17 @@ def _date_only_range(keyword: str, tz: tzinfo) -> str:
             lo = datetime(today.year, today.month - 1, 1, tzinfo=UTC)
         hi = datetime(today.year, today.month, 1, tzinfo=UTC)
         return _iso_range(lo, hi)
+    if keyword == "last_quarter":
+        current_q_start_month = ((today.month - 1) // 3) * 3 + 1
+        last_q_start_month = current_q_start_month - 3
+        if last_q_start_month <= 0:
+            last_q_start_month += 12
+            last_q_year = today.year - 1
+        else:
+            last_q_year = today.year
+        lo = datetime(last_q_year, last_q_start_month, 1, tzinfo=UTC)
+        hi = datetime(today.year, current_q_start_month, 1, tzinfo=UTC)
+        return _iso_range(lo, hi)
     if keyword == "this_year":
         lo = datetime(today.year, 1, 1, tzinfo=UTC)
         return _iso_range(lo, datetime(today.year + 1, 1, 1, tzinfo=UTC))
@@ -153,6 +165,18 @@ def _datetime_range(keyword: str, tz: tzinfo) -> str:
         else:
             last_first = date(today.year, today.month - 1, 1)
         return _iso_range(_midnight(last_first), _midnight(this_first))
+    if keyword == "last_quarter":
+        current_q_start_month = ((today.month - 1) // 3) * 3 + 1
+        last_q_start_month = current_q_start_month - 3
+        if last_q_start_month <= 0:
+            last_q_start_month += 12
+            last_q_year = today.year - 1
+        else:
+            last_q_year = today.year
+        return _iso_range(
+            _midnight(date(last_q_year, last_q_start_month, 1)),
+            _midnight(date(today.year, current_q_start_month, 1)),
+        )
     if keyword == "this_year":
         return _iso_range(
             _midnight(date(today.year, 1, 1)),
@@ -367,6 +391,8 @@ def normalize_query(query: str) -> str:
             query,
             timeout=_REGEX_TIMEOUT,
         )
+        # Example of query to parse: created:[XXX],added:[XXX]
+        query = regex.sub(r"\s*,\s*", " ", query, timeout=_REGEX_TIMEOUT)
         return regex.sub(r" {2,}", " ", query, timeout=_REGEX_TIMEOUT).strip()
     except TimeoutError:  # pragma: no cover
         raise ValueError("Query too complex to process (normalization timed out)")

--- a/src/documents/tests/search/test_query.py
+++ b/src/documents/tests/search/test_query.py
@@ -116,6 +116,13 @@ class TestCreatedDateField:
             ),
             pytest.param(
                 "created",
+                "last_quarter",
+                "2025-10-01T00:00:00Z",
+                "2026-01-01T00:00:00Z",
+                id="last_quarter_q4_2025",
+            ),
+            pytest.param(
+                "created",
                 "last_year",
                 "2025-01-01T00:00:00Z",
                 "2026-01-01T00:00:00Z",
@@ -156,6 +163,26 @@ class TestCreatedDateField:
         )
         assert lo == "2025-12-01T00:00:00Z"
         assert hi == "2026-01-01T00:00:00Z"
+
+    @time_machine.travel(datetime(2026, 1, 15, 12, 0, tzinfo=UTC), tick=False)
+    def test_last_quarter_wraps_to_previous_year(self) -> None:
+        # January is Q1; last quarter is Q4 of the previous year
+        lo, hi = _range(
+            rewrite_natural_date_keywords("created:last_quarter", UTC),
+            "created",
+        )
+        assert lo == "2025-10-01T00:00:00Z"
+        assert hi == "2026-01-01T00:00:00Z"
+
+    @time_machine.travel(datetime(2026, 3, 28, 15, 0, tzinfo=UTC), tick=False)
+    def test_quoted_keyword_accepted(self) -> None:
+        # Frontend sends created:"this_year"
+        lo, hi = _range(
+            rewrite_natural_date_keywords('created:"this_year"', UTC),
+            "created",
+        )
+        assert lo == "2026-01-01T00:00:00Z"
+        assert hi == "2027-01-01T00:00:00Z"
 
     def test_unknown_keyword_raises(self) -> None:
         with pytest.raises(ValueError, match="Unknown keyword"):
@@ -232,6 +259,12 @@ class TestDateTimeFields:
                 id="this_year",
             ),
             pytest.param(
+                "last_quarter",
+                "2025-10-01T00:00:00Z",
+                "2026-01-01T00:00:00Z",
+                id="last_quarter_q4_2025",
+            ),
+            pytest.param(
                 "last_year",
                 "2025-01-01T00:00:00Z",
                 "2026-01-01T00:00:00Z",
@@ -263,6 +296,13 @@ class TestDateTimeFields:
         # January: last month wraps back to December of previous year
         lo, hi = _range(rewrite_natural_date_keywords("added:last_month", UTC), "added")
         assert lo == "2025-12-01T00:00:00Z"
+        assert hi == "2026-01-01T00:00:00Z"
+
+    @time_machine.travel(datetime(2026, 1, 15, 12, 0, tzinfo=UTC), tick=False)
+    def test_last_quarter_wraps_to_previous_year(self) -> None:
+        # January is Q1; last quarter is Q4 of the previous year
+        lo, hi = _range(rewrite_natural_date_keywords("added:last_quarter", UTC), "added")
+        assert lo == "2025-10-01T00:00:00Z"
         assert hi == "2026-01-01T00:00:00Z"
 
     def test_unknown_keyword_raises(self) -> None:


### PR DESCRIPTION
## Proposed change

- Issue 1: `Previous quarter` filter produces a 400 error    

`last_quarter` was absent from `_DATE_KEYWORDS` and thus unhandled in the date range functions.

- Issue 2: Keyword date filters produce a 400 error ("this year", "last month"...)

The regex only matched bare underscore keywords (`created:this_year`), so quoted or space-separated keywords were never recognised. Previous values where containing a space ("this year", "previous week"...)

- Issue 3: Combining Created + Added date filters produces a 400 error

Filter was something like this:
`created:"this year",added:"previous month" => Rejected with a HTTP 400.                                                                                                                                                                                                         

Now the filter matches them properly:
`created:"this_year",added:"last_month"` => Accepts then with a HTTP 200

- Issue 4: Missing checkmark next to "Added" date filter
 
The check icon next to the "Created" relative date dropdown had class text-dark, making it visible. The equivalent icon for "Added" was missing this class.

---

**Warning**: Used AI to generate the .ts tests as I'm not familiar with Typescript (please double-check)

Closes #12598

## Type of change

- [X] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

- [X] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [X] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [X] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [X] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [X] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [X] I have made corresponding changes to the documentation as needed.
- [X] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
