### PR TITLE
feat: add MiniMax LLM provider support

### DIFF
--- a/src/paperless/migrations/0010_alter_applicationconfiguration_llm_backend.py
+++ b/src/paperless/migrations/0010_alter_applicationconfiguration_llm_backend.py
@@ -1,0 +1,26 @@
+from django.db import migrations
+from django.db import models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("paperless", "0009_alter_applicationconfiguration_options"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="applicationconfiguration",
+            name="llm_backend",
+            field=models.CharField(
+                blank=True,
+                choices=[
+                    ("openai", "OpenAI"),
+                    ("ollama", "Ollama"),
+                    ("minimax", "MiniMax"),
+                ],
+                max_length=128,
+                null=True,
+                verbose_name="Sets the LLM backend",
+            ),
+        ),
+    ]

--- a/src/paperless/models.py
+++ b/src/paperless/models.py
@@ -86,6 +86,7 @@ class LLMBackend(models.TextChoices):
 
     OPENAI = ("openai", _("OpenAI"))
     OLLAMA = ("ollama", _("Ollama"))
+    MINIMAX = ("minimax", _("MiniMax"))
 
 
 class ApplicationConfiguration(AbstractSingletonModel):

--- a/src/paperless/settings/__init__.py
+++ b/src/paperless/settings/__init__.py
@@ -1178,7 +1178,7 @@ LLM_EMBEDDING_BACKEND = os.getenv(
     "PAPERLESS_AI_LLM_EMBEDDING_BACKEND",
 )  # "huggingface" or "openai"
 LLM_EMBEDDING_MODEL = os.getenv("PAPERLESS_AI_LLM_EMBEDDING_MODEL")
-LLM_BACKEND = os.getenv("PAPERLESS_AI_LLM_BACKEND")  # "ollama" or "openai"
+LLM_BACKEND = os.getenv("PAPERLESS_AI_LLM_BACKEND")  # "ollama", "openai", or "minimax"
 LLM_MODEL = os.getenv("PAPERLESS_AI_LLM_MODEL")
 LLM_API_KEY = os.getenv("PAPERLESS_AI_LLM_API_KEY")
 LLM_ENDPOINT = os.getenv("PAPERLESS_AI_LLM_ENDPOINT")

--- a/src/paperless_ai/client.py
+++ b/src/paperless_ai/client.py
@@ -50,6 +50,20 @@ class AIClient:
                 api_base=endpoint,
                 api_key=self.settings.llm_api_key,
             )
+        elif self.settings.llm_backend == "minimax":
+            from llama_index.llms.openai import OpenAI
+
+            endpoint = self.settings.llm_endpoint or "https://api.minimax.io/v1"
+            validate_outbound_http_url(
+                endpoint,
+                allow_internal=self.settings.llm_allow_internal_endpoints,
+            )
+            return OpenAI(
+                model=self.settings.llm_model or "MiniMax-M2.7",
+                api_base=endpoint,
+                api_key=self.settings.llm_api_key,
+                temperature=1.0,
+            )
         else:
             raise ValueError(f"Unsupported LLM backend: {self.settings.llm_backend}")
 

--- a/src/paperless_ai/tests/test_client.py
+++ b/src/paperless_ai/tests/test_client.py
@@ -78,6 +78,57 @@ def test_get_llm_unsupported_backend(mock_ai_config):
         AIClient()
 
 
+def test_get_llm_minimax(mock_ai_config, mock_openai_llm):
+    mock_ai_config.llm_backend = "minimax"
+    mock_ai_config.llm_model = "MiniMax-M2.7"
+    mock_ai_config.llm_api_key = "test_minimax_api_key"
+    mock_ai_config.llm_endpoint = None
+
+    client = AIClient()
+
+    mock_openai_llm.assert_called_once_with(
+        model="MiniMax-M2.7",
+        api_base="https://api.minimax.io/v1",
+        api_key="test_minimax_api_key",
+        temperature=1.0,
+    )
+    assert client.llm == mock_openai_llm.return_value
+
+
+def test_get_llm_minimax_custom_endpoint(mock_ai_config, mock_openai_llm):
+    mock_ai_config.llm_backend = "minimax"
+    mock_ai_config.llm_model = "MiniMax-M2.7-highspeed"
+    mock_ai_config.llm_api_key = "test_minimax_api_key"
+    mock_ai_config.llm_endpoint = "https://api.minimax.io/v1"
+
+    client = AIClient()
+
+    mock_openai_llm.assert_called_once_with(
+        model="MiniMax-M2.7-highspeed",
+        api_base="https://api.minimax.io/v1",
+        api_key="test_minimax_api_key",
+        temperature=1.0,
+    )
+    assert client.llm == mock_openai_llm.return_value
+
+
+def test_get_llm_minimax_default_model(mock_ai_config, mock_openai_llm):
+    mock_ai_config.llm_backend = "minimax"
+    mock_ai_config.llm_model = None
+    mock_ai_config.llm_api_key = "test_minimax_api_key"
+    mock_ai_config.llm_endpoint = None
+
+    client = AIClient()
+
+    mock_openai_llm.assert_called_once_with(
+        model="MiniMax-M2.7",
+        api_base="https://api.minimax.io/v1",
+        api_key="test_minimax_api_key",
+        temperature=1.0,
+    )
+    assert client.llm == mock_openai_llm.return_value
+
+
 def test_run_llm_query(mock_ai_config, mock_ollama_llm):
     mock_ai_config.llm_backend = "ollama"
     mock_ai_config.llm_model = "test_model"
@@ -121,3 +172,4 @@ def test_run_chat(mock_ai_config, mock_ollama_llm):
 
     mock_llm_instance.chat.assert_called_once_with(messages)
     assert result == "test_chat_result"
+


### PR DESCRIPTION
## Summary

This PR adds MiniMax as a supported LLM backend for paperless-ngx's AI features.

MiniMax provides an OpenAI-compatible chat API, making it easy to integrate as an additional provider option alongside the existing OpenAI and Ollama backends.

### Changes

- **`src/paperless/models.py`**: Added `MINIMAX = ("minimax", _("MiniMax"))` to `LLMBackend` choices
- **`src/paperless_ai/client.py`**: Added MiniMax handling in `AIClient.get_llm()` — uses `llama_index.llms.openai.OpenAI` with MiniMax's OpenAI-compatible base URL
- **`src/paperless/settings/__init__.py`**: Updated `PAPERLESS_AI_LLM_BACKEND` comment to document `minimax` as a valid option
- **`src/paperless/migrations/0010_*.py`**: Database migration to update `llm_backend` field choices
- **`src/paperless_ai/tests/test_client.py`**: Added three unit tests for the MiniMax backend

### Configuration

Users can configure MiniMax by setting:

```
PAPERLESS_AI_LLM_BACKEND=minimax
PAPERLESS_AI_LLM_API_KEY=<your-minimax-api-key>
PAPERLESS_AI_LLM_MODEL=MiniMax-M2.7  # or MiniMax-M2.7-highspeed
```

The default base URL is `https://api.minimax.io/v1` (can be overridden with `PAPERLESS_AI_LLM_ENDPOINT`).

### MiniMax API Details

MiniMax is an OpenAI-compatible API provider. API reference:
- Chat: https://platform.minimax.io/docs/api-reference/text-openai-api

Supported models:
- `MiniMax-M2.7` (default) — Peak Performance. Ultimate Value. Master the Complex
- `MiniMax-M2.7-highspeed` — Same performance, faster and more agile

### Implementation Notes

- Temperature is set to `1.0` by default (MiniMax requires `temperature > 0`)
- Uses the existing `llama_index.llms.openai.OpenAI` abstraction (no new dependencies required)
- API key is read from the standard `llm_api_key` field (consistent with OpenAI backend)