### PR TITLE
Chore: Store search index information in JSON

### DIFF
--- a/src/documents/search/_schema.py
+++ b/src/documents/search/_schema.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import logging
 import shutil
 from typing import TYPE_CHECKING
@@ -100,9 +101,9 @@ def needs_rebuild(index_dir: Path) -> bool:
     """
     Check if the search index needs rebuilding.
 
-    Compares the current schema version and search language configuration
-    against sentinel files to determine if the index is compatible with
-    the current paperless-ngx version and settings.
+    Reads .index_settings.json to compare the stored schema version and
+    search language against the current configuration. Returns True if the
+    file is missing, unparsable, or either value mismatches.
 
     Args:
         index_dir: Path to the search index directory
@@ -110,24 +111,19 @@ def needs_rebuild(index_dir: Path) -> bool:
     Returns:
         True if the index needs rebuilding, False if it's up to date
     """
-    version_file = index_dir / ".schema_version"
-    if not version_file.exists():
+    settings_file = index_dir / ".index_settings.json"
+    if not settings_file.exists():
         return True
     try:
-        if int(version_file.read_text().strip()) != SCHEMA_VERSION:
+        data = json.loads(settings_file.read_text())
+        if data.get("schema_version") != SCHEMA_VERSION:
             logger.info("Search index schema version mismatch - rebuilding.")
+            return True
+        if "language" not in data or data["language"] != settings.SEARCH_LANGUAGE:
+            logger.info("Search index language changed - rebuilding.")
             return True
     except ValueError:
         return True
-
-    language_file = index_dir / ".schema_language"
-    if not language_file.exists():
-        logger.info("Search index language sentinel missing - rebuilding.")
-        return True
-    if language_file.read_text().strip() != (settings.SEARCH_LANGUAGE or ""):
-        logger.info("Search index language changed - rebuilding.")
-        return True
-
     return False
 
 
@@ -149,9 +145,16 @@ def wipe_index(index_dir: Path) -> None:
 
 
 def _write_sentinels(index_dir: Path) -> None:
-    """Write schema version and language sentinel files so the next index open can skip rebuilding."""
-    (index_dir / ".schema_version").write_text(str(SCHEMA_VERSION))
-    (index_dir / ".schema_language").write_text(settings.SEARCH_LANGUAGE or "")
+    """Write .index_settings.json so the next index open can skip rebuilding."""
+    settings_file = index_dir / ".index_settings.json"
+    settings_file.write_text(
+        json.dumps(
+            {
+                "schema_version": SCHEMA_VERSION,
+                "language": settings.SEARCH_LANGUAGE,
+            },
+        ),
+    )
 
 
 def open_or_rebuild_index(index_dir: Path | None = None) -> tantivy.Index:

--- a/src/documents/tests/search/test_schema.py
+++ b/src/documents/tests/search/test_schema.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING
 
 import pytest
@@ -18,7 +19,7 @@ pytestmark = pytest.mark.search
 class TestNeedsRebuild:
     """needs_rebuild covers all sentinel-file states that require a full reindex."""
 
-    def test_returns_true_when_version_file_missing(self, index_dir: Path) -> None:
+    def test_returns_true_when_settings_file_missing(self, index_dir: Path) -> None:
         assert needs_rebuild(index_dir) is True
 
     def test_returns_false_when_version_and_language_match(
@@ -27,37 +28,51 @@ class TestNeedsRebuild:
         settings: SettingsWrapper,
     ) -> None:
         settings.SEARCH_LANGUAGE = "en"
-        (index_dir / ".schema_version").write_text(str(SCHEMA_VERSION))
-        (index_dir / ".schema_language").write_text("en")
+        (index_dir / ".index_settings.json").write_text(
+            json.dumps({"schema_version": SCHEMA_VERSION, "language": "en"}),
+        )
         assert needs_rebuild(index_dir) is False
 
-    def test_returns_true_on_schema_version_mismatch(self, index_dir: Path) -> None:
-        (index_dir / ".schema_version").write_text(str(SCHEMA_VERSION - 1))
-        assert needs_rebuild(index_dir) is True
-
-    def test_returns_true_when_version_file_not_an_integer(
+    def test_returns_true_on_schema_version_mismatch(
         self,
         index_dir: Path,
+        settings: SettingsWrapper,
     ) -> None:
-        (index_dir / ".schema_version").write_text("not-a-number")
+        settings.SEARCH_LANGUAGE = None
+        (index_dir / ".index_settings.json").write_text(
+            json.dumps({"schema_version": SCHEMA_VERSION - 1, "language": None}),
+        )
         assert needs_rebuild(index_dir) is True
 
-    def test_returns_true_when_language_sentinel_missing(
+    def test_returns_true_when_version_is_not_an_integer(
+        self,
+        index_dir: Path,
+        settings: SettingsWrapper,
+    ) -> None:
+        settings.SEARCH_LANGUAGE = None
+        (index_dir / ".index_settings.json").write_text(
+            json.dumps({"schema_version": "not-a-number", "language": None}),
+        )
+        assert needs_rebuild(index_dir) is True
+
+    def test_returns_true_when_language_key_missing(
         self,
         index_dir: Path,
         settings: SettingsWrapper,
     ) -> None:
         settings.SEARCH_LANGUAGE = "en"
-        (index_dir / ".schema_version").write_text(str(SCHEMA_VERSION))
-        # .schema_language intentionally absent
+        (index_dir / ".index_settings.json").write_text(
+            json.dumps({"schema_version": SCHEMA_VERSION}),
+        )
         assert needs_rebuild(index_dir) is True
 
-    def test_returns_true_when_language_sentinel_content_differs(
+    def test_returns_true_when_language_differs(
         self,
         index_dir: Path,
         settings: SettingsWrapper,
     ) -> None:
         settings.SEARCH_LANGUAGE = "de"
-        (index_dir / ".schema_version").write_text(str(SCHEMA_VERSION))
-        (index_dir / ".schema_language").write_text("en")
+        (index_dir / ".index_settings.json").write_text(
+            json.dumps({"schema_version": SCHEMA_VERSION, "language": "en"}),
+        )
         assert needs_rebuild(index_dir) is True


### PR DESCRIPTION

<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

<!--
⚠️ Important: Pull requests that implement a new feature or enhancement *should almost always target an existing feature request* with evidence of community interest and discussion. This is in order to balance the work of implementing and maintaining new features / enhancements. If that is not currently the case, please open a feature request instead of this PR to gather feedback from both users and the project maintainers.
-->

Replaces the 2 files storing version and language with a JSON file.  It's a minor QoL and means we could store additional information in the future if needed.  JSON also handles the None/null case better, instead of an empty string meaning no language.

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [x] Other. Please explain: QoL

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
