### PR TITLE
Security: Don't allow the example secret key as a secret key

### DIFF
--- a/src/paperless/settings/__init__.py
+++ b/src/paperless/settings/__init__.py
@@ -463,10 +463,11 @@ SECURE_PROXY_SSL_HEADER = (
     else None
 )
 
-SECRET_KEY = os.getenv("PAPERLESS_SECRET_KEY", "")
-if not SECRET_KEY:  # pragma: no cover
+SECRET_KEY = os.getenv("PAPERLESS_SECRET_KEY")
+_INSECURE_SECRET_KEYS = {None, "", "change-me"}
+if not DEBUG and SECRET_KEY in _INSECURE_SECRET_KEYS:  # pragma: no cover
     raise ImproperlyConfigured(
-        "PAPERLESS_SECRET_KEY is not set. "
+        "PAPERLESS_SECRET_KEY is not set or is the default 'change-me' value. "
         "A unique, secret key is required for secure operation. "
         'Generate one with: python3 -c "import secrets; print(secrets.token_urlsafe(64))"',
     )


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

<!--
⚠️ Important: Pull requests that implement a new feature or enhancement *should almost always target an existing feature request* with evidence of community interest and discussion. This is in order to balance the work of implementing and maintaining new features / enhancements. If that is not currently the case, please open a feature request instead of this PR to gather feedback from both users and the project maintainers.
-->

Follow on from #12501, don't allow the `PAPERLESS_SECRET_KEY` value to be "change-me", which is the default in our example conf file, which is mostly going to be bare metal.  It's obviously insecure and we should enforce it having changed.

Closes #(issue or discussion)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
