### PR TITLE
Enhancement: token-based matching in dropdown search fields

### DIFF
--- a/src-ui/src/app/components/common/custom-fields-dropdown/custom-fields-dropdown.component.ts
+++ b/src-ui/src/app/components/common/custom-fields-dropdown/custom-fields-dropdown.component.ts
@@ -23,6 +23,7 @@ import {
 import { CustomFieldsService } from 'src/app/services/rest/custom-fields.service'
 import { ToastService } from 'src/app/services/toast.service'
 import { pngxPopperOptions } from 'src/app/utils/popper-options'
+import { textMatchesTokens } from 'src/app/utils/text-match'
 import { LoadingComponentWithPermissions } from '../../loading-component/loading.component'
 import { CustomFieldEditDialogComponent } from '../edit-dialog/custom-field-edit-dialog/custom-field-edit-dialog.component'
 
@@ -68,10 +69,8 @@ export class CustomFieldsDropdownComponent extends LoadingComponentWithPermissio
   private keyboardIndex: number
 
   public get filteredFields(): CustomField[] {
-    return this.unusedFields.filter(
-      (f) =>
-        !this.filterText ||
-        f.name.toLowerCase().includes(this.filterText.toLowerCase())
+    return this.unusedFields.filter((f) =>
+      textMatchesTokens(f.name, this.filterText)
     )
   }
 

--- a/src-ui/src/app/components/common/input/tags/tags.component.html
+++ b/src-ui/src/app/components/common/input/tags/tags.component.html
@@ -13,6 +13,7 @@
           [closeOnSelect]="false"
           [clearSearchOnAdd]="true"
           [hideSelected]="tags.length > 0"
+          [searchFn]="tagSearchFn"
           [addTag]="allowCreate ? createTagRef : false"
           addTagText="Add tag"
           i18n-addTagText

--- a/src-ui/src/app/components/common/input/tags/tags.component.ts
+++ b/src-ui/src/app/components/common/input/tags/tags.component.ts
@@ -21,6 +21,7 @@ import { NgxBootstrapIconsModule } from 'ngx-bootstrap-icons'
 import { first, firstValueFrom, tap } from 'rxjs'
 import { Tag } from 'src/app/data/tag'
 import { TagService } from 'src/app/services/rest/tag.service'
+import { textMatchesTokens } from 'src/app/utils/text-match'
 import { EditDialogMode } from '../../edit-dialog/edit-dialog.component'
 import { TagEditDialogComponent } from '../../edit-dialog/tag-edit-dialog/tag-edit-dialog.component'
 import { TagComponent } from '../../tag/tag.component'
@@ -113,6 +114,9 @@ export class TagsComponent implements OnInit, ControlValueAccessor {
   tags: Tag[] = []
 
   public createTagRef: (name) => void
+
+  public tagSearchFn = (term: string, item: Tag): boolean =>
+    textMatchesTokens(item?.name, term)
 
   getTag(id: number) {
     if (this.tags) {

--- a/src-ui/src/app/pipes/filter.pipe.spec.ts
+++ b/src-ui/src/app/pipes/filter.pipe.spec.ts
@@ -46,4 +46,23 @@ describe('FilterPipe', () => {
     itemsReturned = pipe.transform(items, 'slug', 'slug')
     expect(itemsReturned).toEqual([items[0]])
   })
+
+  it('should match all whitespace-separated tokens regardless of order', () => {
+    const pipe = new FilterPipe()
+    const items: MatchingModel[] = [
+      {
+        id: 1,
+        name: 'Lorem Ipsum Dolor 2025',
+        slug: 'lorem-ipsum-2025',
+      },
+      {
+        id: 2,
+        name: 'Lorem Ipsum Dolor 2024',
+        slug: 'lorem-ipsum-2024',
+      },
+    ]
+    expect(pipe.transform(items, 'Lor 2025', 'name')).toEqual([items[0]])
+    expect(pipe.transform(items, '2025 lor', 'name')).toEqual([items[0]])
+    expect(pipe.transform(items, 'Lor 2026', 'name')).toEqual([])
+  })
 })

--- a/src-ui/src/app/pipes/filter.pipe.ts
+++ b/src-ui/src/app/pipes/filter.pipe.ts
@@ -1,5 +1,6 @@
 import { Pipe, PipeTransform } from '@angular/core'
 import { MatchingModel } from '../data/matching-model'
+import { textMatchesTokens } from '../utils/text-match'
 
 @Pipe({
   name: 'filter',
@@ -21,9 +22,7 @@ export class FilterPipe implements PipeTransform {
               typeof item[key] === 'string' || typeof item[key] === 'number'
           )
       return keys.some((key) => {
-        return String(item[key])
-          .toLowerCase()
-          .includes(searchText.toLowerCase())
+        return textMatchesTokens(String(item[key]), searchText)
       })
     })
   }

--- a/src-ui/src/app/utils/text-match.spec.ts
+++ b/src-ui/src/app/utils/text-match.spec.ts
@@ -1,0 +1,38 @@
+import { textMatchesTokens } from './text-match'
+
+describe('textMatchesTokens', () => {
+  it('returns true for empty / whitespace-only queries', () => {
+    expect(textMatchesTokens('Hello', '')).toBe(true)
+    expect(textMatchesTokens('Hello', null)).toBe(true)
+    expect(textMatchesTokens('Hello', undefined)).toBe(true)
+    expect(textMatchesTokens('Hello', '   ')).toBe(true)
+  })
+
+  it('returns false when haystack is missing but tokens exist', () => {
+    expect(textMatchesTokens(null, 'foo')).toBe(false)
+    expect(textMatchesTokens(undefined, 'foo')).toBe(false)
+  })
+
+  it('matches a single substring case-insensitively', () => {
+    expect(textMatchesTokens('Lorem Ipsum Dolor 2025', 'lor')).toBe(true)
+    expect(textMatchesTokens('Lorem Ipsum Dolor 2025', 'xyz')).toBe(false)
+  })
+
+  it('matches when all whitespace-separated tokens are present in any order', () => {
+    expect(textMatchesTokens('Lorem Ipsum Dolor 2025', 'Lor 2025')).toBe(true)
+    expect(textMatchesTokens('Lorem Ipsum Dolor 2025', '2025 Lor')).toBe(true)
+    expect(textMatchesTokens('Lorem Ipsum Dolor 2025', 'Lor Ipsum 2025')).toBe(
+      true
+    )
+  })
+
+  it('fails when any token is missing', () => {
+    expect(textMatchesTokens('Lorem Ipsum Dolor 2025', 'Lor 2024')).toBe(false)
+  })
+
+  it('collapses multiple whitespace between tokens', () => {
+    expect(textMatchesTokens('Lorem Ipsum Dolor 2025', 'Lor\t\n  2025')).toBe(
+      true
+    )
+  })
+})

--- a/src-ui/src/app/utils/text-match.ts
+++ b/src-ui/src/app/utils/text-match.ts
@@ -1,0 +1,8 @@
+export function textMatchesTokens(haystack: string, query: string): boolean {
+  if (!query) return true
+  const tokens = query.split(/\s+/).filter((t) => t.length > 0)
+  if (tokens.length === 0) return true
+  if (haystack == null) return false
+  const lowered = haystack.toLowerCase()
+  return tokens.every((token) => lowered.includes(token.toLowerCase()))
+}


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

The search-as-you-type input that filters tag, correspondent,
document type, storage path and custom field dropdowns previously
matched only a single contiguous substring against the candidate
name. A query like "Lor 2025" therefore failed to match a tag
named "Lorem Ipsum 2025" even though both fragments are present.

The filter now splits the input on whitespace and requires every
token to appear somewhere in the candidate text, in any order.
Matching remains case-insensitive (as before).

#### Implementation:
- New shared utility src-ui/src/app/utils/text-match.ts exposes
textMatchesTokens(haystack, query).
- FilterPipe (used by filterable-dropdown for tags, correspondents,
document types, storage paths) delegates to the utility.
- CustomFieldsDropdownComponent.filteredFields uses the utility.
- The tag picker's ng-select instance (input/tags) gets a
[searchFn] binding that wraps the utility.

Other ng-select-based pickers (select, document-link, permissions,
storage-path-edit-dialog test document, custom-fields-query) keep
ng-select's default searchFn for now.

#### Tests:
unit tests for the new utility and additional cases for the
existing FilterPipe spec covering token order and missing tokens.

#### AI Disclosure                                                           
                                                                           
  Parts of this PR were drafted with AI assistance (Claude); all code        
  was reviewed and adjusted by me. No copyrighted material
  was reproduced. 

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

<!--
⚠️ Important: Pull requests that implement a new feature or enhancement *should almost always target an existing feature request* with evidence of community interest and discussion. This is in order to balance the work of implementing and maintaining new features / enhancements. If that is not currently the case, please open a feature request instead of this PR to gather feedback from both users and the project maintainers.
-->

Closes #10872

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [x] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for ~[backend](https://docs.paperless-ngx.com/development/#testing) and / or~ [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
