### PR TITLE
Fix: avoid unnecessary close_old_connections in Celery task dispatch

### DIFF
--- a/src/documents/bulk_edit.py
+++ b/src/documents/bulk_edit.py
@@ -218,7 +218,7 @@ def modify_tags(
     doc_ids: list[int],
     add_tags: list[int],
     remove_tags: list[int],
-) -> Literal["OK"] | Literal["ERROR"]:
+) -> Literal["OK"]:
     qs = Document.objects.filter(id__in=doc_ids).only("pk")
     affected_docs = list(qs.values_list("pk", flat=True))
     DocumentTagRelationship = Document.tags.through
@@ -237,39 +237,34 @@ def modify_tags(
         expanded_remove_tags.add(int(t.id))
         expanded_remove_tags.update(int(pk) for pk in t.get_descendants_pks())
 
-    try:
-        with transaction.atomic():
-            if expanded_remove_tags:
+    with transaction.atomic():
+        if expanded_remove_tags:
+            DocumentTagRelationship.objects.filter(
+                document_id__in=affected_docs,
+                tag_id__in=expanded_remove_tags,
+            ).delete()
+
+        to_create = []
+        if expanded_add_tags:
+            existing_pairs = set(
                 DocumentTagRelationship.objects.filter(
                     document_id__in=affected_docs,
-                    tag_id__in=expanded_remove_tags,
-                ).delete()
+                    tag_id__in=expanded_add_tags,
+                ).values_list("document_id", "tag_id"),
+            )
 
-            to_create = []
-            if expanded_add_tags:
-                existing_pairs = set(
-                    DocumentTagRelationship.objects.filter(
-                        document_id__in=affected_docs,
-                        tag_id__in=expanded_add_tags,
-                    ).values_list("document_id", "tag_id"),
+            to_create = [
+                DocumentTagRelationship(document_id=doc, tag_id=tag)
+                for doc in affected_docs
+                for tag in expanded_add_tags
+                if (doc, tag) not in existing_pairs
+            ]
+
+            if to_create:
+                DocumentTagRelationship.objects.bulk_create(
+                    to_create,
+                    ignore_conflicts=True,
                 )
-
-                to_create = [
-                    DocumentTagRelationship(document_id=doc, tag_id=tag)
-                    for doc in affected_docs
-                    for tag in expanded_add_tags
-                    if (doc, tag) not in existing_pairs
-                ]
-
-                if to_create:
-                    DocumentTagRelationship.objects.bulk_create(
-                        to_create,
-                        ignore_conflicts=True,
-                    )
-
-    except Exception as e:
-        logger.error(f"Error modifying tags: {e}")
-        return "ERROR"
 
     if affected_docs:
         bulk_update_documents.apply_async(

--- a/src/documents/bulk_edit.py
+++ b/src/documents/bulk_edit.py
@@ -218,7 +218,7 @@ def modify_tags(
     doc_ids: list[int],
     add_tags: list[int],
     remove_tags: list[int],
-) -> Literal["OK"]:
+) -> Literal["OK"] | Literal["ERROR"]:
     qs = Document.objects.filter(id__in=doc_ids).only("pk")
     affected_docs = list(qs.values_list("pk", flat=True))
     DocumentTagRelationship = Document.tags.through
@@ -267,14 +267,15 @@ def modify_tags(
                         ignore_conflicts=True,
                     )
 
-            if affected_docs:
-                bulk_update_documents.apply_async(
-                    kwargs={"document_ids": affected_docs},
-                    headers={"trigger_source": PaperlessTask.TriggerSource.SYSTEM},
-                )
     except Exception as e:
         logger.error(f"Error modifying tags: {e}")
         return "ERROR"
+
+    if affected_docs:
+        bulk_update_documents.apply_async(
+            kwargs={"document_ids": affected_docs},
+            headers={"trigger_source": PaperlessTask.TriggerSource.SYSTEM},
+        )
 
     return "OK"
 

--- a/src/documents/signals/handlers.py
+++ b/src/documents/signals/handlers.py
@@ -1122,7 +1122,6 @@ def before_task_publish_handler(
         return
 
     try:
-        close_old_connections()
         _, task_kwargs, _ = body
         task_id = headers["id"]
 


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

<!--
⚠️ Important: Pull requests that implement a new feature or enhancement *should almost always target an existing feature request* with evidence of community interest and discussion. This is in order to balance the work of implementing and maintaining new features / enhancements. If that is not currently the case, please open a feature request instead of this PR to gather feedback from both users and the project maintainers.
-->

The issue appears to be running `close_old_connections` while inside the M2M update transaction results in the transaction never committing.  If anything, this seems like Django is at fault here: it is presumably closing the connection for the transaction.

This shows up after the task system redesign as we now track this type of task, which shows that `before_task_publish_handler` runs in the _same_ process, not the _worker_ process, like all the other handlers do.

Also, there's a slim race condition that I fixed, the transaction hasn't committed, but the task was dispatched.  A fast enough worker could race and not see the tags applied yet.

Closes #12699 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
