### PR TITLE
Fix (dev): respect base path for pdf worker js

### DIFF
--- a/src-ui/src/app/app.component.ts
+++ b/src-ui/src/app/app.component.ts
@@ -41,7 +41,10 @@ export class AppComponent implements OnInit, OnDestroy {
 
   constructor() {
     let anyWindow = window as any
-    anyWindow.pdfWorkerSrc = 'assets/js/pdf.worker.min.mjs'
+    anyWindow.pdfWorkerSrc = new URL(
+      'assets/js/pdf.worker.min.mjs',
+      document.baseURI
+    ).toString()
     this.settings.updateAppearanceSettings()
   }
 

--- a/src-ui/src/app/components/common/pdf-viewer/pdf-viewer.component.spec.ts
+++ b/src-ui/src/app/components/common/pdf-viewer/pdf-viewer.component.spec.ts
@@ -9,6 +9,15 @@ describe('PngxPdfViewerComponent', () => {
   let fixture: ComponentFixture<PngxPdfViewerComponent>
   let component: PngxPdfViewerComponent
 
+  const setBaseHref = (href: string) => {
+    let base = document.querySelector('base')
+    if (!base) {
+      base = document.createElement('base')
+      document.head.appendChild(base)
+    }
+    base.setAttribute('href', href)
+  }
+
   const initComponent = async (src = 'test.pdf') => {
     component.src = src
     fixture.detectChanges()
@@ -24,6 +33,10 @@ describe('PngxPdfViewerComponent', () => {
     component = fixture.componentInstance
   })
 
+  afterEach(() => {
+    setBaseHref('/')
+  })
+
   it('loads a document and emits events', async () => {
     const loadSpy = jest.fn()
     const renderedSpy = jest.fn()
@@ -33,7 +46,7 @@ describe('PngxPdfViewerComponent', () => {
     await initComponent()
 
     expect(pdfjs.GlobalWorkerOptions.workerSrc).toBe(
-      '/assets/js/pdf.worker.min.mjs'
+      new URL('assets/js/pdf.worker.min.mjs', document.baseURI).toString()
     )
     const isVisible = (component as any).findController.onIsPageVisible as
       | (() => boolean)
@@ -44,6 +57,19 @@ describe('PngxPdfViewerComponent', () => {
     )
     expect(renderedSpy).toHaveBeenCalled()
     expect((component as any).pdfViewer).toBeInstanceOf(PDFViewer)
+  })
+
+  it('resolves the worker source relative to the document base URI', async () => {
+    setBaseHref('/paperless/')
+
+    await initComponent()
+
+    expect(pdfjs.GlobalWorkerOptions.workerSrc).toBe(
+      new URL('assets/js/pdf.worker.min.mjs', document.baseURI).toString()
+    )
+    expect(pdfjs.GlobalWorkerOptions.workerSrc).toContain(
+      '/paperless/assets/js/pdf.worker.min.mjs'
+    )
   })
 
   it('initializes single-page viewer and disables text layer', async () => {

--- a/src-ui/src/app/components/common/pdf-viewer/pdf-viewer.component.ts
+++ b/src-ui/src/app/components/common/pdf-viewer/pdf-viewer.component.ts
@@ -1,8 +1,10 @@
 import {
   AfterViewInit,
   Component,
+  DOCUMENT,
   ElementRef,
   EventEmitter,
+  inject,
   Input,
   OnChanges,
   OnDestroy,
@@ -39,6 +41,8 @@ import {
 export class PngxPdfViewerComponent
   implements AfterViewInit, OnChanges, OnDestroy
 {
+  private readonly document = inject<Document>(DOCUMENT)
+
   @Input() src!: PdfSource
   @Input() page?: number
   @Output() pageChange = new EventEmitter<number>()
@@ -166,7 +170,10 @@ export class PngxPdfViewerComponent
     this.lastFindQuery = ''
     this.loadingTask?.destroy()
 
-    GlobalWorkerOptions.workerSrc = '/assets/js/pdf.worker.min.mjs'
+    GlobalWorkerOptions.workerSrc = new URL(
+      'assets/js/pdf.worker.min.mjs',
+      this.document.baseURI
+    ).toString()
     this.loadingTask = getDocument(this.src)
 
     try {


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Purely a frontend (dev) issue, tested and will go ahead and merge.

<img width="1662" height="1163" alt="Screenshot 2026-05-04 at 8 53 38 AM" src="https://github.com/user-attachments/assets/a67af70a-9c24-45ec-b5c1-13a9359f69f4" />

Closes #(issue or discussion)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
