### PR TITLE
Fix (dev): resolve tantivy search-filtered documents in bulk edit

### DIFF
--- a/src/documents/tests/test_api_bulk_edit.py
+++ b/src/documents/tests/test_api_bulk_edit.py
@@ -726,6 +726,26 @@ class TestBulkEditAPI(DirectoriesMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         get_backend.return_value.more_like_this_ids.assert_called_once()
 
+    def test_api_bulk_edit_with_all_true_rejects_multiple_filters(self) -> None:
+        response = self.client.post(
+            "/api/documents/bulk_edit/",
+            json.dumps(
+                {
+                    "all": True,
+                    "filters": {
+                        "text": "B",
+                        "query": "c1",
+                    },
+                    "method": "set_storage_path",
+                    "parameters": {"storage_path": self.sp1.id},
+                },
+            ),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn(b"Specify only one of", response.content)
+
     def test_api_bulk_edit_with_all_true_rejects_unsupported_methods(self) -> None:
         response = self.client.post(
             "/api/documents/bulk_edit/",

--- a/src/documents/tests/test_api_bulk_edit.py
+++ b/src/documents/tests/test_api_bulk_edit.py
@@ -683,7 +683,6 @@ class TestBulkEditAPI(DirectoriesMixin, APITestCase):
         for filters in (
             {"text": "new doc 2017-03-16"},
             {"title_search": "apple"},
-            {"more_like_id": self.doc2.id},
         ):
             with self.subTest(filters=filters):
                 get_backend.return_value.search_ids.return_value = [self.doc2.id]
@@ -709,6 +708,23 @@ class TestBulkEditAPI(DirectoriesMixin, APITestCase):
 
                 m.reset_mock()
                 get_backend.return_value.search_ids.reset_mock()
+
+        # more_like_id is a different path
+        get_backend.return_value.more_like_this_ids.return_value = [self.doc2.id]
+        response = self.client.post(
+            "/api/documents/bulk_edit/",
+            json.dumps(
+                {
+                    "all": True,
+                    "filters": {"more_like_id": self.doc1.id},
+                    "method": "set_storage_path",
+                    "parameters": {"storage_path": self.sp1.id},
+                },
+            ),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        get_backend.return_value.more_like_this_ids.assert_called_once()
 
     def test_api_bulk_edit_with_all_true_rejects_unsupported_methods(self) -> None:
         response = self.client.post(

--- a/src/documents/tests/test_api_bulk_edit.py
+++ b/src/documents/tests/test_api_bulk_edit.py
@@ -683,6 +683,7 @@ class TestBulkEditAPI(DirectoriesMixin, APITestCase):
         for filters in (
             {"text": "new doc 2017-03-16"},
             {"title_search": "apple"},
+            {"more_like_id": self.doc2.id},
         ):
             with self.subTest(filters=filters):
                 get_backend.return_value.search_ids.return_value = [self.doc2.id]

--- a/src/documents/tests/test_api_bulk_edit.py
+++ b/src/documents/tests/test_api_bulk_edit.py
@@ -671,6 +671,44 @@ class TestBulkEditAPI(DirectoriesMixin, APITestCase):
         self.assertEqual(args[0], [self.doc2.id])
         self.assertEqual(kwargs["storage_path"], self.sp1.id)
 
+    @mock.patch("documents.search.get_backend")
+    @mock.patch("documents.serialisers.bulk_edit.set_storage_path")
+    def test_api_bulk_edit_with_all_true_resolves_documents_from_search_filters(
+        self,
+        m,
+        get_backend,
+    ) -> None:
+        self.setup_mock(m, "set_storage_path")
+
+        for filters in (
+            {"text": "new doc 2017-03-16"},
+            {"title_search": "apple"},
+        ):
+            with self.subTest(filters=filters):
+                get_backend.return_value.search_ids.return_value = [self.doc2.id]
+
+                response = self.client.post(
+                    "/api/documents/bulk_edit/",
+                    json.dumps(
+                        {
+                            "all": True,
+                            "filters": filters,
+                            "method": "set_storage_path",
+                            "parameters": {"storage_path": self.sp1.id},
+                        },
+                    ),
+                    content_type="application/json",
+                )
+
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+                get_backend.return_value.search_ids.assert_called_once()
+                args, kwargs = m.call_args
+                self.assertEqual(args[0], [self.doc2.id])
+                self.assertEqual(kwargs["storage_path"], self.sp1.id)
+
+                m.reset_mock()
+                get_backend.return_value.search_ids.reset_mock()
+
     def test_api_bulk_edit_with_all_true_rejects_unsupported_methods(self) -> None:
         response = self.client.post(
             "/api/documents/bulk_edit/",

--- a/src/documents/tests/test_api_search.py
+++ b/src/documents/tests/test_api_search.py
@@ -1028,6 +1028,19 @@ class TestDocumentSearchApi(DirectoriesMixin, APITestCase):
         self.assertIn(d3.id, result_ids)
         self.assertNotIn(d4.id, result_ids)
 
+    def test_more_like_requires_id_of_existing_document(self) -> None:
+        """
+        GIVEN:
+            - No document with the given ID exists
+        WHEN:
+            - API request for more like a given document is made with a non-existent document ID
+        THEN:
+            - 403 Forbidden is returned with an appropriate error message
+        """
+        response = self.client.get("/api/documents/?more_like_id=9999")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.content, b"Invalid more_like_id")
+
     def test_search_more_like_requires_view_permission_on_seed_document(
         self,
     ) -> None:

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -263,6 +263,18 @@ _TANTIVY_INTERSECT_THRESHOLD = 5_000
 _TANTIVY_SEARCH_PARAM_NAMES = ("text", "title_search", "query", "more_like_id")
 
 
+def _get_tantivy_query_and_mode(params):
+    from documents.search import SearchMode
+
+    if "text" in params:
+        return str(params["text"]), SearchMode.TEXT
+    if "title_search" in params:
+        return str(params["title_search"]), SearchMode.TITLE
+    if "query" in params:
+        return str(params["query"]), SearchMode.QUERY
+    return None
+
+
 class IndexView(TemplateView):
     template_name = "index.html"
 
@@ -2187,7 +2199,6 @@ class UnifiedSearchViewSet(DocumentViewSet):
             return super().list(request)
 
         from documents.search import SearchHit
-        from documents.search import SearchMode
         from documents.search import TantivyBackend
         from documents.search import TantivyRelevanceList
         from documents.search import get_backend
@@ -2258,15 +2269,7 @@ class UnifiedSearchViewSet(DocumentViewSet):
             filtered_qs: QuerySet[Document],
         ) -> tuple[list[int], list[SearchHit], int]:
             """Handle text/title/query search: IDs, ORM intersection, page highlights."""
-            if "text" in request.query_params:
-                search_mode = SearchMode.TEXT
-                query_str = request.query_params["text"]
-            elif "title_search" in request.query_params:
-                search_mode = SearchMode.TITLE
-                query_str = request.query_params["title_search"]
-            else:
-                search_mode = SearchMode.QUERY
-                query_str = request.query_params["query"]
+            query_str, search_mode = _get_tantivy_query_and_mode(request.query_params)
 
             # "score" is not a real Tantivy sort field — it means relevance order,
             # which is Tantivy's default when no sort field is specified.
@@ -2531,7 +2534,6 @@ class DocumentSelectionMixin:
                 },
             )
 
-        from documents.search import SearchMode
         from documents.search import get_backend
 
         filter_name = search_filters[0]
@@ -2552,13 +2554,9 @@ class DocumentSelectionMixin:
 
             search_ids = backend.more_like_this_ids(more_like_doc_id, user=search_user)
         else:
-            search_mode = {
-                "text": SearchMode.TEXT,
-                "title_search": SearchMode.TITLE,
-                "query": SearchMode.QUERY,
-            }[filter_name]
+            query_str, search_mode = _get_tantivy_query_and_mode(filters)
             search_ids = backend.search_ids(
-                str(filters[filter_name]),
+                query_str,
                 user=search_user,
                 search_mode=search_mode,
             )

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -272,7 +272,7 @@ def _get_tantivy_query_and_mode(params):
         return str(params["title_search"]), SearchMode.TITLE
     if "query" in params:
         return str(params["query"]), SearchMode.QUERY
-    return None
+    return None  # pragma: no cover
 
 
 def _get_more_like_id(query_params: dict[str, Any], user: User | None) -> int:

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -2588,16 +2588,18 @@ class DocumentSelectionMixin:
             permission_codename,
             Document,
         )
+        # orm-filtered docs
         filtered_documents = DocumentFilterSet(
             data=orm_filters,
             queryset=permitted_documents,
         ).qs.distinct()
-        search_ids = self._get_search_document_ids(
+        # tantivy-filtered docs (if search params provided)
+        search_filtered_ids = self._get_search_document_ids(
             user=user,
             filters=filters,
         )
-        if search_ids is not None:
-            filtered_documents = filtered_documents.filter(pk__in=search_ids)
+        if search_filtered_ids is not None:
+            filtered_documents = filtered_documents.filter(pk__in=search_filtered_ids)
         return list(filtered_documents.values_list("pk", flat=True))
 
 

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -275,6 +275,25 @@ def _get_tantivy_query_and_mode(params):
     return None
 
 
+def _get_more_like_id(query_params: dict[str, Any], user: User) -> int:
+    try:
+        more_like_doc_id = int(query_params["more_like_id"])
+        more_like_doc = Document.objects.select_related("owner").get(
+            pk=more_like_doc_id,
+        )
+    except (TypeError, ValueError, Document.DoesNotExist):
+        raise PermissionDenied(_("Invalid more_like_id"))
+
+    if not has_perms_owner_aware(
+        user,
+        "view_document",
+        more_like_doc,
+    ):
+        raise PermissionDenied(_("Insufficient permissions."))
+
+    return more_like_doc_id
+
+
 class IndexView(TemplateView):
     template_name = "index.html"
 
@@ -2309,20 +2328,7 @@ class UnifiedSearchViewSet(DocumentViewSet):
             filtered_qs: QuerySet[Document],
         ) -> tuple[list[int], list[SearchHit], int]:
             """Handle more_like_id search: permission check, IDs, stub hits."""
-            try:
-                more_like_doc_id = int(request.query_params["more_like_id"])
-                more_like_doc = Document.objects.select_related("owner").get(
-                    pk=more_like_doc_id,
-                )
-            except (TypeError, ValueError, Document.DoesNotExist):
-                raise PermissionDenied(_("Invalid more_like_id"))
-
-            if not has_perms_owner_aware(
-                request.user,
-                "view_document",
-                more_like_doc,
-            ):
-                raise PermissionDenied(_("Insufficient permissions."))
+            more_like_doc_id = _get_more_like_id(request.query_params, user)
 
             all_ids = backend.more_like_this_ids(more_like_doc_id, user=user)
             ordered_ids = intersect_and_order(
@@ -2541,16 +2547,7 @@ class DocumentSelectionMixin:
         search_user = None if user.is_superuser else user
 
         if filter_name == "more_like_id":
-            try:
-                more_like_doc_id = int(filters[filter_name])
-                more_like_doc = Document.objects.select_related("owner").get(
-                    pk=more_like_doc_id,
-                )
-            except (TypeError, ValueError, Document.DoesNotExist):
-                raise PermissionDenied(_("Invalid more_like_id"))
-
-            if not has_perms_owner_aware(user, "view_document", more_like_doc):
-                raise PermissionDenied(_("Insufficient permissions."))
+            more_like_doc_id = _get_more_like_id(filters, user)
 
             search_ids = backend.more_like_this_ids(more_like_doc_id, user=search_user)
         else:

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -260,6 +260,7 @@ logger = logging.getLogger("paperless.api")
 # degrades on SQLite with thousands of parameters.  PostgreSQL handles large IN
 # clauses efficiently, so this threshold mainly protects SQLite users.
 _TANTIVY_INTERSECT_THRESHOLD = 5_000
+_TANTIVY_SEARCH_PARAM_NAMES = ("text", "title_search", "query", "more_like_id")
 
 
 class IndexView(TemplateView):
@@ -2165,8 +2166,6 @@ class ChatStreamingView(GenericAPIView[Any]):
     ),
 )
 class UnifiedSearchViewSet(DocumentViewSet):
-    SEARCH_PARAM_NAMES = ("text", "title_search", "query", "more_like_id")
-
     def get_serializer_class(self):
         if self._is_search_request():
             return SearchResultSerializer
@@ -2175,7 +2174,9 @@ class UnifiedSearchViewSet(DocumentViewSet):
     def _get_active_search_params(self, request: Request | None = None) -> list[str]:
         request = request or self.request
         return [
-            param for param in self.SEARCH_PARAM_NAMES if param in request.query_params
+            param
+            for param in _TANTIVY_SEARCH_PARAM_NAMES
+            if param in request.query_params
         ]
 
     def _is_search_request(self):
@@ -2508,8 +2509,6 @@ class SavedViewViewSet(BulkPermissionMixin, PassUserMixin, ModelViewSet[SavedVie
 
 
 class DocumentSelectionMixin:
-    SEARCH_FILTER_NAMES = ("text", "title_search", "query", "more_like_id")
-
     def _get_search_document_ids(
         self,
         *,
@@ -2518,7 +2517,7 @@ class DocumentSelectionMixin:
     ) -> list[int] | None:
         search_filters = [
             filter_name
-            for filter_name in self.SEARCH_FILTER_NAMES
+            for filter_name in _TANTIVY_SEARCH_PARAM_NAMES
             if filter_name in filters
         ]
         if not search_filters:
@@ -2582,7 +2581,7 @@ class DocumentSelectionMixin:
         orm_filters = {
             key: value
             for key, value in filters.items()
-            if key not in self.SEARCH_FILTER_NAMES
+            if key not in _TANTIVY_SEARCH_PARAM_NAMES
         }
         permitted_documents = get_objects_for_user_owner_aware(
             user,

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -2508,6 +2508,64 @@ class SavedViewViewSet(BulkPermissionMixin, PassUserMixin, ModelViewSet[SavedVie
 
 
 class DocumentSelectionMixin:
+    SEARCH_FILTER_NAMES = ("text", "title_search", "query", "more_like_id")
+
+    def _get_search_document_ids(
+        self,
+        *,
+        user: User,
+        filters: dict[str, Any],
+    ) -> list[int] | None:
+        search_filters = [
+            filter_name
+            for filter_name in self.SEARCH_FILTER_NAMES
+            if filter_name in filters
+        ]
+        if not search_filters:
+            return None
+        if len(search_filters) > 1:
+            raise ValidationError(
+                {
+                    "detail": _(
+                        "Specify only one of text, title_search, query, or more_like_id.",
+                    ),
+                },
+            )
+
+        from documents.search import SearchMode
+        from documents.search import get_backend
+
+        filter_name = search_filters[0]
+        backend = get_backend()
+        search_user = None if user.is_superuser else user
+
+        if filter_name == "more_like_id":
+            try:
+                more_like_doc_id = int(filters[filter_name])
+                more_like_doc = Document.objects.select_related("owner").get(
+                    pk=more_like_doc_id,
+                )
+            except (TypeError, ValueError, Document.DoesNotExist):
+                raise PermissionDenied(_("Invalid more_like_id"))
+
+            if not has_perms_owner_aware(user, "view_document", more_like_doc):
+                raise PermissionDenied(_("Insufficient permissions."))
+
+            search_ids = backend.more_like_this_ids(more_like_doc_id, user=search_user)
+        else:
+            search_mode = {
+                "text": SearchMode.TEXT,
+                "title_search": SearchMode.TITLE,
+                "query": SearchMode.QUERY,
+            }[filter_name]
+            search_ids = backend.search_ids(
+                str(filters[filter_name]),
+                user=search_user,
+                search_mode=search_mode,
+            )
+
+        return search_ids
+
     def _resolve_document_ids(
         self,
         *,
@@ -2521,19 +2579,27 @@ class DocumentSelectionMixin:
 
         # otherwise, reconstruct the document list based on the provided filters
         filters = validated_data.get("filters") or {}
+        orm_filters = {
+            key: value
+            for key, value in filters.items()
+            if key not in self.SEARCH_FILTER_NAMES
+        }
         permitted_documents = get_objects_for_user_owner_aware(
             user,
             permission_codename,
             Document,
         )
-        return list(
-            DocumentFilterSet(
-                data=filters,
-                queryset=permitted_documents,
-            )
-            .qs.distinct()
-            .values_list("pk", flat=True),
+        filtered_documents = DocumentFilterSet(
+            data=orm_filters,
+            queryset=permitted_documents,
+        ).qs.distinct()
+        search_ids = self._get_search_document_ids(
+            user=user,
+            filters=filters,
         )
+        if search_ids is not None:
+            filtered_documents = filtered_documents.filter(pk__in=search_ids)
+        return list(filtered_documents.values_list("pk", flat=True))
 
 
 class DocumentOperationPermissionMixin(PassUserMixin, DocumentSelectionMixin):

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -275,7 +275,7 @@ def _get_tantivy_query_and_mode(params):
     return None
 
 
-def _get_more_like_id(query_params: dict[str, Any], user: User) -> int:
+def _get_more_like_id(query_params: dict[str, Any], user: User | None) -> int:
     try:
         more_like_doc_id = int(query_params["more_like_id"])
         more_like_doc = Document.objects.select_related("owner").get(
@@ -284,7 +284,7 @@ def _get_more_like_id(query_params: dict[str, Any], user: User) -> int:
     except (TypeError, ValueError, Document.DoesNotExist):
         raise PermissionDenied(_("Invalid more_like_id"))
 
-    if not has_perms_owner_aware(
+    if user and not has_perms_owner_aware(
         user,
         "view_document",
         more_like_doc,


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

This was caused by 566afdffcaaf90eb5a63ca9ae3d6f49128fb623c (in combination with the set of PRs that removed passing a long list of ids to bulk edit) which changed what the filter params could be, basically the 'new' tantivy params were getting stripped. So effectively, to bulk edit with `all: true`, we:

1. Pull out search keys: text, title_search, query, more_like_id.
2. Pass the remaining 'normal' (orm) filters into `DocumentFilterSet`.
3. If a tantivy search key exists, ask Tantivy for matching document IDs.
4. Intersect the Django queryset (with perms) with those Tantivy IDs.
5. Bulk edit only that final queryset’s IDs.

Sheesh.

Closes #(issue or discussion)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
