### PR TITLE
Fix: Clear ContentType/guardian caches

### DIFF
--- a/src/documents/management/commands/document_importer.py
+++ b/src/documents/management/commands/document_importer.py
@@ -30,6 +30,7 @@ from django.db.models import Model
 from django.db.models.signals import m2m_changed
 from django.db.models.signals import post_save
 from filelock import FileLock
+from guardian.shortcuts import clear_ct_cache
 
 from documents.file_handling import create_source_path_directory
 from documents.management.commands.base import PaperlessCommand
@@ -428,6 +429,12 @@ class Command(CryptMixin, PaperlessCommand):
             self.stdout.write(self.style.ERROR("Database import failed"))
             self.stdout.write(self.style.ERROR(self._import_error_context_message()))
             raise
+
+        # ContentType/Permission rows were deleted and reinserted above; stale
+        # in-process caches must be invalidated so permission checks use the
+        # new IDs rather than pre-import PKs.
+        ContentType.objects.clear_cache()
+        clear_ct_cache()
 
     def handle(self, *args, **options) -> None:
         logging.getLogger().handlers[0].level = logging.ERROR

--- a/src/documents/tests/conftest.py
+++ b/src/documents/tests/conftest.py
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING
 import filelock
 import pytest
 from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
+from guardian.shortcuts import clear_ct_cache
 from pytest_django.fixtures import SettingsWrapper
 from rest_framework.test import APIClient
 
@@ -156,6 +158,19 @@ def user_client(rest_api_client: APIClient, regular_user: UserModelT) -> APIClie
     rest_api_client.force_authenticate(user=regular_user)
     rest_api_client.credentials(HTTP_ACCEPT="application/json; version=10")
     return rest_api_client
+
+
+@pytest.fixture(autouse=True)
+def _clear_content_type_caches() -> None:
+    """Clear Django's ContentType cache and guardian's lru_cache before each test.
+
+    Tests that delete and reinsert ContentType/Permission rows (e.g. the
+    importer) corrupt both caches. Without this fixture a subsequent test on
+    the same xdist worker sees stale ContentType objects and guardian raises
+    MixedContentTypeError.
+    """
+    ContentType.objects.clear_cache()
+    clear_ct_cache()
 
 
 @pytest.fixture(scope="session", autouse=True)


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

<!--
⚠️ Important: Pull requests that implement a new feature or enhancement *should almost always target an existing feature request* with evidence of community interest and discussion. This is in order to balance the work of implementing and maintaining new features / enhancements. If that is not currently the case, please open a feature request instead of this PR to gather feedback from both users and the project maintainers.
-->

A side effect from the removal of loaddata, with enough test workers, random tests might report `guardian.exceptions.MixedContentTypeError: Content type for given perms and klass differs`.

A two part fix, clear on the import, but also clear in an autouse fixture to be sure everything is fresh.  Basically, there's the DB, then there's some caching layers, and those cache parts weren't being cleared.

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
