### PR TITLE
Fix: create LLM_INDEX_DIR before writing meta.json on first run

### DIFF
--- a/src/paperless_ai/indexing.py
+++ b/src/paperless_ai/indexing.py
@@ -64,6 +64,7 @@ def get_or_create_storage_context(*, rebuild=False):
         settings.LLM_INDEX_DIR.mkdir(parents=True, exist_ok=True)
 
     if rebuild or not settings.LLM_INDEX_DIR.exists():
+        settings.LLM_INDEX_DIR.mkdir(parents=True, exist_ok=True)
         import faiss
         from llama_index.core import StorageContext
         from llama_index.core.storage.docstore import SimpleDocumentStore

--- a/src/paperless_ai/indexing.py
+++ b/src/paperless_ai/indexing.py
@@ -64,13 +64,13 @@ def get_or_create_storage_context(*, rebuild=False):
         settings.LLM_INDEX_DIR.mkdir(parents=True, exist_ok=True)
 
     if rebuild or not settings.LLM_INDEX_DIR.exists():
-        settings.LLM_INDEX_DIR.mkdir(parents=True, exist_ok=True)
         import faiss
         from llama_index.core import StorageContext
         from llama_index.core.storage.docstore import SimpleDocumentStore
         from llama_index.core.storage.index_store import SimpleIndexStore
         from llama_index.vector_stores.faiss import FaissVectorStore
 
+        settings.LLM_INDEX_DIR.mkdir(parents=True, exist_ok=True)
         embedding_dim = get_embedding_dim()
         faiss_index = faiss.IndexFlatL2(embedding_dim)
         vector_store = FaissVectorStore(faiss_index=faiss_index)


### PR DESCRIPTION
## Summary

- `get_embedding_dim()` writes `meta.json` into `LLM_INDEX_DIR`, but on a fresh install that directory doesn't exist yet
- The `mkdir` call in `get_or_create_storage_context` only ran when `rebuild=True`, leaving the non-rebuild first-run path without the directory
- Added `settings.LLM_INDEX_DIR.mkdir(parents=True, exist_ok=True)` at the top of the `if rebuild or not settings.LLM_INDEX_DIR.exists():` block so the directory is always created before `get_embedding_dim()` is called

🤖 Generated with [Claude Code](https://claude.com/claude-code)