### PR TITLE
Fix: Don't embed the metadata which is already embedded into the context

### DIFF
--- a/src/paperless_ai/indexing.py
+++ b/src/paperless_ai/indexing.py
@@ -116,7 +116,15 @@ def build_document_node(document: Document) -> list["BaseNode"]:
     from llama_index.core import Document as LlamaDocument
     from llama_index.core.node_parser import SimpleNodeParser
 
-    doc = LlamaDocument(text=text, metadata=metadata)
+    # Exclude all metadata keys from the embedding text — build_llm_index_text
+    # already encodes this info in the body, so prepending it again would double
+    # the token count and exceed embedding models with small context windows
+    # (e.g. nomic-embed-text via Ollama defaults to num_ctx=2048).
+    doc = LlamaDocument(
+        text=text,
+        metadata=metadata,
+        excluded_embed_metadata_keys=list(metadata.keys()),
+    )
     parser = SimpleNodeParser(
         chunk_size=RAG_CHUNK_SIZE,
         chunk_overlap=get_rag_chunk_overlap(),

--- a/src/paperless_ai/tests/test_ai_indexing.py
+++ b/src/paperless_ai/tests/test_ai_indexing.py
@@ -59,6 +59,26 @@ def test_build_document_node(real_document) -> None:
 
 
 @pytest.mark.django_db
+def test_build_document_node_excludes_metadata_from_embedding(real_document) -> None:
+    """Metadata keys must not be prepended to the embedding text.
+
+    build_llm_index_text already encodes all metadata in the body text, so
+    including it again via llama_index's default MetadataMode.EMBED would
+    double the token count and exceed embedding models with small context
+    windows (e.g. nomic-embed-text via Ollama defaults to num_ctx=2048).
+    """
+    from llama_index.core.schema import MetadataMode
+
+    nodes = indexing.build_document_node(real_document)
+    for node in nodes:
+        embed_text = node.get_content(metadata_mode=MetadataMode.EMBED)
+        for key in node.metadata:
+            assert key not in embed_text, (
+                f"Metadata key '{key}' should not appear in embedding text"
+            )
+
+
+@pytest.mark.django_db
 def test_build_document_node_uses_rag_chunk_settings(real_document) -> None:
     with patch("llama_index.core.node_parser.SimpleNodeParser") as mock_parser:
         mock_parser.return_value.get_nodes_from_documents.return_value = []


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

<!--
⚠️ Important: Pull requests that implement a new feature or enhancement *should almost always target an existing feature request* with evidence of community interest and discussion. This is in order to balance the work of implementing and maintaining new features / enhancements. If that is not currently the case, please open a feature request instead of this PR to gather feedback from both users and the project maintainers.
-->

The text we build already includes the metadata, but LlamaDocument will also embed the metadata, leading to both doubled information and the chance to go over RAG_CHUNK_SIZE

Closes #12791

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
