### PR TITLE
docs: add authentik OIDC example to SOCIALACCOUNT_PROVIDERS

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -707,6 +707,33 @@ for a list of provider configurations. You will also need to include the relevan
 : For OpenID Connect providers, set `settings.token_auth_method` if your identity provider
 requires a specific token endpoint authentication method.
 
+: Example using authentik as an OpenID Connect provider:
+
+    ```yaml
+    # docker-compose environment variable
+    PAPERLESS_APPS: allauth.socialaccount.providers.openid_connect
+    PAPERLESS_SOCIALACCOUNT_PROVIDERS: >
+        {
+          "openid_connect": {
+            "OAUTH_PKCE_ENABLED": true,
+            "SCOPE": ["openid", "profile", "email"],
+            "APPS": [
+              {
+                "provider_id": "authentik",
+                "name": "authentik",
+                "client_id": "<client_id>",
+                "secret": "<client_secret>",
+                "settings": {
+                  "server_url": "https://authentik.example.com/application/o/<application_slug>/.well-known/openid-configuration",
+                  "fetch_userinfo": true
+                }
+              }
+            ]
+          }
+        }
+    PAPERLESS_LOGOUT_REDIRECT_URL: "https://authentik.example.com/application/o/<application_slug>/end-session/"
+    ```
+
     Defaults to None, which does not enable any third party authentication systems.
 
 #### [`PAPERLESS_SOCIAL_AUTO_SIGNUP=<bool>`](#PAPERLESS_SOCIAL_AUTO_SIGNUP) {#PAPERLESS_SOCIAL_AUTO_SIGNUP}


### PR DESCRIPTION
## What does this change?

Adds a concrete example to the `PAPERLESS_SOCIALACCOUNT_PROVIDERS` configuration reference showing how to configure authentik as an OpenID Connect provider.

## Why?

The current docs link to django-allauth's provider reference but don't show a working example. Setting up OIDC with a self-hosted IdP like authentik requires knowing the exact JSON structure, the correct `server_url` format (discovery endpoint URL), and which companion variables to set (`PAPERLESS_APPS`, `PAPERLESS_LOGOUT_REDIRECT_URL`). This trips up a lot of users who end up searching GitHub issues or asking in Discord.

The example format is taken from [authentik's own integration guide for Paperless-ngx](https://docs.goauthentik.io/integrations/services/paperless-ngx/) to ensure consistency.

## Testing

Verified against a working authentik + Paperless-ngx setup. The `server_url` should point to the OIDC discovery endpoint (`/.well-known/openid-configuration`), and `OAUTH_PKCE_ENABLED: true` is needed for authentik's default flow.