### PR TITLE
Refactor DB startup wait to readiness polling in installer

### DIFF
--- a/install-paperless-ngx.sh
+++ b/install-paperless-ngx.sh
@@ -85,6 +85,35 @@ fi
 
 set -e
 
+wait_for_db_ready() {
+	local -r max_wait_seconds=90
+	local -r wait_interval_seconds=3
+	local elapsed_seconds=0
+
+	echo "Waiting for database to become ready (timeout: ${max_wait_seconds}s)..."
+
+	while (( elapsed_seconds < max_wait_seconds )); do
+		if [[ "$DATABASE_BACKEND" == "postgres" ]] ; then
+			if docker compose exec -T db pg_isready --username paperless &> /dev/null ; then
+				echo "Database is ready."
+				return
+			fi
+		elif [[ "$DATABASE_BACKEND" == "mariadb" ]] ; then
+			if docker compose exec -T db mariadb-admin --skip-ssl ping --silent &> /dev/null ; then
+				echo "Database is ready."
+				return
+			fi
+		fi
+
+		sleep "$wait_interval_seconds"
+		elapsed_seconds=$((elapsed_seconds + wait_interval_seconds))
+	done
+
+	echo "Database was not ready after ${max_wait_seconds}s."
+	echo "Please check your Docker logs and try again."
+	exit 1
+}
+
 echo ""
 echo "#############################################"
 echo "###   paperless-ngx docker installation   ###"
@@ -397,8 +426,7 @@ docker compose pull
 if [ "$DATABASE_BACKEND" == "postgres" ] || [ "$DATABASE_BACKEND" == "mariadb" ] ; then
 	echo "Starting DB first for initialization"
 	docker compose up --detach db
-	# hopefully enough time for even the slower systems
-	sleep 15
+	wait_for_db_ready
 	docker compose stop
 fi
 


### PR DESCRIPTION
Replace the fixed database startup sleep with an active readiness loop to reduce unnecessary wait time while keeping slow systems reliable.

Add a database readiness function with configurable timeout and poll interval. Start DB container, then poll every few seconds until it reports ready. Use pg_isready for PostgreSQL and mariadb-admin ping for MariaDB. Exit early as soon as DB is ready instead of always waiting a fixed duration. Fail with a clear timeout error if readiness is not reached within the limit. This improves install speed on fast hosts and avoids brittle fixed-delay behavior.

Used GPT-5.3-Codex in Github copilot. 

Prompt was: "sleep 15 was too little, and sleep 120 is probably overkill. How do i figure out a good compromise? Or is there a way to insert a ping and if still busy, sleep again?"

Start of response: 
I’m going to replace the fixed wait with a readiness loop so startup is fast on quick systems but still reliable on slow ones; first I’ll confirm what DB readiness signals are available in this script and compose setup.

I found a better pattern already used elsewhere in this repo: poll DB readiness with a timeout. I’m now patching the installer to replace the hardcoded 120-second sleep with a retry loop that checks PostgreSQL/MariaDB health every few seconds.

[...]

<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

<!--
⚠️ Important: Pull requests that implement a new feature or enhancement *should almost always target an existing feature request* with evidence of community interest and discussion. This is in order to balance the work of implementing and maintaining new features / enhancements. If that is not currently the case, please open a feature request instead of this PR to gather feedback from both users and the project maintainers.
-->

Closes #12809 and resolves the issues reported in #4033 and #6337

## Type of change

Decided to call it a feature since not everyone has this issue, but it solves it for those with the problem that the database had not yet initialized before the next step of install started. 

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [] Bug fix: non-breaking change which fixes an issue.
- [X] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [X] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
