### PR TITLE
Fix: Defer password removal workflow action until the file is in place

### DIFF
--- a/src/documents/tests/test_workflows.py
+++ b/src/documents/tests/test_workflows.py
@@ -4301,10 +4301,11 @@ class TestWorkflows(
             title="Protected",
         )
 
-        document_consumption_finished.send(
-            sender=self.__class__,
-            document=doc,
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            document_consumption_finished.send(
+                sender=self.__class__,
+                document=doc,
+            )
 
         assert mock_remove_password.call_count == 2
         mock_remove_password.assert_has_calls(
@@ -4325,11 +4326,63 @@ class TestWorkflows(
         )
 
         # ensure handler disconnected after first run
-        document_consumption_finished.send(
-            sender=self.__class__,
-            document=doc,
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            document_consumption_finished.send(
+                sender=self.__class__,
+                document=doc,
+            )
         assert mock_remove_password.call_count == 2
+
+    @mock.patch("documents.bulk_edit.remove_password")
+    def test_password_removal_deferred_until_transaction_commit(
+        self,
+        mock_remove_password,
+    ) -> None:
+        """
+        GIVEN:
+            - Workflow password removal action triggered during consumption
+            - document_consumption_finished signal fires inside a transaction
+        WHEN:
+            - Signal fires but transaction has not yet committed
+        THEN:
+            - Password removal is not attempted until the transaction commits
+        """
+        from django.db import transaction
+
+        action = WorkflowAction.objects.create(
+            type=WorkflowAction.WorkflowActionType.PASSWORD_REMOVAL,
+            passwords=["secret"],
+        )
+
+        temp_dir = Path(tempfile.mkdtemp())
+        original_file = temp_dir / "file.pdf"
+        original_file.write_bytes(b"pdf content")
+        consumable = ConsumableDocument(
+            source=DocumentSource.ApiUpload,
+            original_file=original_file,
+        )
+
+        execute_password_removal_action(action, consumable, logging_group=None)
+
+        doc = Document.objects.create(
+            checksum="pw-checksum-on-commit",
+            title="Protected",
+        )
+
+        with self.captureOnCommitCallbacks(execute=True):
+            with transaction.atomic():
+                document_consumption_finished.send(
+                    sender=self.__class__,
+                    document=doc,
+                )
+                mock_remove_password.assert_not_called()
+
+        mock_remove_password.assert_called_once_with(
+            [doc.id],
+            password="secret",
+            update_document=True,
+            user=doc.owner,
+        )
 
     def test_workflow_trash_action_soft_delete(self) -> None:
         """

--- a/src/documents/workflows/actions.py
+++ b/src/documents/workflows/actions.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from django.conf import settings
 from django.contrib.auth.models import User
+from django.db import transaction
 from django.utils import timezone
 
 from documents.data_models import ConsumableDocument
@@ -295,13 +296,15 @@ def execute_password_removal_action(
         # hook the consumption-finished signal to attempt password removal later
         def handler(sender, **kwargs):
             consumed_document: Document = kwargs.get("document")
-            if consumed_document is not None:
-                execute_password_removal_action(
-                    action,
-                    consumed_document,
-                    logging_group,
-                )
             document_consumption_finished.disconnect(handler)
+            if consumed_document is not None:
+                transaction.on_commit(
+                    lambda: execute_password_removal_action(
+                        action,
+                        consumed_document,
+                        logging_group,
+                    ),
+                )
 
         document_consumption_finished.connect(handler, weak=False)
         return


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

<!--
⚠️ Important: Pull requests that implement a new feature or enhancement *should almost always target an existing feature request* with evidence of community interest and discussion. This is in order to balance the work of implementing and maintaining new features / enhancements. If that is not currently the case, please open a feature request instead of this PR to gather feedback from both users and the project maintainers.
-->

I think it's a little nicer to not thread a path through a call chain, then decide which path to use

Closes #12803 

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
