### PR TITLE
Feature: add COMBINED consumption_scope for body + attachments as one document

### DIFF
--- a/src-ui/src/app/components/common/edit-dialog/mail-rule-edit-dialog/mail-rule-edit-dialog.component.ts
+++ b/src-ui/src/app/components/common/edit-dialog/mail-rule-edit-dialog/mail-rule-edit-dialog.component.ts
@@ -56,6 +56,10 @@ const CONSUMPTION_SCOPE_OPTIONS = [
     id: MailRuleConsumptionScope.Everything,
     name: $localize`Process message as .eml and attachments separately`,
   },
+  {
+    id: MailRuleConsumptionScope.Combined,
+    name: $localize`Process body + attachments as a single document`,
+  },
 ]
 
 const PDF_LAYOUT_OPTIONS = [

--- a/src-ui/src/app/data/mail-rule.ts
+++ b/src-ui/src/app/data/mail-rule.ts
@@ -9,6 +9,7 @@ export enum MailRuleConsumptionScope {
   Attachments = 1,
   EmailOnly = 2,
   Everything = 3,
+  Combined = 4,
 }
 
 export enum MailRulePdfLayout {

--- a/src/paperless_mail/mail.py
+++ b/src/paperless_mail/mail.py
@@ -737,7 +737,13 @@ class MailAccountHandler(LoggingMixin):
         if (
             rule.consumption_scope == MailRule.ConsumptionScope.EML_ONLY
             or rule.consumption_scope == MailRule.ConsumptionScope.EVERYTHING
+            or rule.consumption_scope == MailRule.ConsumptionScope.COMBINED
         ):
+            # COMBINED, like EML_ONLY, hands the full message to the parser as
+            # a single .eml. The semantic difference is intent: COMBINED is
+            # for parsers that render body + attachments into one merged
+            # document; EML_ONLY stores the raw .eml verbatim. Attachments
+            # are not re-extracted as separate documents in either case.
             processed_elements += self._process_eml(
                 message,
                 rule,

--- a/src/paperless_mail/migrations/0004_alter_mailrule_consumption_scope.py
+++ b/src/paperless_mail/migrations/0004_alter_mailrule_consumption_scope.py
@@ -1,0 +1,36 @@
+# Generated to add ConsumptionScope.COMBINED choice.
+
+from django.db import migrations
+from django.db import models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("paperless_mail", "0003_mailrule_stop_processing"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="mailrule",
+            name="consumption_scope",
+            field=models.PositiveSmallIntegerField(
+                choices=[
+                    (1, "Only process attachments."),
+                    (
+                        2,
+                        "Process full Mail (with embedded attachments in file) as .eml",
+                    ),
+                    (
+                        3,
+                        "Process full Mail (with embedded attachments in file) as .eml + process attachments as separate documents",
+                    ),
+                    (
+                        4,
+                        "Process body + attachments merged into a single document (parser is expected to merge attachments into the body)",
+                    ),
+                ],
+                default=1,
+                verbose_name="consumption scope",
+            ),
+        ),
+    ]

--- a/src/paperless_mail/models.py
+++ b/src/paperless_mail/models.py
@@ -110,6 +110,13 @@ class MailRule(document_models.ModelWithOwner):
                 "+ process attachments as separate documents",
             ),
         )
+        COMBINED = (
+            4,
+            _(
+                "Process body + attachments merged into a single document "
+                "(parser is expected to merge attachments into the body)",
+            ),
+        )
 
     class AttachmentProcessing(models.IntegerChoices):
         ATTACHMENTS_ONLY = 1, _("Only process attachments.")

--- a/src/paperless_mail/tests/test_mail.py
+++ b/src/paperless_mail/tests/test_mail.py
@@ -533,6 +533,80 @@ class TestMail(
             ],
         )
 
+    def test_handle_message_consumption_scope_combined(self) -> None:
+        """COMBINED routes the full mail through _process_eml as a single
+        document (parser is expected to merge body + attachments); the
+        per-attachment path is NOT taken so attachments do not become
+        separate documents."""
+        message = self.mailMocker.messageBuilder.create_message(
+            subject="combined-scope mail",
+            from_="Myself",
+            attachments=2,
+        )
+
+        account = MailAccount.objects.create()
+        rule = MailRule(
+            assign_title_from=MailRule.TitleSource.FROM_FILENAME,
+            account=account,
+            consumption_scope=MailRule.ConsumptionScope.COMBINED,
+        )
+        rule.save()
+
+        with (
+            mock.patch.object(
+                self.mail_account_handler,
+                "_process_eml",
+                return_value=1,
+            ) as eml_mock,
+            mock.patch.object(
+                self.mail_account_handler,
+                "_process_attachments",
+                return_value=0,
+            ) as att_mock,
+        ):
+            result = self.mail_account_handler._handle_message(message, rule)
+
+        self.assertEqual(result, 1)
+        eml_mock.assert_called_once()
+        att_mock.assert_not_called()
+
+    def test_handle_message_consumption_scope_combined_no_attachments(self) -> None:
+        """COMBINED on a body-only message (no attachments) still routes
+        through _process_eml so the body becomes a document. Unlike
+        ATTACHMENTS_ONLY, COMBINED does not short-circuit when there are
+        no attachments."""
+        message = self.mailMocker.messageBuilder.create_message(
+            subject="combined-scope body-only",
+            from_="Myself",
+            attachments=0,
+        )
+
+        account = MailAccount.objects.create()
+        rule = MailRule(
+            assign_title_from=MailRule.TitleSource.FROM_SUBJECT,
+            account=account,
+            consumption_scope=MailRule.ConsumptionScope.COMBINED,
+        )
+        rule.save()
+
+        with (
+            mock.patch.object(
+                self.mail_account_handler,
+                "_process_eml",
+                return_value=1,
+            ) as eml_mock,
+            mock.patch.object(
+                self.mail_account_handler,
+                "_process_attachments",
+                return_value=0,
+            ) as att_mock,
+        ):
+            result = self.mail_account_handler._handle_message(message, rule)
+
+        self.assertEqual(result, 1)
+        eml_mock.assert_called_once()
+        att_mock.assert_not_called()
+
     def test_handle_empty_message(self) -> None:
         message = namedtuple("MailMessage", [])
 


### PR DESCRIPTION
## Proposed change

Adds a fourth value to `MailRule.ConsumptionScope` — `COMBINED` — for the workflow where a mail's body and its attachments should land in paperless as **one** rendered document, not as a separate `.eml` plus N independent attachments.

The mail handler routes `COMBINED` through `_process_eml` (the same path EML_ONLY uses), so the full `.eml` is handed to whatever parser is registered for `message/rfc822`. The parser is then expected to do the merge — render the body, convert attachments, concatenate into one PDF, etc. Attachments are NOT extracted as separate documents the way `EVERYTHING` does it.

The semantic difference vs `EML_ONLY`:

| Value | Mail-handler behaviour | Intended downstream |
| --- | --- | --- |
| `EML_ONLY` | hands the `.eml` to the parser | "store the raw `.eml`" workflows |
| `COMBINED` | hands the `.eml` to the parser | "merge body + attachments into one rendered document" workflows |

Both call the same parser entry point; the value of having two enum values is the user-facing label in the rule editor. Today, users who want the "merged document" workflow have to pick `EML_ONLY` and rely on their parser plugin's docs to explain that's what they actually wanted. `COMBINED` lets the rule editor describe the workflow the user is actually after.

This was filed against discussion [#12813](https://github.com/paperless-ngx/paperless-ngx/discussions/12813) (Feature Request, 1 external upvote at time of PR).

Marked as **Draft** because this is speculative — opening it gives you something concrete to evaluate alongside the discussion. Happy to close and stay in the discussion if you'd rather shape the design there first.

Closes #12813

## Type of change

- [x] New feature / Enhancement: non-breaking change which adds functionality.

The change is additive — existing rules continue to behave exactly as before. The enum value, the migration, the mail-handler branch, and the frontend option are all additive; nothing is renamed or repurposed.

## Files

**Backend**
- `src/paperless_mail/models.py` — `ConsumptionScope.COMBINED = 4`
- `src/paperless_mail/mail.py` — `_handle_message` includes `COMBINED` in the `_process_eml` branch; comment explains intent vs `EML_ONLY`
- `src/paperless_mail/migrations/0004_alter_mailrule_consumption_scope.py` — Django migration adding the new choice (format matches `0002_optimize_integer_field_sizes.py`)

**Tests**
- `src/paperless_mail/tests/test_mail.py` — two new `TestMail` cases:
  - `test_handle_message_consumption_scope_combined` — mail with attachments under `COMBINED` calls `_process_eml` once, `_process_attachments` zero times
  - `test_handle_message_consumption_scope_combined_no_attachments` — body-only mail under `COMBINED` still calls `_process_eml` (does not short-circuit like `ATTACHMENTS_ONLY` would)

**Frontend**
- `src-ui/src/app/data/mail-rule.ts` — `Combined = 4` on `MailRuleConsumptionScope`
- `src-ui/src/app/components/common/edit-dialog/mail-rule-edit-dialog/mail-rule-edit-dialog.component.ts` — fourth entry on `CONSUMPTION_SCOPE_OPTIONS` with the user-facing label

## Testing

Locally I ran:

- `ruff check` on the four modified Python files → all checks passed
- `ruff format --check` on the same → all already formatted
- `python -m py_compile` on each → no syntax errors

I did **not** run `pytest` against the full paperless-ngx suite — my dev environment doesn't have the full backend stack (sentence-transformers, sqlite-vec, etc.) set up, so I can't honestly claim a green run. The new test cases follow the existing patterns in `test_mail.py` (parallel to `test_handle_message`, using the same `mailMocker.messageBuilder.create_message` fixture and the same `_handle_message` call surface), and the changes are scoped tightly to the enum + the if-branch. CI will be authoritative.

## Checklist

- [x] I have read & agree with the contributing guidelines.
- [x] If applicable, I have included testing coverage for new code in this PR, for backend and / or front-end changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers — front-end change is a single dropdown option added to the existing list; no new component, no layout change.
- [ ] If applicable, I have checked that all tests pass — disclosed above, the new tests follow existing patterns but I did not run the full suite locally.
- [ ] I have run all Git `pre-commit` hooks — I have not; the contributing docs reference a development setup I'm not running. Ruff is clean.
- [x] I have made corresponding changes to the documentation as needed — no doc changes; the rule editor's dropdown label is the user-facing surface.
- [x] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR — drafted with Claude Code as a pair-programming assistant; the implementation follows the existing patterns in the file (enum extension, the parallel `mail.py` if-branch, `0002`-style migration).

I appreciate what you've built. I hope this small contribution provides value for others.