### PR TITLE
Feature: add COMBINED consumption_scope for body + attachments as one document

### DIFF
--- a/src-ui/src/app/components/common/edit-dialog/mail-rule-edit-dialog/mail-rule-edit-dialog.component.ts
+++ b/src-ui/src/app/components/common/edit-dialog/mail-rule-edit-dialog/mail-rule-edit-dialog.component.ts
@@ -56,6 +56,10 @@ const CONSUMPTION_SCOPE_OPTIONS = [
     id: MailRuleConsumptionScope.Everything,
     name: $localize`Process message as .eml and attachments separately`,
   },
+  {
+    id: MailRuleConsumptionScope.Combined,
+    name: $localize`Process body + attachments as a single document`,
+  },
 ]
 
 const PDF_LAYOUT_OPTIONS = [

--- a/src-ui/src/app/data/mail-rule.ts
+++ b/src-ui/src/app/data/mail-rule.ts
@@ -9,6 +9,7 @@ export enum MailRuleConsumptionScope {
   Attachments = 1,
   EmailOnly = 2,
   Everything = 3,
+  Combined = 4,
 }
 
 export enum MailRulePdfLayout {

--- a/src/paperless_mail/mail.py
+++ b/src/paperless_mail/mail.py
@@ -737,7 +737,13 @@ class MailAccountHandler(LoggingMixin):
         if (
             rule.consumption_scope == MailRule.ConsumptionScope.EML_ONLY
             or rule.consumption_scope == MailRule.ConsumptionScope.EVERYTHING
+            or rule.consumption_scope == MailRule.ConsumptionScope.COMBINED
         ):
+            # COMBINED, like EML_ONLY, hands the full message to the parser as
+            # a single .eml. The semantic difference is intent: COMBINED is
+            # for parsers that render body + attachments into one merged
+            # document; EML_ONLY stores the raw .eml verbatim. Attachments
+            # are not re-extracted as separate documents in either case.
             processed_elements += self._process_eml(
                 message,
                 rule,

--- a/src/paperless_mail/migrations/0004_alter_mailrule_consumption_scope.py
+++ b/src/paperless_mail/migrations/0004_alter_mailrule_consumption_scope.py
@@ -1,0 +1,36 @@
+# Generated to add ConsumptionScope.COMBINED choice.
+
+from django.db import migrations
+from django.db import models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("paperless_mail", "0003_mailrule_stop_processing"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="mailrule",
+            name="consumption_scope",
+            field=models.PositiveSmallIntegerField(
+                choices=[
+                    (1, "Only process attachments."),
+                    (
+                        2,
+                        "Process full Mail (with embedded attachments in file) as .eml",
+                    ),
+                    (
+                        3,
+                        "Process full Mail (with embedded attachments in file) as .eml + process attachments as separate documents",
+                    ),
+                    (
+                        4,
+                        "Process body + attachments merged into a single document (parser is expected to merge attachments into the body)",
+                    ),
+                ],
+                default=1,
+                verbose_name="consumption scope",
+            ),
+        ),
+    ]

--- a/src/paperless_mail/models.py
+++ b/src/paperless_mail/models.py
@@ -110,6 +110,13 @@ class MailRule(document_models.ModelWithOwner):
                 "+ process attachments as separate documents",
             ),
         )
+        COMBINED = (
+            4,
+            _(
+                "Process body + attachments merged into a single document "
+                "(parser is expected to merge attachments into the body)",
+            ),
+        )
 
     class AttachmentProcessing(models.IntegerChoices):
         ATTACHMENTS_ONLY = 1, _("Only process attachments.")

--- a/src/paperless_mail/tests/test_mail.py
+++ b/src/paperless_mail/tests/test_mail.py
@@ -533,6 +533,80 @@ class TestMail(
             ],
         )
 
+    def test_handle_message_consumption_scope_combined(self) -> None:
+        """COMBINED routes the full mail through _process_eml as a single
+        document (parser is expected to merge body + attachments); the
+        per-attachment path is NOT taken so attachments do not become
+        separate documents."""
+        message = self.mailMocker.messageBuilder.create_message(
+            subject="combined-scope mail",
+            from_="Myself",
+            attachments=2,
+        )
+
+        account = MailAccount.objects.create()
+        rule = MailRule(
+            assign_title_from=MailRule.TitleSource.FROM_FILENAME,
+            account=account,
+            consumption_scope=MailRule.ConsumptionScope.COMBINED,
+        )
+        rule.save()
+
+        with (
+            mock.patch.object(
+                self.mail_account_handler,
+                "_process_eml",
+                return_value=1,
+            ) as eml_mock,
+            mock.patch.object(
+                self.mail_account_handler,
+                "_process_attachments",
+                return_value=0,
+            ) as att_mock,
+        ):
+            result = self.mail_account_handler._handle_message(message, rule)
+
+        self.assertEqual(result, 1)
+        eml_mock.assert_called_once()
+        att_mock.assert_not_called()
+
+    def test_handle_message_consumption_scope_combined_no_attachments(self) -> None:
+        """COMBINED on a body-only message (no attachments) still routes
+        through _process_eml so the body becomes a document. Unlike
+        ATTACHMENTS_ONLY, COMBINED does not short-circuit when there are
+        no attachments."""
+        message = self.mailMocker.messageBuilder.create_message(
+            subject="combined-scope body-only",
+            from_="Myself",
+            attachments=0,
+        )
+
+        account = MailAccount.objects.create()
+        rule = MailRule(
+            assign_title_from=MailRule.TitleSource.FROM_SUBJECT,
+            account=account,
+            consumption_scope=MailRule.ConsumptionScope.COMBINED,
+        )
+        rule.save()
+
+        with (
+            mock.patch.object(
+                self.mail_account_handler,
+                "_process_eml",
+                return_value=1,
+            ) as eml_mock,
+            mock.patch.object(
+                self.mail_account_handler,
+                "_process_attachments",
+                return_value=0,
+            ) as att_mock,
+        ):
+            result = self.mail_account_handler._handle_message(message, rule)
+
+        self.assertEqual(result, 1)
+        eml_mock.assert_called_once()
+        att_mock.assert_not_called()
+
     def test_handle_empty_message(self) -> None:
         message = namedtuple("MailMessage", [])
 


### PR DESCRIPTION
## Proposed change

Adds COMBINED to MailRule.ConsumptionScope (=4). COMBINED routes the message through the same code path as EML_ONLY (one .eml handed to the parser, no per-attachment extraction), but exposes a clearer user-facing label for the "body + attachments merged into one document" workflow that parser plugins like paperless-weasyprint implement. Existing rules unchanged.

Body-only messages under COMBINED still produce a document — no short-circuit like ATTACHMENTS_ONLY has.

Refile of #12827, tightened to match the anti-slop bot's prose limits. Same diff.

Closes #12813

## Type of change

- [x] New feature / Enhancement: non-breaking change which adds functionality.

## Files

Backend:
- src/paperless_mail/models.py — new enum value
- src/paperless_mail/mail.py — routing branch in `_handle_message`
- src/paperless_mail/migrations/0004_alter_mailrule_consumption_scope.py — choice migration following the 0002 pattern

Tests:
- src/paperless_mail/tests/test_mail.py — two new TestMail cases assert COMBINED routes through eml processing and not attachment processing, for messages with and without attachments

Frontend:
- src-ui/src/app/data/mail-rule.ts — Combined = 4 on the TS enum
- src-ui/src/app/components/common/edit-dialog/mail-rule-edit-dialog/mail-rule-edit-dialog.component.ts — fourth dropdown option

## Testing

ruff check + ruff format pass on the modified Python files; py_compile clean. Did not run the full pytest suite — dev env lacks the backend stack. The new tests follow the existing test_handle_message pattern.

## Checklist

- [x] Read & agree with the contributing guidelines.
- [x] Backend tests included.
- [x] No doc changes needed.
- [x] AI tool disclosure: drafted with Claude as pair-programmer; implementation follows existing patterns in each touched file.

I appreciate what you've built. I hope this small contribution provides value for others.