### PR TITLE
Fix: clamp integer fields during v3 migration

### DIFF
--- a/src/documents/migrations/0010_optimize_integer_field_sizes.py
+++ b/src/documents/migrations/0010_optimize_integer_field_sizes.py
@@ -5,6 +5,25 @@ from django.db import migrations
 from django.db import models
 
 
+def clamp_small_integer_fields(apps, schema_editor):
+    Workflow = apps.get_model("documents", "Workflow")
+    WorkflowAction = apps.get_model("documents", "WorkflowAction")
+    WorkflowTrigger = apps.get_model("documents", "WorkflowTrigger")
+
+    Workflow.objects.filter(order__gt=32767).update(order=32767)
+    Workflow.objects.filter(order__lt=-32768).update(order=-32768)
+    WorkflowAction.objects.filter(order__gt=32767).update(order=32767)
+    WorkflowTrigger.objects.filter(schedule_offset_days__gt=32767).update(
+        schedule_offset_days=32767,
+    )
+    WorkflowTrigger.objects.filter(schedule_offset_days__lt=-32768).update(
+        schedule_offset_days=-32768,
+    )
+    WorkflowTrigger.objects.filter(schedule_recurring_interval_days__gt=32767).update(
+        schedule_recurring_interval_days=32767,
+    )
+
+
 class Migration(migrations.Migration):
     dependencies = [
         ("documents", "0009_alter_document_content_length"),
@@ -135,6 +154,10 @@ class Migration(migrations.Migration):
                 default=1,
                 verbose_name="matching algorithm",
             ),
+        ),
+        migrations.RunPython(
+            clamp_small_integer_fields,
+            migrations.RunPython.noop,
         ),
         migrations.AlterField(
             model_name="workflow",


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

I agree the whole opener of the issue etc is odd but ultimately the possibility seems plausible and the fix relatively simple imho

Closes #12831

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
