### PR TITLE
Fix: use chord.on_error before apply_async

### DIFF
--- a/src/documents/bulk_edit.py
+++ b/src/documents/bulk_edit.py
@@ -676,9 +676,9 @@ def split(
                     chord(
                         header=consume_tasks,
                         body=delete.si([doc.id]),
-                    ).apply_async(
-                        link_error=[restore_archive_serial_numbers_task.s(backup)],
-                    )
+                    ).on_error(
+                        restore_archive_serial_numbers_task.s(backup),
+                    ).apply_async()
                 except Exception:
                     restore_archive_serial_numbers(backup)
                     raise
@@ -856,9 +856,9 @@ def edit_pdf(
                     chord(
                         header=consume_tasks,
                         body=delete.si([doc.id]),
-                    ).apply_async(
-                        link_error=[restore_archive_serial_numbers_task.s(backup)],
-                    )
+                    ).on_error(
+                        restore_archive_serial_numbers_task.s(backup),
+                    ).apply_async()
                 except Exception:
                     restore_archive_serial_numbers(backup)
                     raise

--- a/src/documents/tests/test_bulk_edit.py
+++ b/src/documents/tests/test_bulk_edit.py
@@ -945,6 +945,10 @@ class TestPDFActions(DirectoriesMixin, TestCase):
         pages = [[1, 2], [3]]
         self.doc2.archive_serial_number = 200
         self.doc2.save()
+        errback = bulk_edit.restore_archive_serial_numbers_task.s(
+            {self.doc2.id: 200},
+        )
+        mock_chord.return_value.on_error.return_value = mock_chord.return_value
 
         result = bulk_edit.split(doc_ids, pages, delete_originals=True)
         self.assertEqual(result, "OK")
@@ -957,6 +961,8 @@ class TestPDFActions(DirectoriesMixin, TestCase):
 
         mock_delete_documents.assert_called()
         mock_chord.assert_called_once()
+        mock_chord.return_value.on_error.assert_called_once_with(errback)
+        mock_chord.return_value.apply_async.assert_called_once_with()
 
         delete_documents_args, _ = mock_delete_documents.call_args
         self.assertEqual(
@@ -991,6 +997,7 @@ class TestPDFActions(DirectoriesMixin, TestCase):
         self.doc2.save()
 
         sig = mock.Mock()
+        sig.on_error.return_value = sig
         sig.apply_async.side_effect = Exception("boom")
         mock_chord.return_value = sig
 
@@ -1256,10 +1263,16 @@ class TestPDFActions(DirectoriesMixin, TestCase):
         operations = [{"page": 1}, {"page": 2}]
         self.doc2.archive_serial_number = 250
         self.doc2.save()
+        errback = bulk_edit.restore_archive_serial_numbers_task.s(
+            {self.doc2.id: 250},
+        )
+        mock_chord.return_value.on_error.return_value = mock_chord.return_value
 
         result = bulk_edit.edit_pdf(doc_ids, operations, delete_original=True)
         self.assertEqual(result, "OK")
         mock_chord.assert_called_once()
+        mock_chord.return_value.on_error.assert_called_once_with(errback)
+        mock_chord.return_value.apply_async.assert_called_once_with()
         self.assertEqual(mock_consume_file.call_args.kwargs["overrides"].asn, 250)
         self.doc2.refresh_from_db()
         self.assertIsNone(self.doc2.archive_serial_number)
@@ -1288,6 +1301,7 @@ class TestPDFActions(DirectoriesMixin, TestCase):
         self.doc2.save()
 
         sig = mock.Mock()
+        sig.on_error.return_value = sig
         sig.apply_async.side_effect = Exception("boom")
         mock_chord.return_value = sig
 


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

Closes #12840

```sh
2026-05-24 07:26:21 [2026-05-24 07:26:21,366] [INFO] [paperless.bulk_edit] Editing PDF of document 60 with 64 operations
2026-05-24 07:26:21 [2026-05-24 07:26:21,508] [INFO] [paperless.bulk_edit] Released archive serial numbers for documents []
2026-05-24 07:26:21 [2026-05-24 07:26:21,545] [INFO] [celery.worker.strategy] Task documents.tasks.consume_file[83a20199-0e73-49c0-be61-af30a0f1b020] received
2026-05-24 07:26:21 [2026-05-24 07:26:21,545] [DEBUG] [celery.pool] TaskPool: Apply <function fast_trace_task at 0xffff8950e160> (args:('documents.tasks.consume_file', '83a20199-0e73-49c0-be61-af30a0f1b020', {'lang': 'py', 'task': 'documents.tasks.consume_file', 'id': '83a20199-0e73-49c0-be61-af30a0f1b020', 'shadow': None, 'eta': None, 'expires': None, 'group': 'e8a7cdf9-799c-4a73-9d7e-73168d42a0e7', 'group_index': 0, 'retries': 0, 'timelimit': [None, None], 'root_id': '83a20199-0e73-49c0-be61-af30a0f1b020', 'parent_id': None, 'argsrepr': '()', 'kwargsrepr': "{'input_doc': ConsumableDocument(source=<DocumentSource.ConsumeFolder: 1>, original_file=PosixPath('/tmp/paperless/tmpexffmpxj/60_edit_1.pdf'), root_document_id=None, original_path=None, mailrule_id=None, mime_type='application/pdf'), 'overrides': DocumentMetadataOverrides(filename=None, title='sat-practice-test-1_pt2-collated', correspondent_id=2, document_type_id=None, tag_ids=[1], storage_path_id=None, created=datetime.date(2025, 1, 11), asn=None, owner_id=3, view_users=[], view_groups=[], change_users=[], change_groups=[], custom_fields={}, skip_asn_if_exists=False,... kwargs:{})
2026-05-24 07:26:21 [2026-05-24 07:26:21,546] [INFO] [celery.worker.strategy] Task documents.tasks.consume_file[fc128537-bd85-4a7c-95df-6f25df16c8b3] received
2026-05-24 07:26:21 [2026-05-24 07:26:21,547] [INFO] [celery.worker.strategy] Task documents.tasks.consume_file[cfbb807a-4400-45e3-a947-7a4aa5472344] received
2026-05-24 07:26:21 [2026-05-24 07:26:21,566] [DEBUG] [paperless.tasks] [83a20199] Executing plugin ConsumerPreflightPlugin
...
2026-05-24 07:26:31 [2026-05-24 07:26:31,478] [DEBUG] [paperless.consumer] [fc128537] Saving record to database
```

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
