### PR TITLE
Fix: handle UTF-16 text files to prevent PostgreSQL NUL byte DataError

### DIFF
--- a/src/paperless/parsers/text.py
+++ b/src/paperless/parsers/text.py
@@ -301,7 +301,7 @@ class TextDocumentParser:
     # ------------------------------------------------------------------
 
     def _read_text(self, filepath: Path) -> str:
-        """Read file content, replacing invalid UTF-8 bytes rather than failing.
+        """Read file content, detecting encoding via BOM and stripping NUL bytes.
 
         Parameters
         ----------
@@ -311,14 +311,27 @@ class TextDocumentParser:
         Returns
         -------
         str
-            File content as a string.
+            File content as a string, with NUL bytes removed so the result
+            is safe to store in PostgreSQL text fields.
         """
+        raw = filepath.read_bytes()
+
+        if raw[:2] in (b"\xff\xfe", b"\xfe\xff"):
+            encoding = "utf-16"
+        elif raw[:3] == b"\xef\xbb\xbf":
+            encoding = "utf-8-sig"
+        else:
+            encoding = "utf-8"
+
         try:
-            return filepath.read_text(encoding="utf-8")
+            text = raw.decode(encoding)
         except UnicodeDecodeError as exc:
             logger.warning(
                 "Unicode error reading %s, replacing bad bytes: %s",
                 filepath,
                 exc,
             )
-            return filepath.read_bytes().decode("utf-8", errors="replace")
+            text = raw.decode("utf-8", errors="replace")
+
+        # PostgreSQL rejects NUL (0x00) bytes in text fields
+        return text.replace("\x00", "")

--- a/src/paperless/parsers/utils.py
+++ b/src/paperless/parsers/utils.py
@@ -114,7 +114,7 @@ def read_file_handle_unicode_errors(
     filepath: Path,
     log: logging.Logger | None = None,
 ) -> str:
-    """Read a file as UTF-8 text, replacing invalid bytes rather than raising.
+    """Read a file as text, detecting encoding via BOM and stripping NUL bytes.
 
     Parameters
     ----------
@@ -127,15 +127,27 @@ def read_file_handle_unicode_errors(
     Returns
     -------
     str
-        File content as a string, with any invalid UTF-8 sequences replaced
-        by the Unicode replacement character.
+        File content as a string, with NUL bytes removed so the result
+        is safe to store in PostgreSQL text fields.
     """
     _log = log or logger
+    raw = filepath.read_bytes()
+
+    if raw[:2] in (b"\xff\xfe", b"\xfe\xff"):
+        encoding = "utf-16"
+    elif raw[:3] == b"\xef\xbb\xbf":
+        encoding = "utf-8-sig"
+    else:
+        encoding = "utf-8"
+
     try:
-        return filepath.read_text(encoding="utf-8")
+        text = raw.decode(encoding)
     except UnicodeDecodeError as e:
         _log.warning("Unicode error during text reading, continuing: %s", e)
-        return filepath.read_bytes().decode("utf-8", errors="replace")
+        text = raw.decode("utf-8", errors="replace")
+
+    # PostgreSQL rejects NUL (0x00) bytes in text fields
+    return text.replace("\x00", "")
 
 
 def get_page_count_for_pdf(


### PR DESCRIPTION
Detect UTF-16 LE/BE encoding via BOM in _read_text (text.py) and read_file_handle_unicode_errors (utils.py). Decode with the correct encoding instead of blindly using UTF-8. Strip residual NUL bytes before returning, since PostgreSQL rejects them in text fields.

Fixes #12844

<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

<!--
⚠️ Important: Pull requests that implement a new feature or enhancement *should almost always target an existing feature request* with evidence of community interest and discussion. This is in order to balance the work of implementing and maintaining new features / enhancements. If that is not currently the case, please open a feature request instead of this PR to gather feedback from both users and the project maintainers.
-->

Closes #(issue or discussion)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain: