### PR TITLE
Documentation: remove duplicate words in three files

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -852,7 +852,7 @@ pages being rotated as well.
 
 #### [`PAPERLESS_OCR_OUTPUT_TYPE=<type>`](#PAPERLESS_OCR_OUTPUT_TYPE) {#PAPERLESS_OCR_OUTPUT_TYPE}
 
-: Specify the the type of PDF documents that paperless should produce.
+: Specify the type of PDF documents that paperless should produce.
 
     -   `pdf`: Modify the PDF document as little as possible.
     -   `pdfa`: Convert PDF documents into PDF/A-2b documents, which is

--- a/src/documents/templating/filters.py
+++ b/src/documents/templating/filters.py
@@ -14,7 +14,7 @@ def localize_date(value: date | datetime | str, format: str, locale: str) -> str
     Args:
         value (date | datetime | str): The date or datetime to format. If a datetime
             is provided, it should be timezone-aware (e.g., UTC from a Django DB object).
-            if str is provided is is parsed as date.
+            If str is provided it is parsed as date.
         format (str): The format to use. Can be one of Babel's preset formats
             ('short', 'medium', 'long', 'full') or a custom pattern string.
         locale (str): The locale code (e.g., 'en_US', 'fr_FR') to use for

--- a/src/documents/tests/test_management_importer.py
+++ b/src/documents/tests/test_management_importer.py
@@ -313,7 +313,7 @@ class TestCommandImport(
         WHEN:
             - An import is attempted
         THEN:
-            - Warning about the the version mismatch is output
+            - Warning about the version mismatch is output
         """
         stdout = StringIO()
 


### PR DESCRIPTION
## Summary

Three small duplicate-word fixes:

- `docs/configuration.md:855` - "Specify the the type" -> "Specify the type"
- `src/documents/templating/filters.py:17` - "if str is provided is is parsed" -> "If str is provided it is parsed" (also fixes the capitalization)
- `src/documents/tests/test_management_importer.py:316` - "Warning about the the version mismatch" -> "Warning about the version mismatch"

Comment, docstring, and docs only; no behavior changes.