### PR TITLE
feat: add MinerU as a self-hosted remote OCR engine

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -930,10 +930,11 @@ for display in the web interface.
 
     !!! note
 
-        The **remote OCR parser** (Azure AI) always produces a searchable
-        PDF and stores it as the archive copy, regardless of this setting.
-        `ARCHIVE_FILE_GENERATION=never` has no effect when the remote
-        parser handles a document.
+        The **remote OCR parser** with the Azure AI engine always produces a
+        searchable PDF and stores it as the archive copy, regardless of this
+        setting. `ARCHIVE_FILE_GENERATION=never` has no effect when the Azure
+        engine handles a document. The MinerU engine is text-only and never
+        produces an archive copy.
 
 #### [`PAPERLESS_OCR_CLEAN=<mode>`](#PAPERLESS_OCR_CLEAN) {#PAPERLESS_OCR_CLEAN}
 
@@ -2004,19 +2005,28 @@ password. All of these options come from their similarly-named [Django settings]
 
 #### [`PAPERLESS_REMOTE_OCR_ENGINE=<str>`](#PAPERLESS_REMOTE_OCR_ENGINE) {#PAPERLESS_REMOTE_OCR_ENGINE}
 
-: The remote OCR engine to use. Currently only Azure AI is supported as "azureai".
+: The remote OCR engine to use. Supported values:
+
+    - `azureai`: Microsoft Azure AI "Document Intelligence" (cloud, paid). Returns a
+      searchable PDF that is stored as the archive copy.
+    - `mineru`: a self-hosted [MinerU](https://github.com/opendatalab/mineru) server
+      (fully local). Returns Markdown text only via the synchronous `/file_parse`
+      API; no archive PDF is produced, so the original file remains the viewable
+      document and there is no selectable text layer.
 
     Defaults to None, which disables remote OCR.
 
 #### [`PAPERLESS_REMOTE_OCR_API_KEY=<str>`](#PAPERLESS_REMOTE_OCR_API_KEY) {#PAPERLESS_REMOTE_OCR_API_KEY}
 
-: The API key to use for the remote OCR engine.
+: The API key to use for the remote OCR engine. Required for `azureai`, not used
+by `mineru`.
 
     Defaults to None.
 
 #### [`PAPERLESS_REMOTE_OCR_ENDPOINT=<str>`](#PAPERLESS_REMOTE_OCR_ENDPOINT) {#PAPERLESS_REMOTE_OCR_ENDPOINT}
 
-: The endpoint to use for the remote OCR engine. This is required for Azure AI.
+: The endpoint to use for the remote OCR engine. Required for both engines. For
+`mineru` this is the MinerU API base URL, e.g. `http://192.168.1.10:8000`.
 
     Defaults to None.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1032,10 +1032,16 @@ how regularly you intend to scan documents and use paperless.
 
     This feature is disabled by default and will always remain strictly "opt-in".
 
-Paperless-ngx supports performing OCR on documents using remote services. At the moment, this is limited to
-[Microsoft's Azure "Document Intelligence" service](https://azure.microsoft.com/en-us/products/ai-services/ai-document-intelligence).
-This is of course a paid service (with a free tier) which requires an Azure account and subscription. Azure AI is not affiliated with
-Paperless-ngx in any way. When enabled, Paperless-ngx will automatically send appropriate documents to Azure for OCR processing, bypassing
+Paperless-ngx supports performing OCR on documents using remote services. Two engines are available:
+
+- [Microsoft's Azure "Document Intelligence" service](https://azure.microsoft.com/en-us/products/ai-services/ai-document-intelligence).
+  This is a paid service (with a free tier) which requires an Azure account and subscription. Azure AI is not affiliated with
+  Paperless-ngx in any way. It returns a searchable PDF that is stored as the archive copy.
+- A self-hosted [MinerU](https://github.com/opendatalab/mineru) server, as a fully local alternative. Point Paperless-ngx at
+  the MinerU API base URL (e.g. `http://192.168.1.10:8000`); no API key is required. MinerU returns extracted text only, so the
+  original file remains the viewable document and no archive PDF with a text layer is produced.
+
+When enabled, Paperless-ngx will automatically send appropriate documents to the configured engine for OCR processing, bypassing
 the local OCR engine. See the [configuration](configuration.md#PAPERLESS_REMOTE_OCR_ENGINE) options for more details.
 
 Additionally, when using a commercial service with this feature, consider both potential costs as well as any associated file size

--- a/src/paperless/checks.py
+++ b/src/paperless/checks.py
@@ -348,6 +348,13 @@ def check_remote_parser_configured(app_configs: Any, **kwargs: Any) -> list[Erro
             ),
         ]
 
+    if settings.REMOTE_OCR_ENGINE == "mineru" and not settings.REMOTE_OCR_ENDPOINT:
+        return [
+            Error(
+                "MinerU remote parser requires an endpoint to be configured.",
+            ),
+        ]
+
     return []
 
 

--- a/src/paperless/parsers/remote.py
+++ b/src/paperless/parsers/remote.py
@@ -1,9 +1,16 @@
 """
 Built-in remote-OCR document parser.
 
-Handles documents by sending them to a configured remote OCR engine
-(currently Azure AI Vision / Document Intelligence) and retrieving both
-the extracted text and a searchable PDF with an embedded text layer.
+Handles documents by sending them to a configured remote OCR engine and
+retrieving the extracted text. Two engines are supported:
+
+* ``azureai`` — Azure AI Vision / Document Intelligence. Returns both the
+  extracted text and a searchable PDF with an embedded text layer, which
+  is stored as the archive copy.
+* ``mineru`` — a self-hosted `MinerU <https://github.com/opendatalab/mineru>`_
+  server. Returns Markdown text only via the synchronous ``/file_parse``
+  API; no archive PDF is produced (text-only), so the original file remains
+  the viewable document.
 
 When no engine is configured, ``score()`` returns ``None`` so the parser
 is effectively invisible to the registry — the tesseract parser handles
@@ -32,6 +39,10 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("paperless.parsing.remote")
 
+# MinerU document parsing can take a while for large documents; allow a
+# generous timeout for the synchronous /file_parse call.
+_MINERU_TIMEOUT_SECONDS: int = 600
+
 _SUPPORTED_MIME_TYPES: dict[str, str] = {
     "application/pdf": ".pdf",
     "image/png": ".png",
@@ -57,12 +68,21 @@ class RemoteEngineConfig:
         self.endpoint = endpoint
 
     def engine_is_valid(self) -> bool:
-        """Return True when the engine is known and fully configured."""
-        return (
-            self.engine in ("azureai",)
-            and self.api_key is not None
-            and not (self.engine == "azureai" and self.endpoint is None)
-        )
+        """Return True when the engine is known and fully configured.
+
+        ``azureai`` requires both an API key and an endpoint. ``mineru`` is
+        self-hosted and only requires an endpoint (the MinerU API base URL).
+
+        Returns
+        -------
+        bool
+            True when the configured engine has all required settings.
+        """
+        if self.engine == "azureai":
+            return self.api_key is not None and self.endpoint is not None
+        if self.engine == "mineru":
+            return self.endpoint is not None
+        return False
 
 
 class RemoteDocumentParser:
@@ -159,10 +179,11 @@ class RemoteDocumentParser:
         Returns
         -------
         bool
-            Always True — the remote engine always returns a PDF with an
-            embedded text layer that serves as the archive copy.
+            True for the Azure engine, which returns a PDF with an embedded
+            text layer that serves as the archive copy. False for the MinerU
+            engine, which is text-only and produces no archive PDF.
         """
-        return True
+        return settings.REMOTE_OCR_ENGINE != "mineru"
 
     @property
     def requires_pdf_rendition(self) -> bool:
@@ -224,8 +245,9 @@ class RemoteDocumentParser:
         mime_type:
             Detected MIME type of the document.
         produce_archive:
-            Ignored — the remote engine always returns a searchable PDF,
-            which is stored as the archive copy regardless of this flag.
+            Ignored. The Azure engine always returns a searchable PDF that
+            is stored as the archive copy; the MinerU engine is text-only and
+            never produces an archive.
         """
         config = RemoteEngineConfig(
             engine=settings.REMOTE_OCR_ENGINE,
@@ -242,6 +264,8 @@ class RemoteDocumentParser:
 
         if config.engine == "azureai":
             self._text = self._azure_ai_vision_parse(document_path, config)
+        elif config.engine == "mineru":
+            self._text = self._mineru_parse(document_path, config)
 
     # ------------------------------------------------------------------
     # Result accessors
@@ -429,5 +453,74 @@ class RemoteDocumentParser:
 
         finally:
             client.close()
+
+        return None
+
+    def _mineru_parse(
+        self,
+        file: Path,
+        config: RemoteEngineConfig,
+    ) -> str | None:
+        """Send ``file`` to a self-hosted MinerU server and return its text.
+
+        Performs a synchronous ``POST {endpoint}/file_parse`` request and
+        returns the Markdown content extracted by MinerU. No archive PDF is
+        produced — MinerU returns text only, so ``self._archive_path`` is left
+        unset and the original file remains the viewable document.
+
+        Parameters
+        ----------
+        file:
+            Absolute path to the document to parse.
+        config:
+            Validated remote engine configuration. ``config.endpoint`` is the
+            MinerU API base URL (e.g. ``http://host:8000``).
+
+        Returns
+        -------
+        str | None
+            Extracted Markdown text, or None if the MinerU call failed (the
+            error is logged).
+
+        Examples
+        --------
+        >>> # With PAPERLESS_REMOTE_OCR_ENGINE=mineru and
+        >>> # PAPERLESS_REMOTE_OCR_ENDPOINT=http://host:8000 configured:
+        >>> parser._mineru_parse(Path("/tmp/doc.pdf"), config)  # doctest: +SKIP
+        '# Document title\\n\\nBody text...'
+        """
+        if TYPE_CHECKING:
+            # Callers must have validated config via engine_is_valid(), which
+            # asserts endpoint is not None for the mineru engine.
+            assert config.endpoint is not None
+
+        import httpx
+
+        url = f"{config.endpoint.rstrip('/')}/file_parse"
+
+        try:
+            with file.open("rb") as fh:
+                response = httpx.post(
+                    url,
+                    files={"files": (file.name, fh, "application/octet-stream")},
+                    data={
+                        "return_md": "true",
+                        "response_format_zip": "false",
+                    },
+                    timeout=_MINERU_TIMEOUT_SECONDS,
+                )
+            response.raise_for_status()
+
+            results = response.json().get("results", {})
+            for entry in results.values():
+                md_content = entry.get("md_content")
+                if md_content is not None:
+                    return md_content
+
+            logger.warning("MinerU response contained no markdown content.")
+            return ""
+
+        except Exception as e:
+            logger.exception("MinerU parsing failed: %s", e)
 
         return None

--- a/src/paperless/tests/parsers/conftest.py
+++ b/src/paperless/tests/parsers/conftest.py
@@ -147,6 +147,25 @@ def no_engine_settings(settings: SettingsWrapper) -> SettingsWrapper:
     return settings
 
 
+@pytest.fixture()
+def mineru_settings(settings: SettingsWrapper) -> SettingsWrapper:
+    """Configure Django settings for a valid self-hosted MinerU OCR engine.
+
+    Sets ``REMOTE_OCR_ENGINE`` to ``"mineru"`` and ``REMOTE_OCR_ENDPOINT`` to
+    a test base URL. No API key is required for MinerU. Settings are restored
+    automatically after the test by pytest-django.
+
+    Returns
+    -------
+    SettingsWrapper
+        The modified settings object (for chaining further overrides).
+    """
+    settings.REMOTE_OCR_ENGINE = "mineru"
+    settings.REMOTE_OCR_API_KEY = None
+    settings.REMOTE_OCR_ENDPOINT = "http://mineru.test:8000"
+    return settings
+
+
 # ------------------------------------------------------------------
 # Tika parser sample files
 # ------------------------------------------------------------------

--- a/src/paperless/tests/parsers/test_remote_parser.py
+++ b/src/paperless/tests/parsers/test_remote_parser.py
@@ -378,6 +378,134 @@ class TestRemoteParserParseError:
 
 
 # ---------------------------------------------------------------------------
+# MinerU engine
+# ---------------------------------------------------------------------------
+
+_MINERU_URL = "http://mineru.test:8000/file_parse"
+_MINERU_TEXT = "# Title\n\nExtracted markdown."
+
+
+class TestRemoteParserMineruScore:
+    """score()/config logic for the self-hosted MinerU engine."""
+
+    @pytest.mark.usefixtures("mineru_settings")
+    @pytest.mark.parametrize(
+        "mime_type",
+        [
+            pytest.param("application/pdf", id="pdf"),
+            pytest.param("image/png", id="png"),
+            pytest.param("image/jpeg", id="jpeg"),
+        ],
+    )
+    def test_score_returns_20_when_configured(self, mime_type: str) -> None:
+        assert RemoteDocumentParser.score(mime_type, "doc.pdf") == 20
+
+    def test_score_returns_none_when_endpoint_missing(
+        self,
+        settings: SettingsWrapper,
+    ) -> None:
+        settings.REMOTE_OCR_ENGINE = "mineru"
+        settings.REMOTE_OCR_API_KEY = None
+        settings.REMOTE_OCR_ENDPOINT = None
+        assert RemoteDocumentParser.score("application/pdf", "doc.pdf") is None
+
+    @pytest.mark.usefixtures("mineru_settings")
+    def test_score_does_not_require_api_key(self) -> None:
+        """MinerU is self-hosted: a missing API key must not disable it."""
+        assert RemoteDocumentParser.score("application/pdf", "doc.pdf") == 20
+
+
+class TestRemoteParserMineruProperties:
+    @pytest.mark.usefixtures("mineru_settings")
+    def test_can_produce_archive_is_false(
+        self,
+        remote_parser: RemoteDocumentParser,
+    ) -> None:
+        """MinerU is text-only and never produces an archive copy."""
+        assert remote_parser.can_produce_archive is False
+
+
+class TestRemoteParserMineruParse:
+    @pytest.mark.usefixtures("mineru_settings")
+    def test_parse_returns_markdown_text(
+        self,
+        remote_parser: RemoteDocumentParser,
+        simple_digital_pdf_file: Path,
+        httpx_mock,
+    ) -> None:
+        httpx_mock.add_response(
+            url=_MINERU_URL,
+            json={
+                "backend": "pipeline",
+                "version": "test",
+                "results": {"simple-digital": {"md_content": _MINERU_TEXT}},
+            },
+        )
+
+        remote_parser.parse(simple_digital_pdf_file, "application/pdf")
+
+        assert remote_parser.get_text() == _MINERU_TEXT
+
+    @pytest.mark.usefixtures("mineru_settings")
+    def test_parse_produces_no_archive(
+        self,
+        remote_parser: RemoteDocumentParser,
+        simple_digital_pdf_file: Path,
+        httpx_mock,
+    ) -> None:
+        httpx_mock.add_response(
+            url=_MINERU_URL,
+            json={"results": {"simple-digital": {"md_content": _MINERU_TEXT}}},
+        )
+
+        remote_parser.parse(simple_digital_pdf_file, "application/pdf")
+
+        assert remote_parser.get_archive_path() is None
+
+    @pytest.mark.usefixtures("mineru_settings")
+    def test_parse_empty_when_no_markdown_in_response(
+        self,
+        remote_parser: RemoteDocumentParser,
+        simple_digital_pdf_file: Path,
+        httpx_mock,
+    ) -> None:
+        httpx_mock.add_response(url=_MINERU_URL, json={"results": {}})
+
+        remote_parser.parse(simple_digital_pdf_file, "application/pdf")
+
+        assert remote_parser.get_text() == ""
+
+    @pytest.mark.usefixtures("mineru_settings")
+    def test_parse_returns_empty_on_http_error(
+        self,
+        remote_parser: RemoteDocumentParser,
+        simple_digital_pdf_file: Path,
+        httpx_mock,
+    ) -> None:
+        httpx_mock.add_response(url=_MINERU_URL, status_code=500)
+
+        remote_parser.parse(simple_digital_pdf_file, "application/pdf")
+
+        assert remote_parser.get_text() == ""
+
+    @pytest.mark.usefixtures("mineru_settings")
+    def test_parse_logs_error_on_failure(
+        self,
+        remote_parser: RemoteDocumentParser,
+        simple_digital_pdf_file: Path,
+        httpx_mock,
+        mocker: MockerFixture,
+    ) -> None:
+        httpx_mock.add_response(url=_MINERU_URL, status_code=500)
+        mock_log = mocker.patch("paperless.parsers.remote.logger")
+
+        remote_parser.parse(simple_digital_pdf_file, "application/pdf")
+
+        mock_log.exception.assert_called_once()
+        assert "MinerU parsing failed" in mock_log.exception.call_args[0][0]
+
+
+# ---------------------------------------------------------------------------
 # get_page_count()
 # ---------------------------------------------------------------------------
 

--- a/src/paperless/tests/test_checks.py
+++ b/src/paperless/tests/test_checks.py
@@ -655,6 +655,27 @@ class TestRemoteParserChecks:
             in msg.msg
         )
 
+    def test_mineru_no_endpoint(self, settings: SettingsWrapper) -> None:
+        settings.REMOTE_OCR_ENGINE = "mineru"
+        settings.REMOTE_OCR_API_KEY = None
+        settings.REMOTE_OCR_ENDPOINT = None
+
+        msgs = check_remote_parser_configured(None)
+
+        assert len(msgs) == 1
+        assert "MinerU remote parser requires an endpoint to be configured." in (
+            msgs[0].msg
+        )
+
+    def test_mineru_with_endpoint_ok(self, settings: SettingsWrapper) -> None:
+        settings.REMOTE_OCR_ENGINE = "mineru"
+        settings.REMOTE_OCR_API_KEY = None
+        settings.REMOTE_OCR_ENDPOINT = "http://mineru.test:8000"
+
+        msgs = check_remote_parser_configured(None)
+
+        assert len(msgs) == 0
+
 
 class TestTesseractChecks:
     def test_default_language(self) -> None:


### PR DESCRIPTION
ASLOP-PR-VERIFY

## Proposed change

Adds support for a self-hosted [MinerU](https://github.com/opendatalab/mineru) server as an alternative remote OCR engine, alongside the existing Azure AI engine. This is a fully local option for users who want higher-quality OCR/text extraction than Tesseract without sending documents to a paid cloud service.

It reuses the existing remote OCR mechanism and is strictly opt-in:

- `PAPERLESS_REMOTE_OCR_ENGINE=mineru`
- `PAPERLESS_REMOTE_OCR_ENDPOINT=http://host:8000` (the MinerU API base URL; no API key required)

When configured, `RemoteDocumentParser` scores above the Tesseract parser and handles PDFs/images by sending them to MinerU's synchronous `POST /file_parse` endpoint and storing the returned Markdown as the document text. MinerU returns text only (not a searchable PDF), so this engine is text-only: no archive PDF is produced and the original file remains the viewable document. `can_produce_archive` reflects this, and a startup check requires an endpoint when the engine is `mineru`.

No new dependencies (uses the existing `httpx`).

This implements one of the engines requested in the long-standing alternative OCR engines discussion.

Closes #5128

## Type of change

- [ ] Bug fix: non-breaking change which fixes an issue.
- [x] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.

---

_AI disclosure: this change was implemented with the assistance of an AI coding agent (Cursor) and reviewed by the PR author. Backend tests (`test_remote_parser.py`, remote-parser checks) pass locally; ruff, prettier and codespell were run on the changed files._
