### PR TITLE
Chore: update broker dependency from Redis 7/8 to Valkey Redis 9

### DIFF
--- a/docker/compose/docker-compose.mariadb-tika.yml
+++ b/docker/compose/docker-compose.mariadb-tika.yml
@@ -30,7 +30,7 @@
 # documentation.
 services:
   broker:
-    image: docker.io/library/redis:8
+    image: docker.io/valkey/valkey:9-alpine
     restart: unless-stopped
     volumes:
       - redisdata:/data

--- a/docker/compose/docker-compose.mariadb.yml
+++ b/docker/compose/docker-compose.mariadb.yml
@@ -26,7 +26,7 @@
 # documentation.
 services:
   broker:
-    image: docker.io/library/redis:8
+    image: docker.io/valkey/valkey:9-alpine
     restart: unless-stopped
     volumes:
       - redisdata:/data

--- a/docker/compose/docker-compose.portainer.yml
+++ b/docker/compose/docker-compose.portainer.yml
@@ -27,7 +27,7 @@
 # documentation.
 services:
   broker:
-    image: docker.io/library/redis:8
+    image: docker.io/valkey/valkey:9-alpine
     restart: unless-stopped
     volumes:
       - redisdata:/data

--- a/docker/compose/docker-compose.postgres-tika.yml
+++ b/docker/compose/docker-compose.postgres-tika.yml
@@ -30,7 +30,7 @@
 # documentation.
 services:
   broker:
-    image: docker.io/library/redis:8
+    image: docker.io/valkey/valkey:9-alpine
     restart: unless-stopped
     volumes:
       - redisdata:/data

--- a/docker/compose/docker-compose.postgres.yml
+++ b/docker/compose/docker-compose.postgres.yml
@@ -26,7 +26,7 @@
 # documentation.
 services:
   broker:
-    image: docker.io/library/redis:8
+    image: docker.io/valkey/valkey:9-alpine
     restart: unless-stopped
     volumes:
       - redisdata:/data

--- a/docker/compose/docker-compose.sqlite-tika.yml
+++ b/docker/compose/docker-compose.sqlite-tika.yml
@@ -30,7 +30,7 @@
 # documentation.
 services:
   broker:
-    image: docker.io/library/redis:8
+    image: docker.io/valkey/valkey:9-alpine
     restart: unless-stopped
     volumes:
       - redisdata:/data

--- a/docker/compose/docker-compose.sqlite.yml
+++ b/docker/compose/docker-compose.sqlite.yml
@@ -23,7 +23,7 @@
 # documentation.
 services:
   broker:
-    image: docker.io/library/redis:8
+    image: docker.io/valkey/valkey:9-alpine
     restart: unless-stopped
     volumes:
       - redisdata:/data

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -30,21 +30,21 @@ or applicable default will be utilized instead.
 fetching, index optimization and for training the automatic document
 matcher.
 
-    -   If your Redis server needs login credentials PAPERLESS_REDIS =
+    -   If your Valkey/Redis server needs login credentials PAPERLESS_REDIS =
         `redis://<username>:<password>@<host>:<port>`
     -   With the requirepass option PAPERLESS_REDIS =
         `redis://:<password>@<host>:<port>`
     -   To include the redis database index PAPERLESS_REDIS =
         `redis://<username>:<password>@<host>:<port>/<DBIndex>`
 
-    [More information on securing your Redis
-    Instance](https://redis.io/docs/latest/operate/oss_and_stack/management/security).
+    [More information on securing your Valkey
+    Instance](https://valkey.io/topics/security/)).
 
     Defaults to `redis://localhost:6379`.
 
 #### [`PAPERLESS_REDIS_PREFIX=<prefix>`](#PAPERLESS_REDIS_PREFIX) {#PAPERLESS_REDIS_PREFIX}
 
-: Prefix to be used in Redis for keys and channels. Useful for sharing one Redis server among multiple Paperless instances.
+: Prefix to be used in Valkey/Redis for keys and channels. Useful for sharing one Valkey/Redis server among multiple Paperless instances.
 
     Defaults to no prefix.
 
@@ -264,7 +264,7 @@ For more details, refer to the [Redis eviction policy documentation](https://red
 
 #### [`PAPERLESS_READ_CACHE_REDIS_URL=<url>`](#PAPERLESS_READ_CACHE_REDIS_URL) {#PAPERLESS_READ_CACHE_REDIS_URL}
 
-: Defines the Redis instance used for the read cache.
+: Defines the Valkey/Redis instance used for the read cache.
 
     Defaults to `None`.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -30,21 +30,21 @@ or applicable default will be utilized instead.
 fetching, index optimization and for training the automatic document
 matcher.
 
-    -   If your Valkey/Redis server needs login credentials PAPERLESS_REDIS =
+    -   If your Redis server needs login credentials PAPERLESS_REDIS =
         `redis://<username>:<password>@<host>:<port>`
     -   With the requirepass option PAPERLESS_REDIS =
         `redis://:<password>@<host>:<port>`
     -   To include the redis database index PAPERLESS_REDIS =
         `redis://<username>:<password>@<host>:<port>/<DBIndex>`
 
-    [More information on securing your Valkey
+    [More information on securing your Redis
     Instance](https://valkey.io/topics/security/)).
 
     Defaults to `redis://localhost:6379`.
 
 #### [`PAPERLESS_REDIS_PREFIX=<prefix>`](#PAPERLESS_REDIS_PREFIX) {#PAPERLESS_REDIS_PREFIX}
 
-: Prefix to be used in Valkey/Redis for keys and channels. Useful for sharing one Valkey/Redis server among multiple Paperless instances.
+: Prefix to be used in Redis for keys and channels. Useful for sharing one Redis server among multiple Paperless instances.
 
     Defaults to no prefix.
 
@@ -264,7 +264,7 @@ For more details, refer to the [Redis eviction policy documentation](https://red
 
 #### [`PAPERLESS_READ_CACHE_REDIS_URL=<url>`](#PAPERLESS_READ_CACHE_REDIS_URL) {#PAPERLESS_READ_CACHE_REDIS_URL}
 
-: Defines the Valkey/Redis instance used for the read cache.
+: Defines the Redis instance used for the read cache.
 
     Defaults to `None`.
 


### PR DESCRIPTION
## Proposed change

This PR updates the bundled example Docker Compose stacks (`docker-compose.*.yml`) to use the official Valkey 9 Alpine image (`docker.io/valkey/valkey:9-alpine`) instead of legacy Redis 7/8 images. 

The PR also changes the Redis security URL in `CONFIGURATION.md` to point to Valkey Redis' version of the same information.

This PR follows a brief discussion with the project maintainers/developers when I inquired as to when paperless-ngx would update to Valkey 9 and one of the maintainers gave me the green light to submit a PR.  This is in the context of the previously used version losing open-source status and redis versions 7/8 eventually entering the sunset phase for maintenance/security patches/etc. 

Existing volume mappings (`redisdata:/data`) have been intentionally preserved to ensure a seamless, non-breaking upgrade path for existing users pulling the new images.

## Type of change

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [x] Other. Please explain: Infrastructure/Dependency Chore: Updated bundled example Docker service images from Redis to Valkey 9.

## Checklist:

- [x] I have read & agree with the contributing guidelines.
- [ ] If applicable, I have included testing coverage for new code in this PR, for backend and / or front-end changes.
- [x] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see documentation.
- [ ] I have run all Git `pre-commit` hooks, see documentation.
- [ ] I have made corresponding changes to the documentation as needed.
- [x] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.