### PR TITLE
Fix: prevent long document titles from overflowing the delete confirmation dialog

### DIFF
--- a/src-ui/src/app/components/common/confirm-dialog/confirm-dialog.component.scss
+++ b/src-ui/src/app/components/common/confirm-dialog/confirm-dialog.component.scss
@@ -1,0 +1,4 @@
+.modal-body {
+  overflow-wrap: break-word;
+  word-break: break-word;
+}


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

ASLOP-PR-VERIFY 

This PR was implemented with assistance from an LLM under close human supervision. Validation was done manually by the human contributor.

## Proposed change

Fix: long document titles without spaces (e.g. filenames with underscores) overflow the delete confirmation dialog's modal body.

The issue is in the `ConfirmDialogComponent` — its `messageBold` text is rendered inside a `<p><b>` element with no CSS for handling unbreakable strings. Adding `overflow-wrap: break-word` and `word-break: break-word` to `.modal-body` ensures the text wraps within the dialog boundaries. This component is used across 25 call sites, so the fix covers all confirm dialogs.

Before:
<img width="568" height="300" alt="bug" src="https://github.com/user-attachments/assets/ddfc009b-5d49-4a03-8a57-0e2108a7a494" />

After:
<img width="530" height="276" alt="fixed" src="https://github.com/user-attachments/assets/4b76b68a-6487-4976-95b6-7d0b06b05209" />


## Type of change

- [X] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality.
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

- [X] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [X] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
