### PR TITLE
Enhancement: Allow embedding via environment variable

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -526,6 +526,16 @@ you're running two instances of paperless on the same host.
 
     Defaults to `""`, which does not alter the cookie names.
 
+#### [`PAPERLESS_CSP_FRAME_ANCESTORS=<comma-separated-list>`](#PAPERLESS_CSP_FRAME_ANCESTORS) {#PAPERLESS_CSP_FRAME_ANCESTORS}
+
+: Allows to emmbed your paperless instance to a different website in 
+a frame or iframe.
+
+Just remember that this is a comma-separated list, so "example.com" is fine, as is "example.com,www.example.com", but NOT " example.com" or "example.com,"
+
+Defaults to `""`, which does not allow to emmbed paperless into any other domain.
+
+
 #### [`PAPERLESS_ENABLE_HTTP_REMOTE_USER=<bool>`](#PAPERLESS_ENABLE_HTTP_REMOTE_USER) {#PAPERLESS_ENABLE_HTTP_REMOTE_USER}
 
 : Allows authentication via HTTP_REMOTE_USER which is used by some SSO

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "paperless-ngx"
-version = "2.20.15"
+version = "2.20.16"
 description = "A community-supported supercharged document management system: scan, index and archive all your physical documents"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -38,6 +38,7 @@ dependencies = [
   "django-multiselectfield~=1.0.1",
   "django-soft-delete~=1.0.18",
   "django-treenode>=0.23.2",
+	"django-csp~=4.0",
   "djangorestframework~=3.16",
   "djangorestframework-guardian~=0.4.0",
   "drf-spectacular~=0.28",

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -589,11 +589,11 @@ HTTP_REMOTE_USER_HEADER_NAME = _parse_remote_user_settings()
 # X-Frame/HTTP CSP options for embedded PDF display and optional embedding into other ancestors 
 X_FRAME_OPTIONS = "SAMEORIGIN"
 
-from csp.constants import NONE, SELF
+from csp.constants import SELF
 CONTENT_SECURITY_POLICY = {
     "DIRECTIVES": {
         "default-src": [SELF],
-        "frame-ancestors": __get_list([SELF], "PAPERLESS_CSP_FRAME_ANCESTORS"),
+        "frame-ancestors": __get_list("PAPERLESS_CSP_FRAME_ANCESTORS", [SELF]),
     },
 }
 

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -335,6 +335,7 @@ INSTALLED_APPS = [
     "drf_spectacular",
     "drf_spectacular_sidecar",
     "treenode",
+    "csp",
     *env_apps,
 ]
 
@@ -374,6 +375,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "allauth.account.middleware.AccountMiddleware",
+    "csp.middleware.CSPMiddleware",
 ]
 
 # Optional to enable compression
@@ -584,8 +586,16 @@ def _parse_remote_user_settings() -> str:
 
 HTTP_REMOTE_USER_HEADER_NAME = _parse_remote_user_settings()
 
-# X-Frame options for embedded PDF display:
+# X-Frame/HTTP CSP options for embedded PDF display and optional embedding into other ancestors 
 X_FRAME_OPTIONS = "SAMEORIGIN"
+
+from csp.constants import NONE, SELF
+CONTENT_SECURITY_POLICY = {
+    "DIRECTIVES": {
+        "default-src": [SELF],
+        "frame-ancestors": __get_list([SELF], "PAPERLESS_CSP_FRAME_ANCESTORS"),
+    },
+}
 
 # The next 3 settings can also be set using just PAPERLESS_URL
 CSRF_TRUSTED_ORIGINS = __get_list("PAPERLESS_CSRF_TRUSTED_ORIGINS")

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -586,10 +586,11 @@ def _parse_remote_user_settings() -> str:
 
 HTTP_REMOTE_USER_HEADER_NAME = _parse_remote_user_settings()
 
-# X-Frame/HTTP CSP options for embedded PDF display and optional embedding into other ancestors 
+# X-Frame HTTP CSP options for embedded PDF display and optional embedding into other ancestors 
 X_FRAME_OPTIONS = "SAMEORIGIN"
 
 from csp.constants import SELF
+
 CONTENT_SECURITY_POLICY = {
     "DIRECTIVES": {
         "default-src": [SELF],


### PR DESCRIPTION

## Proposed change


Based on pull request #6941 (as well as the previously discussed or requested discussions/issues #1837 and #2415), I have added support for the HTTP Content Security Policy and enabled the specification of frame-ancestors as a means of integration with other apps, such as Nextcloud (using the ‘External Sites’ app) or Home Assistant.


## Type of change

- [ ] Bug fix: non-breaking change which fixes an issue.
- [x] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [ ] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
