### PR TITLE
Feature: Add Mistral OCR as a remote OCR engine

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -934,9 +934,9 @@ for display in the web interface.
 
     !!! note
 
-        The **remote OCR parser** (Azure AI) always produces a searchable
-        PDF and stores it as the archive copy, regardless of this setting.
-        `ARCHIVE_FILE_GENERATION=never` has no effect when the remote
+        The **remote OCR parser** (Azure AI or Mistral) always produces a
+        searchable PDF and stores it as the archive copy, regardless of this
+        setting. `ARCHIVE_FILE_GENERATION=never` has no effect when the remote
         parser handles a document.
 
 #### [`PAPERLESS_OCR_CLEAN=<mode>`](#PAPERLESS_OCR_CLEAN) {#PAPERLESS_OCR_CLEAN}
@@ -2008,19 +2008,25 @@ password. All of these options come from their similarly-named [Django settings]
 
 #### [`PAPERLESS_REMOTE_OCR_ENGINE=<str>`](#PAPERLESS_REMOTE_OCR_ENGINE) {#PAPERLESS_REMOTE_OCR_ENGINE}
 
-: The remote OCR engine to use. Currently only Azure AI is supported as "azureai".
+: The remote OCR engine to use. Supported values are `"azureai"` for
+    Azure AI Document Intelligence and `"mistral"` for Mistral OCR
+    (`mistral-ocr-latest`).
 
     Defaults to None, which disables remote OCR.
 
 #### [`PAPERLESS_REMOTE_OCR_API_KEY=<str>`](#PAPERLESS_REMOTE_OCR_API_KEY) {#PAPERLESS_REMOTE_OCR_API_KEY}
 
-: The API key to use for the remote OCR engine.
+: The API key to use for the remote OCR engine. Required for both engines.
 
     Defaults to None.
 
 #### [`PAPERLESS_REMOTE_OCR_ENDPOINT=<str>`](#PAPERLESS_REMOTE_OCR_ENDPOINT) {#PAPERLESS_REMOTE_OCR_ENDPOINT}
 
 : The endpoint to use for the remote OCR engine. This is required for Azure AI.
+
+    For Mistral this is optional and defaults to the hosted API at
+    `https://api.mistral.ai`; set it only when targeting a self-hosted
+    Mistral OCR deployment.
 
     Defaults to None.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1051,11 +1051,20 @@ how regularly you intend to scan documents and use paperless.
 
     This feature is disabled by default and will always remain strictly "opt-in".
 
-Paperless-ngx supports performing OCR on documents using remote services. At the moment, this is limited to
-[Microsoft's Azure "Document Intelligence" service](https://azure.microsoft.com/en-us/products/ai-services/ai-document-intelligence).
-This is of course a paid service (with a free tier) which requires an Azure account and subscription. Azure AI is not affiliated with
-Paperless-ngx in any way. When enabled, Paperless-ngx will automatically send appropriate documents to Azure for OCR processing, bypassing
-the local OCR engine. See the [configuration](configuration.md#PAPERLESS_REMOTE_OCR_ENGINE) options for more details.
+Paperless-ngx supports performing OCR on documents using remote services. Two engines are currently supported:
+
+- [Microsoft's Azure "Document Intelligence" service](https://azure.microsoft.com/en-us/products/ai-services/ai-document-intelligence),
+  selected with `PAPERLESS_REMOTE_OCR_ENGINE=azureai`.
+- [Mistral OCR](https://mistral.ai/news/mistral-ocr) (`mistral-ocr-latest`), selected with `PAPERLESS_REMOTE_OCR_ENGINE=mistral`.
+  Mistral returns markdown text plus paragraph-level bounding boxes; Paperless-ngx assembles the searchable PDF archive locally by
+  overlaying an invisible text layer on the page images. Highlighting therefore works at paragraph rather than word granularity.
+  Mistral OCR can also be [self-hosted](https://mistral.ai/news/mistral-ocr) via a container, in which case point
+  `PAPERLESS_REMOTE_OCR_ENDPOINT` at your instance.
+
+These are of course paid services (with free tiers) which require an account and API key with the respective provider. Neither provider is
+affiliated with Paperless-ngx in any way. When enabled, Paperless-ngx will automatically send appropriate documents to the configured
+service for OCR processing, bypassing the local OCR engine. See the [configuration](configuration.md#PAPERLESS_REMOTE_OCR_ENGINE) options
+for more details.
 
 Additionally, when using a commercial service with this feature, consider both potential costs as well as any associated file size
 or page limitations (e.g. with a free tier).

--- a/src/paperless/checks.py
+++ b/src/paperless/checks.py
@@ -348,6 +348,13 @@ def check_remote_parser_configured(app_configs: Any, **kwargs: Any) -> list[Erro
             ),
         ]
 
+    if settings.REMOTE_OCR_ENGINE == "mistral" and not settings.REMOTE_OCR_API_KEY:
+        return [
+            Error(
+                "Mistral remote parser requires an API key to be configured.",
+            ),
+        ]
+
     return []
 
 

--- a/src/paperless/parsers/remote.py
+++ b/src/paperless/parsers/remote.py
@@ -1,9 +1,16 @@
 """
 Built-in remote-OCR document parser.
 
-Handles documents by sending them to a configured remote OCR engine
-(currently Azure AI Vision / Document Intelligence) and retrieving both
-the extracted text and a searchable PDF with an embedded text layer.
+Handles documents by sending them to a configured remote OCR engine and
+retrieving both the extracted text and a searchable PDF with an embedded
+text layer.  Two engines are supported:
+
+* ``azureai`` — Azure AI Vision / Document Intelligence, which returns a
+  ready-made searchable PDF.
+* ``mistral`` — Mistral OCR (``mistral-ocr-latest``), which returns markdown
+  text plus paragraph-level bounding boxes.  Because Mistral does not return
+  a PDF, the searchable archive is assembled locally by rendering an
+  invisible text layer over the page image via ocrmypdf's fpdf2 renderer.
 
 When no engine is configured, ``score()`` returns ``None`` so the parser
 is effectively invisible to the registry — the tesseract parser handles
@@ -27,6 +34,9 @@ if TYPE_CHECKING:
     import datetime
     from types import TracebackType
 
+    from ocrmypdf.models.ocr_element import BoundingBox
+    from ocrmypdf.models.ocr_element import OcrElement
+
     from paperless.parsers import MetadataEntry
     from paperless.parsers import ParserContext
 
@@ -41,6 +51,21 @@ _SUPPORTED_MIME_TYPES: dict[str, str] = {
     "image/gif": ".gif",
     "image/webp": ".webp",
 }
+
+#: Default base URL for the hosted Mistral OCR API.  Overridable via
+#: ``PAPERLESS_REMOTE_OCR_ENDPOINT`` for self-hosted deployments.
+MISTRAL_DEFAULT_ENDPOINT: str = "https://api.mistral.ai"
+
+#: Mistral OCR model identifier.
+MISTRAL_OCR_MODEL: str = "mistral-ocr-latest"
+
+#: Request timeout (seconds) for a single Mistral OCR call.  OCR of large
+#: documents can take a while, so this is intentionally generous.
+MISTRAL_OCR_TIMEOUT: float = 600.0
+
+#: DPI used to rasterise PDF pages before overlaying the invisible text
+#: layer.  Only relevant for the Mistral engine.
+_RENDER_DPI: int = 200
 
 
 class RemoteEngineConfig:
@@ -57,12 +82,17 @@ class RemoteEngineConfig:
         self.endpoint = endpoint
 
     def engine_is_valid(self) -> bool:
-        """Return True when the engine is known and fully configured."""
-        return (
-            self.engine in ("azureai",)
-            and self.api_key is not None
-            and not (self.engine == "azureai" and self.endpoint is None)
-        )
+        """Return True when the engine is known and fully configured.
+
+        Both engines require an API key.  ``azureai`` additionally requires
+        an endpoint; ``mistral`` defaults to the hosted endpoint when none is
+        given, so an endpoint is optional there.
+        """
+        if self.api_key is None:
+            return False
+        if self.engine == "azureai":
+            return self.endpoint is not None
+        return self.engine == "mistral"
 
 
 class RemoteDocumentParser:
@@ -242,6 +272,8 @@ class RemoteDocumentParser:
 
         if config.engine == "azureai":
             self._text = self._azure_ai_vision_parse(document_path, config)
+        elif config.engine == "mistral":
+            self._text = self._mistral_ocr_parse(document_path, mime_type, config)
 
     # ------------------------------------------------------------------
     # Result accessors
@@ -431,3 +463,353 @@ class RemoteDocumentParser:
             client.close()
 
         return None
+
+    def _mistral_ocr_parse(
+        self,
+        file: Path,
+        mime_type: str,
+        config: RemoteEngineConfig,
+    ) -> str | None:
+        """Send ``file`` to the Mistral OCR API and return the extracted text.
+
+        Mistral returns markdown text plus paragraph-level bounding boxes but
+        no PDF, so a searchable archive is assembled locally and stored at
+        ``self._archive_path``.  Returns the extracted text, or ``None`` on
+        failure (the error is logged and the archive path is cleared).
+
+        Parameters
+        ----------
+        file:
+            Absolute path to the document to analyse.
+        mime_type:
+            Detected MIME type of the document.
+        config:
+            Validated remote engine configuration.
+
+        Returns
+        -------
+        str | None
+            Extracted text, or None if the Mistral call failed.
+        """
+        if TYPE_CHECKING:
+            # engine_is_valid() guarantees api_key is not None for mistral.
+            assert config.api_key is not None
+
+        import httpx
+
+        endpoint = (config.endpoint or MISTRAL_DEFAULT_ENDPOINT).rstrip("/")
+        url = f"{endpoint}/v1/ocr"
+
+        document_uri = _data_uri(mime_type, file.read_bytes())
+        if mime_type == "application/pdf":
+            document = {"type": "document_url", "document_url": document_uri}
+        else:
+            document = {"type": "image_url", "image_url": document_uri}
+
+        payload = {
+            "model": MISTRAL_OCR_MODEL,
+            "document": document,
+            "include_blocks": True,
+        }
+        headers = {
+            "Authorization": f"Bearer {config.api_key}",
+            "Content-Type": "application/json",
+        }
+
+        try:
+            response = httpx.post(
+                url,
+                json=payload,
+                headers=headers,
+                timeout=MISTRAL_OCR_TIMEOUT,
+            )
+            response.raise_for_status()
+            pages = response.json().get("pages", [])
+
+            self._archive_path = self._tempdir / "archive.pdf"
+            self._build_searchable_pdf(file, mime_type, pages, self._archive_path)
+
+            return _mistral_pages_to_text(pages)
+
+        except Exception as e:
+            logger.exception("Mistral OCR parsing failed: %s", e)
+            self._archive_path = None
+
+        return None
+
+    def _build_searchable_pdf(
+        self,
+        source: Path,
+        mime_type: str,
+        pages: list[dict],
+        out_path: Path,
+    ) -> None:
+        """Assemble a searchable PDF from the original file and OCR results.
+
+        Each page image (rasterised from PDF input, or the image itself) is
+        rendered with an invisible text layer positioned using Mistral's
+        paragraph-level bounding boxes, using ocrmypdf's fpdf2 renderer and
+        its bundled Unicode font.  The per-page PDFs are merged into
+        ``out_path``.
+
+        Parameters
+        ----------
+        source:
+            Absolute path to the original document.
+        mime_type:
+            Detected MIME type of the original document.
+        pages:
+            The ``pages`` array returned by the Mistral OCR API.
+        out_path:
+            Destination path for the merged searchable PDF.
+        """
+        import ocrmypdf
+        import pikepdf
+        from ocrmypdf.font import MultiFontManager
+        from ocrmypdf.fpdf_renderer import Fpdf2PdfRenderer
+
+        images = _load_page_images(source, mime_type, _RENDER_DPI)
+        font_dir = Path(ocrmypdf.__file__).parent / "data"
+        font_manager = MultiFontManager(font_dir)
+
+        merged = pikepdf.Pdf.new()
+        opened: list = []
+        try:
+            for index, image in enumerate(images):
+                page_data = pages[index] if index < len(pages) else {}
+
+                image_path = self._tempdir / f"page-{index}.png"
+                image.save(image_path)
+
+                ocr_page = _build_ocr_page(
+                    page_data,
+                    image.width,
+                    image.height,
+                    _RENDER_DPI,
+                )
+
+                page_pdf_path = self._tempdir / f"page-{index}.pdf"
+                Fpdf2PdfRenderer(
+                    page=ocr_page,
+                    dpi=_RENDER_DPI,
+                    multi_font_manager=font_manager,
+                    invisible_text=True,
+                    image=image_path,
+                ).render(page_pdf_path)
+
+                page_pdf = pikepdf.open(page_pdf_path)
+                opened.append(page_pdf)
+                merged.pages.extend(page_pdf.pages)
+
+            merged.save(out_path)
+        finally:
+            for page_pdf in opened:
+                page_pdf.close()
+            merged.close()
+
+
+# ----------------------------------------------------------------------
+# Mistral OCR helpers (pure, framework-independent)
+# ----------------------------------------------------------------------
+
+
+def _data_uri(mime_type: str, data: bytes) -> str:
+    """Encode ``data`` as a ``data:`` URI for the given MIME type."""
+    import base64
+
+    encoded = base64.b64encode(data).decode("ascii")
+    return f"data:{mime_type};base64,{encoded}"
+
+
+def _mistral_pages_to_text(pages: list[dict]) -> str:
+    """Concatenate the markdown content of every page, blank pages dropped."""
+    parts = [str(page.get("markdown", "")).strip() for page in pages]
+    return "\n\n".join(part for part in parts if part)
+
+
+def _block_text(block: dict) -> str:
+    """Best-effort extraction of a block's text content."""
+    for key in ("markdown", "text", "content"):
+        value = block.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
+
+
+def _block_bounding_box(block: dict) -> tuple[float, float, float, float] | None:
+    """Best-effort extraction of a block bbox as ``(left, top, right, bottom)``.
+
+    Supports the bounding-box shapes Mistral has used across API revisions:
+    a ``bbox`` list ``[x0, y0, x1, y1]``, a ``bbox`` dict with
+    ``left/top/right/bottom``, or the image-style
+    ``top_left_x/top_left_y/bottom_right_x/bottom_right_y`` keys (either nested
+    under ``bbox`` or directly on the block).  Returns ``None`` when no usable
+    box is present.
+    """
+    corner_keys = ("top_left_x", "top_left_y", "bottom_right_x", "bottom_right_y")
+    edge_keys = ("left", "top", "right", "bottom")
+
+    candidates = [block.get("bbox"), block]
+    for candidate in candidates:
+        if isinstance(candidate, (list, tuple)) and len(candidate) == 4:
+            try:
+                return tuple(float(v) for v in candidate)  # type: ignore[return-value]
+            except (TypeError, ValueError):
+                continue
+        if isinstance(candidate, dict):
+            for keys in (edge_keys, corner_keys):
+                if all(k in candidate for k in keys):
+                    try:
+                        return tuple(float(candidate[k]) for k in keys)  # type: ignore[return-value]
+                    except (TypeError, ValueError):
+                        continue
+    return None
+
+
+def _clamp_bbox(
+    left: float,
+    top: float,
+    right: float,
+    bottom: float,
+    max_width: float,
+    max_height: float,
+) -> BoundingBox | None:
+    """Clamp a bbox to the page and return a valid ``BoundingBox`` or ``None``.
+
+    ``BoundingBox`` rejects degenerate boxes (``right <= left`` etc.), so this
+    also filters out empty or inverted boxes.
+    """
+    from ocrmypdf.models.ocr_element import BoundingBox
+
+    left = max(0.0, min(left, max_width))
+    right = max(0.0, min(right, max_width))
+    top = max(0.0, min(top, max_height))
+    bottom = max(0.0, min(bottom, max_height))
+    if right <= left or bottom <= top:
+        return None
+    return BoundingBox(left, top, right, bottom)
+
+
+def _text_band_elements(
+    text: str,
+    left: float,
+    top: float,
+    right: float,
+    bottom: float,
+    max_width: float,
+    max_height: float,
+    dpi: float,
+) -> list[OcrElement]:
+    """Lay ``text`` into one thin invisible ``ocr_line`` band per text line.
+
+    A single tall box makes the fpdf2 renderer scale text so aggressively that
+    the glyphs become unrecoverable, so the box is divided into one horizontal
+    band per line of text and each band's height is capped to roughly a single
+    line.  Returns the resulting ``ocr_line`` elements (each wrapping one
+    ``ocrx_word``); an empty list when there is no usable text.
+    """
+    from ocrmypdf.models.ocr_element import OcrElement
+
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    if not lines:
+        return []
+
+    band_cap = dpi * 0.3
+    slot = (bottom - top) / len(lines)
+    elements: list[OcrElement] = []
+    for index, line in enumerate(lines):
+        band_top = top + index * slot
+        band_bottom = band_top + min(slot, band_cap)
+        bbox = _clamp_bbox(left, band_top, right, band_bottom, max_width, max_height)
+        if bbox is None:
+            continue
+        word = OcrElement(ocr_class="ocrx_word", text=line, bbox=bbox)
+        elements.append(OcrElement(ocr_class="ocr_line", bbox=bbox, children=[word]))
+    return elements
+
+
+def _build_ocr_page(
+    page_data: dict,
+    image_width: int,
+    image_height: int,
+    dpi: float,
+) -> OcrElement:
+    """Build an ``OcrElement`` page tree from a Mistral OCR page result.
+
+    Each content block's text is laid into thin invisible bands positioned at
+    the block's (scaled) bounding box.  When no usable blocks are present, the
+    whole page markdown is laid across the full page instead, so the archive
+    stays searchable either way.
+    """
+    from ocrmypdf.models.ocr_element import BoundingBox
+    from ocrmypdf.models.ocr_element import OcrElement
+
+    dimensions = page_data.get("dimensions") or {}
+    source_width = dimensions.get("width") or image_width
+    source_height = dimensions.get("height") or image_height
+    scale_x = image_width / source_width if source_width else 1.0
+    scale_y = image_height / source_height if source_height else 1.0
+
+    children: list[OcrElement] = []
+    for block in page_data.get("blocks") or []:
+        if not isinstance(block, dict):
+            continue
+        text = _block_text(block)
+        box = _block_bounding_box(block)
+        if not text or box is None:
+            continue
+        left, top, right, bottom = box
+        children.extend(
+            _text_band_elements(
+                text,
+                left * scale_x,
+                top * scale_y,
+                right * scale_x,
+                bottom * scale_y,
+                image_width,
+                image_height,
+                dpi,
+            ),
+        )
+
+    if not children:
+        # Fallback: no positioned blocks — keep the page searchable by laying
+        # the full markdown text across the whole page as invisible text.
+        children.extend(
+            _text_band_elements(
+                str(page_data.get("markdown", "")).strip(),
+                0,
+                0,
+                image_width,
+                image_height,
+                image_width,
+                image_height,
+                dpi,
+            ),
+        )
+
+    return OcrElement(
+        ocr_class="ocr_page",
+        bbox=BoundingBox(0, 0, image_width, image_height),
+        dpi=dpi,
+        page_number=page_data.get("index", 0),
+        children=children,
+    )
+
+
+def _load_page_images(source: Path, mime_type: str, dpi: int) -> list:
+    """Return one RGB ``PIL.Image`` per page of the source document.
+
+    PDF input is rasterised with pdf2image; image input (including multi-frame
+    TIFF) is loaded directly, one entry per frame.
+    """
+    from PIL import Image
+    from PIL import ImageSequence
+
+    if mime_type == "application/pdf":
+        from pdf2image import convert_from_path
+
+        return convert_from_path(source, dpi=dpi)
+
+    with Image.open(source) as opened:
+        return [frame.convert("RGB") for frame in ImageSequence.Iterator(opened)]

--- a/src/paperless/settings/__init__.py
+++ b/src/paperless/settings/__init__.py
@@ -1183,6 +1183,10 @@ WEBHOOKS_ALLOW_INTERNAL_REQUESTS = get_bool_from_env(
 ###############################################################################
 # Remote Parser                                                               #
 ###############################################################################
+# Supported engines: "azureai" (Azure AI Document Intelligence) and "mistral"
+# (Mistral OCR). Both require REMOTE_OCR_API_KEY. "azureai" also requires
+# REMOTE_OCR_ENDPOINT; for "mistral" the endpoint is optional and only needed
+# to target a self-hosted deployment.
 REMOTE_OCR_ENGINE = os.getenv("PAPERLESS_REMOTE_OCR_ENGINE")
 REMOTE_OCR_API_KEY = os.getenv("PAPERLESS_REMOTE_OCR_API_KEY")
 REMOTE_OCR_ENDPOINT = os.getenv("PAPERLESS_REMOTE_OCR_ENDPOINT")

--- a/src/paperless/tests/parsers/conftest.py
+++ b/src/paperless/tests/parsers/conftest.py
@@ -133,6 +133,24 @@ def azure_settings(settings: SettingsWrapper) -> SettingsWrapper:
 
 
 @pytest.fixture()
+def mistral_settings(settings: SettingsWrapper) -> SettingsWrapper:
+    """Configure Django settings for a valid Mistral OCR engine.
+
+    Sets ``REMOTE_OCR_ENGINE`` and ``REMOTE_OCR_API_KEY`` and leaves
+    ``REMOTE_OCR_ENDPOINT`` as ``None`` (Mistral defaults to the hosted API).
+
+    Returns
+    -------
+    SettingsWrapper
+        The modified settings object (for chaining further overrides).
+    """
+    settings.REMOTE_OCR_ENGINE = "mistral"
+    settings.REMOTE_OCR_API_KEY = "test-api-key"
+    settings.REMOTE_OCR_ENDPOINT = None
+    return settings
+
+
+@pytest.fixture()
 def no_engine_settings(settings: SettingsWrapper) -> SettingsWrapper:
     """Configure Django settings with no remote engine configured.
 

--- a/src/paperless/tests/parsers/test_remote_parser.py
+++ b/src/paperless/tests/parsers/test_remote_parser.py
@@ -501,3 +501,254 @@ class TestRemoteParserRegistry:
         )
 
         assert parser_cls is None
+
+
+# ---------------------------------------------------------------------------
+# Mistral engine — helpers
+# ---------------------------------------------------------------------------
+
+_MISTRAL_URL = "https://api.mistral.ai/v1/ocr"
+
+
+def _mistral_response(text: str = _DEFAULT_TEXT) -> dict:
+    """Build a minimal Mistral OCR API response with one positioned block."""
+    return {
+        "pages": [
+            {
+                "index": 0,
+                "markdown": text,
+                "dimensions": {"dpi": 200, "width": 800, "height": 1000},
+                "blocks": [{"bbox": [50, 50, 700, 120], "markdown": text}],
+            },
+        ],
+        "model": "mistral-ocr-latest",
+        "usage_info": {},
+    }
+
+
+class TestMistralHelpers:
+    """Unit tests for the pure, framework-independent Mistral helpers."""
+
+    def test_pages_to_text_joins_and_skips_blank(self) -> None:
+        from paperless.parsers.remote import _mistral_pages_to_text
+
+        pages = [
+            {"markdown": "Page one."},
+            {"markdown": "   "},
+            {"markdown": "Page two."},
+            {},
+        ]
+        assert _mistral_pages_to_text(pages) == "Page one.\n\nPage two."
+
+    def test_data_uri_roundtrip(self) -> None:
+        import base64
+
+        from paperless.parsers.remote import _data_uri
+
+        uri = _data_uri("application/pdf", b"%PDF-1.4 hello")
+        assert uri.startswith("data:application/pdf;base64,")
+        payload = uri.split(",", 1)[1]
+        assert base64.b64decode(payload) == b"%PDF-1.4 hello"
+
+    @pytest.mark.parametrize(
+        "block",
+        [
+            pytest.param({"bbox": [1, 2, 3, 4]}, id="list"),
+            pytest.param(
+                {"bbox": {"left": 1, "top": 2, "right": 3, "bottom": 4}},
+                id="edge-dict",
+            ),
+            pytest.param(
+                {
+                    "top_left_x": 1,
+                    "top_left_y": 2,
+                    "bottom_right_x": 3,
+                    "bottom_right_y": 4,
+                },
+                id="corner-keys",
+            ),
+        ],
+    )
+    def test_block_bounding_box_variants(self, block: dict) -> None:
+        from paperless.parsers.remote import _block_bounding_box
+
+        assert _block_bounding_box(block) == (1.0, 2.0, 3.0, 4.0)
+
+    def test_block_bounding_box_missing_returns_none(self) -> None:
+        from paperless.parsers.remote import _block_bounding_box
+
+        assert _block_bounding_box({"markdown": "no box"}) is None
+
+    def test_build_ocr_page_uses_blocks(self) -> None:
+        from paperless.parsers.remote import _build_ocr_page
+
+        page = _build_ocr_page(_mistral_response()["pages"][0], 800, 1000, 200)
+        assert page.ocr_class == "ocr_page"
+        words = page.words
+        assert words and words[0].text == _DEFAULT_TEXT
+
+    def test_build_ocr_page_falls_back_to_markdown(self) -> None:
+        from paperless.parsers.remote import _build_ocr_page
+
+        page_data = {"index": 0, "markdown": "Only text, no boxes."}
+        page = _build_ocr_page(page_data, 800, 1000, 200)
+        assert any(w.text == "Only text, no boxes." for w in page.words)
+
+
+# ---------------------------------------------------------------------------
+# Mistral engine — score()
+# ---------------------------------------------------------------------------
+
+
+class TestMistralScore:
+    @pytest.mark.usefixtures("mistral_settings")
+    def test_score_returns_20_when_configured(self) -> None:
+        assert RemoteDocumentParser.score("application/pdf", "doc.pdf") == 20
+
+    def test_score_returns_20_without_endpoint(
+        self,
+        settings: SettingsWrapper,
+    ) -> None:
+        """Mistral does not require an endpoint (it defaults to the hosted API)."""
+        settings.REMOTE_OCR_ENGINE = "mistral"
+        settings.REMOTE_OCR_API_KEY = "key"
+        settings.REMOTE_OCR_ENDPOINT = None
+        assert RemoteDocumentParser.score("application/pdf", "doc.pdf") == 20
+
+    def test_score_returns_none_when_api_key_missing(
+        self,
+        settings: SettingsWrapper,
+    ) -> None:
+        settings.REMOTE_OCR_ENGINE = "mistral"
+        settings.REMOTE_OCR_API_KEY = None
+        settings.REMOTE_OCR_ENDPOINT = None
+        assert RemoteDocumentParser.score("application/pdf", "doc.pdf") is None
+
+
+# ---------------------------------------------------------------------------
+# Mistral engine — parse()
+# ---------------------------------------------------------------------------
+
+
+class TestMistralParse:
+    def test_parse_returns_text(
+        self,
+        remote_parser: RemoteDocumentParser,
+        simple_png_file: Path,
+        mistral_settings: SettingsWrapper,
+        httpx_mock,
+    ) -> None:
+        httpx_mock.add_response(url=_MISTRAL_URL, json=_mistral_response())
+
+        remote_parser.parse(simple_png_file, "image/png")
+
+        assert remote_parser.get_text() == _DEFAULT_TEXT
+
+    def test_parse_builds_valid_archive_pdf(
+        self,
+        remote_parser: RemoteDocumentParser,
+        simple_png_file: Path,
+        mistral_settings: SettingsWrapper,
+        httpx_mock,
+    ) -> None:
+        import pikepdf
+
+        httpx_mock.add_response(url=_MISTRAL_URL, json=_mistral_response())
+
+        remote_parser.parse(simple_png_file, "image/png")
+
+        archive = remote_parser.get_archive_path()
+        assert archive is not None
+        assert archive.exists()
+        assert archive.suffix == ".pdf"
+        with pikepdf.open(archive) as pdf:
+            assert len(pdf.pages) == 1
+
+    def test_parse_archive_is_searchable(
+        self,
+        remote_parser: RemoteDocumentParser,
+        simple_png_file: Path,
+        mistral_settings: SettingsWrapper,
+        httpx_mock,
+    ) -> None:
+        extract_text = pytest.importorskip("pdfminer.high_level").extract_text
+
+        httpx_mock.add_response(
+            url=_MISTRAL_URL,
+            json=_mistral_response("Rechnung Grüße"),
+        )
+
+        remote_parser.parse(simple_png_file, "image/png")
+
+        archive = remote_parser.get_archive_path()
+        assert archive is not None
+        assert "Rechnung Grüße" in extract_text(str(archive))
+
+    def test_parse_sends_expected_request(
+        self,
+        remote_parser: RemoteDocumentParser,
+        simple_png_file: Path,
+        mistral_settings: SettingsWrapper,
+        httpx_mock,
+    ) -> None:
+        import json
+
+        httpx_mock.add_response(url=_MISTRAL_URL, json=_mistral_response())
+
+        remote_parser.parse(simple_png_file, "image/png")
+
+        request = httpx_mock.get_requests()[0]
+        assert request.headers["Authorization"] == "Bearer test-api-key"
+        body = json.loads(request.content)
+        assert body["model"] == "mistral-ocr-latest"
+        assert body["include_blocks"] is True
+        assert body["document"]["type"] == "image_url"
+        assert body["document"]["image_url"].startswith("data:image/png;base64,")
+
+    @pytest.mark.usefixtures("no_engine_settings")
+    def test_parse_sets_empty_text_when_not_configured(
+        self,
+        remote_parser: RemoteDocumentParser,
+        simple_png_file: Path,
+    ) -> None:
+        remote_parser.parse(simple_png_file, "image/png")
+
+        assert remote_parser.get_text() == ""
+        assert remote_parser.get_archive_path() is None
+
+
+# ---------------------------------------------------------------------------
+# Mistral engine — failure path
+# ---------------------------------------------------------------------------
+
+
+class TestMistralParseError:
+    def test_parse_returns_empty_on_http_error(
+        self,
+        remote_parser: RemoteDocumentParser,
+        simple_png_file: Path,
+        mistral_settings: SettingsWrapper,
+        httpx_mock,
+    ) -> None:
+        httpx_mock.add_response(url=_MISTRAL_URL, status_code=500)
+
+        remote_parser.parse(simple_png_file, "image/png")
+
+        assert remote_parser.get_text() == ""
+        assert remote_parser.get_archive_path() is None
+
+    def test_parse_logs_error_on_failure(
+        self,
+        remote_parser: RemoteDocumentParser,
+        simple_png_file: Path,
+        mistral_settings: SettingsWrapper,
+        httpx_mock,
+        mocker: MockerFixture,
+    ) -> None:
+        httpx_mock.add_response(url=_MISTRAL_URL, status_code=500)
+        mock_log = mocker.patch("paperless.parsers.remote.logger")
+
+        remote_parser.parse(simple_png_file, "image/png")
+
+        mock_log.exception.assert_called_once()
+        assert "Mistral OCR parsing failed" in mock_log.exception.call_args[0][0]


### PR DESCRIPTION
## Proposed change

Adds **Mistral OCR** (`mistral-ocr-latest`) as a second `PAPERLESS_REMOTE_OCR_ENGINE`, alongside the existing Azure AI engine introduced in #10320. It follows the exact same strictly opt-in remote-parser pattern.

Enable it with:

```
PAPERLESS_REMOTE_OCR_ENGINE=mistral
PAPERLESS_REMOTE_OCR_API_KEY=<your key>
# optional, only for a self-hosted Mistral OCR deployment:
# PAPERLESS_REMOTE_OCR_ENDPOINT=https://your-instance
```

### How it works

Unlike Azure, Mistral OCR returns markdown text plus **paragraph-level bounding boxes**, not a ready-made PDF. To satisfy the remote-parser requirement that a **searchable PDF archive** is always produced, the parser assembles the PDF locally:

- The original is rasterised per page (`pdf2image` for PDFs, Pillow for images).
- An **invisible, Unicode-capable text layer** is rendered over each page image using ocrmypdf's bundled fpdf2 renderer and its generic `OcrElement` model (the bundled Noto font covers Latin/European scripts).
- Per-page PDFs are merged with pikepdf into the archive copy.

**No new dependencies** are added - `httpx`, `ocrmypdf`, `pikepdf`, `pdf2image` and Pillow are already used by Paperless-ngx.

### Notes / trade-offs

- Because Mistral provides paragraph-level (not word-level) boxes, in-document **highlighting works at paragraph granularity**. Text search and selection work fully.
- Mistral OCR is a paid cloud service (with a free tier) and is not affiliated with Paperless-ngx. Documents are sent to Mistral for processing. Mistral OCR can also be **self-hosted** in a container, in which case set `PAPERLESS_REMOTE_OCR_ENDPOINT` to your instance.
- The API key is required; the endpoint is optional and defaults to `https://api.mistral.ai`. A system check enforces that `mistral` has an API key configured.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read & agree with the contributing guidelines.
- [x] Tests added/updated: scoring, request shape, extracted text, a valid & searchable archive PDF, the not-configured and failure paths, and the pure helpers (`src/paperless/tests/parsers/test_remote_parser.py`).
- [x] Documentation updated (`docs/configuration.md`, `docs/usage.md`).