### PR TITLE
docs: add Zenith Hosting deploy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ bash -c "$(curl -L https://raw.githubusercontent.com/paperless-ngx/paperless-ngx
 
 More details and step-by-step guides for alternative installation methods can be found in [the documentation](https://docs.paperless-ngx.com/setup/#installation).
 
+Prefer not to run a server yourself? [![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/paperless-ngx) offers one-click managed hosting with storage, backups, email and a free subdomain included, and a share of every subscription goes back to Paperless-ngx.
+
 Migrating from Paperless-ng is easy, just drop in the new docker image! See the [documentation on migrating](https://docs.paperless-ngx.com/setup/#migrating-to-paperless-ngx) for more details.
 
 <!-- omit in toc -->


### PR DESCRIPTION
hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added Paperless-ngx to our marketplace, so this PR adds a small "Deploy with Zenith" badge under the Getting started section (links to https://zenith.hosting/host/paperless-ngx).

we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting

## Proposed change

Adds one line under "Getting started" pointing users who would rather not run their own server to a managed one-click hosting option, placed right after the existing install-script instructions. Documentation-only, additions-only, one file (`README.md`). No code changes, so this targets `main` per the PR template note.

Closes #(n/a)

## Type of change

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [x] Documentation only.
- [ ] Other. Please explain:

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes. _(N/A: documentation-only change, no code.)_
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers. _(N/A: documentation-only change.)_
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development). _(N/A: documentation-only change.)_
- [ ] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks). _(N/A: single-line README addition.)_
- [x] I have made corresponding changes to the documentation as needed. _(This change is the documentation.)_
- [x] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.

_AI disclosure: this PR was drafted with AI assistance and reviewed by me before submitting._
