### PR TITLE
refactor(matching): remove deprecated TODO and simplify fuzzy match return.

### DIFF
--- a/src/documents/matching.py
+++ b/src/documents/matching.py
@@ -244,16 +244,14 @@ def matches(matching_model: MatchingModel, document: Document):
             match = match.lower()
             text = text.lower()
         if fuzz.partial_ratio(match, text, score_cutoff=90):
-            # TODO: make this better
             log_reason(
                 matching_model,
                 document,
-                f"parts of the document content somehow match the string "
-                f"{matching_model.match}",
+                f"Document content has a fuzzy match with the string '{matching_model.match}' (score >= 90)",
             )
             return True
-        else:
-            return False
+
+        return False
 
     elif matching_model.matching_algorithm == MatchingModel.MATCH_AUTO:
         # this is done elsewhere.


### PR DESCRIPTION
## Description
This small PR refactors the fuzzy matching block in `src/documents/matching.py` by:
1. Removing an old `# TODO: make this better` comment.
2. Formatting the log string correctly.
3. Simplifying the logic to avoid redundant `else: return False` block.

All unit tests for matchables have been executed and pass successfully.
