### PR TITLE
Fix native document previews in Chrome

### DIFF
--- a/src-ui/src/app/components/document-detail/document-detail.component.html
+++ b/src-ui/src/app/components/document-detail/document-detail.component.html
@@ -482,9 +482,7 @@
             </pngx-pdf-viewer>
           </div>
         } @else {
-          <object [data]="previewUrl() | safeUrl" class="preview-sticky" width="100%">
-            <span>Preview is unavailable.</span>
-          </object>
+          <object [data]="previewUrl() | safeUrl" class="preview-sticky" width="100%"></object>
         }
       }
       @case (ContentRenderType.Text) {
@@ -505,9 +503,7 @@
         }
       }
       @case (ContentRenderType.Other) {
-        <object [data]="previewUrl() | safeUrl" class="preview-sticky" width="100%">
-          <span>Preview is unavailable.</span>
-        </object>
+        <object [data]="previewUrl() | safeUrl" class="preview-sticky" width="100%"></object>
       }
     }
     @if (requiresPassword) {

--- a/src-ui/src/app/components/document-detail/document-detail.component.spec.ts
+++ b/src-ui/src/app/components/document-detail/document-detail.component.spec.ts
@@ -1212,7 +1212,9 @@ describe('DocumentDetailComponent', () => {
     settingsService.set(SETTINGS_KEYS.USE_NATIVE_PDF_VIEWER, true)
     expect(component.useNativePdfViewer).toBeTruthy()
     fixture.detectChanges()
-    expect(fixture.debugElement.query(By.css('object'))).not.toBeNull()
+    const object = fixture.debugElement.query(By.css('object'))
+    expect(object).not.toBeNull()
+    expect(object.nativeElement.childElementCount).toEqual(0)
   })
 
   it('should attempt to retrieve metadata', () => {


### PR DESCRIPTION
## Summary
- keep native document `<object>` elements empty so Chrome loads their `data` resource
- remove fallback child content from PDF and other native previews
- extend the native PDF viewer test to guard against child elements

Chrome did not issue a request for the PDF when fallback content was present inside the object. Replacing the object with the previously used empty form immediately triggered the embedded PDF request.

## Test plan
- [x] Reproduced with Chrome 150 against v3.0.0-beta.rc2
- [x] Verified an empty object triggers Chrome's embedded PDF request
- [x] `pnpm exec jest --runInBand src/app/components/document-detail/document-detail.component.spec.ts`
- [x] `pnpm run lint`

Made with [Cursor](https://cursor.com)