### PR TITLE
Only download new mail, and remember mail that yields no document

### DIFF
--- a/src/paperless_mail/mail.py
+++ b/src/paperless_mail/mail.py
@@ -73,6 +73,12 @@ APPLE_MAIL_TAG_COLORS = {
     "grey": ["$MailFlagBit1", "$MailFlagBit2"],
 }
 
+# Fetch new mail in batches rather than all at once. This caps peak memory use
+# and keeps each IMAP SEARCH/FETCH command within server line-length limits,
+# which matters on the first run against a large existing folder where there
+# can be tens of thousands of new UIDs to name in a single command.
+MAIL_FETCH_BATCH_SIZE = 500
+
 
 class MailError(Exception):
     pass
@@ -535,6 +541,75 @@ class MailAccountHandler(LoggingMixin):
             )
         return None
 
+    def _get_processed_uids(self, rule: MailRule) -> set[str]:
+        """
+        Return the set of message UIDs already handled for this rule + folder,
+        so their bodies don't need to be downloaded again.
+
+        Respects UIDVALIDITY: rows whose stored validity no longer matches the
+        folder's current value are ignored, since the same UID may now point at
+        a different message and should be treated as new.
+        """
+        processed = ProcessedMail.objects.filter(rule=rule, folder=rule.folder)
+        if self._current_uid_validity is not None:
+            processed = processed.filter(
+                Q(uid_validity=self._current_uid_validity)
+                | Q(uid_validity__isnull=True),
+            )
+        return set(processed.values_list("uid", flat=True))
+
+    def _fetch_messages_by_uid(
+        self,
+        M: MailBox,
+        rule: MailRule,
+        uids: list[str],
+    ):
+        """
+        Yield the full messages for the given UIDs, fetched in bounded batches
+        so a single IMAP command never has to name (or download) the whole set
+        at once.
+        """
+        for start in range(0, len(uids), MAIL_FETCH_BATCH_SIZE):
+            batch = uids[start : start + MAIL_FETCH_BATCH_SIZE]
+            yield from M.fetch(
+                criteria=AND(uid=",".join(batch)),
+                mark_seen=False,
+                charset=rule.account.character_set,
+                bulk=True,
+            )
+
+    def _mark_processed_without_consumption(
+        self,
+        message: MailMessage,
+        rule: MailRule,
+    ) -> None:
+        """
+        Record that a message was examined but produced nothing to consume, so
+        it isn't fetched and examined again on the next run.
+
+        Without this, a message that never yields a document (e.g. one with no
+        attachments under an attachments-only rule) is never recorded in the DB
+        and never flagged on the server, so it keeps matching the folder search
+        and gets re-downloaded in full every cycle.
+        """
+        if not ProcessedMail.objects.filter(
+            rule=rule,
+            uid=message.uid,
+            folder=rule.folder,
+            uid_validity=self._current_uid_validity,
+        ).exists():
+            ProcessedMail.objects.create(
+                rule=rule,
+                folder=rule.folder,
+                uid=message.uid,
+                uid_validity=self._current_uid_validity,
+                subject=message.subject,
+                received=make_aware(message.date)
+                if is_naive(message.date)
+                else message.date,
+                status="PROCESSED_WO_CONSUMPTION",
+            )
+
     def _get_correspondent(
         self,
         message: MailMessage,
@@ -680,23 +755,34 @@ class MailAccountHandler(LoggingMixin):
             f"Rule {rule}: Searching folder with criteria {criterias}",
         )
 
+        # Ask the server which messages match, then download the bodies of only
+        # the ones we haven't handled before. Previously the full body of every
+        # matching message was fetched on each run and de-duplicated in Python
+        # afterwards, so a large folder was re-downloaded in its entirety every
+        # scheduling cycle.
         try:
-            messages = M.fetch(
+            matching_uids = M.uids(
                 criteria=criterias,
-                mark_seen=False,
                 charset=rule.account.character_set,
-                bulk=True,
             )
         except Exception as err:
             raise MailError(
-                f"Rule {rule}: Error while fetching folder {rule.folder}",
+                f"Rule {rule}: Error while searching folder {rule.folder}",
             ) from err
+
+        already_processed_uids = self._get_processed_uids(rule)
+        new_uids = [uid for uid in matching_uids if uid not in already_processed_uids]
+
+        self.log.debug(
+            f"Rule {rule}: {len(matching_uids)} mail(s) matched search, "
+            f"{len(new_uids)} new to fetch",
+        )
 
         mails_processed = 0
         total_processed_files = 0
         rule_seen_messages: set[tuple[str, str | None]] = set()
 
-        for message in messages:
+        for message in self._fetch_messages_by_uid(M, rule, new_uids):
             if TYPE_CHECKING:
                 assert isinstance(message, MailMessage)
 
@@ -711,22 +797,6 @@ class MailAccountHandler(LoggingMixin):
             if message_key in consumed_messages:
                 self.log.debug(
                     f"Skipping mail '{message.uid}' subject '{message.subject}' from '{message.from_}', already queued by a previous rule in this run.",
-                )
-                continue
-
-            already_processed = ProcessedMail.objects.filter(
-                rule=rule,
-                uid=message.uid,
-                folder=rule.folder,
-            )
-            if self._current_uid_validity is not None:
-                already_processed = already_processed.filter(
-                    Q(uid_validity=self._current_uid_validity)
-                    | Q(uid_validity__isnull=True),
-                )
-            if already_processed.exists():
-                self.log.debug(
-                    f"Skipping mail '{message.uid}' subject '{message.subject}' from '{message.from_}', already processed.",
                 )
                 continue
 
@@ -752,11 +822,13 @@ class MailAccountHandler(LoggingMixin):
         processed_elements = 0
 
         # Skip Message handling when only attachments are to be processed but
-        # message doesn't have any.
+        # message doesn't have any. Record it as processed first, so it isn't
+        # fetched and re-examined on every subsequent run.
         if (
             not message.attachments
             and rule.consumption_scope == MailRule.ConsumptionScope.ATTACHMENTS_ONLY
         ):
+            self._mark_processed_without_consumption(message, rule)
             return processed_elements
 
         self.log.debug(
@@ -957,24 +1029,9 @@ class MailAccountHandler(LoggingMixin):
                 uid_validity=self._current_uid_validity,
             )
         else:
-            # No files to consume, just mark as processed if it wasn't by .eml processing
-            if not ProcessedMail.objects.filter(
-                rule=rule,
-                uid=message.uid,
-                folder=rule.folder,
-                uid_validity=self._current_uid_validity,
-            ).exists():
-                ProcessedMail.objects.create(
-                    rule=rule,
-                    folder=rule.folder,
-                    uid=message.uid,
-                    uid_validity=self._current_uid_validity,
-                    subject=message.subject,
-                    received=make_aware(message.date)
-                    if is_naive(message.date)
-                    else message.date,
-                    status="PROCESSED_WO_CONSUMPTION",
-                )
+            # No files to consume, just mark as processed so it isn't fetched
+            # and re-examined on every subsequent run.
+            self._mark_processed_without_consumption(message, rule)
 
         return processed_attachments
 

--- a/src/paperless_mail/tests/test_mail.py
+++ b/src/paperless_mail/tests/test_mail.py
@@ -134,10 +134,15 @@ class BogusMailBox(AbstractContextManager):
         if username != self.USERNAME or access_token != self.ACCESS_TOKEN:
             raise MailboxLoginError("BAD", "OK")
 
-    def fetch(self, criteria, mark_seen, charset="", *, bulk=True):
+    def _search(self, criteria) -> list[MailMessage]:
         msg = self.messages
 
         criteria = str(criteria).strip("()").split(" ")
+
+        if "UID" in criteria:
+            # A fetch narrowed to an explicit set of UIDs, e.g. "UID 1,2,3"
+            wanted = criteria[criteria.index("UID") + 1].split(",")
+            msg = filter(lambda m: m.uid in wanted, msg)
 
         if "UNSEEN" in criteria:
             msg = filter(lambda m: not m.seen, msg)
@@ -169,6 +174,12 @@ class BogusMailBox(AbstractContextManager):
             msg = filter(lambda m: "processed" not in m.flags, msg)
 
         return list(msg)
+
+    def uids(self, criteria="ALL", charset="", sort=None) -> list[str]:
+        return [m.uid for m in self._search(criteria)]
+
+    def fetch(self, criteria, mark_seen, charset="", *, bulk=True):
+        return self._search(criteria)
 
     def delete(self, uid_list) -> None:
         self.messages = list(filter(lambda m: m.uid not in uid_list, self.messages))
@@ -538,15 +549,26 @@ class TestMail(
         )
 
     def test_handle_empty_message(self) -> None:
-        message = namedtuple("MailMessage", [])
+        # A message with no attachments under an attachments-only rule has
+        # nothing to consume, but it must still be recorded as processed so it
+        # isn't fetched and re-examined on every subsequent run.
+        message = self.mailMocker.messageBuilder.create_message(attachments=[])
 
-        message.attachments = []
-        rule = MailRule()
+        account = MailAccount.objects.create()
+        rule = MailRule(account=account)
+        rule.save()
 
         result = self.mail_account_handler._handle_message(message, rule)
 
         self.mailMocker._queue_consumption_tasks_mock.assert_not_called()
         self.assertEqual(result, 0)
+        self.assertTrue(
+            ProcessedMail.objects.filter(
+                rule=rule,
+                uid=message.uid,
+                status="PROCESSED_WO_CONSUMPTION",
+            ).exists(),
+        )
 
     def test_handle_unknown_mime_type(self) -> None:
         message = self.mailMocker.messageBuilder.create_message(
@@ -1645,6 +1667,80 @@ class TestMail(
                     self.mailMocker._queue_consumption_tasks_mock.call_count,
                     expected_mail_count,
                 )
+
+    def test_already_processed_mail_not_refetched(self) -> None:
+        """
+        GIVEN:
+            - A folder containing mail that yields no document (no attachments
+              under an attachments-only rule), which is therefore never flagged
+              on the server and keeps matching the folder search
+        WHEN:
+            - The account is handled a second time
+        THEN:
+            - The already-handled mail is recorded as processed on the first
+              run, and is not downloaded again on the second run even though it
+              still matches the server-side search
+        """
+        account = MailAccount.objects.create(
+            name="test",
+            imap_server="",
+            username=BogusMailBox.USERNAME,
+            password=BogusMailBox.ASCII_PASSWORD,
+        )
+        rule = MailRule.objects.create(
+            name="testrule",
+            account=account,
+            action=MailRule.MailAction.MARK_READ,
+            # Avoid a date-based search term so the criteria is purely UNSEEN
+            maximum_age=0,
+        )
+
+        with_attachment = self.mailMocker.messageBuilder.create_message(
+            subject="has attachment",
+            attachments=1,
+            seen=False,
+        )
+        without_attachment = self.mailMocker.messageBuilder.create_message(
+            subject="no attachment",
+            attachments=[],
+            seen=False,
+        )
+        self.mailMocker.bogus_mailbox.messages = [with_attachment, without_attachment]
+        self.mailMocker.bogus_mailbox.updateClient()
+
+        # First run: consume the one with an attachment and record the other as
+        # processed-without-consumption.
+        self.mail_account_handler.handle_mail_account(account)
+        self.mailMocker.apply_mail_actions()
+
+        self.assertEqual(self.mailMocker._queue_consumption_tasks_mock.call_count, 1)
+        self.assertEqual(ProcessedMail.objects.count(), 2)
+        self.assertTrue(
+            ProcessedMail.objects.filter(
+                rule=rule,
+                uid=without_attachment.uid,
+                status="PROCESSED_WO_CONSUMPTION",
+            ).exists(),
+        )
+
+        # The attachment-less mail was never marked \Seen, so it still matches
+        # the folder search...
+        self.assertIn(
+            without_attachment.uid,
+            self.mailMocker.bogus_mailbox.uids(criteria="UNSEEN"),
+        )
+
+        # ...but a second run must not download it (or anything) again.
+        self.mailMocker._queue_consumption_tasks_mock.reset_mock()
+        with mock.patch.object(
+            self.mailMocker.bogus_mailbox,
+            "fetch",
+            wraps=self.mailMocker.bogus_mailbox.fetch,
+        ) as fetch_spy:
+            self.mail_account_handler.handle_mail_account(account)
+
+        fetch_spy.assert_not_called()
+        self.mailMocker._queue_consumption_tasks_mock.assert_not_called()
 
     def test_auth_plain_fallback(self) -> None:
         """


### PR DESCRIPTION
## Problem

Fetching a mail folder is structured as *"download everything the server search
matches, then throw away what we've already handled."* `_handle_mail_rule` calls:

```python
messages = M.fetch(criteria=criterias, mark_seen=False, bulk=True)
```

`imap_tools.MailBox.fetch()` defaults to `headers_only=False` with no `limit`, so
this downloads the **full RFC822 body of every message** the IMAP `SEARCH`
matches, and the `ProcessedMail` de-duplication then happens in Python. The cost
of a run is therefore bounded by *how many messages match the search*, never by
*how many are actually new*.

On its own that would still converge, because handled mail normally drops out of
the search (it gets marked `\Seen` / `\Flagged` / tagged / moved / deleted). But
the server-side mark is only applied **after a message produces a document**. A
message with no attachments under an attachments-only rule hits the early return
in `_handle_message` and is *never* flagged **and never recorded** — so it keeps
matching the `UNSEEN` search forever.

The two problems compound into a pathological case: an account whose inbox is
mostly ordinary (attachment-less) mail re-downloads **every message in full on
every scheduling cycle** — by default every 10 minutes. For a large inbox
(tens of thousands of messages) that is a full re-download of the whole folder
every 10 minutes, indefinitely.

## Fix

Both halves are addressed in `paperless_mail/mail.py`:

1. **Diff UIDs before fetching bodies.** Ask the server for the matching UIDs
   first via `M.uids()` (a `UID SEARCH`, no bodies), subtract the UIDs already in
   `ProcessedMail` for this rule+folder (respecting `UIDVALIDITY`), and only fetch
   the bodies of what's left. Steady state drops from *O(everything matching)* to
   *O(new since last run)* — usually zero, i.e. a single cheap `UID SEARCH`.
   Bodies are pulled in bounded batches (`MAIL_FETCH_BATCH_SIZE = 500`) so the
   first run against a large existing folder doesn't name tens of thousands of
   UIDs in one command or hold them all in memory.

2. **Always record a `ProcessedMail` row** for a message we've finished with,
   including the "nothing to consume" early return — not just the path that
   already did it. This is what lets the UID diff in (1) actually exclude such
   mail, so convergence no longer depends on an IMAP flag being set, and it works
   uniformly across mark-read / flag / tag rules and servers that don't persist
   keywords. (The existing `PROCESSED_WO_CONSUMPTION` record path in
   `_process_attachments` is refactored into a shared helper and reused here.)

The action's server-side criteria (`{seen: False}`, `{flagged: False}`,
`no_keyword=…`) is kept as-is: it still usefully narrows the candidate set, and
preserves the existing "don't process mail the user already read/flagged
themselves" behaviour.

## Behaviour change

A message that produced no document is now remembered permanently. Since an
existing message can't grow an attachment later, that's correct; and a user who
changes a rule's scope can still delete the `ProcessedMail` rows (Mail →
Processed Mails) to force a re-scan, exactly as today.

## Tests

- New `test_already_processed_mail_not_refetched`: an attachment-less mail under a
  mark-read rule is recorded on the first run and, on a second run, is **not**
  downloaded again (a `fetch` spy asserts zero body fetches) even though it still
  matches the `UNSEEN` search.
- `test_handle_empty_message` updated to assert the no-attachment path now records
  a `PROCESSED_WO_CONSUMPTION` row.
- Test mailbox mock (`BogusMailBox`) gains a `uids()` method and shares its
  criteria matching with `fetch()`, including handling an explicit `UID` set.

Full `paperless_mail` suite passes (176 passed); `ruff check` / `ruff format`
clean.
