### PR TITLE
Add jitter to the scheduled mail check to avoid a thundering herd

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1182,6 +1182,16 @@ should be a valid crontab(5) expression describing when to run.
 
     Defaults to `*/10 * * * *` or every ten minutes.
 
+#### [`PAPERLESS_EMAIL_TASK_JITTER_SECONDS=<int>`](#PAPERLESS_EMAIL_TASK_JITTER_SECONDS) {#PAPERLESS_EMAIL_TASK_JITTER_SECONDS}
+
+: Delays each _scheduled_ email fetch by a random number of seconds between 0
+and this value. Because the fetch is scheduled with a plain crontab, every
+install would otherwise connect to its mail server at the exact same instant
+(e.g. on the minute); this spreads that load out. Manually triggered fetches
+are not delayed.
+
+    Defaults to 90. Set to 0 to disable the delay.
+
 #### [`PAPERLESS_TRAIN_TASK_CRON=<cron expression>`](#PAPERLESS_TRAIN_TASK_CRON) {#PAPERLESS_TRAIN_TASK_CRON}
 
 : Configures the scheduled automatic classifier training frequency. The value

--- a/src/paperless/settings/__init__.py
+++ b/src/paperless/settings/__init__.py
@@ -703,6 +703,14 @@ CELERY_BEAT_SCHEDULE = parse_beat_schedule()
 # https://docs.celeryq.dev/en/stable/userguide/configuration.html#beat-schedule-filename
 CELERY_BEAT_SCHEDULE_FILENAME = str(DATA_DIR / "celerybeat-schedule.db")
 
+# Every Paperless install runs the mail check on the same crontab boundary
+# (default "*/10 * * * *", i.e. exactly on the wall-clock minute). Without any
+# jitter, every instance in the world logs in to its mail server at the same
+# instant, which shows up as a thundering herd of simultaneous IMAP logins on
+# the X0:00 / X5:00 second. Delay the scheduled run by a random number of
+# seconds in [0, N] to spread that load out. Set to 0 to disable.
+EMAIL_TASK_JITTER_SECONDS = int(os.getenv("PAPERLESS_EMAIL_TASK_JITTER_SECONDS", 90))
+
 
 # Cachalot: Database read cache.
 def _parse_cachalot_settings():

--- a/src/paperless_mail/tasks.py
+++ b/src/paperless_mail/tasks.py
@@ -1,6 +1,9 @@
 import logging
+import random
+import time
 
 from celery import shared_task
+from django.conf import settings
 
 from paperless_mail.mail import MailAccountHandler
 from paperless_mail.mail import MailError
@@ -10,8 +13,26 @@ from paperless_mail.models import MailRule
 logger = logging.getLogger("paperless.mail.tasks")
 
 
-@shared_task
-def process_mail_accounts(account_ids: list[int] | None = None) -> str:
+@shared_task(bind=True)
+def process_mail_accounts(self, account_ids: list[int] | None = None) -> str:
+    # The beat schedule fires this task on a fixed crontab boundary, so every
+    # install would otherwise hit its mail server at the exact same second.
+    # Spread scheduled runs out with a small random delay. Manual runs (from
+    # the UI, which pass an explicit account_ids) are left untouched so the
+    # user isn't kept waiting.
+    jitter = getattr(settings, "EMAIL_TASK_JITTER_SECONDS", 0)
+    trigger_source = getattr(self.request, "trigger_source", None)
+    if trigger_source is None:
+        # Depending on the celery version the custom header may only be
+        # reachable via the request's headers mapping.
+        headers = getattr(self.request, "headers", None) or {}
+        trigger_source = headers.get("trigger_source")
+    is_scheduled = trigger_source == "scheduled"
+    if jitter > 0 and account_ids is None and is_scheduled:
+        delay = random.uniform(0, jitter)
+        logger.debug(f"Jittering scheduled mail check by {delay:.1f}s")
+        time.sleep(delay)
+
     total_new_documents = 0
     accounts = (
         MailAccount.objects.filter(pk__in=account_ids)


### PR DESCRIPTION
## Problem

The mail check is scheduled as a Celery beat entry with a plain `crontab`
(`parse_beat_schedule()` in `paperless/settings/custom.py`), defaulting to
`*/10 * * * *`. A crontab fires at second 0 of the minute, and there is no jitter
anywhere in the schedule, so **every Paperless install runs the mail check at the
same instant** — on the exact `:00` of minutes 0/10/20/30/40/50.

Downstream (e.g. at a mail provider) this shows up as a burst of simultaneous
IMAP logins landing on the exact `X0:00` / `X5:00` second, from many independent
Paperless instances at once.

## Fix

Delay scheduled runs by a random `0..N` seconds at the start of
`process_mail_accounts`:

- New setting `EMAIL_TASK_JITTER_SECONDS` (env
  `PAPERLESS_EMAIL_TASK_JITTER_SECONDS`), default **90**; set to `0` to disable
  and restore the previous behaviour.
- Only **scheduled** (beat) runs are delayed. The task is now `bind=True` and
  checks the `trigger_source == "scheduled"` header (already set by the beat
  schedule). Manual runs from the UI/CLI pass explicit `account_ids` and are
  never jittered, so an admin clicking "process now" isn't left waiting.

This spreads a 10-minute cycle's logins across a 90s window instead of one
second.

## Trade-off / alternatives

The task sleeps, so a worker is held for the duration of the jitter. Given the
default 10-minute cadence and a ≤90s window that's cheap. A fancier approach
would re-dispatch the task with a random `countdown` instead of sleeping, but
this is the smallest change that gives a default install some jitter, and it
keeps the logic in one obvious place.

Documented under `PAPERLESS_EMAIL_TASK_JITTER_SECONDS` in `docs/configuration.md`.
