### PR TITLE
Tweakhancement (beta): allow some bulk operations with all

### DIFF
--- a/src-ui/src/app/components/document-list/bulk-editor/bulk-editor.component.html
+++ b/src-ui/src/app/components/document-list/bulk-editor/bulk-editor.component.html
@@ -103,13 +103,13 @@
         class="btn btn-sm btn-outline-primary"
         id="dropdownSend"
         ngbDropdownToggle
-        [disabled]="disabled || !list.hasSelection || list.allSelected"
+        [disabled]="disabled || !canSendSelection"
       >
         <i-bs name="send"></i-bs><div class="d-none d-sm-inline ms-1"><ng-container i18n>Send</ng-container>
         </div>
       </button>
       <div ngbDropdownMenu aria-labelledby="dropdownSend" class="shadow">
-        <button ngbDropdownItem (click)="createShareLinkBundle()" [disabled]="list.allSelected">
+        <button ngbDropdownItem (click)="createShareLinkBundle()" [disabled]="!canSendSelection">
           <i-bs name="link" class="me-1"></i-bs><ng-container i18n>Create a share link bundle</ng-container>
         </button>
         <button ngbDropdownItem (click)="manageShareLinkBundles()">
@@ -117,7 +117,7 @@
         </button>
         <div class="dropdown-divider"></div>
         @if (emailEnabled) {
-          <button ngbDropdownItem (click)="emailSelected()" [disabled]="list.allSelected">
+          <button ngbDropdownItem (click)="emailSelected()" [disabled]="!canSendSelection">
             <i-bs name="envelope" class="me-1"></i-bs><ng-container i18n>Email</ng-container>
           </button>
         }

--- a/src-ui/src/app/components/document-list/bulk-editor/bulk-editor.component.spec.ts
+++ b/src-ui/src/app/components/document-list/bulk-editor/bulk-editor.component.spec.ts
@@ -208,6 +208,50 @@ describe('BulkEditorComponent', () => {
     expect(component.tagSelectionModel.selectionSize()).toEqual(1)
   })
 
+  it('should allow sending an all-filtered selection that fits on the current page', () => {
+    jest
+      .spyOn(documentListViewService, 'hasSelection', 'get')
+      .mockReturnValue(true)
+    jest
+      .spyOn(documentListViewService, 'allSelected', 'get')
+      .mockReturnValue(true)
+    jest
+      .spyOn(documentListViewService, 'selectedCount', 'get')
+      .mockReturnValue(5)
+    jest
+      .spyOn(documentListViewService, 'selected', 'get')
+      .mockReturnValue(new Set([1, 2, 3, 4, 5]))
+
+    fixture.detectChanges()
+
+    expect(component.canSendSelection).toBe(true)
+    expect(
+      fixture.debugElement.query(By.css('#dropdownSend')).nativeElement.disabled
+    ).toBe(false)
+  })
+
+  it('should prevent sending an all-filtered selection spanning multiple pages', () => {
+    jest
+      .spyOn(documentListViewService, 'hasSelection', 'get')
+      .mockReturnValue(true)
+    jest
+      .spyOn(documentListViewService, 'allSelected', 'get')
+      .mockReturnValue(true)
+    jest
+      .spyOn(documentListViewService, 'selectedCount', 'get')
+      .mockReturnValue(6)
+    jest
+      .spyOn(documentListViewService, 'selected', 'get')
+      .mockReturnValue(new Set([1, 2, 3, 4, 5]))
+
+    fixture.detectChanges()
+
+    expect(component.canSendSelection).toBe(false)
+    expect(
+      fixture.debugElement.query(By.css('#dropdownSend')).nativeElement.disabled
+    ).toBe(true)
+  })
+
   it('should apply selection data to correspondents menu', () => {
     jest.spyOn(permissionsService, 'currentUserCan').mockReturnValue(true)
     fixture.detectChanges()
@@ -1597,6 +1641,7 @@ describe('BulkEditorComponent', () => {
     expect(modal.componentInstance.customFields.length).toEqual(2)
     expect(modal.componentInstance.fieldsToAddIds).toEqual([1, 2])
     expect(modal.componentInstance.selection).toEqual({ documents: [3, 4] })
+    expect(modal.componentInstance.selectionCount).toEqual(2)
     expect(modal.componentInstance.documents).toEqual([3, 4])
 
     modal.componentInstance.failed.emit()

--- a/src-ui/src/app/components/document-list/bulk-editor/bulk-editor.component.ts
+++ b/src-ui/src/app/components/document-list/bulk-editor/bulk-editor.component.ts
@@ -1041,6 +1041,14 @@ export class BulkEditorComponent
     return this.settings.get(SETTINGS_KEYS.EMAIL_ENABLED)
   }
 
+  public get canSendSelection(): boolean {
+    return (
+      this.list.hasSelection &&
+      (!this.list.allSelected ||
+        this.list.selectedCount === this.list.selected.size)
+    )
+  }
+
   createShareLinkBundle() {
     const modal = this.modalService.open(ShareLinkBundleDialogComponent, {
       backdrop: 'static',


### PR DESCRIPTION
## Proposed change

While not a bug, simple enough to change this, we allow the 'all' button to still do some bulk operations (e.g. send) if the list is ≤ page size (i.e. the IDs are already loaded). I think this makes some intuitive sense

<img width="2069" height="1225" alt="Screenshot 2026-07-22 at 8 22 35 AM" src="https://github.com/user-attachments/assets/bc33b4e9-e2a7-44ec-ade1-206f2412dc69" />

See part of #13190

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
