### PR TITLE
Chore (beta): mark first batch of thumbnails as priorty for LCP warning

### DIFF
--- a/src-ui/src/app/components/document-list/document-card-large/document-card-large.component.html
+++ b/src-ui/src/app/components/document-list/document-card-large/document-card-large.component.html
@@ -2,7 +2,11 @@
   <div class="row g-0">
     <div class="col-md-2 doc-img-container rounded-start" (click)="this.toggleSelected.emit($event)" (dblclick)="dblClickDocument.emit()">
        @if (document()) {
-        <img [ngSrc]="getThumbUrl()" fill [priority]="priority()" class="card-img doc-img border-end rounded-start" [class.inverted]="getIsThumbInverted()">
+        @if (priority()) {
+          <img [ngSrc]="getThumbUrl()" fill priority class="card-img doc-img border-end rounded-start" [class.inverted]="getIsThumbInverted()">
+        } @else {
+          <img [ngSrc]="getThumbUrl()" fill class="card-img doc-img border-end rounded-start" [class.inverted]="getIsThumbInverted()">
+        }
 
         <div class="border-end border-bottom bg-light document-card-check">
           <div class="form-check">

--- a/src-ui/src/app/components/document-list/document-card-large/document-card-large.component.html
+++ b/src-ui/src/app/components/document-list/document-card-large/document-card-large.component.html
@@ -2,7 +2,7 @@
   <div class="row g-0">
     <div class="col-md-2 doc-img-container rounded-start" (click)="this.toggleSelected.emit($event)" (dblclick)="dblClickDocument.emit()">
        @if (document()) {
-        <img [ngSrc]="getThumbUrl()" fill class="card-img doc-img border-end rounded-start" [class.inverted]="getIsThumbInverted()">
+        <img [ngSrc]="getThumbUrl()" fill [priority]="priority()" class="card-img doc-img border-end rounded-start" [class.inverted]="getIsThumbInverted()">
 
         <div class="border-end border-bottom bg-light document-card-check">
           <div class="form-check">

--- a/src-ui/src/app/components/document-list/document-card-large/document-card-large.component.html
+++ b/src-ui/src/app/components/document-list/document-card-large/document-card-large.component.html
@@ -3,9 +3,9 @@
     <div class="col-md-2 doc-img-container rounded-start" (click)="this.toggleSelected.emit($event)" (dblclick)="dblClickDocument.emit()">
        @if (document()) {
         @if (priority()) {
-          <img [ngSrc]="getThumbUrl()" fill priority class="card-img doc-img border-end rounded-start" [class.inverted]="getIsThumbInverted()">
+          <img [ngSrc]="getThumbUrl()" fill priority class="card-img doc-img border-end rounded-start" [class.inverted]="getIsThumbInverted()" alt="{{ document().title | documentTitle }} thumbnail" i18n-alt>
         } @else {
-          <img [ngSrc]="getThumbUrl()" fill class="card-img doc-img border-end rounded-start" [class.inverted]="getIsThumbInverted()">
+          <img [ngSrc]="getThumbUrl()" fill class="card-img doc-img border-end rounded-start" [class.inverted]="getIsThumbInverted()" alt="{{ document().title | documentTitle }} thumbnail" i18n-alt>
         }
 
         <div class="border-end border-bottom bg-light document-card-check">

--- a/src-ui/src/app/components/document-list/document-card-large/document-card-large.component.spec.ts
+++ b/src-ui/src/app/components/document-list/document-card-large/document-card-large.component.spec.ts
@@ -95,14 +95,7 @@ describe('DocumentCardLargeComponent', () => {
   })
 
   it('should prioritize the thumbnail when requested', () => {
-    fixture.destroy()
-    fixture = TestBed.createComponent(DocumentCardLargeComponent)
     fixture.componentRef.setInput('priority', true)
-    fixture.componentRef.setInput('document', {
-      ...doc,
-      tags: [...doc.tags],
-      notes: [...doc.notes],
-    })
     fixture.detectChanges()
     const thumbnail: HTMLImageElement =
       fixture.nativeElement.querySelector('img.doc-img')

--- a/src-ui/src/app/components/document-list/document-card-large/document-card-large.component.spec.ts
+++ b/src-ui/src/app/components/document-list/document-card-large/document-card-large.component.spec.ts
@@ -94,6 +94,22 @@ describe('DocumentCardLargeComponent', () => {
     expect(thumbnail.getAttribute('loading')).toEqual('lazy')
   })
 
+  it('should prioritize the thumbnail when requested', () => {
+    fixture.destroy()
+    fixture = TestBed.createComponent(DocumentCardLargeComponent)
+    fixture.componentRef.setInput('priority', true)
+    fixture.componentRef.setInput('document', {
+      ...doc,
+      tags: [...doc.tags],
+      notes: [...doc.notes],
+    })
+    fixture.detectChanges()
+    const thumbnail: HTMLImageElement =
+      fixture.nativeElement.querySelector('img.doc-img')
+    expect(thumbnail.getAttribute('loading')).toEqual('eager')
+    expect(thumbnail.getAttribute('fetchpriority')).toEqual('high')
+  })
+
   it('should trim content', () => {
     expect(component.contentTrimmed).toHaveLength(503) // includes ...
   })

--- a/src-ui/src/app/components/document-list/document-card-large/document-card-large.component.ts
+++ b/src-ui/src/app/components/document-list/document-card-large/document-card-large.component.ts
@@ -66,6 +66,7 @@ export class DocumentCardLargeComponent
   private documentService = inject(DocumentService)
   settingsService = inject(SettingsService)
   readonly selected = input(false)
+  readonly priority = input(false)
   readonly displayFields = input<string[]>(
     DEFAULT_DISPLAY_FIELDS.map((f) => f.id)
   )

--- a/src-ui/src/app/components/document-list/document-card-small/document-card-small.component.html
+++ b/src-ui/src/app/components/document-list/document-card-small/document-card-small.component.html
@@ -2,7 +2,7 @@
   <div class="card h-100 shadow-sm document-card" [class.placeholder-glow]="!document()" [class.card-selected]="selected()" (mouseleave)="mouseLeaveCard()">
     <div class="border-bottom doc-img-container rounded-top" (click)="this.toggleSelected.emit($event)" (dblclick)="dblClickDocument.emit(this)">
        @if (document()) {
-        <img class="card-img doc-img" [class.inverted]="getIsThumbInverted()" [ngSrc]="getThumbUrl()" fill>
+        <img class="card-img doc-img" [class.inverted]="getIsThumbInverted()" [ngSrc]="getThumbUrl()" fill [priority]="priority()">
 
         <div class="border-end border-bottom bg-light py-1 px-2 document-card-check">
           <div class="form-check">

--- a/src-ui/src/app/components/document-list/document-card-small/document-card-small.component.html
+++ b/src-ui/src/app/components/document-list/document-card-small/document-card-small.component.html
@@ -3,9 +3,9 @@
     <div class="border-bottom doc-img-container rounded-top" (click)="this.toggleSelected.emit($event)" (dblclick)="dblClickDocument.emit(this)">
        @if (document()) {
         @if (priority()) {
-          <img class="card-img doc-img" [class.inverted]="getIsThumbInverted()" [ngSrc]="getThumbUrl()" fill priority>
+          <img class="card-img doc-img" [class.inverted]="getIsThumbInverted()" [ngSrc]="getThumbUrl()" fill priority alt="{{ document().title | documentTitle }} thumbnail" i18n-alt>
         } @else {
-          <img class="card-img doc-img" [class.inverted]="getIsThumbInverted()" [ngSrc]="getThumbUrl()" fill>
+          <img class="card-img doc-img" [class.inverted]="getIsThumbInverted()" [ngSrc]="getThumbUrl()" fill alt="{{ document().title | documentTitle }} thumbnail" i18n-alt>
         }
 
         <div class="border-end border-bottom bg-light py-1 px-2 document-card-check">

--- a/src-ui/src/app/components/document-list/document-card-small/document-card-small.component.html
+++ b/src-ui/src/app/components/document-list/document-card-small/document-card-small.component.html
@@ -2,7 +2,11 @@
   <div class="card h-100 shadow-sm document-card" [class.placeholder-glow]="!document()" [class.card-selected]="selected()" (mouseleave)="mouseLeaveCard()">
     <div class="border-bottom doc-img-container rounded-top" (click)="this.toggleSelected.emit($event)" (dblclick)="dblClickDocument.emit(this)">
        @if (document()) {
-        <img class="card-img doc-img" [class.inverted]="getIsThumbInverted()" [ngSrc]="getThumbUrl()" fill [priority]="priority()">
+        @if (priority()) {
+          <img class="card-img doc-img" [class.inverted]="getIsThumbInverted()" [ngSrc]="getThumbUrl()" fill priority>
+        } @else {
+          <img class="card-img doc-img" [class.inverted]="getIsThumbInverted()" [ngSrc]="getThumbUrl()" fill>
+        }
 
         <div class="border-end border-bottom bg-light py-1 px-2 document-card-check">
           <div class="form-check">

--- a/src-ui/src/app/components/document-list/document-card-small/document-card-small.component.spec.ts
+++ b/src-ui/src/app/components/document-list/document-card-small/document-card-small.component.spec.ts
@@ -67,6 +67,18 @@ describe('DocumentCardSmallComponent', () => {
     expect(thumbnail.getAttribute('loading')).toEqual('lazy')
   })
 
+  it('should prioritize the thumbnail when requested', () => {
+    fixture.destroy()
+    fixture = TestBed.createComponent(DocumentCardSmallComponent)
+    fixture.componentRef.setInput('priority', true)
+    fixture.componentRef.setInput('document', Object.assign({}, doc))
+    fixture.detectChanges()
+    const thumbnail: HTMLImageElement =
+      fixture.nativeElement.querySelector('img.doc-img')
+    expect(thumbnail.getAttribute('loading')).toEqual('eager')
+    expect(thumbnail.getAttribute('fetchpriority')).toEqual('high')
+  })
+
   it('should display a document, limit tags to 5', () => {
     expect(fixture.nativeElement.textContent).toContain('Document 10')
     expect(

--- a/src-ui/src/app/components/document-list/document-card-small/document-card-small.component.spec.ts
+++ b/src-ui/src/app/components/document-list/document-card-small/document-card-small.component.spec.ts
@@ -68,10 +68,7 @@ describe('DocumentCardSmallComponent', () => {
   })
 
   it('should prioritize the thumbnail when requested', () => {
-    fixture.destroy()
-    fixture = TestBed.createComponent(DocumentCardSmallComponent)
     fixture.componentRef.setInput('priority', true)
-    fixture.componentRef.setInput('document', Object.assign({}, doc))
     fixture.detectChanges()
     const thumbnail: HTMLImageElement =
       fixture.nativeElement.querySelector('img.doc-img')

--- a/src-ui/src/app/components/document-list/document-card-small/document-card-small.component.ts
+++ b/src-ui/src/app/components/document-list/document-card-small/document-card-small.component.ts
@@ -66,6 +66,7 @@ export class DocumentCardSmallComponent
   private documentService = inject(DocumentService)
   settingsService = inject(SettingsService)
   readonly selected = input(false)
+  readonly priority = input(false)
   readonly document = input<Document>(undefined)
   readonly displayFields = input<string[]>(
     DEFAULT_DISPLAY_FIELDS.map((f) => f.id)

--- a/src-ui/src/app/components/document-list/document-list.component.html
+++ b/src-ui/src/app/components/document-list/document-list.component.html
@@ -164,9 +164,10 @@
   } @else {
     @if (list.displayMode === DisplayMode.LARGE_CARDS) {
       <div>
-        @for (d of list.documents; track d.id) {
+        @for (d of list.documents; track d.id; let i = $index) {
           <pngx-document-card-large
             [selected]="list.isSelected(d)"
+            [priority]="i < 2"
             (toggleSelected)="toggleSelected(d, $event)"
             (dblClickDocument)="openDocumentDetail(d)"
             [document]="d"
@@ -398,9 +399,10 @@
     }
     @if (list.displayMode === DisplayMode.SMALL_CARDS) {
       <div class="row row-cols-paperless-cards">
-        @for (d of list.documents; track d.id) {
+        @for (d of list.documents; track d.id; let i = $index) {
           <pngx-document-card-small class="p-0"
             [selected]="list.isSelected(d)"
+            [priority]="i < 6"
             (toggleSelected)="toggleSelected(d, $event)"
             (dblClickDocument)="openDocumentDetail(d)"
             [document]="d"


### PR DESCRIPTION
## Proposed change

Again, just a small thing. Now that we lazy-load thumbnails Angular issues a warning when one of them is the LCP element. So, paradoxically, we do want some to load fast, just not all... Obviously it would be 'best' to figure out what the top row or two are and mark only those ones but I think using these hard-coded limits is good enough for now, and if we really do want to make this fancier in the future its quite easy. Again, super safe change.

tl;dr mark the first 2 large card and first 6 small card thumbnails with `priority`

```
common.mjs:571 NG02955: The NgOptimizedImage directive (activated on an <img> element with the `ngSrc="http://localhost:8000/api/documents/1/thumb/"`) has detected that this image is the Largest Contentful Paint (LCP) element but was not marked "priority". This image should be marked "priority" in order to prioritize its loading. To fix this, add the "priority" attribute.
```

Closes #(issue or discussion)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
