### PR TITLE
Fix: handle notes without a user when building the search index

### DIFF
--- a/src/documents/search/_backend.py
+++ b/src/documents/search/_backend.py
@@ -475,7 +475,13 @@ class TantivyBackend:
         note_texts: list[str] = []
         for note in document.notes.all():
             num_notes += 1
-            doc.add_json("notes", {"note": note.note, "user": note.user.username})
+            doc.add_json(
+                "notes",
+                {
+                    "note": note.note,
+                    "user": note.user.username if note.user else None,
+                },
+            )
             note_texts.append(note.note)
         if note_texts:
             doc.add_text("notes_text", " ".join(note_texts))

--- a/src/documents/tests/search/test_backend.py
+++ b/src/documents/tests/search/test_backend.py
@@ -844,6 +844,23 @@ class TestFieldHandling:
             f"Expected 1, got {len(ids)}. Note content should be searchable via notes.note: prefix."
         )
 
+    def test_notes_without_user_are_indexed(self, backend: TantivyBackend) -> None:
+        """Notes whose user was deleted (SET_NULL) must not break indexing."""
+        doc = Document.objects.create(
+            title="Doc with orphaned note",
+            content="test",
+            checksum="NT2",
+            pk=81,
+        )
+        Note.objects.create(document=doc, note="Orphaned note", user=None)
+
+        backend.add_or_update(doc)
+
+        ids = backend.search_ids("notes.note:orphaned", user=None)
+        assert len(ids) == 1, (
+            f"Expected 1, got {len(ids)}. Notes without a user should still be indexed."
+        )
+
 
 class TestHighlightHits:
     """Test highlight_hits returns proper HTML strings, not raw Snippet objects."""


### PR DESCRIPTION
## Description

`Note.user` is nullable (`on_delete=models.SET_NULL`), so notes whose author was deleted legitimately have `user=None`. The tantivy indexer accessed `note.user.username` unconditionally in `_build_tantivy_doc`, which crashes with `AttributeError: 'NoneType' object has no attribute 'username'`.

Because the exception propagates, a single orphaned note aborts the **entire** `document_index reindex --recreate` run, leaving the search index incomplete — documents indexed after the failing one are silently missing from search results. This is especially painful right after the v3 upgrade, where a full Whoosh → tantivy rebuild is required.

Fixes #13259

## Changes

- Index `user: None` for notes without a user instead of crashing (mirrors how the REST API already tolerates empty note users, see #9846)
- Add a regression test: a note with `user=None` must be indexed and its content searchable

## Test

```
pytest src/documents/tests/search/test_backend.py -k notes
3 passed
```

The new test fails with the exact `AttributeError` from the issue when run without the fix.
