### PR TITLE
implements feature request #13277

### DIFF
--- a/src/documents/tests/test_share_link_bundles.py
+++ b/src/documents/tests/test_share_link_bundles.py
@@ -137,13 +137,21 @@ class ShareLinkBundleAPITests(DirectoriesMixin, APITestCase):
         bundle.documents.set([self.document])
 
         self.client.logout()
-        response = self.client.get(f"/share/{bundle.slug}/")
+        with self.assertLogs("paperless.api", level="INFO") as logs:
+            response = self.client.get(f"/share/{bundle.slug}/")
         content = b"".join(response.streaming_content)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response["Content-Type"], "application/zip")
         self.assertEqual(content, b"binary-zip-content")
         self.assertIn("attachment;", response["Content-Disposition"])
+        self.assertEqual(
+            logs.output,
+            [
+                f"INFO:paperless.api:Share link bundle {bundle.pk} downloaded "
+                "from IP address `127.0.0.1`. User-Agent: `unknown`.",
+            ],
+        )
 
     def test_download_pending_bundle_returns_202(self) -> None:
         bundle = ShareLinkBundle.objects.create(
@@ -167,9 +175,41 @@ class ShareLinkBundleAPITests(DirectoriesMixin, APITestCase):
         bundle.documents.set([self.document])
 
         self.client.logout()
-        response = self.client.get(f"/share/{bundle.slug}/")
+        with self.assertLogs("paperless.api", level="INFO") as logs:
+            response = self.client.get(f"/share/{bundle.slug}/")
 
         self.assertEqual(response.status_code, status.HTTP_503_SERVICE_UNAVAILABLE)
+        self.assertEqual(
+            logs.output,
+            [
+                f"INFO:paperless.api:Share link bundle {bundle.pk} access failed, "
+                "bundle unavailable from IP address `127.0.0.1`. "
+                "User-Agent: `unknown`.",
+            ],
+        )
+
+    def test_download_expired_bundle_redirects(self) -> None:
+        bundle = ShareLinkBundle.objects.create(
+            slug="expiredbundle",
+            file_version=ShareLink.FileVersion.ARCHIVE,
+            status=ShareLinkBundle.Status.READY,
+            expiration=timezone.now() - timedelta(hours=1),
+        )
+        bundle.documents.set([self.document])
+
+        self.client.logout()
+        with self.assertLogs("paperless.api", level="INFO") as logs:
+            response = self.client.get(f"/share/{bundle.slug}/")
+
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        self.assertIn("sharelink_expired=1", response["Location"])
+        self.assertEqual(
+            logs.output,
+            [
+                f"INFO:paperless.api:Expired share link bundle {bundle.pk} "
+                "accessed from IP address `127.0.0.1`. User-Agent: `unknown`.",
+            ],
+        )
 
     def test_expired_share_link_redirects(self) -> None:
         share_link = ShareLink.objects.create(
@@ -180,17 +220,35 @@ class ShareLinkBundleAPITests(DirectoriesMixin, APITestCase):
         )
 
         self.client.logout()
-        response = self.client.get(f"/share/{share_link.slug}/")
+        with self.assertLogs("paperless.api", level="INFO") as logs:
+            response = self.client.get(f"/share/{share_link.slug}/")
 
         self.assertEqual(response.status_code, status.HTTP_302_FOUND)
         self.assertIn("sharelink_expired=1", response["Location"])
+        self.assertEqual(
+            logs.output,
+            [
+                f"INFO:paperless.api:Expired share link for document "
+                f"{self.document.pk} accessed from IP address `127.0.0.1`. "
+                "User-Agent: `unknown`.",
+            ],
+        )
 
     def test_unknown_share_link_redirects(self) -> None:
         self.client.logout()
-        response = self.client.get("/share/unknownsharelink/")
+        with self.assertLogs("paperless.api", level="INFO") as logs:
+            response = self.client.get("/share/unknownsharelink/")
 
         self.assertEqual(response.status_code, status.HTTP_302_FOUND)
         self.assertIn("sharelink_notfound=1", response["Location"])
+        self.assertEqual(
+            logs.output,
+            [
+                "INFO:paperless.api:Share link access attempted with unknown "
+                "slug `unknownsharelink` from IP address `127.0.0.1`. "
+                "User-Agent: `unknown`.",
+            ],
+        )
 
 
 class ShareLinkBundleTaskTests(DirectoriesMixin, APITestCase):

--- a/src/documents/tests/test_views.py
+++ b/src/documents/tests/test_views.py
@@ -158,9 +158,21 @@ class TestViews(DirectoriesMixin, TestCase):
         self.client.logout()
 
         # Valid
-        response = self.client.get(f"/share/{sl1.slug}")
+        with self.assertLogs("paperless.api", level="INFO") as logs:
+            response = self.client.get(
+                f"/share/{sl1.slug}",
+                HTTP_X_FORWARDED_FOR="177.139.233.139",
+                HTTP_USER_AGENT="test-agent",
+            )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(read_streaming_response(response), content)
+        self.assertEqual(
+            logs.output,
+            [
+                f"INFO:paperless.api:Share link for document {doc.pk} accessed "
+                "from IP address `177.139.233.139`. User-Agent: `test-agent`.",
+            ],
+        )
 
         # Invalid
         response = self.client.get("/share/123notaslug", follow=True)
@@ -176,6 +188,115 @@ class TestViews(DirectoriesMixin, TestCase):
         response.render()
         self.assertEqual(response.request["PATH_INFO"], "/accounts/login/")
         self.assertContains(response, b"Share link has expired")
+
+    def test_share_link_create_delete_logging(self) -> None:
+        """
+        GIVEN:
+            - A user with permission to manage share links
+        WHEN:
+            - The user creates a share link
+            - The user deletes the share link
+        THEN:
+            - Both events are logged with the user, document and IP
+        """
+        doc = Document.objects.create(
+            title="none",
+            filename="none.pdf",
+            mime_type="application/pdf",
+        )
+
+        sharelink_permissions = Permission.objects.filter(
+            codename__contains="sharelink",
+        )
+        self.user.user_permissions.add(*sharelink_permissions)
+        self.user.save()
+
+        self.client.force_login(self.user)
+
+        expiration = timezone.now() + timedelta(days=7)
+        with self.assertLogs("paperless.api", level="INFO") as logs:
+            response = self.client.post(
+                "/api/share_links/",
+                {
+                    "document": doc.pk,
+                    "file_version": "original",
+                    "expiration": expiration.isoformat(),
+                },
+                HTTP_X_FORWARDED_FOR="177.139.233.139",
+                HTTP_USER_AGENT="test-agent",
+            )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        share_link = ShareLink.objects.get(document=doc)
+        self.assertEqual(
+            logs.output,
+            [
+                f"INFO:paperless.api:Share link created for document {doc.pk} "
+                f"by user `testuser` (duration: 7 days, link ending in "
+                f"`...{share_link.slug[-8:]}`) from IP address "
+                f"`177.139.233.139`. User-Agent: `test-agent`.",
+            ],
+        )
+
+        with self.assertLogs("paperless.api", level="INFO") as logs:
+            response = self.client.delete(
+                f"/api/share_links/{share_link.pk}/",
+                HTTP_X_FORWARDED_FOR="177.139.233.139",
+                HTTP_USER_AGENT="test-agent",
+            )
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(
+            logs.output,
+            [
+                f"INFO:paperless.api:Share link for document {doc.pk} deleted "
+                f"by user `testuser` (link ending in `...{share_link.slug[-8:]}`) "
+                f"from IP address `177.139.233.139`. User-Agent: `test-agent`.",
+            ],
+        )
+
+    def test_share_link_create_logging_no_expiration(self) -> None:
+        """
+        GIVEN:
+            - A user with permission to manage share links
+        WHEN:
+            - The user creates a share link with no expiration
+        THEN:
+            - The creation is logged with "no expiration" as the duration
+        """
+        doc = Document.objects.create(
+            title="none",
+            filename="none2.pdf",
+            mime_type="application/pdf",
+        )
+
+        sharelink_permissions = Permission.objects.filter(
+            codename__contains="sharelink",
+        )
+        self.user.user_permissions.add(*sharelink_permissions)
+        self.user.save()
+
+        self.client.force_login(self.user)
+
+        with self.assertLogs("paperless.api", level="INFO") as logs:
+            response = self.client.post(
+                "/api/share_links/",
+                {
+                    "document": doc.pk,
+                    "file_version": "original",
+                },
+                HTTP_X_FORWARDED_FOR="177.139.233.139",
+                HTTP_USER_AGENT="test-agent",
+            )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        share_link = ShareLink.objects.get(document=doc)
+        self.assertEqual(
+            logs.output,
+            [
+                f"INFO:paperless.api:Share link created for document {doc.pk} "
+                f"by user `testuser` (duration: no expiration, link ending in "
+                f"`...{share_link.slug[-8:]}`) from IP address "
+                f"`177.139.233.139`. User-Agent: `test-agent`.",
+            ],
+        )
 
     def test_share_link_archive_falls_back_to_original(self) -> None:
         """

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -239,6 +239,7 @@ from paperless.models import ApplicationConfiguration
 from paperless.parsers.registry import get_parser_registry
 from paperless.serialisers import GroupSerializer
 from paperless.serialisers import UserSerializer
+from paperless.utils import describe_client_suffix
 from paperless.views import StandardPagination
 from paperless_ai.ai_classifier import get_ai_document_classification
 from paperless_ai.chat import stream_chat_with_documents
@@ -4446,6 +4447,36 @@ class ShareLinkViewSet(
     filterset_class = ShareLinkFilterSet
     ordering_fields = ("created", "expiration", "document")
 
+    def perform_create(self, serializer):
+        instance = serializer.save()
+
+        if instance.expiration is None:
+            duration = "no expiration"
+        else:
+            days = round(
+                (instance.expiration - instance.created).total_seconds() / 86400,
+            )
+            duration = "1 day" if days == 1 else f"{days} days"
+
+        log_output = (
+            f"Share link created for document {instance.document_id} "
+            f"by user `{self.request.user}` (duration: {duration}, "
+            f"link ending in `...{instance.slug[-8:]}`)"
+        )
+        log_output += describe_client_suffix(self.request)
+        logger.info(log_output)
+
+    def perform_destroy(self, instance):
+        document_id = instance.document_id
+        slug_suffix = instance.slug[-8:]
+        log_output = (
+            f"Share link for document {document_id} deleted "
+            f"by user `{self.request.user}` (link ending in `...{slug_suffix}`)"
+        )
+        log_output += describe_client_suffix(self.request)
+        instance.delete()
+        logger.info(log_output)
+
 
 @extend_schema_view(
     rebuild=extend_schema(
@@ -4589,13 +4620,23 @@ class SharedLinkView(View):
     permission_classes = []
 
     def get(self, request, slug):
+        client_suffix = describe_client_suffix(request)
+
         share_link = ShareLink.objects.filter(slug=slug).first()
         if share_link is not None:
             if (
                 share_link.expiration is not None
                 and share_link.expiration < timezone.now()
             ):
+                logger.info(
+                    f"Expired share link for document {share_link.document_id} "
+                    f"accessed{client_suffix}",
+                )
                 return HttpResponseRedirect("/accounts/login/?sharelink_expired=1")
+            logger.info(
+                f"Share link for document {share_link.document_id} "
+                f"accessed{client_suffix}",
+            )
             return serve_file(
                 doc=share_link.document,
                 use_archive=share_link.file_version == ShareLink.FileVersion.ARCHIVE
@@ -4605,9 +4646,15 @@ class SharedLinkView(View):
 
         bundle = ShareLinkBundle.objects.filter(slug=slug).first()
         if bundle is None:
+            logger.info(
+                f"Share link access attempted with unknown slug `{slug}`{client_suffix}",
+            )
             return HttpResponseRedirect("/accounts/login/?sharelink_notfound=1")
 
         if bundle.expiration is not None and bundle.expiration < timezone.now():
+            logger.info(
+                f"Expired share link bundle {bundle.pk} accessed{client_suffix}",
+            )
             return HttpResponseRedirect("/accounts/login/?sharelink_expired=1")
 
         if bundle.status in {
@@ -4624,12 +4671,18 @@ class SharedLinkView(View):
         file_path = bundle.absolute_file_path
 
         if bundle.status == ShareLinkBundle.Status.FAILED or file_path is None:
+            logger.info(
+                f"Share link bundle {bundle.pk} access failed, bundle "
+                f"unavailable{client_suffix}",
+            )
             return HttpResponse(
                 _(
                     "The share link bundle is unavailable.",
                 ),
                 status=status.HTTP_503_SERVICE_UNAVAILABLE,
             )
+
+        logger.info(f"Share link bundle {bundle.pk} downloaded{client_suffix}")
 
         response = FileResponse(file_path.open("rb"), content_type="application/zip")
         short_slug = bundle.slug[:12]

--- a/src/paperless/apps.py
+++ b/src/paperless/apps.py
@@ -3,6 +3,7 @@ from django.utils.translation import gettext_lazy as _
 
 from paperless.signals import handle_failed_login
 from paperless.signals import handle_social_account_updated
+from paperless.signals import handle_successful_login
 
 
 class PaperlessConfig(AppConfig):
@@ -11,9 +12,11 @@ class PaperlessConfig(AppConfig):
     verbose_name = _("Paperless")
 
     def ready(self) -> None:
+        from django.contrib.auth.signals import user_logged_in
         from django.contrib.auth.signals import user_login_failed
 
         user_login_failed.connect(handle_failed_login)
+        user_logged_in.connect(handle_successful_login)
 
         from allauth.socialaccount.signals import social_account_updated
 

--- a/src/paperless/signals.py
+++ b/src/paperless/signals.py
@@ -1,17 +1,14 @@
 import logging
 
 from django.conf import settings
-from python_ipware import IpWare
+
+from paperless.utils import describe_client_suffix
 
 logger = logging.getLogger("paperless.auth")
 
 
 # https://docs.djangoproject.com/en/4.1/ref/contrib/auth/#django.contrib.auth.signals.user_login_failed
 def handle_failed_login(sender, credentials, request, **kwargs):
-    ipware = IpWare(proxy_list=settings.TRUSTED_PROXIES)
-    client_ip, _ = ipware.get_client_ip(
-        meta=request.META,
-    )
     username = credentials.get("username")
     log_output = (
         "No authentication provided"
@@ -19,15 +16,20 @@ def handle_failed_login(sender, credentials, request, **kwargs):
         else f"Login failed for user `{username}`"
     )
 
-    if client_ip is None:
-        log_output += ". Unable to determine IP address."
-    else:
-        if client_ip.is_global:
-            # We got the client's IP address
-            log_output += f" from IP `{client_ip}`."
-        else:
-            # The client's IP address is private
-            log_output += f" from private IP `{client_ip}`."
+    log_output += describe_client_suffix(request)
+
+    logger.info(log_output)
+
+
+# https://docs.djangoproject.com/en/4.1/ref/contrib/auth/#django.contrib.auth.signals.user_logged_in
+def handle_successful_login(sender, request, user, **kwargs):
+    if settings.AUTO_LOGIN_USERNAME:
+        # Auto-login re-authenticates the fixed user on every request, so
+        # this isn't a meaningful login event worth logging.
+        return
+
+    log_output = f"Login successful for user `{user.get_username()}`"
+    log_output += describe_client_suffix(request)
 
     logger.info(log_output)
 

--- a/src/paperless/tests/test_signals.py
+++ b/src/paperless/tests/test_signals.py
@@ -1,3 +1,4 @@
+import logging
 from unittest.mock import Mock
 
 from django.contrib.auth.models import Group
@@ -9,6 +10,7 @@ from django.test import override_settings
 from documents.models import UiSettings
 from paperless.signals import handle_failed_login
 from paperless.signals import handle_social_account_updated
+from paperless.signals import handle_successful_login
 
 
 class TestFailedLoginLogging(TestCase):
@@ -35,7 +37,7 @@ class TestFailedLoginLogging(TestCase):
             self.assertEqual(
                 logs.output,
                 [
-                    "INFO:paperless.auth:No authentication provided. Unable to determine IP address.",
+                    "INFO:paperless.auth:No authentication provided. Unable to determine IP address. User-Agent: `unknown`.",
                 ],
             )
 
@@ -56,7 +58,7 @@ class TestFailedLoginLogging(TestCase):
             self.assertEqual(
                 logs.output,
                 [
-                    "INFO:paperless.auth:Login failed for user `john lennon`. Unable to determine IP address.",
+                    "INFO:paperless.auth:Login failed for user `john lennon`. Unable to determine IP address. User-Agent: `unknown`.",
                 ],
             )
 
@@ -72,6 +74,7 @@ class TestFailedLoginLogging(TestCase):
         request = HttpRequest()
         request.META = {
             "HTTP_X_FORWARDED_FOR": "177.139.233.139",
+            "HTTP_USER_AGENT": "Mozilla/5.0",
         }
         with self.assertLogs("paperless.auth") as logs:
             handle_failed_login(None, self.creds, request)
@@ -79,7 +82,7 @@ class TestFailedLoginLogging(TestCase):
             self.assertEqual(
                 logs.output,
                 [
-                    "INFO:paperless.auth:Login failed for user `john lennon` from IP `177.139.233.139`.",
+                    "INFO:paperless.auth:Login failed for user `john lennon` from IP address `177.139.233.139`. User-Agent: `Mozilla/5.0`.",
                 ],
             )
 
@@ -91,7 +94,6 @@ class TestFailedLoginLogging(TestCase):
             - Request provided to signal handler
         THEN:
             - Expected IP is logged
-            - IP is noted to be a private IP
         """
         request = HttpRequest()
         request.META = {
@@ -103,9 +105,101 @@ class TestFailedLoginLogging(TestCase):
             self.assertEqual(
                 logs.output,
                 [
-                    "INFO:paperless.auth:Login failed for user `john lennon` from private IP `10.0.0.1`.",
+                    "INFO:paperless.auth:Login failed for user `john lennon` from IP address `10.0.0.1`. User-Agent: `unknown`.",
                 ],
             )
+
+
+class TestSuccessfulLoginLogging(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.user = User.objects.create_user(username="john lennon")
+
+    def test_public_ip(self) -> None:
+        """
+        GIVEN:
+            - Request with publicly routeable IP and a user-agent
+        WHEN:
+            - Request provided to signal handler after a successful login
+        THEN:
+            - Username, IP and user-agent are logged
+        """
+        request = HttpRequest()
+        request.META = {
+            "HTTP_X_FORWARDED_FOR": "177.139.233.139",
+            "HTTP_USER_AGENT": "Mozilla/5.0",
+        }
+        with self.assertLogs("paperless.auth") as logs:
+            handle_successful_login(None, request, self.user)
+
+            self.assertEqual(
+                logs.output,
+                [
+                    "INFO:paperless.auth:Login successful for user `john lennon` from IP address `177.139.233.139`. User-Agent: `Mozilla/5.0`.",
+                ],
+            )
+
+    def test_private_ip(self) -> None:
+        """
+        GIVEN:
+            - Request with a private range IP
+        WHEN:
+            - Request provided to signal handler after a successful login
+        THEN:
+            - IP is logged
+        """
+        request = HttpRequest()
+        request.META = {
+            "HTTP_X_FORWARDED_FOR": "10.0.0.1",
+        }
+        with self.assertLogs("paperless.auth") as logs:
+            handle_successful_login(None, request, self.user)
+
+            self.assertEqual(
+                logs.output,
+                [
+                    "INFO:paperless.auth:Login successful for user `john lennon` from IP address `10.0.0.1`. User-Agent: `unknown`.",
+                ],
+            )
+
+    def test_no_ip(self) -> None:
+        """
+        GIVEN:
+            - Request with no determinable IP
+        WHEN:
+            - Request provided to signal handler after a successful login
+        THEN:
+            - Unable to determine IP is logged
+        """
+        request = HttpRequest()
+        request.META = {}
+        with self.assertLogs("paperless.auth") as logs:
+            handle_successful_login(None, request, self.user)
+
+            self.assertEqual(
+                logs.output,
+                [
+                    "INFO:paperless.auth:Login successful for user `john lennon`. Unable to determine IP address. User-Agent: `unknown`.",
+                ],
+            )
+
+    @override_settings(AUTO_LOGIN_USERNAME="john lennon")
+    def test_auto_login_not_logged(self) -> None:
+        """
+        GIVEN:
+            - Auto-login is configured, so every request re-authenticates
+              a fixed user
+        WHEN:
+            - Request provided to signal handler after a successful login
+        THEN:
+            - Nothing is logged, since this isn't a meaningful login event
+        """
+        request = HttpRequest()
+        request.META = {}
+        logger = logging.getLogger("paperless.auth")
+        with self.assertNoLogs(logger, level="INFO"):
+            handle_successful_login(None, request, self.user)
 
 
 class TestSyncSocialLoginGroups(TestCase):

--- a/src/paperless/utils.py
+++ b/src/paperless/utils.py
@@ -1,8 +1,40 @@
 import logging
 
 from dateparser.languages.loader import LocaleDataLoader
+from django.conf import settings
+from django.http import HttpRequest
+from python_ipware import IpWare
 
 logger = logging.getLogger("paperless.utils")
+
+
+def get_client_ip(request: HttpRequest):
+    """
+    Resolve the client's IP address, respecting X-Forwarded-For only from
+    proxies listed in PAPERLESS_TRUSTED_PROXIES.
+    """
+    ipware = IpWare(proxy_list=settings.TRUSTED_PROXIES)
+    client_ip, _ = ipware.get_client_ip(meta=request.META)
+    return client_ip
+
+
+def get_user_agent(request: HttpRequest) -> str:
+    return request.META.get("HTTP_USER_AGENT") or "unknown"
+
+
+def describe_client_suffix(request: HttpRequest) -> str:
+    """
+    Build a `<ip clause>. User-Agent: \\`<agent>\\`.` suffix for log messages,
+    e.g. " from IP address `1.2.3.4`. User-Agent: `curl/8.0`."
+    """
+    client_ip = get_client_ip(request)
+    if client_ip is None:
+        ip_clause = ". Unable to determine IP address."
+    else:
+        ip_clause = f" from IP address `{client_ip}`."
+
+    return f"{ip_clause} User-Agent: `{get_user_agent(request)}`."
+
 
 OCR_TO_DATEPARSER_LANGUAGES = {
     """


### PR DESCRIPTION
ASLOP-PR-VERIFY

<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

This app previously did not log successful/failed logins with enough context, and had no logging at all for document share-link creation, deletion, or access.

- **Login logging** (`paperless/signals.py`, `paperless/apps.py`)
  - Added a handler for Django's `user_logged_in` signal to log successful logins (username, IP, User-Agent). Skips logging when `PAPERLESS_AUTO_LOGIN_USERNAME` is set, since that re-authenticates a fixed user on every request and isn't a meaningful login event.
  - The existing failed-login handler now also logs the User-Agent (it already logged username/IP).

- **Shared IP/User-Agent formatting** (`paperless/utils.py`)
  - Extracted `get_client_ip`, `get_user_agent`, and `describe_client_suffix` helpers, reusing the existing `python_ipware`-based IP resolution (which respects `X-Forwarded-For` only from proxies listed in `PAPERLESS_TRUSTED_PROXIES`) so all new logging is consistent.

- **Share link logging** (`documents/views.py`)
  - `ShareLinkViewSet.perform_create`: logs creator, document, chosen expiration duration (e.g. "7 days" / "no expiration"), and a masked slug (last 8 characters only, never the full secret).
  - `ShareLinkViewSet.perform_destroy`: logs who deleted the link, the document, and the same masked slug.
  - `SharedLinkView.get` (the unauthenticated `/share/<slug>` endpoint): logs successful access, expired-link access attempts, unknown/invalid slug attempts, and share-link-bundle downloads/expired/unavailable cases — all with IP and User-Agent, since this endpoint requires no authentication.

**Testing:** Added/updated coverage in `paperless/tests/test_signals.py`, `documents/tests/test_views.py`, and `documents/tests/test_share_link_bundles.py` for every new log path. I was not able to run the suite in the environment this was written in (no Django install available) — please run before merging.

**AI disclosure:** This PR (code and description) was written with the assistance of an AI coding tool.

<!--
⚠️ Important: Pull requests that implement a new feature or enhancement *should almost always target an existing feature request* with evidence of community interest and discussion. This is in order to balance the work of implementing and maintaining new features / enhancements. If that is not currently the case, please open a feature request instead of this PR to gather feedback from both users and the project maintainers.
-->

Closes #(issue or discussion)

## Type of change

- [ ] Bug fix: non-breaking change which fixes an issue.
- [x] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
