### PR TITLE
LLM-generated title suggestion should not include correspondent

### DIFF
--- a/src/paperless_ai/ai_classifier.py
+++ b/src/paperless_ai/ai_classifier.py
@@ -38,7 +38,9 @@ def build_prompt_without_rag(
     You are a document classification assistant.
 
     Analyze the following document and extract the following information:
-    - A short descriptive title
+    - A short descriptive title. The title must describe the document itself;
+      do not include the correspondent, sender, issuer, or organization name
+      unless it is part of the document's official title.
     - Tags that reflect the content
     - Names of people or organizations mentioned
     - The type or category of the document

--- a/src/paperless_ai/tests/test_ai_classifier.py
+++ b/src/paperless_ai/tests/test_ai_classifier.py
@@ -216,7 +216,10 @@ def test_prompt_with_without_rag(mock_document):
         prompt = build_prompt_without_rag(mock_document, config)
         assert "Additional context from similar documents" not in prompt
         assert "for generated" not in prompt
-        assert "do not include the correspondent, sender, issuer, or organization name" in prompt
+        assert (
+            "do not include the correspondent, sender, issuer, or organization name"
+            in prompt
+        )
         assert "unless it is part of the document's official title" in prompt
 
         prompt = build_prompt_with_rag(mock_document, config)

--- a/src/paperless_ai/tests/test_ai_classifier.py
+++ b/src/paperless_ai/tests/test_ai_classifier.py
@@ -216,6 +216,8 @@ def test_prompt_with_without_rag(mock_document):
         prompt = build_prompt_without_rag(mock_document, config)
         assert "Additional context from similar documents" not in prompt
         assert "for generated" not in prompt
+        assert "do not include the correspondent, sender, issuer, or organization name" in prompt
+        assert "unless it is part of the document's official title" in prompt
 
         prompt = build_prompt_with_rag(mock_document, config)
         assert "Additional context from similar documents" in prompt


### PR DESCRIPTION
## Proposed change

Currently the LLM-generated title suggestions often include the correspondent, which does not make sense as paperless has a correspondent as an extra field. This PR instructs the LLM not to include the correspondent, sender, issuer, or organization name unless it is part of the document’s official title.
Correspondent extraction remains unchanged and is still returned separately in the `correspondents` suggestion field. Added prompt-level regression coverage.

## Type of change

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
