### PR TITLE
Fix: ask the LLM for the document sender, not every name mentioned

### DIFF
--- a/src/paperless_ai/ai_classifier.py
+++ b/src/paperless_ai/ai_classifier.py
@@ -40,7 +40,9 @@ def build_prompt_without_rag(
     Analyze the following document and extract the following information:
     - A short descriptive title
     - Tags that reflect the content
-    - Names of people or organizations mentioned
+    - The organization or person that issued or sent this document.
+      Not the recipient: if the document is addressed to someone, that
+      person is not the answer.
     - The type or category of the document
     - Suggested folder paths for storing the document
     - Up to 3 relevant dates in YYYY-MM-DD format

--- a/src/paperless_ai/tests/test_ai_classifier.py
+++ b/src/paperless_ai/tests/test_ai_classifier.py
@@ -235,6 +235,22 @@ def test_prompt_with_without_rag(mock_document):
         assert "Do not translate correspondents or dates" in prompt
 
 
+@pytest.mark.django_db
+@override_settings(
+    LLM_EMBEDDING_BACKEND="huggingface",
+    LLM_BACKEND="ollama",
+    LLM_MODEL="some_model",
+)
+def test_prompt_asks_for_sender_not_mentioned_names(mock_document):
+    """The correspondent is the issuer, so the prompt must not ask for every
+    name that appears in the document - the recipient appears in most of them.
+    """
+    prompt = build_prompt_without_rag(mock_document, AIConfig())
+
+    assert "issued or sent this document" in prompt
+    assert "Not the recipient" in prompt
+
+
 def test_get_language_name_falls_back_to_language_code():
     assert get_language_name("zz-zz") == "zz-zz"
 


### PR DESCRIPTION
Fixes #13292

The classification prompt in `build_prompt_without_rag()` asks for:

```
- Names of people or organizations mentioned
```

The result is passed to `match_correspondents_by_name()` and the first match becomes the suggested correspondent. But the archive owner is named in nearly every document they receive, so they are correctly returned as a "mentioned name" and often rank first — the suggestion ends up being the recipient rather than the issuer.

Measured over 254 documents in my inbox, single run, `openai-like` backend:

| Observation | Documents |
|---|---|
| Archive owner is the **first** correspondent suggestion | 84 / 254 (33%) |
| Archive owner appears anywhere in the returned list | 112 / 254 (44%) |

This changes the prompt to ask for the issuing organization or person, and to state that the recipient is not the answer. `build_prompt_with_rag()` builds on the same base prompt, so both paths are covered.

Only the correspondent bullet changed; title, tags, type, storage paths and dates are untouched.

## Testing

`pytest paperless_ai/` — 132 passed, including a new test covering the prompt wording.
