### PR TITLE
Fix: actually disable Ollama thinking for AI suggestions

### DIFF
--- a/src/paperless_ai/client.py
+++ b/src/paperless_ai/client.py
@@ -67,6 +67,13 @@ class AIClient:
                 context_window=self.settings.llm_context_size,
                 request_timeout=self.settings.llm_request_timeout,
                 system_prompt=LLM_SYSTEM_PROMPT,
+                # Also set thinking at the instance level. run_llm_query() passes
+                # think=False per call, but llama-index resolves it as
+                # `kwargs.pop("think", None) or self.thinking`, so a per-call False
+                # is discarded and `think` is dropped from the request entirely
+                # (run-llama/llama_index#22467). Setting it here makes the flag
+                # survive that fallback; it stays correct once #22468 lands.
+                thinking=False,
                 client=Client(
                     host=endpoint,
                     timeout=self.settings.llm_request_timeout,

--- a/src/paperless_ai/tests/test_client.py
+++ b/src/paperless_ai/tests/test_client.py
@@ -49,6 +49,7 @@ def test_get_llm_ollama(mock_ai_config, mock_ollama_llm):
         context_window=8192,
         request_timeout=120,
         system_prompt=LLM_SYSTEM_PROMPT,
+        thinking=False,
         client=ANY,
         async_client=ANY,
     )
@@ -122,6 +123,44 @@ def test_run_llm_query_ollama_uses_structured_json(mock_ai_config, mock_ollama_l
         format=ANY,
         think=False,
     )
+
+
+def test_run_llm_query_ollama_sends_think_false_to_ollama(mock_ai_config):
+    """
+    Regression test for thinking not actually being disabled.
+
+    The per-call think=False in run_llm_query() is not enough on its own:
+    llama-index resolves it as `kwargs.pop("think", None) or self.thinking`,
+    so a False is discarded and `think` never reaches Ollama. This asserts on
+    the real request instead of on our own call, so it fails if the flag is
+    dropped anywhere between us and the Ollama client.
+    """
+    mock_ai_config.llm_backend = "ollama"
+    mock_ai_config.llm_model = "test_model"
+    mock_ai_config.llm_endpoint = "http://test-url"
+
+    with patch("ollama.Client") as mock_client_cls:
+        mock_client = mock_client_cls.return_value
+        mock_client.chat.return_value = {
+            "message": {
+                "role": "assistant",
+                "content": json.dumps(
+                    {
+                        "title": "Test Title",
+                        "tags": [],
+                        "correspondents": [],
+                        "document_types": [],
+                        "storage_paths": [],
+                        "dates": [],
+                    },
+                ),
+            },
+        }
+
+        client = AIClient()
+        client.run_llm_query("test_prompt")
+
+    assert mock_client.chat.call_args.kwargs["think"] is False
 
 
 def test_run_llm_query_openai_uses_tools(mock_ai_config, mock_openai_llm):


### PR DESCRIPTION
ASLOP-PR-VERIFY

## Proposed change

`AIClient.run_llm_query()` passes `think=False` to the Ollama LLM, but that flag never
reaches Ollama, so thinking-capable models still generate a full reasoning trace on every
suggestion.

`llama-index-llms-ollama` resolves the flag as:

```python
think = kwargs.pop("think", None) or self.thinking
```

Paperless does not set `thinking` on the instance, so it defaults to `None`, and
`False or None` evaluates to `None` — the `think` field is then omitted from the request
body entirely and the model falls back to its server-side default. This is an upstream
bug (run-llama/llama_index#22467, fix PR #22468, currently unmerged), but paperless can
sidestep it in one line by also setting `thinking=False` at construction: `False or False`
is `False`, which is sent on the wire.

The change is forward-compatible — once the upstream PR lands, the per-call `think=False`
takes effect on its own and both paths agree on `False`.

### Impact

Measured on the real `build_prompt_with_rag()` path (10,456-char prompt, one document),
against a local Ollama with the model resident in VRAM:

| | wall | eval_count | thinking trace |
|---|---|---|---|
| `qwen3.5:9b`, current behaviour | 33.4 s | 280 | 10,700 chars |
| `qwen3.5:9b`, with this change | **3.0 s** | 243 | none |
| `qwen2.5:7b` (no thinking mode) | 5.6 s | 147 | none |

End to end, `get_ai_document_classification()` goes from unusable to 7.5 s warm, and
`GET /api/documents/<id>/ai_suggestions/` returns in 6.7 s.

Suggestion quality did not regress — in this sample the thinking run was actually worse,
titling a bank statement "123 Current Account Statement" where the non-thinking run
produced "Santander Current Account Statement".

Models without a thinking mode are unaffected either way, which is why this has gone
unnoticed: `qwen2.5:7b` and similar defaults never exercise the broken path.

### Testing

- `test_get_llm_ollama` updated for the new constructor argument.
- New `test_run_llm_query_ollama_sends_think_false_to_ollama` asserts on the request that
  actually reaches the Ollama client rather than on paperless's own call, so it fails if
  the flag is dropped anywhere in between. Verified it fails without the one-line change
  and passes with it.
- `pytest src/paperless_ai/` — 132 passed.
- pre-commit hooks run, all passing.
- Also run live: the patched `client.py` was mounted into a running 3.0.3 container and
  exercised from the web UI against a real Ollama backend. Capturing the outgoing request
  confirms `think: false` is now present on the wire, where previously the field was
  absent from the request body entirely.

No existing issue to close; happy to open one first if preferred.

## Type of change

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality.
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers. (n/a — backend only)
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed. (none needed)
- [x] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.

### AI tool disclosure

The diagnosis, the patch and the tests were produced with Claude Code. The behaviour was
verified empirically against a real Ollama instance, and the regression test was confirmed
to fail without the fix.
