### PR TITLE
Fix: detect duplicates when a pre-consume script modifies the document

### DIFF
--- a/src/documents/consumer.py
+++ b/src/documents/consumer.py
@@ -242,6 +242,61 @@ class ConsumerPluginMixin:
         self.log.error(log_message or message, exc_info=exc_info)
         raise ConsumerError(f"{self.filename}: {log_message or message}") from exception
 
+    def _check_duplicate(self, checksum: str) -> None:
+        """
+        Check the given checksum against existing documents. If any match,
+        a warning is logged. If CONSUMER_DELETE_DUPLICATES is also enabled,
+        the input file is deleted and consumption is rejected via
+        ConsumeFileDuplicateError.
+        """
+        existing_doc = Document.global_objects.filter(
+            Q(checksum=checksum) | Q(archive_checksum=checksum),
+        )
+        if existing_doc.exists():
+            existing_doc = existing_doc.order_by("-created")
+            duplicates_in_trash = existing_doc.filter(deleted_at__isnull=False)
+            log_msg = (
+                f"Consuming duplicate {self.filename}: "
+                f"{existing_doc.count()} existing document(s) share the same content."
+            )
+
+            if duplicates_in_trash.exists():
+                log_msg += " Note: at least one existing document is in the trash."
+
+            self.log.warning(log_msg)
+
+            if settings.CONSUMER_DELETE_DUPLICATES:
+                duplicate = existing_doc.first()
+                duplicate_label = (
+                    duplicate.title
+                    or duplicate.original_filename
+                    or (Path(duplicate.filename).name if duplicate.filename else None)
+                    or str(duplicate.pk)
+                )
+
+                Path(self.input_doc.original_file).unlink()
+
+                failure_msg = (
+                    f"Not consuming {self.filename}: "
+                    f"It is a duplicate of {duplicate_label} (#{duplicate.pk})"
+                )
+                status_msg = ConsumerStatusShortMessage.DOCUMENT_ALREADY_EXISTS
+
+                if duplicates_in_trash.exists():
+                    status_msg = (
+                        ConsumerStatusShortMessage.DOCUMENT_ALREADY_EXISTS_IN_TRASH
+                    )
+                    failure_msg += " Note: existing document is in the trash."
+
+                self._send_progress(100, 100, ProgressStatusOptions.FAILED, status_msg)
+                self.log.error(failure_msg)
+                in_trash = duplicates_in_trash.exists()
+                raise ConsumeFileDuplicateError(
+                    f"{self.filename}: {failure_msg}",
+                    duplicate.pk,
+                    in_trash=in_trash,
+                )
+
 
 class ConsumerPlugin(
     AlwaysRunPluginMixin,
@@ -314,6 +369,8 @@ class ConsumerPlugin(
         working_file_path = str(self.working_copy)
         original_file_path = str(self.input_doc.original_file)
 
+        checksum_before = compute_checksum(self.working_copy)
+
         script_env = os.environ.copy()
         script_env["DOCUMENT_SOURCE_PATH"] = original_file_path
         script_env["DOCUMENT_WORKING_PATH"] = working_file_path
@@ -335,6 +392,20 @@ class ConsumerPlugin(
                 exc_info=True,
                 exception=e,
             )
+
+        # The script may have replaced the file with new content (e.g. an
+        # external OCR service). The stored checksum will be computed from the
+        # modified file, so the preflight check against the unmodified input
+        # cannot catch duplicates of it. Re-check with the checksum the
+        # document would actually be stored under.
+        if self.working_copy.is_file():
+            checksum_after = compute_checksum(self.working_copy)
+            if checksum_after != checksum_before:
+                self.log.debug(
+                    "Pre-consume script modified the working file, "
+                    "re-checking for duplicates",
+                )
+                self._check_duplicate(checksum_after)
 
     def run_post_consume_script(self, document: Document) -> None:
         """
@@ -986,54 +1057,7 @@ class ConsumerPreflightPlugin(
         """
         Using the SHA256 of the file, check this exact file doesn't already exist
         """
-        checksum = compute_checksum(Path(self.input_doc.original_file))
-        existing_doc = Document.global_objects.filter(
-            Q(checksum=checksum) | Q(archive_checksum=checksum),
-        )
-        if existing_doc.exists():
-            existing_doc = existing_doc.order_by("-created")
-            duplicates_in_trash = existing_doc.filter(deleted_at__isnull=False)
-            log_msg = (
-                f"Consuming duplicate {self.filename}: "
-                f"{existing_doc.count()} existing document(s) share the same content."
-            )
-
-            if duplicates_in_trash.exists():
-                log_msg += " Note: at least one existing document is in the trash."
-
-            self.log.warning(log_msg)
-
-            if settings.CONSUMER_DELETE_DUPLICATES:
-                duplicate = existing_doc.first()
-                duplicate_label = (
-                    duplicate.title
-                    or duplicate.original_filename
-                    or (Path(duplicate.filename).name if duplicate.filename else None)
-                    or str(duplicate.pk)
-                )
-
-                Path(self.input_doc.original_file).unlink()
-
-                failure_msg = (
-                    f"Not consuming {self.filename}: "
-                    f"It is a duplicate of {duplicate_label} (#{duplicate.pk})"
-                )
-                status_msg = ConsumerStatusShortMessage.DOCUMENT_ALREADY_EXISTS
-
-                if duplicates_in_trash.exists():
-                    status_msg = (
-                        ConsumerStatusShortMessage.DOCUMENT_ALREADY_EXISTS_IN_TRASH
-                    )
-                    failure_msg += " Note: existing document is in the trash."
-
-                self._send_progress(100, 100, ProgressStatusOptions.FAILED, status_msg)
-                self.log.error(failure_msg)
-                in_trash = duplicates_in_trash.exists()
-                raise ConsumeFileDuplicateError(
-                    f"{self.filename}: {failure_msg}",
-                    duplicate.pk,
-                    in_trash=in_trash,
-                )
+        self._check_duplicate(compute_checksum(Path(self.input_doc.original_file)))
 
     def pre_check_directories(self) -> None:
         """

--- a/src/documents/tests/test_consumer.py
+++ b/src/documents/tests/test_consumer.py
@@ -1,7 +1,9 @@
 import datetime
+import hashlib
 import shutil
 import stat
 import tempfile
+from contextlib import contextmanager
 from pathlib import Path
 from unittest import mock
 from unittest.mock import MagicMock
@@ -1433,6 +1435,100 @@ class PreConsumeTestCase(DirectoriesMixin, GetConsumerMixin, TestCase):
                         ConsumerError,
                         c.run,
                     )
+
+    @contextmanager
+    def get_modifying_script(self):
+        """
+        A pre-consume script which deterministically replaces the working
+        file, as e.g. an external OCR service would.
+        """
+        with tempfile.NamedTemporaryFile(mode="w") as script:
+            with script.file as outfile:
+                outfile.write("#!/usr/bin/env bash\n")
+                outfile.write('printf "modified content" > "$DOCUMENT_WORKING_PATH"\n')
+
+            st = Path(script.name).stat()
+            Path(script.name).chmod(st.st_mode | stat.S_IEXEC)
+
+            with override_settings(PRE_CONSUME_SCRIPT=script.name):
+                yield hashlib.sha256(b"modified content").hexdigest()
+
+    @override_settings(CONSUMER_DELETE_DUPLICATES=True)
+    def test_script_modified_file_duplicate_rejected(self) -> None:
+        """
+        GIVEN:
+            - A pre-consume script which replaces the file content
+            - An existing document whose checksum matches the modified content
+        WHEN:
+            - The file is consumed
+        THEN:
+            - The file passes the preflight check (its unmodified checksum is
+              unknown), but is rejected after the script has modified it
+        """
+        with self.get_modifying_script() as modified_checksum:
+            existing = Document.objects.create(
+                title="Existing document",
+                content="",
+                checksum=modified_checksum,
+                mime_type="application/pdf",
+            )
+
+            with self.get_consumer(self.test_file) as c:
+                self.assertRaisesMessage(
+                    ConsumerError,
+                    f"It is a duplicate of {existing.title} (#{existing.pk})",
+                    c.run,
+                )
+
+            self.assertFalse(self.test_file.is_file())
+            self.assertEqual(Document.objects.count(), 1)
+
+    def test_script_modified_file_duplicate_warns(self) -> None:
+        """
+        GIVEN:
+            - A pre-consume script which replaces the file content
+            - An existing document whose checksum matches the modified content
+        WHEN:
+            - The pre-consume script is run without CONSUMER_DELETE_DUPLICATES
+        THEN:
+            - A duplicate warning is logged, consumption is not rejected
+        """
+        with self.get_modifying_script() as modified_checksum:
+            Document.objects.create(
+                title="Existing document",
+                content="",
+                checksum=modified_checksum,
+                mime_type="application/pdf",
+            )
+
+            with self.get_consumer(self.test_file) as c:
+                c.working_copy = self.dirs.scratch_dir / "working.pdf"
+                shutil.copy(self.test_file, c.working_copy)
+
+                with self.assertLogs("paperless.consumer", level="WARNING") as cm:
+                    c.run_pre_consume_script()
+
+                self.assertTrue(
+                    any("share the same content" in line for line in cm.output),
+                )
+
+    def test_script_modified_file_no_duplicate(self) -> None:
+        """
+        GIVEN:
+            - A pre-consume script which replaces the file content
+            - No existing document matches the modified content
+        WHEN:
+            - The pre-consume script is run
+        THEN:
+            - No duplicate warning is logged
+        """
+        with self.get_modifying_script():
+            with self.get_consumer(self.test_file) as c:
+                c.working_copy = self.dirs.scratch_dir / "working.pdf"
+                shutil.copy(self.test_file, c.working_copy)
+
+                with self.assertNoLogs("paperless.consumer", level="WARNING"):
+                    c.run_pre_consume_script()
 
 
 class PostConsumeTestCase(DirectoriesMixin, GetConsumerMixin, TestCase):


### PR DESCRIPTION

## Description

The preflight duplicate check hashes the unmodified input file, but the stored checksum is computed from the working copy — which a pre-consume script may have replaced (e.g. with the output of an external OCR service). For such setups, consuming the exact same file twice is never caught at consume time, even with `PAPERLESS_CONSUMER_DELETE_DUPLICATES` enabled: the raw input hash matches no stored checksum. The resulting documents *do* show up in the v3 Duplicates tab (their stored checksums match), which confirms the comparison simply happens at the wrong point in time.

Fixes #13326

## Changes

- Move the duplicate warn/reject logic unchanged from `ConsumerPreflightPlugin.pre_check_duplicate` into a shared `ConsumerPluginMixin._check_duplicate(checksum)`; the preflight check now calls it with the input file's checksum as before.
- In `run_pre_consume_script`, hash the working copy before and after the script. If the script changed the file, re-run the duplicate check with the new checksum — the one the document would actually be stored under.
- Semantics are unchanged in all other paths: without a script (or when the script does not modify the file) only the preflight check runs, warn-only default behavior is preserved, and `CONSUMER_DELETE_DUPLICATES` keeps its existing meaning (delete input, fail task with "It is a duplicate of …", trash note included).

## Tests

Three new tests in `PreConsumeTestCase`:

- `test_script_modified_file_duplicate_rejected` — full consume run with `CONSUMER_DELETE_DUPLICATES=True`: passes preflight, rejected after the script modified the file; input deleted, no new document
- `test_script_modified_file_duplicate_warns` — default settings: duplicate warning logged, consumption not rejected
- `test_script_modified_file_no_duplicate` — modified content matching nothing: no warning

```
pytest src/documents/tests/test_consumer.py -k "duplicate or script"
17 passed
```

(3 unrelated failures in my local environment are missing-OCR-binary issues, present on a clean checkout as well.)
