### PR TITLE
AI: minimize sensitive metadata sent to the embedding index

### DIFF
--- a/src/paperless_ai/embedding.py
+++ b/src/paperless_ai/embedding.py
@@ -9,7 +9,6 @@ if TYPE_CHECKING:
     from llama_index.core.base.embeddings.base import BaseEmbedding
 
 from documents.models import Document
-from documents.models import Note
 from paperless.config import AIConfig
 from paperless.models import LLMEmbeddingBackend
 from paperless.network import validate_outbound_http_url
@@ -80,22 +79,18 @@ def get_embedding_dim() -> int:
 
 
 def build_llm_index_text(doc: Document) -> str:
+    """Build the minimal text representation used for embedding/indexing.
+
+    Only include fields that are useful for retrieval and avoid notes, custom
+    fields, archive serial numbers, and other potentially sensitive metadata.
+    """
     lines = [
         f"Title: {doc.title}",
         f"Filename: {doc.filename}",
-        f"Created: {doc.created}",
-        f"Added: {doc.added}",
-        f"Modified: {doc.modified}",
         f"Tags: {', '.join(tag.name for tag in doc.tags.all())}",
         f"Document Type: {doc.document_type.name if doc.document_type else ''}",
         f"Correspondent: {doc.correspondent.name if doc.correspondent else ''}",
-        f"Storage Path: {doc.storage_path.name if doc.storage_path else ''}",
-        f"Archive Serial Number: {doc.archive_serial_number or ''}",
-        f"Notes: {','.join([str(c.note) for c in Note.objects.filter(document=doc)])}",
     ]
-
-    for instance in doc.custom_fields.all():
-        lines.append(f"Custom Field - {instance.field.name}: {instance}")
 
     lines.append("\nContent:\n")
     lines.append(doc.content or "")

--- a/src/paperless_ai/tests/test_embedding.py
+++ b/src/paperless_ai/tests/test_embedding.py
@@ -167,10 +167,15 @@ def test_build_llm_index_text(mock_document):
 
         assert "Title: Test Title" in result
         assert "Filename: test_file.pdf" in result
-        assert "Created: 2023-01-01" in result
+        assert "Created: 2023-01-01" not in result
+        assert "Added: 2023-01-02" not in result
+        assert "Modified: 2023-01-03" not in result
         assert "Tags: Tag1, Tag2" in result
         assert "Document Type: Invoice" in result
         assert "Correspondent: Test Correspondent" in result
-        assert "Notes: Note1,Note2" in result
+        assert "Storage Path:" not in result
+        assert "Archive Serial Number:" not in result
+        assert "Notes: Note1,Note2" not in result
         assert "Content:\n\nThis is the document content." in result
-        assert "Custom Field - Field1: Value1\nCustom Field - Field2: Value2" in result
+        assert "Custom Field - Field1: Value1" not in result
+        assert "Custom Field - Field2: Value2" not in result


### PR DESCRIPTION
**What this does**

Trims what `build_llm_index_text` puts into the embedding/index text down to the
retrieval-useful fields (title, filename, tags, document type, correspondent, and
content), and stops embedding fields that are more likely to carry sensitive or
personal metadata: Notes, Custom Fields, Archive Serial Number, Storage Path, and
the created/added/modified timestamps. Updates the unit test accordingly.

**Why**

The text built here is sent to the configured embedding backend — which may be a
third-party/cloud model — so it's worth being deliberate about what leaves the
instance. Notes and custom fields in particular often contain free-form personal
or sensitive information, while contributing little to semantic retrieval
compared to the document content itself. Minimizing what's embedded is a common
data-protection expectation (OWASP LLM02 – Sensitive Information Disclosure; GDPR
Art. 5(1)(c) data minimization).

**Honest tradeoff (please weigh in)**

This *does* reduce what the AI chat/search can match on via those fields — e.g. a
user searching by a note or a custom-field value would no longer hit it through
the embedding index. If you'd rather keep that behavior, I'm very happy to make
this **opt-in/configurable** instead (e.g. a `PAPERLESS_AI_INDEX_*` setting or an
allowlist) rather than changing the default. Opening this as a concrete starting
point for that discussion — happy to go whichever way you prefer.

**Policy basis** (context, not a compliance claim)

- **OWASP Top 10 for LLM Applications — LLM02, Sensitive Information Disclosure**:
  minimize sensitive data exposed to/through the model. —
  https://genai.owasp.org/llm-top-10/
- **GDPR Art. 5(1)(c) — data minimization**: process only data that is adequate,
  relevant, and limited to what's necessary. —
  https://gdpr-info.eu/art-5-gdpr/

**Scope**

- `src/paperless_ai/embedding.py` — reduce fields in `build_llm_index_text`; drop the now-unused `Note` import.
- `src/paperless_ai/tests/test_embedding.py` — assert the trimmed fields are absent.

**Testing**

Compiles and passes `ruff` with the repo's config; the updated unit test asserts
the excluded fields are no longer present. (I couldn't run the full paperless
suite locally without its services, so CI covers the rest.)

---
*I found this with my compliance scanner **Janus**, an AI-governance tool we're
building out of our research. I drafted the change with the tool, then reviewed,
understood, and tested it myself before opening this. If it isn't a fit for your
roadmap, please just close it; happy to revise to your conventions — including
making it configurable rather than a default change. If you're interested in what
we're building, we're at [januscomp.com](https://januscomp.com). :]*
