### PR TITLE
Feature: add CSV export for selected document metadata

### DIFF
--- a/src-ui/src/app/components/document-list/bulk-editor/bulk-editor.component.html
+++ b/src-ui/src/app/components/document-list/bulk-editor/bulk-editor.component.html
@@ -138,6 +138,10 @@
       <div ngbDropdown class="me-2 d-flex btn-group" role="group">
         <button type="button" class="btn btn-sm btn-outline-primary dropdown-toggle-split rounded-end" ngbDropdownToggle></button>
         <div ngbDropdownMenu aria-labelledby="dropdownSelect" class="shadow">
+          <button ngbDropdownItem (click)="exportCsvSelected()">
+            <i-bs name="file-text" class="me-1"></i-bs><ng-container i18n>Export CSV</ng-container>
+          </button>
+          <div class="dropdown-divider"></div>
           <form [formGroup]="downloadForm" class="px-3 py-1">
             <p class="mb-1" i18n>Include:</p>
             <div class="form-group ps-3 mb-2">

--- a/src-ui/src/app/components/document-list/bulk-editor/bulk-editor.component.spec.ts
+++ b/src-ui/src/app/components/document-list/bulk-editor/bulk-editor.component.spec.ts
@@ -43,8 +43,13 @@ import { TagEditDialogComponent } from '../../common/edit-dialog/tag-edit-dialog
 import { FilterableDropdownComponent } from '../../common/filterable-dropdown/filterable-dropdown.component'
 import { ShareLinkBundleDialogComponent } from '../../common/share-link-bundle-dialog/share-link-bundle-dialog.component'
 import { ShareLinkBundleManageDialogComponent } from '../../common/share-link-bundle-manage-dialog/share-link-bundle-manage-dialog.component'
+import { saveAs } from 'file-saver'
 import { BulkEditorComponent } from './bulk-editor.component'
 import { ExportCsvDialogComponent } from './export-csv-dialog/export-csv-dialog.component'
+
+jest.mock('file-saver', () => ({
+  saveAs: jest.fn(),
+}))
 
 const selectionData: SelectionData = {
   selected_tags: [
@@ -1339,6 +1344,7 @@ describe('BulkEditorComponent', () => {
     expect(modalRef.componentInstance.selectionCount).toEqual(2)
 
     succeeded.emit(new Blob(['csv']))
+    expect(saveAs).toHaveBeenCalledWith(expect.any(Blob), 'documents.csv')
     failed.emit(new Error('export failed'))
     expect(toastErrorSpy).toHaveBeenCalled()
   })

--- a/src-ui/src/app/components/document-list/bulk-editor/bulk-editor.component.spec.ts
+++ b/src-ui/src/app/components/document-list/bulk-editor/bulk-editor.component.spec.ts
@@ -44,6 +44,7 @@ import { FilterableDropdownComponent } from '../../common/filterable-dropdown/fi
 import { ShareLinkBundleDialogComponent } from '../../common/share-link-bundle-dialog/share-link-bundle-dialog.component'
 import { ShareLinkBundleManageDialogComponent } from '../../common/share-link-bundle-manage-dialog/share-link-bundle-manage-dialog.component'
 import { BulkEditorComponent } from './bulk-editor.component'
+import { ExportCsvDialogComponent } from './export-csv-dialog/export-csv-dialog.component'
 
 const selectionData: SelectionData = {
   selected_tags: [
@@ -1299,6 +1300,47 @@ describe('BulkEditorComponent', () => {
     httpTestingController.match(
       `${environment.apiBaseUrl}documents/bulk_download/`
     )
+  })
+
+  it('should open CSV export dialog for selected documents and handle success and failure', () => {
+    jest.spyOn(permissionsService, 'currentUserCan').mockReturnValue(true)
+    jest
+      .spyOn(documentListViewService, 'documents', 'get')
+      .mockReturnValue([{ id: 3 }, { id: 4 }])
+    jest
+      .spyOn(documentListViewService, 'selected', 'get')
+      .mockReturnValue(new Set([3, 4]))
+    fixture.detectChanges()
+
+    const succeeded = new EventEmitter<Blob>()
+    const failed = new EventEmitter<any>()
+    const modalRef: Partial<NgbModalRef> = {
+      componentInstance: {
+        selection: null,
+        selectionCount: null,
+        succeeded,
+        failed,
+      },
+    }
+    const openSpy = jest
+      .spyOn(modalService, 'open')
+      .mockReturnValue(modalRef as NgbModalRef)
+    const toastErrorSpy = jest.spyOn(toastService, 'showError')
+
+    component.exportCsvSelected()
+
+    expect(openSpy).toHaveBeenCalledWith(
+      ExportCsvDialogComponent,
+      expect.objectContaining({ backdrop: 'static', size: 'lg' })
+    )
+    expect(modalRef.componentInstance.selection).toEqual({
+      documents: [3, 4],
+    })
+    expect(modalRef.componentInstance.selectionCount).toEqual(2)
+
+    succeeded.emit(new Blob(['csv']))
+    failed.emit(new Error('export failed'))
+    expect(toastErrorSpy).toHaveBeenCalled()
   })
 
   it('should support bulk permissions update', () => {

--- a/src-ui/src/app/components/document-list/bulk-editor/bulk-editor.component.ts
+++ b/src-ui/src/app/components/document-list/bulk-editor/bulk-editor.component.ts
@@ -70,6 +70,7 @@ import { ShareLinkBundleDialogComponent } from '../../common/share-link-bundle-d
 import { ShareLinkBundleManageDialogComponent } from '../../common/share-link-bundle-manage-dialog/share-link-bundle-manage-dialog.component'
 import { ComponentWithPermissions } from '../../with-permissions/with-permissions.component'
 import { CustomFieldsBulkEditDialogComponent } from './custom-fields-bulk-edit-dialog/custom-fields-bulk-edit-dialog.component'
+import { ExportCsvDialogComponent } from './export-csv-dialog/export-csv-dialog.component'
 
 @Component({
   selector: 'pngx-bulk-editor',
@@ -902,10 +903,31 @@ export class BulkEditorComponent
         this.downloadForm.get('downloadUseFormatting').value
       )
       .pipe(first())
-      .subscribe((result: any) => {
-        saveAs(result, 'documents.zip')
-        this.awaitingDownload.set(false)
+      .subscribe({
+        next: (result: any) => {
+          saveAs(result, 'documents.zip')
+          this.awaitingDownload.set(false)
+        },
+        error: () => {
+          this.awaitingDownload.set(false)
+        },
       })
+  }
+
+  exportCsvSelected() {
+    const modal = this.modalService.open(ExportCsvDialogComponent, {
+      backdrop: 'static',
+      size: 'lg',
+    })
+    const dialog = modal.componentInstance as ExportCsvDialogComponent
+    dialog.selection = this.getSelectionQuery()
+    dialog.selectionCount = this.getSelectionSize()
+    dialog.succeeded.pipe(first()).subscribe((blob: Blob) => {
+      saveAs(blob, 'documents.csv')
+    })
+    dialog.failed.pipe(first()).subscribe((error) => {
+      this.toastService.showError($localize`Error exporting CSV`, error)
+    })
   }
 
   reprocessSelected() {

--- a/src-ui/src/app/components/document-list/bulk-editor/export-csv-dialog/export-csv-dialog.component.html
+++ b/src-ui/src/app/components/document-list/bulk-editor/export-csv-dialog/export-csv-dialog.component.html
@@ -1,0 +1,68 @@
+<div class="modal-header">
+  <h4 class="modal-title" id="modal-basic-title" i18n>Export CSV</h4>
+  <button type="button" class="btn-close" aria-label="Close" (click)="cancel()"></button>
+</div>
+<div class="modal-body">
+  <p class="text-muted small" i18n>Select the document properties and custom fields to include in the CSV export.</p>
+  <div class="mb-3">
+    <div class="d-flex justify-content-between align-items-center mb-2">
+      <h6 class="mb-0" i18n>Document properties</h6>
+      <div class="btn-group btn-group-sm">
+        <button type="button" class="btn btn-outline-secondary btn-sm" (click)="selectAllDocumentFields()" i18n>Select all</button>
+        <button type="button" class="btn btn-outline-secondary btn-sm" (click)="selectNoDocumentFields()" i18n>Select none</button>
+      </div>
+    </div>
+    <div class="row">
+      @for (field of documentFields; track field.id) {
+        <div class="col-sm-6 col-lg-4">
+          <div class="form-check">
+            <input
+              type="checkbox"
+              class="form-check-input"
+              [id]="'export-field-' + field.id"
+              [checked]="selectedDocumentFields.has(field.id)"
+              (change)="toggleDocumentField(field.id)"
+            />
+            <label class="form-check-label" [for]="'export-field-' + field.id">{{ field.name }}</label>
+          </div>
+        </div>
+      }
+    </div>
+  </div>
+  @if (customFields.length > 0) {
+    <div>
+      <div class="d-flex justify-content-between align-items-center mb-2">
+        <h6 class="mb-0" i18n>Custom fields</h6>
+        <div class="btn-group btn-group-sm">
+          <button type="button" class="btn btn-outline-secondary btn-sm" (click)="selectAllCustomFields()" i18n>Select all</button>
+          <button type="button" class="btn btn-outline-secondary btn-sm" (click)="selectNoCustomFields()" i18n>Select none</button>
+        </div>
+      </div>
+      <div class="row">
+        @for (field of customFields; track field.id) {
+          <div class="col-sm-6 col-lg-4">
+            <div class="form-check">
+              <input
+                type="checkbox"
+                class="form-check-input"
+                [id]="'export-custom-field-' + field.id"
+                [checked]="selectedCustomFields.has(field.id)"
+                (change)="toggleCustomField(field.id)"
+              />
+              <label class="form-check-label" [for]="'export-custom-field-' + field.id">{{ field.name }}</label>
+            </div>
+          </div>
+        }
+      </div>
+    </div>
+  }
+</div>
+<div class="modal-footer">
+  <button type="button" class="btn btn-outline-secondary" (click)="cancel()" i18n [disabled]="exporting">Cancel</button>
+  <button type="button" class="btn btn-primary" (click)="export()" i18n [disabled]="exporting || !hasSelection">
+    @if (exporting) {
+      <span class="spinner-border spinner-border-sm me-1" role="status"></span>
+    }
+    Export
+  </button>
+</div>

--- a/src-ui/src/app/components/document-list/bulk-editor/export-csv-dialog/export-csv-dialog.component.spec.ts
+++ b/src-ui/src/app/components/document-list/bulk-editor/export-csv-dialog/export-csv-dialog.component.spec.ts
@@ -1,0 +1,248 @@
+import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http'
+import { provideHttpClientTesting } from '@angular/common/http/testing'
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap'
+import { of, throwError } from 'rxjs'
+import { CustomFieldDataType } from 'src/app/data/custom-field'
+import {
+  CSV_EXPORT_CUSTOM_FIELDS_STORAGE_KEY,
+  CSV_EXPORT_FIELDS_STORAGE_KEY,
+  DEFAULT_CSV_EXPORT_FIELDS,
+} from 'src/app/data/document'
+import { SETTINGS_KEYS } from 'src/app/data/ui-settings'
+import { PermissionsService } from 'src/app/services/permissions.service'
+import { CustomFieldsService } from 'src/app/services/rest/custom-fields.service'
+import { DocumentService } from 'src/app/services/rest/document.service'
+import { SettingsService } from 'src/app/services/settings.service'
+import { ExportCsvDialogComponent } from './export-csv-dialog.component'
+
+describe('ExportCsvDialogComponent', () => {
+  let component: ExportCsvDialogComponent
+  let fixture: ComponentFixture<ExportCsvDialogComponent>
+  let documentService: DocumentService
+  let customFieldsService: CustomFieldsService
+  let permissionsService: PermissionsService
+  let settingsService: SettingsService
+  let activeModal: NgbActiveModal
+
+  beforeEach(async () => {
+    localStorage.clear()
+
+    TestBed.configureTestingModule({
+      imports: [ExportCsvDialogComponent],
+      providers: [
+        NgbActiveModal,
+        provideHttpClient(withInterceptorsFromDi()),
+        provideHttpClientTesting(),
+      ],
+    }).compileComponents()
+
+    documentService = TestBed.inject(DocumentService)
+    customFieldsService = TestBed.inject(CustomFieldsService)
+    permissionsService = TestBed.inject(PermissionsService)
+    settingsService = TestBed.inject(SettingsService)
+    activeModal = TestBed.inject(NgbActiveModal)
+
+    jest.spyOn(permissionsService, 'currentUserCan').mockReturnValue(true)
+    jest.spyOn(settingsService, 'get').mockImplementation((key) => {
+      if (key === SETTINGS_KEYS.NOTES_ENABLED) {
+        return true
+      }
+      return null
+    })
+    jest.spyOn(customFieldsService, 'listAll').mockReturnValue(
+      of({
+        count: 2,
+        all: [1, 2],
+        results: [
+          {
+            id: 1,
+            name: 'Amount',
+            data_type: CustomFieldDataType.Monetary,
+          },
+          {
+            id: 2,
+            name: 'Vendor',
+            data_type: CustomFieldDataType.String,
+          },
+        ],
+      })
+    )
+
+    fixture = TestBed.createComponent(ExportCsvDialogComponent)
+    component = fixture.componentInstance
+    component.selection = { documents: [3, 4] }
+    component.selectionCount = 2
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  it('should initialize with default document fields and load custom fields', () => {
+    fixture.detectChanges()
+
+    expect(component.documentFields.length).toBeGreaterThan(0)
+    expect(component.customFields).toHaveLength(2)
+    expect(component.hasSelection).toBeTruthy()
+    for (const field of DEFAULT_CSV_EXPORT_FIELDS) {
+      expect(component.selectedDocumentFields.has(field)).toBeTruthy()
+    }
+  })
+
+  it('should restore saved document and custom field selections', () => {
+    localStorage.setItem(
+      CSV_EXPORT_FIELDS_STORAGE_KEY,
+      JSON.stringify(['title', 'filename', 'unknown_field'])
+    )
+    localStorage.setItem(
+      CSV_EXPORT_CUSTOM_FIELDS_STORAGE_KEY,
+      JSON.stringify([1, 99])
+    )
+
+    fixture.detectChanges()
+
+    expect(component.selectedDocumentFields.has('title')).toBeTruthy()
+    expect(component.selectedDocumentFields.has('filename')).toBeTruthy()
+    expect(component.selectedDocumentFields.has('unknown_field')).toBeFalsy()
+    expect(component.selectedCustomFields.has(1)).toBeTruthy()
+    expect(component.selectedCustomFields.has(99)).toBeFalsy()
+  })
+
+  it('should fall back to defaults when saved document fields are invalid JSON', () => {
+    localStorage.setItem(CSV_EXPORT_FIELDS_STORAGE_KEY, '{not-json')
+
+    fixture.detectChanges()
+
+    for (const field of DEFAULT_CSV_EXPORT_FIELDS) {
+      expect(component.selectedDocumentFields.has(field)).toBeTruthy()
+    }
+  })
+
+  it('should ignore invalid saved custom field JSON', () => {
+    localStorage.setItem(CSV_EXPORT_CUSTOM_FIELDS_STORAGE_KEY, '{not-json')
+
+    fixture.detectChanges()
+
+    expect(component.selectedCustomFields.size).toEqual(0)
+  })
+
+  it('should hide notes when notes are disabled', () => {
+    ;(settingsService.get as jest.Mock).mockImplementation((key) => {
+      if (key === SETTINGS_KEYS.NOTES_ENABLED) {
+        return false
+      }
+      return null
+    })
+
+    fixture.detectChanges()
+
+    expect(
+      component.documentFields.some((field) => field.id === 'note')
+    ).toBeFalsy()
+  })
+
+  it('should hide permission-gated fields when user lacks view permission', () => {
+    ;(permissionsService.currentUserCan as jest.Mock).mockReturnValue(false)
+
+    fixture.detectChanges()
+
+    expect(
+      component.documentFields.some((field) => field.id === 'correspondent')
+    ).toBeFalsy()
+    expect(
+      component.documentFields.some((field) => field.id === 'title')
+    ).toBeTruthy()
+    expect(component.customFields).toHaveLength(0)
+  })
+
+  it('should toggle document and custom fields', () => {
+    fixture.detectChanges()
+
+    component.toggleDocumentField('title')
+    expect(component.selectedDocumentFields.has('title')).toBeFalsy()
+    component.toggleDocumentField('title')
+    expect(component.selectedDocumentFields.has('title')).toBeTruthy()
+
+    component.toggleCustomField(1)
+    expect(component.selectedCustomFields.has(1)).toBeTruthy()
+    component.toggleCustomField(1)
+    expect(component.selectedCustomFields.has(1)).toBeFalsy()
+  })
+
+  it('should select all and none for document and custom fields', () => {
+    fixture.detectChanges()
+
+    component.selectAllDocumentFields()
+    expect(component.selectedDocumentFields.size).toEqual(
+      component.documentFields.length
+    )
+    component.selectNoDocumentFields()
+    expect(component.selectedDocumentFields.size).toEqual(0)
+
+    component.selectAllCustomFields()
+    expect(component.selectedCustomFields.size).toEqual(2)
+    component.selectNoCustomFields()
+    expect(component.selectedCustomFields.size).toEqual(0)
+  })
+
+  it('should not export when nothing is selected', () => {
+    fixture.detectChanges()
+    const exportSpy = jest.spyOn(documentService, 'bulkExportCsv')
+
+    component.selectNoDocumentFields()
+    component.selectNoCustomFields()
+    component.export()
+
+    expect(exportSpy).not.toHaveBeenCalled()
+  })
+
+  it('should export CSV, persist selection, emit success and close modal', () => {
+    fixture.detectChanges()
+    const blob = new Blob(['csv'])
+    const exportSpy = jest
+      .spyOn(documentService, 'bulkExportCsv')
+      .mockReturnValue(of(blob))
+    const successSpy = jest.spyOn(component.succeeded, 'emit')
+    const closeSpy = jest.spyOn(activeModal, 'close')
+
+    component.selectedDocumentFields = new Set(['title', 'filename'])
+    component.selectedCustomFields = new Set([1])
+    component.export()
+
+    expect(exportSpy).toHaveBeenCalledWith(
+      { documents: [3, 4] },
+      ['title', 'filename'],
+      [1]
+    )
+    expect(
+      JSON.parse(localStorage.getItem(CSV_EXPORT_FIELDS_STORAGE_KEY))
+    ).toEqual(['title', 'filename'])
+    expect(
+      JSON.parse(localStorage.getItem(CSV_EXPORT_CUSTOM_FIELDS_STORAGE_KEY))
+    ).toEqual([1])
+    expect(successSpy).toHaveBeenCalledWith(blob)
+    expect(closeSpy).toHaveBeenCalled()
+    expect(component.exporting).toBeFalsy()
+  })
+
+  it('should emit failed on export error', () => {
+    fixture.detectChanges()
+    const error = new Error('export failed')
+    jest
+      .spyOn(documentService, 'bulkExportCsv')
+      .mockReturnValue(throwError(() => error))
+    const failSpy = jest.spyOn(component.failed, 'emit')
+
+    component.export()
+
+    expect(failSpy).toHaveBeenCalledWith(error)
+    expect(component.exporting).toBeFalsy()
+  })
+
+  it('should dismiss modal on cancel', () => {
+    const dismissSpy = jest.spyOn(activeModal, 'dismiss')
+    component.cancel()
+    expect(dismissSpy).toHaveBeenCalled()
+  })
+})

--- a/src-ui/src/app/components/document-list/bulk-editor/export-csv-dialog/export-csv-dialog.component.ts
+++ b/src-ui/src/app/components/document-list/bulk-editor/export-csv-dialog/export-csv-dialog.component.ts
@@ -1,0 +1,235 @@
+import { CommonModule } from '@angular/common'
+import { Component, EventEmitter, OnInit, Output, inject } from '@angular/core'
+import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap'
+import { first } from 'rxjs'
+import { CustomField } from 'src/app/data/custom-field'
+import {
+  CSV_EXPORT_CUSTOM_FIELDS_STORAGE_KEY,
+  CSV_EXPORT_FIELDS_STORAGE_KEY,
+  DEFAULT_CSV_EXPORT_FIELDS,
+  EXPORT_DOCUMENT_FIELDS,
+} from 'src/app/data/document'
+import { SETTINGS_KEYS } from 'src/app/data/ui-settings'
+import {
+  PermissionAction,
+  PermissionsService,
+  PermissionType,
+} from 'src/app/services/permissions.service'
+import { CustomFieldsService } from 'src/app/services/rest/custom-fields.service'
+import {
+  DocumentSelectionQuery,
+  DocumentService,
+} from 'src/app/services/rest/document.service'
+import { SettingsService } from 'src/app/services/settings.service'
+
+@Component({
+  selector: 'pngx-export-csv-dialog',
+  templateUrl: './export-csv-dialog.component.html',
+  styleUrl: './export-csv-dialog.component.scss',
+  imports: [CommonModule],
+})
+export class ExportCsvDialogComponent implements OnInit {
+  private activeModal = inject(NgbActiveModal)
+  private documentService = inject(DocumentService)
+  private customFieldService = inject(CustomFieldsService)
+  private permissionsService = inject(PermissionsService)
+  private settingsService = inject(SettingsService)
+
+  @Output()
+  succeeded = new EventEmitter<Blob>()
+
+  @Output()
+  failed = new EventEmitter<any>()
+
+  selection: DocumentSelectionQuery
+  selectionCount: number
+
+  documentFields: Array<{ id: string; name: string }> = []
+  customFields: CustomField[] = []
+  selectedDocumentFields = new Set<string>()
+  selectedCustomFields = new Set<number>()
+  exporting = false
+
+  ngOnInit(): void {
+    this.documentFields = this.getAvailableDocumentFields()
+    this.loadSavedSelection()
+
+    if (
+      this.permissionsService.currentUserCan(
+        PermissionAction.View,
+        PermissionType.CustomField
+      )
+    ) {
+      this.customFieldService
+        .listAll()
+        .pipe(first())
+        .subscribe((result) => {
+          this.customFields = result.results
+          this.loadSavedCustomFieldSelection()
+        })
+    }
+  }
+
+  get hasSelection(): boolean {
+    return (
+      this.selectedDocumentFields.size > 0 || this.selectedCustomFields.size > 0
+    )
+  }
+
+  private getAvailableDocumentFields(): Array<{ id: string; name: string }> {
+    return EXPORT_DOCUMENT_FIELDS.filter((field) => {
+      if (
+        field.id === 'id' ||
+        field.id === 'modified' ||
+        field.id === 'mime_type' ||
+        field.id === 'filename' ||
+        field.id === 'archived_filename' ||
+        field.id === 'content'
+      ) {
+        return true
+      }
+
+      if (
+        field.id === 'note' &&
+        !this.settingsService.get(SETTINGS_KEYS.NOTES_ENABLED)
+      ) {
+        return false
+      }
+
+      if (
+        ['title', 'created', 'added', 'asn', 'pagecount', 'shared'].includes(
+          field.id
+        )
+      ) {
+        return true
+      }
+
+      let type: PermissionType = Object.values(PermissionType).find((t) =>
+        t.includes(field.id)
+      )
+      if (field.id === 'owner') {
+        type = PermissionType.User
+      }
+
+      return this.permissionsService.currentUserCan(PermissionAction.View, type)
+    })
+  }
+
+  private loadSavedSelection(): void {
+    const saved = localStorage.getItem(CSV_EXPORT_FIELDS_STORAGE_KEY)
+    if (saved) {
+      try {
+        const parsed = JSON.parse(saved) as string[]
+        const available = new Set(this.documentFields.map((field) => field.id))
+        parsed
+          .filter((field) => available.has(field))
+          .forEach((field) => this.selectedDocumentFields.add(field))
+      } catch {
+        this.applyDefaultDocumentFields()
+      }
+    } else {
+      this.applyDefaultDocumentFields()
+    }
+  }
+
+  private loadSavedCustomFieldSelection(): void {
+    const saved = localStorage.getItem(CSV_EXPORT_CUSTOM_FIELDS_STORAGE_KEY)
+    if (saved) {
+      try {
+        const parsed = JSON.parse(saved) as number[]
+        const available = new Set(this.customFields.map((field) => field.id))
+        parsed
+          .filter((fieldId) => available.has(fieldId))
+          .forEach((fieldId) => this.selectedCustomFields.add(fieldId))
+      } catch {
+        // ignore invalid saved state
+      }
+    }
+  }
+
+  private applyDefaultDocumentFields(): void {
+    const available = new Set(this.documentFields.map((field) => field.id))
+    DEFAULT_CSV_EXPORT_FIELDS.filter((field) => available.has(field)).forEach(
+      (field) => this.selectedDocumentFields.add(field)
+    )
+  }
+
+  toggleDocumentField(fieldId: string): void {
+    if (this.selectedDocumentFields.has(fieldId)) {
+      this.selectedDocumentFields.delete(fieldId)
+    } else {
+      this.selectedDocumentFields.add(fieldId)
+    }
+  }
+
+  toggleCustomField(fieldId: number): void {
+    if (this.selectedCustomFields.has(fieldId)) {
+      this.selectedCustomFields.delete(fieldId)
+    } else {
+      this.selectedCustomFields.add(fieldId)
+    }
+  }
+
+  selectAllDocumentFields(): void {
+    this.documentFields.forEach((field) =>
+      this.selectedDocumentFields.add(field.id)
+    )
+  }
+
+  selectNoDocumentFields(): void {
+    this.selectedDocumentFields.clear()
+  }
+
+  selectAllCustomFields(): void {
+    this.customFields.forEach((field) =>
+      this.selectedCustomFields.add(field.id)
+    )
+  }
+
+  selectNoCustomFields(): void {
+    this.selectedCustomFields.clear()
+  }
+
+  private saveSelection(): void {
+    localStorage.setItem(
+      CSV_EXPORT_FIELDS_STORAGE_KEY,
+      JSON.stringify(Array.from(this.selectedDocumentFields))
+    )
+    localStorage.setItem(
+      CSV_EXPORT_CUSTOM_FIELDS_STORAGE_KEY,
+      JSON.stringify(Array.from(this.selectedCustomFields))
+    )
+  }
+
+  export(): void {
+    if (!this.hasSelection) {
+      return
+    }
+
+    this.exporting = true
+    this.saveSelection()
+
+    this.documentService
+      .bulkExportCsv(
+        this.selection,
+        Array.from(this.selectedDocumentFields),
+        Array.from(this.selectedCustomFields)
+      )
+      .pipe(first())
+      .subscribe({
+        next: (result) => {
+          this.exporting = false
+          this.succeeded.emit(result)
+          this.activeModal.close()
+        },
+        error: (error) => {
+          this.exporting = false
+          this.failed.emit(error)
+        },
+      })
+  }
+
+  cancel(): void {
+    this.activeModal.dismiss()
+  }
+}

--- a/src-ui/src/app/data/document.ts
+++ b/src-ui/src/app/data/document.ts
@@ -77,6 +77,41 @@ export const DEFAULT_DISPLAY_FIELDS = [
 
 export const DEFAULT_DASHBOARD_VIEW_PAGE_SIZE = 10
 
+export const EXPORT_DOCUMENT_FIELDS = [
+  { id: 'id', name: $localize`ID` },
+  { id: DisplayField.TITLE, name: $localize`Title` },
+  { id: DisplayField.CREATED, name: $localize`Created` },
+  { id: DisplayField.ADDED, name: $localize`Added` },
+  { id: 'modified', name: $localize`Modified` },
+  { id: DisplayField.TAGS, name: $localize`Tags` },
+  { id: DisplayField.CORRESPONDENT, name: $localize`Correspondent` },
+  { id: DisplayField.DOCUMENT_TYPE, name: $localize`Document type` },
+  { id: DisplayField.STORAGE_PATH, name: $localize`Storage path` },
+  { id: DisplayField.NOTES, name: $localize`Notes` },
+  { id: DisplayField.OWNER, name: $localize`Owner` },
+  { id: DisplayField.SHARED, name: $localize`Shared` },
+  { id: DisplayField.ASN, name: $localize`ASN` },
+  { id: DisplayField.PAGE_COUNT, name: $localize`Pages` },
+  { id: 'mime_type', name: $localize`MIME type` },
+  { id: 'filename', name: $localize`Filename` },
+  { id: 'archived_filename', name: $localize`Archived filename` },
+  { id: 'content', name: $localize`Content` },
+]
+
+export const DEFAULT_CSV_EXPORT_FIELDS = [
+  DisplayField.CREATED,
+  DisplayField.ADDED,
+  DisplayField.TITLE,
+  DisplayField.CORRESPONDENT,
+  DisplayField.TAGS,
+  DisplayField.DOCUMENT_TYPE,
+  'filename',
+]
+
+export const CSV_EXPORT_FIELDS_STORAGE_KEY = 'paperless_csv_export_fields'
+export const CSV_EXPORT_CUSTOM_FIELDS_STORAGE_KEY =
+  'paperless_csv_export_custom_fields'
+
 export const DEFAULT_DASHBOARD_DISPLAY_FIELDS = [
   DisplayField.CREATED,
   DisplayField.TITLE,

--- a/src-ui/src/app/services/rest/document.service.spec.ts
+++ b/src-ui/src/app/services/rest/document.service.spec.ts
@@ -219,6 +219,24 @@ describe(`DocumentService`, () => {
     })
   })
 
+  it('should call appropriate api endpoint for bulk CSV export', () => {
+    const ids = [1, 2, 3]
+    const fields = ['title', 'created', 'filename']
+    const customFields = [5, 12]
+    subscription = service
+      .bulkExportCsv({ documents: ids }, fields, customFields)
+      .subscribe()
+    const req = httpTestingController.expectOne(
+      `${environment.apiBaseUrl}${endpoint}/bulk_export_csv/`
+    )
+    expect(req.request.method).toEqual('POST')
+    expect(req.request.body).toEqual({
+      documents: ids,
+      fields,
+      custom_fields: customFields,
+    })
+  })
+
   it('should call appropriate api endpoint for bulk edit', () => {
     const ids = [1, 2, 3]
     const method = 'modify_tags'

--- a/src-ui/src/app/services/rest/document.service.ts
+++ b/src-ui/src/app/services/rest/document.service.ts
@@ -430,6 +430,22 @@ export class DocumentService extends AbstractPaperlessService<Document> {
     )
   }
 
+  bulkExportCsv(
+    selection: DocumentSelectionQuery,
+    fields: string[],
+    customFields: number[] = []
+  ) {
+    return this.http.post(
+      this.getResourceUrl(null, 'bulk_export_csv'),
+      {
+        ...selection,
+        fields,
+        custom_fields: customFields,
+      },
+      { responseType: 'blob' }
+    )
+  }
+
   public set searchQuery(query: string) {
     this._searchQuery = query.trim()
   }

--- a/src/documents/bulk_export.py
+++ b/src/documents/bulk_export.py
@@ -1,0 +1,199 @@
+import csv
+import io
+from typing import TYPE_CHECKING
+
+from django.utils.translation import gettext as _
+
+from documents.models import CustomField
+from documents.models import Document
+from documents.serialisers import OwnedObjectSerializer
+
+if TYPE_CHECKING:
+    from django.contrib.auth.models import User
+
+CUSTOM_FIELD_PREFIX = "custom_field_"
+
+FIELD_LABELS: dict[str, str] = {
+    "id": _("ID"),
+    "title": _("Title"),
+    "created": _("Created"),
+    "added": _("Added"),
+    "modified": _("Modified"),
+    "tag": _("Tags"),
+    "correspondent": _("Correspondent"),
+    "documenttype": _("Document type"),
+    "storagepath": _("Storage path"),
+    "note": _("Notes"),
+    "owner": _("Owner"),
+    "shared": _("Shared"),
+    "asn": _("ASN"),
+    "pagecount": _("Pages"),
+    "mime_type": _("MIME type"),
+    "filename": _("Filename"),
+    "archived_filename": _("Archived filename"),
+    "content": _("Content"),
+}
+
+STANDARD_FIELDS = frozenset(FIELD_LABELS.keys())
+
+
+def custom_field_column_id(field_id: int) -> str:
+    return f"{CUSTOM_FIELD_PREFIX}{field_id}"
+
+
+def build_export_field_list(
+    fields: list[str],
+    custom_field_ids: list[int],
+) -> list[str]:
+    export_fields = list(fields)
+    for field_id in custom_field_ids:
+        export_fields.append(custom_field_column_id(field_id))
+    return export_fields
+
+
+def get_custom_field_names(field_ids: list[int]) -> dict[int, str]:
+    if not field_ids:
+        return {}
+    return dict(
+        CustomField.objects.filter(id__in=field_ids).values_list("id", "name"),
+    )
+
+
+def get_csv_headers(
+    fields: list[str],
+    custom_field_names: dict[int, str],
+) -> list[str]:
+    headers = []
+    for field in fields:
+        if field.startswith(CUSTOM_FIELD_PREFIX):
+            field_id = int(field[len(CUSTOM_FIELD_PREFIX) :])
+            headers.append(custom_field_names.get(field_id, field))
+        else:
+            headers.append(str(FIELD_LABELS.get(field, field)))
+    return headers
+
+
+def _format_date(value) -> str:
+    if value is None:
+        return ""
+    return value.isoformat()
+
+
+def _get_field_value(
+    document: Document,
+    field: str,
+    *,
+    user: "User | None" = None,
+    shared_object_pks: set[int] | None = None,
+    notes_count: int | None = None,
+    custom_field_values: dict[int, str] | None = None,
+) -> str:
+    if field.startswith(CUSTOM_FIELD_PREFIX):
+        field_id = int(field[len(CUSTOM_FIELD_PREFIX) :])
+        return (custom_field_values or {}).get(field_id, "")
+
+    if field == "id":
+        return str(document.id)
+    if field == "title":
+        return document.title or ""
+    if field == "created":
+        return _format_date(document.created)
+    if field == "added":
+        return _format_date(document.added)
+    if field == "modified":
+        return _format_date(document.modified)
+    if field == "tag":
+        return ", ".join(tag.name for tag in document.tags.all())
+    if field == "correspondent":
+        return document.correspondent.name if document.correspondent else ""
+    if field == "documenttype":
+        return document.document_type.name if document.document_type else ""
+    if field == "storagepath":
+        return document.storage_path.name if document.storage_path else ""
+    if field == "note":
+        if notes_count is not None:
+            return str(notes_count)
+        return str(document.notes.count())
+    if field == "owner":
+        return document.owner.username if document.owner else ""
+    if field == "shared":
+        if user is None:
+            return ""
+        is_shared = (
+            document.owner == user
+            and shared_object_pks is not None
+            and document.id in shared_object_pks
+        )
+        return _("Yes") if is_shared else _("No")
+    if field == "asn":
+        return (
+            str(document.archive_serial_number)
+            if document.archive_serial_number is not None
+            else ""
+        )
+    if field == "pagecount":
+        return str(document.page_count) if document.page_count is not None else ""
+    if field == "mime_type":
+        return document.mime_type or ""
+    if field == "filename":
+        return document.original_filename or ""
+    if field == "archived_filename":
+        if document.has_archive_version:
+            return document.get_public_filename(archive=True)
+        return ""
+    if field == "content":
+        return document.content or ""
+
+    return ""
+
+
+def export_documents_to_csv(
+    documents: list[Document],
+    fields: list[str],
+    *,
+    user: "User | None" = None,
+) -> bytes:
+    custom_field_ids = [
+        int(field[len(CUSTOM_FIELD_PREFIX) :])
+        for field in fields
+        if field.startswith(CUSTOM_FIELD_PREFIX)
+    ]
+    custom_field_names = get_custom_field_names(custom_field_ids)
+    shared_object_pks = None
+    if user is not None and "shared" in fields:
+        shared_object_pks = OwnedObjectSerializer.get_shared_object_pks(
+            documents,
+        )
+
+    output = io.StringIO()
+    writer = csv.writer(output)
+    writer.writerow(get_csv_headers(fields, custom_field_names))
+
+    for document in documents:
+        notes_count = None
+        if "note" in fields and hasattr(document, "notes_count"):
+            notes_count = document.notes_count
+
+        custom_field_values = {}
+        if custom_field_ids:
+            for instance in document.custom_fields.all():
+                if instance.field_id in custom_field_ids:
+                    value = instance.value_for_search
+                    custom_field_values[instance.field_id] = (
+                        "" if value is None else str(value)
+                    )
+
+        row = [
+            _get_field_value(
+                document,
+                field,
+                user=user,
+                shared_object_pks=shared_object_pks,
+                notes_count=notes_count,
+                custom_field_values=custom_field_values,
+            )
+            for field in fields
+        ]
+        writer.writerow(row)
+
+    return output.getvalue().encode("utf-8")

--- a/src/documents/serialisers.py
+++ b/src/documents/serialisers.py
@@ -2354,6 +2354,69 @@ class DocumentVersionLabelSerializer(serializers.Serializer[dict[str, str | None
         return normalized or None
 
 
+class BulkExportCsvSerializer(DocumentSelectionSerializer):
+    fields = serializers.ListField(
+        child=serializers.CharField(),
+        required=False,
+        default=list,
+        write_only=True,
+        label="Fields",
+    )
+
+    custom_fields = serializers.ListField(
+        child=serializers.IntegerField(),
+        required=False,
+        default=list,
+        write_only=True,
+        label="Custom fields",
+    )
+
+    def validate(self, attrs):
+        attrs = super().validate(attrs)
+        fields = attrs.get("fields", [])
+        custom_fields = attrs.get("custom_fields", [])
+
+        if not fields and not custom_fields:
+            raise serializers.ValidationError(
+                _("At least one field must be selected for export."),
+            )
+
+        from documents.bulk_export import STANDARD_FIELDS
+        from documents.bulk_export import build_export_field_list
+
+        invalid_fields = [field for field in fields if field not in STANDARD_FIELDS]
+        if invalid_fields:
+            raise serializers.ValidationError(
+                {
+                    "fields": _(
+                        "Invalid export fields: %(fields)s",
+                    )
+                    % {"fields": ", ".join(invalid_fields)},
+                },
+            )
+
+        if custom_fields:
+            existing_ids = set(
+                CustomField.objects.filter(id__in=custom_fields).values_list(
+                    "id",
+                    flat=True,
+                ),
+            )
+            missing_ids = sorted(set(custom_fields) - existing_ids)
+            if missing_ids:
+                raise serializers.ValidationError(
+                    {
+                        "custom_fields": _(
+                            "Some custom fields don't exist: %(ids)s",
+                        )
+                        % {"ids": ", ".join(str(field_id) for field_id in missing_ids)},
+                    },
+                )
+
+        attrs["export_fields"] = build_export_field_list(fields, custom_fields)
+        return attrs
+
+
 class BulkDownloadSerializer(DocumentSelectionSerializer):
     content = serializers.ChoiceField(
         choices=["archive", "originals", "both"],

--- a/src/documents/tests/test_api_bulk_export_csv.py
+++ b/src/documents/tests/test_api_bulk_export_csv.py
@@ -1,6 +1,7 @@
 import csv
 import io
 import json
+from unittest import mock
 
 from django.contrib.auth.models import User
 from django.test import override_settings
@@ -8,6 +9,7 @@ from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APITestCase
 
+from documents.bulk_export import STANDARD_FIELDS
 from documents.models import Correspondent
 from documents.models import CustomField
 from documents.models import CustomFieldInstance
@@ -16,6 +18,7 @@ from documents.models import DocumentType
 from documents.models import Tag
 from documents.tests.utils import DirectoriesMixin
 from documents.tests.utils import SampleDirMixin
+from documents.views import BulkExportCsvView
 
 
 class TestBulkExportCsv(DirectoriesMixin, SampleDirMixin, APITestCase):
@@ -162,3 +165,92 @@ class TestBulkExportCsv(DirectoriesMixin, SampleDirMixin, APITestCase):
         self.assertEqual(len(rows), 3)
         titles = {row[0] for row in rows[1:]}
         self.assertEqual(titles, {"Invoice 1", "Invoice 2"})
+
+    def test_export_invalid_custom_field(self) -> None:
+        response = self.client.post(
+            self.ENDPOINT,
+            json.dumps(
+                {
+                    "documents": [self.doc1.id],
+                    "fields": ["title"],
+                    "custom_fields": [99999],
+                },
+            ),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_export_custom_fields_only(self) -> None:
+        response = self.client.post(
+            self.ENDPOINT,
+            json.dumps(
+                {
+                    "documents": [self.doc1.id],
+                    "fields": [],
+                    "custom_fields": [self.custom_field.id],
+                },
+            ),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        rows = self._read_csv(response)
+        self.assertEqual(rows[0], ["Reference"])
+        self.assertEqual(rows[1], ["REF-001"])
+
+    def test_export_all_standard_fields(self) -> None:
+        response = self.client.post(
+            self.ENDPOINT,
+            json.dumps(
+                {
+                    "documents": [self.doc1.id],
+                    "fields": sorted(STANDARD_FIELDS),
+                },
+            ),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        rows = self._read_csv(response)
+        self.assertEqual(len(rows[0]), len(STANDARD_FIELDS))
+        self.assertEqual(len(rows), 2)
+
+    def test_export_insufficient_permissions(self) -> None:
+        user = User.objects.create_user(username="temp_user")
+        self.client.force_authenticate(user=user)
+
+        self.doc2.owner = self.user
+        self.doc2.save()
+
+        response = self.client.post(
+            self.ENDPOINT,
+            json.dumps(
+                {
+                    "documents": [self.doc2.id],
+                    "fields": ["title"],
+                },
+            ),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.content, b"Insufficient permissions")
+
+    @mock.patch.object(BulkExportCsvView, "_resolve_document_ids")
+    def test_export_skips_missing_documents(
+        self,
+        resolve_document_ids,
+    ) -> None:
+        resolve_document_ids.return_value = [self.doc1.id, 99999]
+
+        response = self.client.post(
+            self.ENDPOINT,
+            json.dumps({"documents": [self.doc1.id], "fields": ["title"]}),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        rows = self._read_csv(response)
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(rows[1][0], "Invoice 1")

--- a/src/documents/tests/test_api_bulk_export_csv.py
+++ b/src/documents/tests/test_api_bulk_export_csv.py
@@ -1,0 +1,164 @@
+import csv
+import io
+import json
+
+from django.contrib.auth.models import User
+from django.test import override_settings
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from documents.models import Correspondent
+from documents.models import CustomField
+from documents.models import CustomFieldInstance
+from documents.models import Document
+from documents.models import DocumentType
+from documents.models import Tag
+from documents.tests.utils import DirectoriesMixin
+from documents.tests.utils import SampleDirMixin
+
+
+class TestBulkExportCsv(DirectoriesMixin, SampleDirMixin, APITestCase):
+    ENDPOINT = "/api/documents/bulk_export_csv/"
+
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.user = User.objects.create_superuser(username="temp_admin")
+        self.client.force_authenticate(user=self.user)
+
+        self.correspondent = Correspondent.objects.create(name="ACME Corp")
+        self.document_type = DocumentType.objects.create(name="Invoice")
+        self.tag = Tag.objects.create(name="important")
+
+        self.doc1 = Document.objects.create(
+            title="Invoice 1",
+            checksum="A",
+            mime_type="application/pdf",
+            created=timezone.datetime(2024, 1, 15).date(),
+            original_filename="invoice1.pdf",
+            correspondent=self.correspondent,
+            document_type=self.document_type,
+            archive_serial_number=42,
+            page_count=3,
+        )
+        self.doc1.tags.add(self.tag)
+
+        self.doc2 = Document.objects.create(
+            title="Invoice 2",
+            checksum="B",
+            mime_type="application/pdf",
+            created=timezone.datetime(2024, 2, 20).date(),
+            original_filename="invoice2.pdf",
+        )
+
+        self.custom_field = CustomField.objects.create(
+            name="Reference",
+            data_type=CustomField.FieldDataType.STRING,
+        )
+        CustomFieldInstance.objects.create(
+            document=self.doc1,
+            field=self.custom_field,
+            value_text="REF-001",
+        )
+
+    def _read_csv(self, response) -> list[list[str]]:
+        return list(csv.reader(io.StringIO(response.content.decode("utf-8"))))
+
+    def test_export_selected_documents(self) -> None:
+        response = self.client.post(
+            self.ENDPOINT,
+            json.dumps(
+                {
+                    "documents": [self.doc1.id, self.doc2.id],
+                    "fields": [
+                        "title",
+                        "created",
+                        "added",
+                        "correspondent",
+                        "tag",
+                        "documenttype",
+                        "filename",
+                    ],
+                    "custom_fields": [self.custom_field.id],
+                },
+            ),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response["Content-Type"], "text/csv")
+        self.assertIn("documents.csv", response["Content-Disposition"])
+
+        rows = self._read_csv(response)
+        self.assertEqual(len(rows), 3)
+        self.assertEqual(
+            rows[0],
+            [
+                "Title",
+                "Created",
+                "Added",
+                "Correspondent",
+                "Tags",
+                "Document type",
+                "Filename",
+                "Reference",
+            ],
+        )
+
+        doc1_row = next(row for row in rows[1:] if row[0] == "Invoice 1")
+        self.assertEqual(doc1_row[1], "2024-01-15")
+        self.assertEqual(doc1_row[3], "ACME Corp")
+        self.assertEqual(doc1_row[4], "important")
+        self.assertEqual(doc1_row[5], "Invoice")
+        self.assertEqual(doc1_row[6], "invoice1.pdf")
+        self.assertEqual(doc1_row[7], "REF-001")
+
+        doc2_row = next(row for row in rows[1:] if row[0] == "Invoice 2")
+        self.assertEqual(doc2_row[3], "")
+        self.assertEqual(doc2_row[4], "")
+        self.assertEqual(doc2_row[7], "")
+
+    def test_export_requires_at_least_one_field(self) -> None:
+        response = self.client.post(
+            self.ENDPOINT,
+            json.dumps(
+                {"documents": [self.doc1.id], "fields": [], "custom_fields": []},
+            ),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_export_invalid_field(self) -> None:
+        response = self.client.post(
+            self.ENDPOINT,
+            json.dumps(
+                {"documents": [self.doc1.id], "fields": ["not_a_real_field"]},
+            ),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    @override_settings(
+        PASSWORD_HASHERS=["django.contrib.auth.hashers.MD5PasswordHasher"],
+    )
+    def test_export_all_filtered_documents(self) -> None:
+        response = self.client.post(
+            self.ENDPOINT,
+            json.dumps(
+                {
+                    "all": True,
+                    "filters": {"title__icontains": "Invoice"},
+                    "fields": ["title"],
+                },
+            ),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        rows = self._read_csv(response)
+        self.assertEqual(len(rows), 3)
+        titles = {row[0] for row in rows[1:]}
+        self.assertEqual(titles, {"Invoice 1", "Invoice 2"})

--- a/src/documents/tests/test_bulk_export.py
+++ b/src/documents/tests/test_bulk_export.py
@@ -1,0 +1,227 @@
+import csv
+import io
+import shutil
+
+from django.contrib.auth.models import User
+from django.db.models import Count
+from django.test import TestCase
+from django.utils import timezone
+from guardian.shortcuts import assign_perm
+
+from documents.bulk_export import STANDARD_FIELDS
+from documents.bulk_export import _get_field_value
+from documents.bulk_export import build_export_field_list
+from documents.bulk_export import custom_field_column_id
+from documents.bulk_export import export_documents_to_csv
+from documents.bulk_export import get_csv_headers
+from documents.bulk_export import get_custom_field_names
+from documents.models import Correspondent
+from documents.models import CustomField
+from documents.models import CustomFieldInstance
+from documents.models import Document
+from documents.models import DocumentType
+from documents.models import Note
+from documents.models import StoragePath
+from documents.models import Tag
+from documents.tests.utils import DirectoriesMixin
+from documents.tests.utils import SampleDirMixin
+
+
+class TestBulkExport(DirectoriesMixin, SampleDirMixin, TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.owner = User.objects.create_user(username="owner")
+        self.other_user = User.objects.create_user(username="other")
+        self.correspondent = Correspondent.objects.create(name="ACME Corp")
+        self.document_type = DocumentType.objects.create(name="Invoice")
+        self.storage_path = StoragePath.objects.create(
+            name="Default",
+            path="{title}",
+        )
+        self.tag = Tag.objects.create(name="important")
+        self.custom_field = CustomField.objects.create(
+            name="Reference",
+            data_type=CustomField.FieldDataType.STRING,
+        )
+        self.empty_custom_field = CustomField.objects.create(
+            name="Optional",
+            data_type=CustomField.FieldDataType.STRING,
+        )
+
+        self.document = Document.objects.create(
+            title="Invoice 1",
+            checksum="A",
+            mime_type="application/pdf",
+            content="OCR text",
+            created=timezone.datetime(2024, 1, 15).date(),
+            original_filename="invoice1.pdf",
+            correspondent=self.correspondent,
+            document_type=self.document_type,
+            storage_path=self.storage_path,
+            owner=self.owner,
+            archive_serial_number=42,
+            page_count=3,
+            archive_filename="archive.pdf",
+            archive_checksum="ARCHIVE",
+        )
+        self.document.tags.add(self.tag)
+        shutil.copy(self.SAMPLE_DIR / "test_with_bom.pdf", self.document.archive_path)
+
+        CustomFieldInstance.objects.create(
+            document=self.document,
+            field=self.custom_field,
+            value_text="REF-001",
+        )
+        CustomFieldInstance.objects.create(
+            document=self.document,
+            field=self.empty_custom_field,
+        )
+        Note.objects.create(
+            document=self.document,
+            note="A note",
+            user=self.owner,
+        )
+        assign_perm("view_document", self.other_user, self.document)
+
+    def test_helper_functions(self) -> None:
+        self.assertEqual(custom_field_column_id(5), "custom_field_5")
+        self.assertEqual(
+            build_export_field_list(["title"], [1, 2]),
+            ["title", "custom_field_1", "custom_field_2"],
+        )
+        self.assertEqual(get_custom_field_names([]), {})
+        self.assertEqual(
+            get_custom_field_names([self.custom_field.id]),
+            {self.custom_field.id: "Reference"},
+        )
+        self.assertEqual(
+            get_csv_headers(
+                ["title", custom_field_column_id(999)],
+                {},
+            ),
+            ["Title", "custom_field_999"],
+        )
+
+    def test_get_field_value_covers_all_standard_fields(self) -> None:
+        document = (
+            Document.objects.filter(pk=self.document.pk)
+            .select_related(
+                "correspondent",
+                "document_type",
+                "storage_path",
+                "owner",
+            )
+            .prefetch_related("tags", "custom_fields__field")
+            .annotate(notes_count=Count("notes"))
+            .get()
+        )
+        shared_pks = {document.id}
+
+        self.assertEqual(_get_field_value(document, "id"), str(document.id))
+        self.assertEqual(_get_field_value(document, "title"), "Invoice 1")
+        self.assertEqual(_get_field_value(document, "created"), "2024-01-15")
+        self.assertTrue(_get_field_value(document, "added"))
+        self.assertTrue(_get_field_value(document, "modified"))
+        self.assertEqual(_get_field_value(document, "tag"), "important")
+        self.assertEqual(_get_field_value(document, "correspondent"), "ACME Corp")
+        self.assertEqual(_get_field_value(document, "documenttype"), "Invoice")
+        self.assertEqual(_get_field_value(document, "storagepath"), "Default")
+        self.assertEqual(
+            _get_field_value(document, "note", notes_count=document.notes_count),
+            "1",
+        )
+        self.assertEqual(_get_field_value(document, "owner"), "owner")
+        self.assertEqual(
+            _get_field_value(
+                document,
+                "shared",
+                user=self.owner,
+                shared_object_pks=shared_pks,
+            ),
+            "Yes",
+        )
+        self.assertEqual(
+            _get_field_value(
+                document,
+                "shared",
+                user=self.owner,
+                shared_object_pks=set(),
+            ),
+            "No",
+        )
+        self.assertEqual(_get_field_value(document, "shared", user=None), "")
+        self.assertEqual(_get_field_value(document, "asn"), "42")
+        self.assertEqual(_get_field_value(document, "pagecount"), "3")
+        self.assertEqual(_get_field_value(document, "mime_type"), "application/pdf")
+        self.assertEqual(_get_field_value(document, "filename"), "invoice1.pdf")
+        self.assertTrue(_get_field_value(document, "archived_filename"))
+        self.assertEqual(_get_field_value(document, "content"), "OCR text")
+        self.assertEqual(
+            _get_field_value(
+                document,
+                custom_field_column_id(self.custom_field.id),
+                custom_field_values={self.custom_field.id: "REF-001"},
+            ),
+            "REF-001",
+        )
+        self.assertEqual(_get_field_value(document, "unknown_field"), "")
+
+    def test_export_documents_to_csv_with_all_fields(self) -> None:
+        document = (
+            Document.objects.filter(pk=self.document.pk)
+            .select_related(
+                "correspondent",
+                "document_type",
+                "storage_path",
+                "owner",
+            )
+            .prefetch_related("tags", "custom_fields__field")
+            .annotate(notes_count=Count("notes"))
+            .get()
+        )
+        fields = build_export_field_list(
+            sorted(STANDARD_FIELDS),
+            [self.custom_field.id, self.empty_custom_field.id],
+        )
+
+        csv_bytes = export_documents_to_csv([document], fields, user=self.owner)
+        rows = list(csv.reader(io.StringIO(csv_bytes.decode("utf-8"))))
+
+        self.assertEqual(len(rows), 2)
+        self.assertIn("Reference", rows[0])
+        self.assertIn("Optional", rows[0])
+        self.assertIn("REF-001", rows[1])
+        self.assertIn("Yes", rows[1])
+
+    def test_export_documents_to_csv_counts_notes_without_annotation(self) -> None:
+        document = (
+            Document.objects.filter(pk=self.document.pk)
+            .prefetch_related("tags", "custom_fields__field")
+            .get()
+        )
+
+        csv_bytes = export_documents_to_csv([document], ["note"])
+        rows = list(csv.reader(io.StringIO(csv_bytes.decode("utf-8"))))
+
+        self.assertEqual(rows[1][0], "1")
+
+    def test_export_documents_to_csv_without_archive_or_optional_values(self) -> None:
+        document = Document.objects.create(
+            title="Plain",
+            checksum="B",
+            mime_type="application/pdf",
+        )
+
+        csv_bytes = export_documents_to_csv(
+            [document],
+            ["archived_filename", "asn", "pagecount", "owner"],
+        )
+        rows = list(csv.reader(io.StringIO(csv_bytes.decode("utf-8"))))
+
+        self.assertEqual(rows[1], ["", "", "", ""])
+
+    def test_format_date_none(self) -> None:
+        from documents.bulk_export import _format_date
+
+        self.assertEqual(_format_date(None), "")

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -109,6 +109,7 @@ from documents import bulk_edit
 from documents.bulk_download import ArchiveOnlyStrategy
 from documents.bulk_download import OriginalAndArchiveStrategy
 from documents.bulk_download import OriginalsOnlyStrategy
+from documents.bulk_export import export_documents_to_csv
 from documents.caching import get_llm_suggestion_cache
 from documents.caching import get_metadata_cache
 from documents.caching import get_suggestion_cache
@@ -185,6 +186,7 @@ from documents.serialisers import AcknowledgeTasksViewSerializer
 from documents.serialisers import BulkDownloadSerializer
 from documents.serialisers import BulkEditObjectsSerializer
 from documents.serialisers import BulkEditSerializer
+from documents.serialisers import BulkExportCsvSerializer
 from documents.serialisers import CorrespondentSerializer
 from documents.serialisers import CustomFieldSerializer
 from documents.serialisers import DeleteDocumentsSerializer
@@ -3895,6 +3897,68 @@ class BulkDownloadView(DocumentSelectionMixin, GenericAPIView[Any]):
             as_attachment=True,
             filename="documents.zip",
             content_type="application/zip",
+        )
+
+
+@extend_schema_view(
+    post=extend_schema(
+        operation_id="bulk_export_csv",
+        description="Export document metadata for selected documents as CSV.",
+        responses={
+            (HTTPStatus.OK, "text/csv"): OpenApiTypes.BINARY,
+            HTTPStatus.FORBIDDEN: None,
+        },
+    ),
+)
+class BulkExportCsvView(DocumentSelectionMixin, GenericAPIView[Any]):
+    permission_classes = (IsAuthenticated,)
+    serializer_class = BulkExportCsvSerializer
+    parser_classes = (parsers.JSONParser,)
+
+    def post(self, request, format=None):
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        ids = self._resolve_document_ids(
+            user=request.user,
+            validated_data=serializer.validated_data,
+        )
+        documents = (
+            Document.objects.filter(pk__in=ids)
+            .select_related(
+                "correspondent",
+                "document_type",
+                "storage_path",
+                "owner",
+            )
+            .prefetch_related(
+                "tags",
+                "custom_fields__field",
+            )
+            .annotate(notes_count=Count("notes"))
+        )
+        documents_by_id = {document.id: document for document in documents}
+
+        versioned_documents = []
+        for document_id in ids:
+            document = documents_by_id.get(document_id)
+            if document is None:
+                continue
+            root_doc = get_root_document(document)
+            if not has_perms_owner_aware(request.user, "view_document", root_doc):
+                return HttpResponseForbidden("Insufficient permissions")
+            versioned_documents.append(get_latest_version_for_root(root_doc))
+
+        csv_data = export_documents_to_csv(
+            versioned_documents,
+            serializer.validated_data["export_fields"],
+            user=request.user,
+        )
+
+        return HttpResponse(
+            csv_data,
+            content_type="text/csv",
+            headers={"Content-Disposition": 'attachment; filename="documents.csv"'},
         )
 
 

--- a/src/paperless/urls.py
+++ b/src/paperless/urls.py
@@ -18,6 +18,7 @@ from rest_framework.routers import DefaultRouter
 from documents.views import BulkDownloadView
 from documents.views import BulkEditObjectsView
 from documents.views import BulkEditView
+from documents.views import BulkExportCsvView
 from documents.views import ChatStreamingView
 from documents.views import CorrespondentViewSet
 from documents.views import CustomFieldViewSet
@@ -186,6 +187,11 @@ urlpatterns = [
                                 "^bulk_download/",
                                 BulkDownloadView.as_view(),
                                 name="bulk_download",
+                            ),
+                            re_path(
+                                "^bulk_export_csv/",
+                                BulkExportCsvView.as_view(),
+                                name="bulk_export_csv",
                             ),
                             re_path(
                                 "^selection_data/",


### PR DESCRIPTION
## Proposed change
Adds CSV export for selected documents from the document list. Users can choose which document properties and custom fields to include via checkboxes in an export dialog, accessible from **Download → Export CSV**.
Closes #1796
## Type of change
- [ ] Bug fix: non-breaking change which fixes an issue.
- [x] New feature / Enhancement: non-breaking change which adds functionality.
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:
## Checklist:
- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for backend and / or front-end changes.
- [x] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass.
- [x] I have run all Git pre-commit hooks.
- [ ] I have made corresponding changes to the documentation as needed.
- [x] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
## AI disclosure
AI tools were used during development of this feature.
## Test plan
- [x] Select multiple documents → Download → Export CSV → verify `documents.csv` downloads
- [ ] Toggle document property checkboxes and confirm columns match
- [ ] Toggle custom field checkboxes and confirm values appear
- [ ] Verify only selected documents are included (not the full filtered list unless all are selected)
- [ ] Run `pytest documents/tests/test_api_bulk_export_csv.py`