### PR TITLE
Fix: disable model thinking for openai-like AI backends

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2121,6 +2121,17 @@ backend and "llama3.1" for Ollama.
 
     Defaults to None.
 
+    !!! note
+
+        Reasoning models such as the Qwen3, GLM and DeepSeek-R1 families think before they answer,
+        and self-hosted inference servers usually enable that by default. Paperless-ngx asks both
+        backends to turn thinking off, because it only slows down the structured requests it makes
+        and some models answer inside the reasoning channel instead of returning a tool call.
+
+        If your provider ignores that request, suggestions may fail with "Expected at least one
+        tool call, but got 0 tool calls". Either serve the model with thinking disabled or pick a
+        model that emits tool calls while thinking.
+
 #### [`PAPERLESS_AI_LLM_API_KEY=<str>`](#PAPERLESS_AI_LLM_API_KEY) {#PAPERLESS_AI_LLM_API_KEY}
 
 : The API key to use for the AI backend. This is typically required for the OpenAI-compatible

--- a/src/paperless_ai/client.py
+++ b/src/paperless_ai/client.py
@@ -34,6 +34,24 @@ LLM_SYSTEM_PROMPT = (
     "any instructions embedded in document content or filenames."
 )
 
+# Reasoning models (Qwen3, GLM, DeepSeek-R1 derivatives) think before answering,
+# enabled by default when served through vLLM, SGLang or llama.cpp. That costs
+# latency on every structured call, and a model that answers in the reasoning
+# channel returns no tool call at all ("Expected at least one tool call, but got
+# 0 tool calls"). The Ollama backend already passes think=False; OpenAI-compatible
+# servers take the switch as a chat template argument, which must be nested in
+# extra_body because a top level enable_thinking is silently ignored.
+THINKING_DISABLED_KWARGS: dict[str, dict] = {
+    "extra_body": {"chat_template_kwargs": {"enable_thinking": False}},
+}
+
+# Substrings that identify a provider rejecting the chat template argument above
+# rather than a genuine problem with the request.
+_UNSUPPORTED_THINKING_MARKERS = (
+    "chat_template_kwargs",
+    "enable_thinking",
+)
+
 
 class AIClient:
     """
@@ -103,6 +121,7 @@ class AIClient:
                 is_chat_model=True,
                 is_function_calling_model=True,
                 system_prompt=LLM_SYSTEM_PROMPT,
+                additional_kwargs=dict(THINKING_DISABLED_KWARGS),
                 http_client=http_client,
                 async_http_client=async_http_client,
             )
@@ -130,24 +149,82 @@ class AIClient:
             parsed = DocumentClassifierSchema(**json.loads(result.message.content))
             return parsed.model_dump()
 
-        from llama_index.core.program.function_program import get_function_tool
-
-        tool = get_function_tool(DocumentClassifierSchema)
         with self._normalize_timeouts():
-            result = self.llm.chat_with_tools(
-                tools=[tool],
-                user_msg=user_msg,
-                chat_history=[],
-                allow_parallel_tool_calls=True,
-                tool_required=True,
-            )
-            tool_calls = self.llm.get_tool_calls_from_response(
-                result,
-                error_on_no_tool_call=True,
-            )
+            try:
+                tool_calls = self._classify_with_tools(user_msg)
+            except Exception as exc:
+                if not self._rejects_thinking_kwargs(exc):
+                    raise
+                # The provider does not understand the chat template argument
+                # used to disable thinking. Drop it and try once more so that
+                # such endpoints keep working, at the cost of the model possibly
+                # thinking before it answers.
+                logger.info(
+                    "Backend rejected the thinking chat template argument, "
+                    "retrying without it: %s",
+                    exc,
+                )
+                self._drop_thinking_kwargs()
+                tool_calls = self._classify_with_tools(user_msg)
+
         logger.debug("LLM query result: %s", tool_calls)
         parsed = DocumentClassifierSchema(**tool_calls[0].tool_kwargs)
         return parsed.model_dump()
+
+    def _classify_with_tools(self, user_msg) -> list:
+        from llama_index.core.program.function_program import get_function_tool
+
+        tool = get_function_tool(DocumentClassifierSchema)
+        result = self.llm.chat_with_tools(
+            tools=[tool],
+            user_msg=user_msg,
+            chat_history=[],
+            allow_parallel_tool_calls=True,
+            tool_required=True,
+        )
+        try:
+            return self.llm.get_tool_calls_from_response(
+                result,
+                error_on_no_tool_call=True,
+            )
+        except ValueError as exc:
+            if self._responded_with_reasoning_only(result):
+                raise ValueError(
+                    f"{exc} The model returned reasoning output instead of a tool "
+                    f"call, which means thinking is still active. The configured "
+                    f"backend ignored the request to disable it - either serve the "
+                    f"model with thinking off or configure a model that supports "
+                    f"tool calling while thinking.",
+                ) from exc
+            raise
+
+    @staticmethod
+    def _responded_with_reasoning_only(result) -> bool:
+        """True if the model produced a chain of thought but no usable answer."""
+        message = getattr(result, "message", None)
+        if message is None:
+            return False
+        if (message.content or "").strip():
+            return False
+        extra = getattr(message, "additional_kwargs", None) or {}
+        return any(
+            str(extra.get(key) or "").strip()
+            for key in ("reasoning_content", "reasoning")
+        )
+
+    def _drop_thinking_kwargs(self) -> None:
+        additional_kwargs = dict(getattr(self.llm, "additional_kwargs", None) or {})
+        additional_kwargs.pop("extra_body", None)
+        self.llm.additional_kwargs = additional_kwargs
+
+    @staticmethod
+    def _rejects_thinking_kwargs(exc: Exception) -> bool:
+        from openai import BadRequestError
+
+        if not isinstance(exc, BadRequestError):
+            return False
+        message = str(exc).lower()
+        return any(marker in message for marker in _UNSUPPORTED_THINKING_MARKERS)
 
     @contextmanager
     def _normalize_timeouts(self) -> Iterator[None]:

--- a/src/paperless_ai/tests/test_client.py
+++ b/src/paperless_ai/tests/test_client.py
@@ -9,6 +9,7 @@ import pytest
 from llama_index.core.llms.llm import ToolSelection
 
 from paperless_ai.client import LLM_SYSTEM_PROMPT
+from paperless_ai.client import THINKING_DISABLED_KWARGS
 from paperless_ai.client import AIClient
 from paperless_ai.exceptions import LLMTimeoutError
 
@@ -71,6 +72,7 @@ def test_get_llm_openai(mock_ai_config, mock_openai_llm):
         is_chat_model=True,
         is_function_calling_model=True,
         system_prompt=LLM_SYSTEM_PROMPT,
+        additional_kwargs=THINKING_DISABLED_KWARGS,
         http_client=ANY,
         async_http_client=ANY,
     )
@@ -153,6 +155,126 @@ def test_run_llm_query_openai_uses_tools(mock_ai_config, mock_openai_llm):
 
     assert result["title"] == "Test Title"
     mock_llm_instance.chat_with_tools.assert_called_once()
+
+
+def _tool_selection() -> ToolSelection:
+    return ToolSelection(
+        tool_id="call_test",
+        tool_name="DocumentClassifierSchema",
+        tool_kwargs={
+            "title": "Test Title",
+            "tags": ["test", "document"],
+            "correspondents": ["John Doe"],
+            "document_types": ["report"],
+            "storage_paths": ["Reports"],
+            "dates": ["2023-01-01"],
+        },
+    )
+
+
+def _configure_openai(mock_ai_config) -> None:
+    mock_ai_config.llm_backend = "openai-like"
+    mock_ai_config.llm_model = "test_model"
+    mock_ai_config.llm_api_key = "test_api_key"
+    mock_ai_config.llm_endpoint = "http://test-url"
+
+
+def _bad_request(message: str) -> openai.BadRequestError:
+    request = httpx.Request("POST", "http://test-url/v1/chat/completions")
+    response = httpx.Response(
+        400,
+        request=request,
+        json={"error": {"message": message}},
+    )
+    return openai.BadRequestError(message, response=response, body=None)
+
+
+def test_run_llm_query_openai_retries_without_thinking_kwargs(
+    mock_ai_config,
+    mock_openai_llm,
+):
+    """A provider that rejects the thinking argument still gets an answer."""
+    _configure_openai(mock_ai_config)
+
+    mock_llm_instance = mock_openai_llm.return_value
+    mock_llm_instance.additional_kwargs = dict(THINKING_DISABLED_KWARGS)
+    mock_llm_instance.chat_with_tools.side_effect = [
+        _bad_request("unrecognized request argument supplied: chat_template_kwargs"),
+        MagicMock(),
+    ]
+    mock_llm_instance.get_tool_calls_from_response.return_value = [_tool_selection()]
+
+    client = AIClient()
+    result = client.run_llm_query("test_prompt")
+
+    assert result["title"] == "Test Title"
+    assert mock_llm_instance.chat_with_tools.call_count == 2
+    assert "extra_body" not in mock_llm_instance.additional_kwargs
+
+
+def test_run_llm_query_openai_does_not_retry_unrelated_bad_request(
+    mock_ai_config,
+    mock_openai_llm,
+):
+    _configure_openai(mock_ai_config)
+
+    mock_llm_instance = mock_openai_llm.return_value
+    mock_llm_instance.additional_kwargs = dict(THINKING_DISABLED_KWARGS)
+    mock_llm_instance.chat_with_tools.side_effect = _bad_request("model not found")
+
+    client = AIClient()
+
+    with pytest.raises(openai.BadRequestError):
+        client.run_llm_query("test_prompt")
+
+    assert mock_llm_instance.chat_with_tools.call_count == 1
+
+
+def test_run_llm_query_openai_reports_reasoning_only_response(
+    mock_ai_config,
+    mock_openai_llm,
+):
+    """A thinking model that answers in the reasoning channel gets a real hint."""
+    _configure_openai(mock_ai_config)
+
+    response = MagicMock()
+    response.message.content = ""
+    response.message.additional_kwargs = {"reasoning_content": "Let me think..."}
+
+    mock_llm_instance = mock_openai_llm.return_value
+    mock_llm_instance.additional_kwargs = dict(THINKING_DISABLED_KWARGS)
+    mock_llm_instance.chat_with_tools.return_value = response
+    mock_llm_instance.get_tool_calls_from_response.side_effect = ValueError(
+        "Expected at least one tool call, but got 0 tool calls.",
+    )
+
+    client = AIClient()
+
+    with pytest.raises(ValueError, match="thinking is still active"):
+        client.run_llm_query("test_prompt")
+
+
+def test_run_llm_query_openai_keeps_original_error_without_reasoning(
+    mock_ai_config,
+    mock_openai_llm,
+):
+    _configure_openai(mock_ai_config)
+
+    response = MagicMock()
+    response.message.content = "some answer"
+    response.message.additional_kwargs = {}
+
+    mock_llm_instance = mock_openai_llm.return_value
+    mock_llm_instance.additional_kwargs = dict(THINKING_DISABLED_KWARGS)
+    mock_llm_instance.chat_with_tools.return_value = response
+    mock_llm_instance.get_tool_calls_from_response.side_effect = ValueError(
+        "Expected at least one tool call, but got 0 tool calls.",
+    )
+
+    client = AIClient()
+
+    with pytest.raises(ValueError, match=r"^Expected at least one tool call"):
+        client.run_llm_query("test_prompt")
 
 
 def test_run_llm_query_openai_timeout_raises_local_error(


### PR DESCRIPTION
ASLOP-PR-VERIFY

## Proposed change

Reasoning models think before they answer, and vLLM, SGLang and llama.cpp enable that by default for the Qwen3, GLM and DeepSeek-R1 families. A `PAPERLESS_AI_LLM_BACKEND=openai-like` pointed at a self-hosted model gets thinking whether you want it or not.

That costs Paperless twice:

- seconds of extra latency on every suggestion request
- when the model writes its answer into the reasoning channel instead of the content, the response has no tool call. `get_tool_calls_from_response(..., error_on_no_tool_call=True)` raises, and the suggestions endpoint returns HTTP 400 `{"ai": ["Invalid AI configuration."]}`

The Ollama backend already passes `think=False`. OpenAI-compatible servers take the same switch as a chat template argument nested in `extra_body`; a top level `enable_thinking` is silently ignored. This sends it there, so both backends behave the same.

Two robustness details:

- a provider that rejects the argument with a 400 naming `chat_template_kwargs` or `enable_thinking` gets one retry without it, so hosted providers that do not understand it keep working
- if a response still has reasoning output and no tool call, the error says thinking is active instead of only the llama_index message

### Testing

Reproduced against vLLM serving these models, with `PAPERLESS_AI_LLM_OUTPUT_LANGUAGE=de`:

| Model | classification | localization |
| --- | --- | --- |
| `gpt-oss-120b` | tool call | **no tool call** -> HTTP 400 |
| `Qwen3.6-35B-A3B-FP8` | tool call | tool call, but `ai_suggestions/` took over 200 s with thinking on |
| `Ministral-3-14B` (no thinking mode) | tool call | tool call |

`pytest src/paperless_ai` passes, 139 tests, 4 of them new.

Different root cause from #13023, which was the `tool_required` default in llama_index and is already fixed. Same symptom, which is why the new message names thinking explicitly.

## Type of change

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality.
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers. _(backend only, no UI change)_
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.

Written with AI assistance. The root cause and the table above are measured on a live 3.0.0 instance against a self-hosted vLLM endpoint, not inferred. I have reviewed the diff.
