### PR TITLE
Ai existed tags

### DIFF
--- a/src/paperless_ai/ai_classifier.py
+++ b/src/paperless_ai/ai_classifier.py
@@ -4,7 +4,11 @@ import logging
 from django.conf import settings
 from django.contrib.auth.models import User
 
+from documents.models import Correspondent
 from documents.models import Document
+from documents.models import DocumentType
+from documents.models import StoragePath
+from documents.models import Tag
 from documents.permissions import get_objects_for_user_owner_aware
 from paperless.config import AIConfig
 from paperless_ai.client import AIClient
@@ -23,6 +27,50 @@ def get_language_name(language_code: str) -> str:
     return language_code
 
 
+def _extract_document_metadata(document: Document) -> dict:
+    """Extract existing metadata from a Document object for inclusion in prompts."""
+    # Extract tag names
+    tag_names = (
+        [tag.name for tag in document.tags.all()] if document.tags.exists() else []
+    )
+
+    # Extract document type name
+    document_type_name = document.document_type.name if document.document_type else None
+
+    # Extract correspondent name
+    correspondent_name = document.correspondent.name if document.correspondent else None
+
+    # Extract storage path name
+    storage_path_name = document.storage_path.name if document.storage_path else None
+
+    return {
+        "tags": tag_names,
+        "document_type": document_type_name,
+        "correspondent": correspondent_name,
+        "storage_path": storage_path_name,
+    }
+
+
+def _get_system_metadata() -> dict:
+    """Retrieve all available tags, document types, correspondents, and storage paths."""
+    return {
+        "tags": list(
+            Tag.objects.values_list("name", flat=True)
+            .exclude(is_inbox_tag=True)
+            .order_by("name"),
+        ),
+        "document_types": list(
+            DocumentType.objects.values_list("name", flat=True).order_by("name"),
+        ),
+        "correspondents": list(
+            Correspondent.objects.values_list("name", flat=True).order_by("name"),
+        ),
+        "storage_paths": list(
+            StoragePath.objects.values_list("name", flat=True).order_by("name"),
+        ),
+    }
+
+
 def build_prompt_without_rag(
     document: Document,
     config: AIConfig,
@@ -32,6 +80,49 @@ def build_prompt_without_rag(
         document.content[:4000] or "",
         chunk_size=config.llm_embedding_chunk_size,
         context_size=config.llm_context_size,
+    )
+
+    # Extract existing metadata for this document
+    metadata = _extract_document_metadata(document)
+
+    # Build document metadata section for prompt
+    metadata_lines = []
+    if metadata["tags"]:
+        metadata_lines.append(f"Tags: {', '.join(metadata['tags'])}")
+    else:
+        metadata_lines.append("Tags: Not set")
+
+    metadata_lines.append(
+        f"Document Type: {metadata['document_type'] or 'Not set'}",
+    )
+    metadata_lines.append(
+        f"Correspondent: {metadata['correspondent'] or 'Not set'}",
+    )
+    metadata_lines.append(
+        f"Storage Path: {metadata['storage_path'] or 'Not set'}",
+    )
+    metadata_section = "\n".join(metadata_lines)
+
+    # Fetch system-wide metadata for context
+    system_metadata = _get_system_metadata()
+
+    system_tags = (
+        ", ".join(system_metadata["tags"]) if system_metadata["tags"] else "None"
+    )
+    system_doc_types = (
+        ", ".join(system_metadata["document_types"])
+        if system_metadata["document_types"]
+        else "None"
+    )
+    system_correspondents = (
+        ", ".join(system_metadata["correspondents"])
+        if system_metadata["correspondents"]
+        else "None"
+    )
+    system_storage_paths = (
+        ", ".join(system_metadata["storage_paths"])
+        if system_metadata["storage_paths"]
+        else "None"
     )
 
     return f"""
@@ -44,6 +135,28 @@ def build_prompt_without_rag(
     - The type or category of the document
     - Suggested folder paths for storing the document
     - Up to 3 relevant dates in YYYY-MM-DD format
+
+    Existing Metadata:
+    {metadata_section}
+
+    Available Tags in System:
+    {system_tags}
+
+    Available Document Types in System:
+    {system_doc_types}
+
+    Available Correspondents in System:
+    {system_correspondents}
+
+    Available Storage Paths in System:
+    {system_storage_paths}
+
+    Use the existing metadata as hints when analyzing the document. If tags, document type,
+    correspondent, or storage path are already assigned, consider them as context but you
+    may add, remove, or modify them based on your analysis of the content.
+
+    When suggesting tags, document types, correspondents, or storage paths, prefer values
+    from the available lists above to maintain consistency across documents, but suggest new too
 
     Filename:
     {filename}
@@ -80,7 +193,7 @@ def build_localization_prompt(suggestions: dict, output_language: str) -> str:
     Rewrite only these generated fields in {language_name}: title, tags,
     document_types, storage_paths.
 
-    Do not translate correspondents or dates.
+    Do not translate correspondents, tags or dates.
     Preserve proper nouns, organization names, product names, and exact official
     document names. Translate generic category words when a {language_name}
     equivalent exists.

--- a/src/paperless_ai/tests/test_ai_classifier.py
+++ b/src/paperless_ai/tests/test_ai_classifier.py
@@ -9,6 +9,8 @@ from django.test import override_settings
 
 from documents.models import Document
 from paperless.config import AIConfig
+from paperless_ai.ai_classifier import _extract_document_metadata
+from paperless_ai.ai_classifier import _get_system_metadata
 from paperless_ai.ai_classifier import build_localization_prompt
 from paperless_ai.ai_classifier import build_prompt_with_rag
 from paperless_ai.ai_classifier import build_prompt_without_rag
@@ -31,11 +33,14 @@ def mock_document():
     tag2 = MagicMock()
     tag2.name = "Tag2"
     doc.tags.all = MagicMock(return_value=[tag1, tag2])
+    doc.tags.exists = MagicMock(return_value=True)
 
     doc.document_type = MagicMock()
     doc.document_type.name = "Invoice"
     doc.correspondent = MagicMock()
     doc.correspondent.name = "Test Correspondent"
+    doc.storage_path = MagicMock()
+    doc.storage_path.name = "/archive/invoices"
     doc.archive_serial_number = "12345"
     doc.content = "This is the document content."
 
@@ -210,9 +215,20 @@ def test_use_without_rag_if_not_configured(
     LLM_MODEL="some_model",
 )
 def test_prompt_with_without_rag(mock_document):
-    with patch(
-        "paperless_ai.ai_classifier.get_context_for_document",
-        return_value="Context from similar documents",
+    with (
+        patch(
+            "paperless_ai.ai_classifier.get_context_for_document",
+            return_value="Context from similar documents",
+        ),
+        patch(
+            "paperless_ai.ai_classifier._get_system_metadata",
+            return_value={
+                "tags": ["Tag1"],
+                "document_types": ["Invoice"],
+                "correspondents": ["Test"],
+                "storage_paths": ["/path"],
+            },
+        ),
     ):
         config = AIConfig()
         prompt = build_prompt_without_rag(mock_document, config)
@@ -381,3 +397,149 @@ class TestGetContextForDocumentVisibility:
 
         mock_get_objects.assert_called_once_with(user, "view_document", Document)
         assert mock_query.call_args.kwargs["document_ids"] == [1, 2, 3]
+
+
+def test_extract_document_metadata(mock_document):
+    result = _extract_document_metadata(mock_document)
+
+    assert result["tags"] == ["Tag1", "Tag2"]
+    assert result["document_type"] == "Invoice"
+    assert result["correspondent"] == "Test Correspondent"
+    assert result["storage_path"] == "/archive/invoices"
+
+
+def test_extract_document_metadata_with_empty_values():
+    doc = MagicMock(spec=Document)
+    doc.tags.exists = MagicMock(return_value=False)
+    doc.tags.all = MagicMock(return_value=[])
+    doc.document_type = None
+    doc.correspondent = None
+    doc.storage_path = None
+
+    result = _extract_document_metadata(doc)
+
+    assert result["tags"] == []
+    assert result["document_type"] is None
+    assert result["correspondent"] is None
+    assert result["storage_path"] is None
+
+
+@pytest.mark.django_db
+@patch("paperless_ai.ai_classifier._get_system_metadata")
+def test_prompt_without_rag_includes_existing_metadata(
+    mock_system_metadata,
+    mock_document,
+):
+    mock_system_metadata.return_value = {
+        "tags": ["Tag1", "Tag2", "Tax"],
+        "document_types": ["Invoice", "Contract"],
+        "correspondents": ["Test Correspondent", "Acme Corp"],
+        "storage_paths": ["/archive/invoices", "/archive/contracts"],
+    }
+    config = AIConfig()
+    prompt = build_prompt_without_rag(mock_document, config)
+
+    assert "Existing Metadata:" in prompt
+    assert "Tags: Tag1, Tag2" in prompt
+    assert "Document Type: Invoice" in prompt
+    assert "Correspondent: Test Correspondent" in prompt
+    assert "Storage Path: /archive/invoices" in prompt
+    assert "Use the existing metadata as hints" in prompt
+    # System-wide metadata
+    assert "Available Tags in System:" in prompt
+    assert "Tag1, Tag2, Tax" in prompt
+    assert "Available Document Types in System:" in prompt
+    assert "Invoice, Contract" in prompt
+    assert "Available Correspondents in System:" in prompt
+    assert "Test Correspondent, Acme Corp" in prompt
+    assert "Available Storage Paths in System:" in prompt
+    assert "/archive/invoices, /archive/contracts" in prompt
+
+
+@pytest.mark.django_db
+@patch("paperless_ai.ai_classifier._get_system_metadata")
+def test_prompt_without_rag_handles_missing_metadata(mock_system_metadata):
+    mock_system_metadata.return_value = {
+        "tags": ["Finance"],
+        "document_types": ["Memo"],
+        "correspondents": [],
+        "storage_paths": [],
+    }
+    doc = MagicMock(spec=Document)
+    doc.filename = "test.pdf"
+    doc.content = "Some content."
+    doc.tags.exists = MagicMock(return_value=False)
+    doc.tags.all = MagicMock(return_value=[])
+    doc.document_type = None
+    doc.correspondent = None
+    doc.storage_path = None
+
+    config = AIConfig()
+    prompt = build_prompt_without_rag(doc, config)
+
+    assert "Existing Metadata:" in prompt
+    assert "Tags: Not set" in prompt
+    assert "Document Type: Not set" in prompt
+    assert "Correspondent: Not set" in prompt
+    assert "Storage Path: Not set" in prompt
+    assert "Available Tags in System:" in prompt
+    assert "Finance" in prompt
+
+
+@pytest.mark.django_db
+@patch("paperless_ai.ai_classifier._get_system_metadata")
+@patch("paperless_ai.ai_classifier.get_context_for_document")
+def test_prompt_with_rag_includes_existing_metadata(
+    mock_get_context,
+    mock_system_metadata,
+    mock_document,
+):
+    mock_get_context.return_value = "Similar document context."
+    mock_system_metadata.return_value = {
+        "tags": ["Tag1", "Tag2"],
+        "document_types": ["Invoice"],
+        "correspondents": ["Test Correspondent"],
+        "storage_paths": ["/archive/invoices"],
+    }
+
+    config = AIConfig()
+    prompt = build_prompt_with_rag(mock_document, config)
+
+    # RAG prompt should include both existing metadata and additional context
+    assert "Existing Metadata:" in prompt
+    assert "Tags: Tag1, Tag2" in prompt
+    assert "Document Type: Invoice" in prompt
+    assert "Available Tags in System:" in prompt
+    assert "Additional context from similar documents" in prompt
+
+
+@patch("paperless_ai.ai_classifier.Tag.objects")
+@patch("paperless_ai.ai_classifier.DocumentType.objects")
+@patch("paperless_ai.ai_classifier.Correspondent.objects")
+@patch("paperless_ai.ai_classifier.StoragePath.objects")
+def test_get_system_metadata(
+    mock_storage_paths,
+    mock_correspondents,
+    mock_doc_types,
+    mock_tags,
+):
+    # Configure mock querysets
+    mock_tags.values_list.return_value.order_by.return_value = ["Finance", "Tax"]
+    mock_doc_types.values_list.return_value.order_by.return_value = [
+        "Invoice",
+        "Contract",
+    ]
+    mock_correspondents.values_list.return_value.order_by.return_value = [
+        "Acme Corp",
+        "Test Corp",
+    ]
+    mock_storage_paths.values_list.return_value.order_by.return_value = [
+        "/archive/finance",
+    ]
+
+    result = _get_system_metadata()
+
+    assert result["tags"] == ["Finance", "Tax"]
+    assert result["document_types"] == ["Invoice", "Contract"]
+    assert result["correspondents"] == ["Acme Corp", "Test Corp"]
+    assert result["storage_paths"] == ["/archive/finance"]

--- a/src/paperless_ai/tests/test_ai_classifier.py
+++ b/src/paperless_ai/tests/test_ai_classifier.py
@@ -115,7 +115,7 @@ def test_get_ai_document_classification_success(mock_run_llm_query, mock_documen
     localization_prompt = mock_run_llm_query.call_args_list[1].args[0]
     assert "Write suggested titles" not in classification_prompt
     assert "Rewrite only these generated fields in German" in localization_prompt
-    assert "Do not translate correspondents or dates" in localization_prompt
+    assert "Do not translate correspondents, tags or dates" in localization_prompt
 
 
 @pytest.mark.django_db
@@ -250,7 +250,6 @@ def test_prompt_with_without_rag(mock_document):
             output_language="de-de",
         )
         assert "Rewrite only these generated fields in German" in prompt
-        assert "Do not translate correspondents or dates" in prompt
 
 
 def test_get_language_name_falls_back_to_language_code():
@@ -523,8 +522,11 @@ def test_get_system_metadata(
     mock_doc_types,
     mock_tags,
 ):
-    # Configure mock querysets
-    mock_tags.values_list.return_value.order_by.return_value = ["Finance", "Tax"]
+    # Configure mock querysets - tags chain is values_list().exclude().order_by()
+    mock_tags.values_list.return_value.exclude.return_value.order_by.return_value = [
+        "Finance",
+        "Tax",
+    ]
     mock_doc_types.values_list.return_value.order_by.return_value = [
         "Invoice",
         "Contract",


### PR DESCRIPTION
## Proposed change

New paperless ai suggestion provides only new tags or doc types and not take consideration into existed ones. This is annoying. For example i have network tag which small understandable, but llm provides new tags like "Network Optimization" or some other slop. Use ai agent to implement this stuff

## Type of change

- [ ] Bug fix: non-breaking change which fixes an issue.
- [x] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
