### PR TITLE
Fix: parse unpadded yyyy-mm-dd date input regardless of locale

### DIFF
--- a/src-ui/src/app/utils/ngb-date-parser-formatter.spec.ts
+++ b/src-ui/src/app/utils/ngb-date-parser-formatter.spec.ts
@@ -57,6 +57,19 @@ describe('LocalizedDateParserFormatter', () => {
     expect(val).toEqual({ day: 4, month: 5, year: 2023 })
   })
 
+  it('should parse yyyy-mm-dd input with unpadded month or day by locale', () => {
+    let val = dateParserFormatter.parse('2023-5-4')
+    expect(val).toEqual({ day: 4, month: 5, year: 2023 })
+
+    settingsService.setLanguage('de-de') // dd.mm.yyyy
+    val = dateParserFormatter.parse('2023-5-4')
+    expect(val).toEqual({ day: 4, month: 5, year: 2023 })
+
+    settingsService.setLanguage('tr-tr') // yyyy-mm-dd
+    val = dateParserFormatter.parse('2023-5-4')
+    expect(val).toEqual({ day: 4, month: 5, year: 2023 })
+  })
+
   it('should parse date struct to string by locale', () => {
     const dateStruct = {
       day: 4,

--- a/src-ui/src/app/utils/ngb-date-parser-formatter.ts
+++ b/src-ui/src/app/utils/ngb-date-parser-formatter.ts
@@ -52,15 +52,11 @@ export class LocalizedDateParserFormatter extends NgbDateParserFormatter {
       let segments = value.split(this.separatorRegExp)
 
       // always accept strict yyyy*mm*dd format even if that's not the input format since we can be certain its not yyyy*dd*mm
-      if (
-        value.length == 10 &&
-        segments.length == 3 &&
-        segments[0].length == 4
-      ) {
+      if (segments.length == 3 && segments[0].length == 4) {
         return inputFormat
           .replace('yyyy', segments[0])
-          .replace('mm', segments[1])
-          .replace('dd', segments[2])
+          .replace('mm', segments[1].padStart(2, '0'))
+          .replace('dd', segments[2].padStart(2, '0'))
       } else {
         // otherwise pad & re-join without separator
         value = segments.map((segment) => segment.padStart(2, '0')).join('')


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

The date input parser deliberately accepts `yyyy-mm-dd` input regardless of the configured locale format (see the existing comment and the "Always accept yyyy-mm-dd date inputs" commit), on the basis that a 4-digit leading segment can only be a year. That branch was gated on `value.length == 10`, which only holds when the month and day happen to be zero-padded.

An unpadded value such as `2023-5-4` therefore misses the branch and falls through to the generic path, which strips the separators to `20230504` and then splits it by the locale's field order. The result is not rejected, it is silently wrong:

| Input | Locale format | Before | After |
| --- | --- | --- | --- |
| `2023-05-04` | `mm/dd/yyyy` | `{ day: 4, month: 5, year: 2023 }` | unchanged |
| `2023-5-4` | `mm/dd/yyyy` | `{ day: 23, month: 20, year: 504 }` | `{ day: 4, month: 5, year: 2023 }` |
| `2023-5-4` | `dd.mm.yyyy` | `{ day: 20, month: 23, year: 504 }` | `{ day: 4, month: 5, year: 2023 }` |

Since no supported locale has a 4-digit day or month, a three-segment value whose first segment is 4 digits is unambiguously `yyyy-mm-dd`. The length check is therefore replaced by padding the month and day segments, which is what the length check was standing in for.

Only inputs that currently yield a nonsensical date change behaviour. Anything that parses correctly today is unaffected, since the branch is still limited to three-segment values with a 4-digit leading segment.

No existing issue - found while reading through the date input parser. Reproduction is in the table above.

### Testing

Added a regression test covering unpadded input under the `mm/dd/yyyy`, `dd.mm.yyyy` and `yyyy-mm-dd` locales. On `dev` it fails with `{ day: 23, month: 20, year: 504 }`; it passes with this change.

- `pnpm run test` - 176 suites / 1500 tests pass
- `pnpm run build` - succeeds
- `pnpm run lint` - clean
- `prek run --files ...` - all applicable hooks pass

### Use of AI

This change was written with AI assistance. I have reviewed it, confirmed the reported behaviour and the reasoning behind the 4-digit-segment check, and verified the tests fail without the fix and pass with it.

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers. _Not applicable - this changes pure parsing logic with no UI or layout change, and is covered by unit tests._
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
