### PR TITLE
feat: add include_deleted param to permitted_document_ids

### DIFF
--- a/src/documents/permissions.py
+++ b/src/documents/permissions.py
@@ -173,9 +173,7 @@ def permitted_document_ids(user, *, include_deleted: bool = False):
     """
 
     manager = Document.global_objects if include_deleted else Document.objects
-    base_docs = (
-        manager.all() if include_deleted else manager.filter(deleted_at__isnull=True)
-    )
+    base_docs = manager.all()
     base_docs = base_docs.only("id", "owner")
 
     if user is None or not getattr(user, "is_authenticated", False):

--- a/src/documents/permissions.py
+++ b/src/documents/permissions.py
@@ -163,14 +163,20 @@ def set_permissions_for_object(
                         )
 
 
-def permitted_document_ids(user):
+def permitted_document_ids(user, *, include_deleted: bool = False):
     """
-    Return a queryset of document IDs the user may view, limited to non-deleted
-    documents. This intentionally avoids ``get_objects_for_user`` to keep the
-    subquery small and index-friendly.
+    Return a queryset of document IDs the user may view. By default limited
+    to non-deleted documents; pass ``include_deleted=True`` for callers that
+    need to check permission on soft-deleted documents (e.g. trash restore).
+    This intentionally avoids ``get_objects_for_user`` to keep the subquery
+    small and index-friendly.
     """
 
-    base_docs = Document.objects.filter(deleted_at__isnull=True).only("id", "owner")
+    manager = Document.global_objects if include_deleted else Document.objects
+    base_docs = (
+        manager.all() if include_deleted else manager.filter(deleted_at__isnull=True)
+    )
+    base_docs = base_docs.only("id", "owner")
 
     if user is None or not getattr(user, "is_authenticated", False):
         # Just Anonymous user e.g. for drf-spectacular

--- a/src/documents/tests/test_permission_filtering_security.py
+++ b/src/documents/tests/test_permission_filtering_security.py
@@ -125,3 +125,29 @@ class TestPermittedDocumentIdsSecurity:
             expected_visible=[unowned.pk],
             expected_hidden=[owned.pk],
         )
+
+
+@pytest.mark.django_db
+class TestPermittedDocumentIdsIncludeDeleted:
+    def test_include_deleted_true_reveals_soft_deleted_owned_document(self):
+        owner = User.objects.create_user(username="owner")
+        doc = DocumentFactory(owner=owner)
+        doc.delete()
+
+        assert_visible_document_ids(
+            permitted_document_ids(owner, include_deleted=True),
+            expected_visible=[doc.pk],
+            expected_hidden=[],
+        )
+
+    def test_include_deleted_true_still_respects_permission_boundary(self):
+        owner = User.objects.create_user(username="owner")
+        stranger = User.objects.create_user(username="mallory")
+        doc = DocumentFactory(owner=owner)
+        doc.delete()
+
+        assert_visible_document_ids(
+            permitted_document_ids(stranger, include_deleted=True),
+            expected_visible=[],
+            expected_hidden=[doc.pk],
+        )


### PR DESCRIPTION
## Proposed change

Adds an `include_deleted` param to `permitted_document_ids()` so the trash-restore/soft-deleted-document code paths (later in this stack) can reuse it instead of the old per-row owner-aware lookup. Part of the stack fixing #13276 — see #13505 for full context, root-cause writeup, and benchmarks.

## Type of change

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality.
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
