### PR TITLE
feat: add perm param to permitted_document_ids for change/delete checks

### DIFF
--- a/src/documents/permissions.py
+++ b/src/documents/permissions.py
@@ -163,13 +163,18 @@ def set_permissions_for_object(
                         )
 
 
-def permitted_document_ids(user, *, include_deleted: bool = False):
+def permitted_document_ids(
+    user,
+    *,
+    perm: str = "view_document",
+    include_deleted: bool = False,
+):
     """
-    Return a queryset of document IDs the user may view. By default limited
-    to non-deleted documents; pass ``include_deleted=True`` for callers that
-    need to check permission on soft-deleted documents (e.g. trash restore).
-    This intentionally avoids ``get_objects_for_user`` to keep the subquery
-    small and index-friendly.
+    Return a queryset of document IDs the user has ``perm`` on (default
+    ``"view_document"``). By default limited to non-deleted documents; pass
+    ``include_deleted=True`` for callers that need to check permission on
+    soft-deleted documents (e.g. trash restore). This intentionally avoids
+    ``get_objects_for_user`` to keep the subquery small and index-friendly.
     """
 
     manager = Document.global_objects if include_deleted else Document.objects
@@ -185,7 +190,7 @@ def permitted_document_ids(user, *, include_deleted: bool = False):
 
     document_ct = ContentType.objects.get_for_model(Document)
     perm_filter = {
-        "permission__codename": "view_document",
+        "permission__codename": perm,
         "permission__content_type": document_ct,
     }
 

--- a/src/documents/permissions.py
+++ b/src/documents/permissions.py
@@ -188,6 +188,12 @@ def permitted_document_ids(
     if getattr(user, "is_superuser", False):
         return base_docs.values_list("id", flat=True)
 
+    # Guardian's UserObjectPermission/GroupObjectPermission always store a bare
+    # codename, but has_perm()-style callers commonly pass the qualified
+    # "app_label.codename" form. content_type already disambiguates the
+    # codename, so just drop any prefix rather than silently under-permitting.
+    perm = perm.rsplit(".", 1)[-1]
+
     document_ct = ContentType.objects.get_for_model(Document)
     perm_filter = {
         "permission__codename": perm,

--- a/src/documents/tests/test_permission_filtering_security.py
+++ b/src/documents/tests/test_permission_filtering_security.py
@@ -217,3 +217,47 @@ class TestDuplicateDocumentsPermissionBoundary:
 
         result_stranger = _get_viewable_duplicates(original, stranger)
         assert {d.pk for d in result_stranger} == {dup_visible.pk}
+
+
+@pytest.mark.django_db
+class TestPermittedDocumentIdsArbitraryPermission:
+    def test_change_document_permission_is_distinct_from_view(self):
+        owner = User.objects.create_user(username="owner")
+        viewer_only = User.objects.create_user(username="viewer")
+        editor = User.objects.create_user(username="editor")
+        doc = DocumentFactory(owner=owner)
+        assign_perm("view_document", viewer_only, doc)
+        assign_perm("change_document", editor, doc)
+        assign_perm("view_document", editor, doc)
+
+        assert_visible_document_ids(
+            permitted_document_ids(editor, perm="change_document"),
+            expected_visible=[doc.pk],
+            expected_hidden=[],
+        )
+        assert_visible_document_ids(
+            permitted_document_ids(viewer_only, perm="change_document"),
+            expected_visible=[],
+            expected_hidden=[doc.pk],
+        )
+
+    def test_delete_permission_with_include_deleted_for_trash_restore(self):
+        owner = User.objects.create_user(username="owner")
+        stranger = User.objects.create_user(username="mallory")
+        doc = DocumentFactory(owner=owner)
+        doc.delete()
+
+        assert_visible_document_ids(
+            permitted_document_ids(owner, perm="delete_document", include_deleted=True),
+            expected_visible=[doc.pk],
+            expected_hidden=[],
+        )
+        assert_visible_document_ids(
+            permitted_document_ids(
+                stranger,
+                perm="delete_document",
+                include_deleted=True,
+            ),
+            expected_visible=[],
+            expected_hidden=[doc.pk],
+        )

--- a/src/documents/tests/test_permission_filtering_security.py
+++ b/src/documents/tests/test_permission_filtering_security.py
@@ -241,6 +241,18 @@ class TestPermittedDocumentIdsArbitraryPermission:
             expected_hidden=[doc.pk],
         )
 
+    def test_qualified_permission_string_is_normalized_to_codename(self):
+        owner = User.objects.create_user(username="owner")
+        editor = User.objects.create_user(username="editor")
+        doc = DocumentFactory(owner=owner)
+        assign_perm("change_document", editor, doc)
+
+        assert_visible_document_ids(
+            permitted_document_ids(editor, perm="documents.change_document"),
+            expected_visible=[doc.pk],
+            expected_hidden=[],
+        )
+
     def test_delete_permission_with_include_deleted_for_trash_restore(self):
         owner = User.objects.create_user(username="owner")
         stranger = User.objects.create_user(username="mallory")

--- a/src/documents/tests/test_permission_filtering_security.py
+++ b/src/documents/tests/test_permission_filtering_security.py
@@ -244,7 +244,9 @@ class TestPermittedDocumentIdsArbitraryPermission:
     def test_delete_permission_with_include_deleted_for_trash_restore(self):
         owner = User.objects.create_user(username="owner")
         stranger = User.objects.create_user(username="mallory")
+        view_only = User.objects.create_user(username="viewer")
         doc = DocumentFactory(owner=owner)
+        assign_perm("view_document", view_only, doc)
         doc.delete()
 
         assert_visible_document_ids(
@@ -255,6 +257,15 @@ class TestPermittedDocumentIdsArbitraryPermission:
         assert_visible_document_ids(
             permitted_document_ids(
                 stranger,
+                perm="delete_document",
+                include_deleted=True,
+            ),
+            expected_visible=[],
+            expected_hidden=[doc.pk],
+        )
+        assert_visible_document_ids(
+            permitted_document_ids(
+                view_only,
                 perm="delete_document",
                 include_deleted=True,
             ),


### PR DESCRIPTION
## Proposed change

Adds a `perm` param to `permitted_document_ids()` so `change_document`/`delete_document` checks (not just `view_document`) can use the same resolved-once-per-request path. Part of the stack fixing #13276 — see #13505 for full context, root-cause writeup, and benchmarks.

## Type of change

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality.
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
