### PR TITLE
Fix: crash filtering document link custom fields with an unset or unrelated field present

### DIFF
--- a/src/documents/filters.py
+++ b/src/documents/filters.py
@@ -725,9 +725,13 @@ class CustomFieldQueryParser:
             )
 
         # First we look up reverse links from the requested documents.
+        # Scoped to this specific field (not just any document link field) and
+        # excluding unset instances, which have a null value_document_ids and
+        # are equivalent to having no reverse link at all.
         links = CustomFieldInstance.objects.filter(
             document_id__in=value,
-            field__data_type=CustomField.FieldDataType.DOCUMENTLINK,
+            field=custom_field,
+            value_document_ids__isnull=False,
         )
 
         # Check if any of the requested IDs are missing.

--- a/src/documents/tests/test_api_filter_by_custom_fields.py
+++ b/src/documents/tests/test_api_filter_by_custom_fields.py
@@ -8,6 +8,7 @@ from django.contrib.auth.models import User
 from rest_framework.test import APITestCase
 
 from documents.models import CustomField
+from documents.models import CustomFieldInstance
 from documents.models import Document
 from documents.models import SavedView
 from documents.models import SavedViewFilterRule
@@ -604,6 +605,56 @@ class TestCustomFieldsSearch(DirectoriesMixin, APITestCase):
                 and set(document["documentlink_field"]) >= {self.documents[6].id}
             ),
             match_nothing_ok=True,
+        )
+
+    def test_document_link_contains_unset_reverse_link(self) -> None:
+        # Another edge case: the document in the value list has the same
+        # document link field attached, but it was never given a value
+        # (value_document_ids is None). This must be treated the same as
+        # having no reverse link at all, not raise a TypeError.
+        unset_document = self.documents[6]
+        CustomFieldInstance.objects.create(
+            document=unset_document,
+            field=self.custom_fields["documentlink_field"],
+            value_document_ids=None,
+        )
+        self._assert_query_match_predicate(
+            ["documentlink_field", "contains", [unset_document.id]],
+            lambda document: (
+                "documentlink_field" in document
+                and document["documentlink_field"] is not None
+                and set(document["documentlink_field"]) >= {unset_document.id}
+            ),
+            match_nothing_ok=True,
+        )
+
+    def test_document_link_contains_ignores_unrelated_document_link_field(
+        self,
+    ) -> None:
+        # A document referenced in the value list may have a *different*
+        # Document Link custom field attached with no value set. This must
+        # not be pulled into the reverse-link lookup for the field being
+        # queried, and must not crash.
+        unrelated_field = CustomField.objects.create(
+            name="unrelated_documentlink_field",
+            data_type=CustomField.FieldDataType.DOCUMENTLINK,
+        )
+        # self.documents[0] is reciprocally linked from self.documents[35]
+        # (documentlink_field=[documents[0].id, documents[1].id, documents[2].id]).
+        target_document = self.documents[0]
+        CustomFieldInstance.objects.create(
+            document=target_document,
+            field=unrelated_field,
+            value_document_ids=None,
+        )
+
+        self._assert_query_match_predicate(
+            ["documentlink_field", "contains", [target_document.id]],
+            lambda document: (
+                "documentlink_field" in document
+                and document["documentlink_field"] is not None
+                and set(document["documentlink_field"]) >= {target_document.id}
+            ),
         )
 
     # ==========================================================#


### PR DESCRIPTION
## Proposed change

The Document Link custom field "contains" filter (`_parse_atom_doc_link_contains` in `documents/filters.py`) had two bugs:
- It matched *any* Document Link field on a document instead of the specific one being queried, so documents with multiple Document Link fields could return wrong (usually empty) results.
- It crashed with `TypeError: 'NoneType' object is not iterable` if a matched field instance was attached but never given a value

Fixed by scoping the lookup to the queried field and excluding unset instances. Added two regression tests covering both cases.

Closes #13517

## Type of change

- [X] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

⚠️**Use of AI for writing unit tests**

## Checklist:

- [X] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [X] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [X] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [X] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [X] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
