### PR TITLE
Fix: don't duplicate text search term when combining created and added relative date filters

### DIFF
--- a/src-ui/src/app/components/document-list/filter-editor/filter-editor.component.spec.ts
+++ b/src-ui/src/app/components/document-list/filter-editor/filter-editor.component.spec.ts
@@ -1842,6 +1842,46 @@ describe('FilterEditorComponent', () => {
     ])
   })
 
+  it('should not duplicate carried-over text filter when setting both created and added relative dates', () => {
+    component.textFilter = 'foo'
+    const datesDropdown = fixture.debugElement.query(
+      By.directive(DatesDropdownComponent)
+    )
+    component.dateCreatedRelativeDate = RelativeDate.WITHIN_1_WEEK
+    component.dateAddedRelativeDate = RelativeDate.WITHIN_1_MONTH
+    datesDropdown.triggerEventHandler('datesSet')
+    fixture.detectChanges()
+    tick(400)
+    expect(component.filterRules).toEqual([
+      {
+        rule_type: FILTER_FULLTEXT_QUERY,
+        value: 'foo,created:[-1 week to now],added:[-1 month to now]',
+      },
+    ])
+  })
+
+  it('should replace stale relative date clauses instead of duplicating them when re-editing', () => {
+    component.filterRules = [
+      {
+        rule_type: FILTER_FULLTEXT_QUERY,
+        value: 'foo,created:[-1 week to now],added:[-1 month to now]',
+      },
+    ]
+    const datesDropdown = fixture.debugElement.query(
+      By.directive(DatesDropdownComponent)
+    )
+    component.dateCreatedRelativeDate = RelativeDate.WITHIN_3_MONTHS
+    datesDropdown.triggerEventHandler('datesSet')
+    fixture.detectChanges()
+    tick(400)
+    expect(component.filterRules).toEqual([
+      {
+        rule_type: FILTER_FULLTEXT_QUERY,
+        value: 'foo,created:[-3 month to now],added:[-1 month to now]',
+      },
+    ])
+  })
+
   it('should convert user input to correct filter on permissions select my docs', () => {
     const permissionsDropdown = fixture.debugElement.query(
       By.directive(PermissionsFilterDropdownComponent)

--- a/src-ui/src/app/components/document-list/filter-editor/filter-editor.component.ts
+++ b/src-ui/src/app/components/document-list/filter-editor/filter-editor.component.ts
@@ -1016,7 +1016,6 @@ export class FilterEditorComponent
       this.dateAddedRelativeDate !== null ||
       this.dateCreatedRelativeDate !== null
     ) {
-      let queryArgs: Array<string> = []
       let existingRule = filterRules.find(
         (fr) => fr.rule_type == FILTER_FULLTEXT_QUERY
       )
@@ -1038,7 +1037,17 @@ export class FilterEditorComponent
         existingRule.rule_type = FILTER_FULLTEXT_QUERY
       }
 
-      let existingRuleArgs = existingRule?.value.split(',')
+      // Start from the existing terms with any stale created:/added: clauses
+      // stripped out, then append the currently active relative date clauses.
+      let queryArgs: Array<string> = existingRule
+        ? existingRule.value
+            .split(',')
+            .filter(
+              (arg) =>
+                !arg.match(RELATIVE_DATE_QUERY_REGEXP_CREATED) &&
+                !arg.match(RELATIVE_DATE_QUERY_REGEXP_ADDED)
+            )
+        : []
       if (this.dateCreatedRelativeDate !== null) {
         const rd = RELATIVE_DATE_QUERYSTRINGS.find(
           (qS) => qS.relativeDate == this.dateCreatedRelativeDate
@@ -1046,11 +1055,6 @@ export class FilterEditorComponent
         queryArgs.push(
           `created:${rd.isRange ? `[${rd.dateQuery}]` : `"${rd.dateQuery}"`}`
         )
-        if (existingRule) {
-          queryArgs = existingRuleArgs
-            .filter((arg) => !arg.match(RELATIVE_DATE_QUERY_REGEXP_CREATED))
-            .concat(queryArgs)
-        }
       }
       if (this.dateAddedRelativeDate !== null) {
         const rd = RELATIVE_DATE_QUERYSTRINGS.find(
@@ -1059,11 +1063,6 @@ export class FilterEditorComponent
         queryArgs.push(
           `added:${rd.isRange ? `[${rd.dateQuery}]` : `"${rd.dateQuery}"`}`
         )
-        if (existingRule) {
-          queryArgs = existingRuleArgs
-            .filter((arg) => !arg.match(RELATIVE_DATE_QUERY_REGEXP_ADDED))
-            .concat(queryArgs)
-        }
       }
 
       if (existingRule) {


### PR DESCRIPTION
## Proposed change

When a text search (Title, or Title & content) was active and the user set relative quick-date filters for **both** "Created" and "Added" at the same time, the code that merges the date clauses into the advanced-search query duplicated the existing search term(s) (`"foo,foo,created:[...],added:[...]"` instead of `"foo,created:[...],added:[...]"`).

Closes #13519

⚠️Use of Claude code for finding the root cause and handling the unit tests (I don't know much about TypeScript)

- [X] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

- [X] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [X] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [X] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [X] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [X] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
