### PR TITLE
Documentation: note TRUSTED_PROXIES needs the container-visible source IP

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -522,6 +522,15 @@ do CORS calls. Set this to your public domain name.
 fail2ban with log entries for failed authorization attempts. Value should be
 IP address(es).
 
+    Use the IP address as Paperless-ngx actually sees it, which is not always
+    the proxy's LAN address: when the reverse proxy runs on the same Docker
+    host, its requests usually reach the Paperless-ngx container from the
+    Docker bridge gateway (a hairpin/SNAT address such as `172.x.0.1`), not
+    from the host IP, so the host IP will never match. To find the value the
+    container actually sees, check the source address of an incoming proxied
+    request from inside the container (for example in the webserver access
+    log).
+
     By default, this setting also controls allauth's trusted proxy count,
     which is set to the number of proxies listed here. Override that default
     with [`PAPERLESS_ALLAUTH_TRUSTED_PROXY_COUNT`](#PAPERLESS_ALLAUTH_TRUSTED_PROXY_COUNT)


### PR DESCRIPTION
PAPERLESS_TRUSTED_PROXIES says to list the proxy IP but not which address the container actually sees. With a reverse proxy on the same Docker host, requests reach the container from the bridge gateway (hairpin SNAT), not the host IP, so the obvious host-IP value never matches.

Document that the value must be the address as the container sees it, with a short recipe to find it.

Drafted with AI assistance (Claude), reviewed by the author.

## Type of change

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [x] Documentation only.
- [ ] Other. Please explain:

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
