### PR TITLE
docs: recommend a multilingual embedding model for non-English archives

### DIFF
--- a/docs/advanced_usage.md
+++ b/docs/advanced_usage.md
@@ -150,6 +150,19 @@ Enable it by setting
 (`huggingface` for fully-local embeddings, or `ollama` / `openai-like`). The index is only
 built when AI is enabled **and** an embedding backend is set.
 
+!!! tip
+
+    The default Huggingface model (`all-MiniLM-L6-v2`) is trained mainly on
+    English text. If your archive is largely non-English, a multilingual
+    embedding model usually retrieves noticeably better. Set
+    [`PAPERLESS_AI_LLM_EMBEDDING_MODEL`](configuration.md#PAPERLESS_AI_LLM_EMBEDDING_MODEL)
+    to a multilingual model such as `intfloat/multilingual-e5-small`,
+    `intfloat/multilingual-e5-base`, or `BAAI/bge-m3`. Larger models tend to
+    retrieve better but use more RAM per query and take longer to build the
+    index, so prefer the smallest model that covers your languages. Changing
+    the model requires rebuilding the LLM index (see
+    [Managing the LLM index](administration.md#llm-index)).
+
 The index is updated automatically on a schedule controlled by
 [`PAPERLESS_LLM_INDEX_TASK_CRON`](configuration.md#PAPERLESS_LLM_INDEX_TASK_CRON) (daily by
 default), and can be rebuilt or compacted manually — see


### PR DESCRIPTION
The AI/RAG docs explain how to set the embedding backend and model but give no guidance on which model to choose. The Huggingface default all-MiniLM-L6-v2 is English-centric, so non-English archives get weaker retrieval with no hint in the docs.

Add a tip pointing non-English setups at multilingual models (multilingual-e5, bge-m3) via PAPERLESS_AI_LLM_EMBEDDING_MODEL, and note the RAM/index-build tradeoff and that changing the model needs an index rebuild.

Drafted with AI assistance (Claude), reviewed by the author.

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [x] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
