### PR TITLE
Fix: strip quote characters in simple search

### DIFF
--- a/src/documents/search/_query.py
+++ b/src/documents/search/_query.py
@@ -132,6 +132,20 @@ _FIELD_BOOSTS = {"title": 2.0}
 _SIMPLE_FIELD_BOOSTS = {"simple_title": 2.0}
 
 
+# Double-quote characters (plus their typographic variants) are search syntax,
+# not content. The simple-search analyzer tokenizes on \S+, so it keeps a quote
+# glued to the adjacent word ('"digital'), and no indexed token can match that.
+# Single quotes are deliberately not included: apostrophes occur inside real
+# words ("don't", "O'Brien") and are indexed as part of the token, so stripping
+# them here would break matching rather than fix it.
+_QUOTE_CHARS: Final[str] = '["“”„″]'
+
+
+def _strip_quote_syntax(raw_query: str) -> str:
+    # Replaced with a space rather than removed, so 'foo"bar' stays two tokens.
+    return regex.sub(_QUOTE_CHARS, " ", raw_query, timeout=_REGEX_TIMEOUT)
+
+
 def _simple_query_tokens(raw_query: str) -> list[str]:
     # Tokenize and fold via the same analyzer used to index simple_title /
     # simple_content, so query terms fold identically to the indexed terms
@@ -263,12 +277,14 @@ def parse_simple_query(
     Parse a plain-text query using Tantivy over a restricted field set.
 
     Query string is escaped and normalized to be treated as "simple" text query.
+    Quote characters are stripped: simple search has no phrase concept, so they
+    are meaningless syntax here, and leaving them in makes the query unmatchable.
     When cjk_fields is provided and the query contains CJK characters, an
     additional Should clause searches those bigram-tokenized fields, which match
     CJK substrings the simple analyzer can't (long whitespace-free runs are
     dropped by remove_long).
     """
-    tokens = _simple_query_tokens(raw_query)
+    tokens = _simple_query_tokens(_strip_quote_syntax(raw_query))
 
     clauses: list[tuple[tantivy.Occur, tantivy.Query]] = []
     if tokens:
@@ -322,8 +338,9 @@ def parse_simple_text_highlight_query(
 
     # Strip Tantivy operator chars before tokenizing: this is a plain-text
     # highlight query, not a structured boolean query, so +/- are separators.
+    # Quotes go too, so highlighting stays consistent with what actually matched.
     tokens = _simple_query_tokens(
-        regex.sub(r"[-+]", " ", raw_query, timeout=_REGEX_TIMEOUT),
+        regex.sub(r"[-+]", " ", _strip_quote_syntax(raw_query), timeout=_REGEX_TIMEOUT),
     )
     if not tokens:
         return tantivy.Query.empty_query()

--- a/src/documents/tests/search/test_query.py
+++ b/src/documents/tests/search/test_query.py
@@ -13,7 +13,11 @@ import time_machine
 
 from documents.search._dates import _date_only_range
 from documents.search._dates import _datetime_range
+from documents.search._query import SIMPLE_SEARCH_FIELDS
+from documents.search._query import _simple_query_tokens
+from documents.search._query import _strip_quote_syntax
 from documents.search._query import build_permission_filter
+from documents.search._query import parse_simple_query
 from documents.search._query import parse_simple_text_highlight_query
 from documents.search._query import parse_user_query
 from documents.search._schema import build_schema
@@ -793,6 +797,73 @@ class TestParseSimpleTextHighlightQuery:
     ) -> None:
         result = parse_simple_text_highlight_query(query_index, "- +")
         assert isinstance(result, tantivy.Query)
+
+
+class TestSimpleQuoteHandling:
+    """
+    Simple search has no phrase concept, so quote characters are syntax rather
+    than content. The simple analyzer tokenizes on \\S+, so an unstripped quote
+    stays glued to the adjacent word ('"digital') and can never match an indexed
+    token - making any quoted query return zero results.
+    """
+
+    @pytest.fixture
+    def query_index(self) -> tantivy.Index:
+        schema = build_schema()
+        idx = tantivy.Index(schema, path=None)
+        register_tokenizers(idx, "")
+        return idx
+
+    @pytest.mark.parametrize(
+        ("raw_query", "expected"),
+        [
+            pytest.param('"digital ocean"', ["digital", "ocean"], id="wrapped"),
+            pytest.param('"digital" "ocean"', ["digital", "ocean"], id="each_wrapped"),
+            pytest.param('digital "ocean', ["digital", "ocean"], id="unbalanced"),
+            pytest.param("“digital ocean”", ["digital", "ocean"], id="curly_quotes"),
+            pytest.param('foo"bar', ["foo", "bar"], id="infix_quote_splits"),
+        ],
+    )
+    def test_quotes_are_stripped_before_tokenizing(
+        self,
+        raw_query: str,
+        expected: list[str],
+    ) -> None:
+        assert _simple_query_tokens(_strip_quote_syntax(raw_query)) == expected
+
+    def test_apostrophes_are_preserved(self) -> None:
+        # Apostrophes are indexed as part of the token, so stripping them here
+        # would break matching rather than fix it.
+        assert _simple_query_tokens(_strip_quote_syntax("o'brien don't")) == [
+            "o'brien",
+            "don't",
+        ]
+
+    def test_quoted_and_unquoted_produce_equivalent_tokens(self) -> None:
+        quoted = _simple_query_tokens(_strip_quote_syntax('"tax document"'))
+        unquoted = _simple_query_tokens(_strip_quote_syntax("tax document"))
+        assert quoted == unquoted
+
+    def test_quote_only_query_yields_no_tokens(self) -> None:
+        assert _simple_query_tokens(_strip_quote_syntax('" ""  "')) == []
+
+    def test_parse_simple_query_accepts_quoted_input(
+        self,
+        query_index: tantivy.Index,
+    ) -> None:
+        assert isinstance(
+            parse_simple_query(query_index, '"tax document"', SIMPLE_SEARCH_FIELDS),
+            tantivy.Query,
+        )
+
+    def test_highlight_query_also_strips_quotes(
+        self,
+        query_index: tantivy.Index,
+    ) -> None:
+        assert isinstance(
+            parse_simple_text_highlight_query(query_index, '"tax document"'),
+            tantivy.Query,
+        )
 
 
 class TestPermissionFilter:


### PR DESCRIPTION
## Description

Quoted queries always return **zero results** in simple search mode, even when the phrase appears verbatim in a document. Unquoted queries with the same words work correctly.

I could not find an existing issue for this, so the analysis is included here.

### Root cause

The simple-search analyzer tokenizes on `\S+` — deliberately, so punctuation inside terms like `Z-Berichte` or `invoice#123` is preserved. But `parse_simple_query` passes the raw query straight to it, so a user-typed quote gets glued to the adjacent word:

```python
_simple_query_tokens('"digital ocean"')  # ['"digital', 'ocean"']
_simple_query_tokens('digital ocean')    # ['digital', 'ocean']
```

`_build_simple_token_query` then builds regex queries looking for indexed tokens that contain a literal `"` character. Nothing matches, so the query returns nothing — silently, with no error.

Advanced search is unaffected, because Tantivy's own query parser consumes quotes as phrase delimiters. That is also why this looks at first glance like a phrase/positions problem in the index; it isn't. On the instance where I found this, the index is fine and phrase queries execute correctly against it:

- `meta.json` records `"record": "position"` for every text field
- `parse_user_query('"Digital Ocean"')` builds a correct `PhraseQuery { phrase_terms: [(0, "digit"), (1, "ocean")], slop: 0 }`
- Executed directly against the searcher, that query returns 3 hits

The query simply never reaches the index in a form that can match. Since simple mode is the default in the UI, any user typing quotes hits this.

### Fix

Strip double-quote characters before tokenizing in simple mode — the same treatment `parse_simple_text_highlight_query` already applies to `+`/`-`. Simple search has no phrase concept, so quotes are meaningless syntax there rather than something to honor.

The highlight path gets the same strip so highlighting stays consistent with what actually matched.

**Single quotes are deliberately left alone.** Apostrophes occur inside real words (`don't`, `O'Brien`) and are indexed as part of the token, so stripping them would break matching rather than fix it. Typographic variants (`“ ” „ ″`) are included, since `ascii_fold` maps them onto the plain quote anyway.

Quotes are replaced with a space rather than removed, so `foo"bar` becomes two tokens instead of being fused into `foobar`.

### Verification

Against a real 132-document index, before and after:

| Query | Before | After |
|---|---|---|
| `Tax Document` | 13 | 13 |
| `"Tax Document"` | **0** | **13** |
| `“Tax Document”` | **0** | **13** |

Unquoted behavior is unchanged; quoted now matches it.

Added `TestSimpleQuoteHandling` covering wrapped, individually-wrapped, unbalanced, curly, and infix quotes, apostrophe preservation, quote-only input, and both `parse_simple_query` and the highlight path.

`pytest src/documents/tests/search/` — **357 passed**. `ruff check` and `ruff format --check` clean.

### Notes

Happy to adjust the approach if you'd rather simple mode *honor* quotes as a phrase instead of discarding them — that would be a larger change, since simple mode matches via regex queries rather than term/phrase queries, and I took the minimal fix that makes the observed behavior correct.

Worth noting the underlying shape of the bug is "raw query text is tokenized without sanitizing search syntax," so quotes may not be the only character with this problem. I've only fixed the one I could demonstrate.
