### PR TITLE
Document installation of custom Tesseract language data

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1951,6 +1951,15 @@ specified as "chi-tra".
 
     Defaults to none, which does not install any additional languages.
 
+    `PAPERLESS_OCR_LANGUAGES` installs Debian Tesseract language packages by
+    package name. It cannot install an arbitrary `.traineddata` file, such as
+    a locally trained or contributed domain model. For custom language data,
+    build a derived Paperless image that copies the file into the image's
+    Tesseract `tessdata` directory, verify it with `tesseract --list-langs`,
+    and set `PAPERLESS_OCR_LANGUAGE` to the model's language code. Do not use
+    `PAPERLESS_OCR_LANGUAGES` for that custom code unless a matching Debian
+    package exists.
+
     !!! warning
 
          This option must not be used in rootless containers.


### PR DESCRIPTION
## What changed

Document how custom `.traineddata` files differ from Debian language packages configured through `PAPERLESS_OCR_LANGUAGES`.

## Why

Contributed and locally trained Tesseract models cannot be installed by the package-name mechanism. Users need to know that they must provide the model in a derived image (or another installation method), verify it with `tesseract --list-langs`, and then select its language code with `PAPERLESS_OCR_LANGUAGE`.

This keeps Paperless's existing package-install behavior unchanged and does not add any model or training data to the project.
