### PR TITLE
fix(search): call garbage_collect_files() after each Tantivy index commit (#13679)

### DIFF
--- a/src/documents/search/_backend.py
+++ b/src/documents/search/_backend.py
@@ -234,6 +234,12 @@ class WriteBatch:
                 # the file lock so the next writer doesn't race against an
                 # in-progress merge on the same index files.
                 self._writer.wait_merging_threads()
+                # Remove segment files that are no longer referenced by the
+                # index after the commit and any background merges.  Without
+                # this call, old segments accumulate indefinitely on disk —
+                # the index can grow by one full active-index generation per
+                # write batch even though the live index is tiny.
+                self._writer.garbage_collect_files()
                 self._backend._index.reload()
         finally:
             # Always release the writer (and Tantivy's internal writer lock),
@@ -1016,6 +1022,8 @@ class TantivyBackend:
             # Wait for background merge threads to finish so all segments are
             # fully merged and persisted before the index is considered rebuilt.
             writer.wait_merging_threads()
+            # Remove any unreferenced segment files left after the rebuild.
+            writer.garbage_collect_files()
             new_index.reload()
         except BaseException:  # pragma: no cover
             # Restore old index on failure so the backend remains usable

--- a/src/documents/tests/search/test_backend.py
+++ b/src/documents/tests/search/test_backend.py
@@ -45,6 +45,47 @@ class TestWriteBatch:
         ids = backend.search_ids("should survive", user=None)
         assert len(ids) == 1
 
+    def test_garbage_collect_called_after_successful_commit(
+        self,
+        backend: TantivyBackend,
+        mocker: MockerFixture,
+    ) -> None:
+        """garbage_collect_files() must be called after every successful commit.
+
+        Without it, segment files that are no longer referenced by the index
+        accumulate on disk indefinitely — the index can grow by one full
+        active-index generation per write batch even though the live data is
+        tiny.  See issue #13679.
+        """
+        doc = Document.objects.create(
+            title="GC Test Doc",
+            content="segment accumulation regression",
+            checksum="GC1",
+            pk=101,
+        )
+
+        mock_writer = mocker.MagicMock()
+        mocker.patch.object(
+            WriteBatch,
+            "_writer",
+            new_callable=mocker.PropertyMock,
+            return_value=mock_writer,
+        )
+
+        with backend.batch_update() as batch:
+            batch.add_or_update(doc)
+
+        mock_writer.commit.assert_called_once()
+        mock_writer.wait_merging_threads.assert_called_once()
+        mock_writer.garbage_collect_files.assert_called_once()
+        # garbage_collect_files must be called AFTER wait_merging_threads
+        call_order = [
+            c[0]
+            for c in mock_writer.method_calls
+            if c[0] in ("wait_merging_threads", "garbage_collect_files")
+        ]
+        assert call_order == ["wait_merging_threads", "garbage_collect_files"]
+
     def test_writer_released_when_commit_fails(
         self,
         backend: TantivyBackend,


### PR DESCRIPTION
ASLOP-PR-VERIFY

## Proposed change

Tantivy accumulates unreferenced segment files whenever `commit()` is called without a subsequent `garbage_collect_files()`. After each commit + background merge cycle, the stale segments are not referenced by `meta.json` but remain on disk indefinitely. On installations with frequent writes this causes the index directory to grow by roughly one full active-index generation per write batch — several GiB per day even though the live index may be under 100 MB (reported in #13679).

**Root cause:** `WriteBatch.__exit__()` calls `commit()` → `wait_merging_threads()` → `reload()` but never `garbage_collect_files()`. The same omission exists in the full-rebuild path in `reindex()`.

**Fix:** add `writer.garbage_collect_files()` after `wait_merging_threads()` and before `reload()` in both code paths.

**Safe ordering:** `garbage_collect_files()` removes only files not referenced by the current `meta.json`. Calling it after `wait_merging_threads()` (which ensures all background merges are complete) and before `reload()` is the correct and safe sequence:
1. `commit()` — write new segments, mark old ones unreferenced
2. `wait_merging_threads()` — background merge completes, may free more segments
3. `garbage_collect_files()` — remove all unreferenced segment files
4. `reload()` — reader picks up the freshly committed generation

Closes #13679

## Type of change

- [x] Bug fix: non-breaking change which fixes an issue.

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes. Added `test_garbage_collect_called_after_successful_commit` in `TestWriteBatch` which verifies both that `garbage_collect_files()` is called and that it is called after `wait_merging_threads()`.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed. (No documentation change required — `garbage_collect_files` is an internal Tantivy writer API and not part of the user-facing paperless-ngx API.)
- [x] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.

**AI assistance disclosure:** Root-cause analysis and implementation prepared with Claude Code (Anthropic). The fix was reviewed against the tantivy Python API and the existing test patterns before submission.