### PR TITLE
Feature: templated mail metadata in WorkflowAction custom-field values

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -691,6 +691,23 @@ The following placeholders are only available for "added" or "updated" triggers
 - `{{doc_url}}`: URL to the document in the web UI. Requires the `PAPERLESS_URL` setting to be set.
 - `{{doc_id}}`: Document ID
 
+##### Mail metadata placeholders
+
+When a document is consumed via a mail rule, the source email is exposed to templates:
+
+- `{{ mail.subject }}`: email subject
+- `{{ mail.sender }}`: sender address
+- `{{ mail.recipients }}`: list of recipient addresses (join with `|join(', ')`)
+- `{{ mail.date }}`: email date as a Python `date`, or `None` if unavailable
+
+These are only populated for the "Consumption Started" trigger on mail-sourced documents. In any
+other trigger phase, or for documents not consumed from mail, `mail.subject`, `mail.sender`, and
+`mail.recipients` render as empty (empty string and empty list) and `mail.date` is `None`. Templates
+that reference them still render without error.
+
+The Assignment action's custom-field values also accept Jinja templates for string-type fields,
+using the same placeholders. Rendered values are NFC-normalized and truncated to 128 characters.
+
 ##### Examples
 
 ```jinja2

--- a/src-ui/src/app/components/common/input/custom-fields-values/custom-fields-values.component.html
+++ b/src-ui/src/app/components/common/input/custom-fields-values/custom-fields-values.component.html
@@ -79,4 +79,7 @@
       </button>
     </div>
   }
+  @if (selectedFields?.length > 0) {
+    <small class="form-text text-muted"><span i18n>String fields support Jinja templates, including mail placeholders</span> <code>&#123;&#123; mail.subject &#125;&#125;</code>, <code>&#123;&#123; mail.sender &#125;&#125;</code>, <code>&#123;&#123; mail.recipients &#125;&#125;</code>, <code>&#123;&#123; mail.date &#125;&#125;</code> <span i18n>(populated only when consumed via a mail rule). See <a target="_blank" href="https://docs.paperless-ngx.com/usage/#workflows">documentation</a>.</span></small>
+  }
 </div>

--- a/src/documents/consumer.py
+++ b/src/documents/consumer.py
@@ -78,7 +78,12 @@ class WorkflowTriggerPlugin(
             trigger_type=WorkflowTrigger.WorkflowTriggerType.CONSUMPTION,
             document=self.input_doc,
             logging_group=None,
-            overrides=DocumentMetadataOverrides(),
+            # Seed mail_context from the incoming metadata so the templating
+            # layer can expose the `mail` namespace when the doc originated
+            # from a mail rule.
+            overrides=DocumentMetadataOverrides(
+                mail_context=self.metadata.mail_context,
+            ),
         )
         if overrides:
             self.metadata.update(overrides)

--- a/src/documents/data_models.py
+++ b/src/documents/data_models.py
@@ -34,6 +34,10 @@ class DocumentMetadataOverrides:
     skip_asn_if_exists: bool = False
     version_label: str | None = None
     actor_id: int | None = None
+    # Metadata about the originating mail message, populated by paperless_mail
+    # when a document is consumed via a mail rule. Consumed by the workflow
+    # templating layer to expose a `mail` namespace to Jinja templates.
+    mail_context: dict | None = None
 
     def update(self, other: "DocumentMetadataOverrides") -> "DocumentMetadataOverrides":
         """
@@ -95,6 +99,11 @@ class DocumentMetadataOverrides:
             self.custom_fields = other.custom_fields
         elif other.custom_fields is not None:
             self.custom_fields.update(other.custom_fields)
+
+        if self.mail_context is None:
+            self.mail_context = other.mail_context
+        elif other.mail_context is not None:
+            self.mail_context.update(other.mail_context)
 
         return self
 

--- a/src/documents/serialisers.py
+++ b/src/documents/serialisers.py
@@ -3198,6 +3198,29 @@ class WorkflowActionSerializer(serializers.ModelSerializer[WorkflowAction]):
                 field_id: (None if value == "" else value)
                 for field_id, value in attrs["assign_custom_fields_values"].items()
             }
+            # Templates on string custom-field values are rendered at apply
+            # time; validate them here so bad templates surface at save.
+            string_field_ids = set(
+                CustomField.objects.filter(
+                    pk__in=[int(fid) for fid in attrs["assign_custom_fields_values"]],
+                    data_type=CustomField.FieldDataType.STRING,
+                ).values_list("pk", flat=True),
+            )
+            template_errors: dict[str, str] = {}
+            for field_id, value in attrs["assign_custom_fields_values"].items():
+                if (
+                    isinstance(value, str)
+                    and "{{" in value
+                    and int(field_id) in string_field_ids
+                ):
+                    try:
+                        validate_workflow_template(value)
+                    except (ValueError, KeyError) as e:
+                        template_errors[str(field_id)] = f"{e.args[0]}"
+            if template_errors:
+                raise serializers.ValidationError(
+                    {"assign_custom_fields_values": template_errors},
+                )
 
         if (
             "type" in attrs

--- a/src/documents/templating/workflows.py
+++ b/src/documents/templating/workflows.py
@@ -24,6 +24,31 @@ _LogStrictUndefined = make_logging_undefined(logger, StrictUndefined)
 
 _template_environment.undefined = _LogStrictUndefined
 
+
+# The `mail` namespace exposed to templates when a document was consumed via
+# a mail rule. Non-mail triggers get this same shape with empty values so that
+# `{{ mail.subject }}` renders as an empty string rather than blowing up under
+# StrictUndefined.
+_EMPTY_MAIL_CONTEXT: dict = {
+    "subject": "",
+    "sender": "",
+    "recipients": [],
+    "date": None,
+}
+
+
+def _resolve_mail_context(mail_context: dict | None) -> dict:
+    """
+    Return a fully-populated mail namespace dict, filling any missing keys
+    from `_EMPTY_MAIL_CONTEXT` so template access never trips StrictUndefined.
+    """
+    if not mail_context:
+        return dict(_EMPTY_MAIL_CONTEXT)
+    resolved = dict(_EMPTY_MAIL_CONTEXT)
+    resolved.update(mail_context)
+    return resolved
+
+
 _template_environment.filters["datetime"] = format_datetime
 
 _template_environment.filters["slugify"] = django_slugify
@@ -56,7 +81,26 @@ _known_placeholder_names = {
     "doc_title",
     "doc_url",
     "doc_id",
+    "mail",
 }
+
+
+def render_workflow_custom_field_string(
+    text: str,
+    mail_context: dict | None = None,
+) -> str:
+    """
+    Render a string custom-field value that may contain a Jinja template.
+
+    Only the `mail` namespace is exposed for v1 (see WorkflowAction docstring).
+    Raises the underlying jinja2 exception on syntax or security errors so the
+    caller can decide how loudly to fail; unlike `parse_w_workflow_placeholders`
+    this always returns a string on success (never None) so the caller can
+    write the result directly to a value_text column.
+    """
+    formatting = {"mail": _resolve_mail_context(mail_context)}
+    template = _template_environment.from_string(text, template_class=Template)
+    return template.render(formatting)
 
 
 def validate_workflow_template(text: str) -> None:
@@ -86,6 +130,7 @@ def parse_w_workflow_placeholders(
     doc_title: str | None = None,
     doc_url: str | None = None,
     doc_id: int | None = None,
+    mail_context: dict | None = None,
 ) -> str:
     """
     Available title placeholders for Workflows depend on what has already been assigned,
@@ -127,6 +172,8 @@ def parse_w_workflow_placeholders(
         formatting.update({"doc_url": doc_url})
     if doc_id is not None:
         formatting.update({"doc_id": str(doc_id)})
+
+    formatting["mail"] = _resolve_mail_context(mail_context)
 
     logger.debug(f"Parsing Workflow Jinja template: {text}")
     try:

--- a/src/documents/tests/test_workflows.py
+++ b/src/documents/tests/test_workflows.py
@@ -2093,6 +2093,181 @@ class TestWorkflows(
         doc.refresh_from_db()
         self.assertEqual(doc.custom_fields.get(field=self.cf1).value, "new value")
 
+    def test_document_added_workflow_string_cf_template_no_mail(self) -> None:
+        """
+        GIVEN:
+            - Existing workflow with DOCUMENT_ADDED trigger assigning a STRING
+              custom field whose value is a Jinja template referencing the
+              `mail` namespace
+        WHEN:
+            - Workflow runs for a non-mail document
+        THEN:
+            - The `mail.*` variables resolve to their empty defaults so the
+              rendered value is a well-formed string (not a crash)
+        """
+        trigger = WorkflowTrigger.objects.create(
+            type=WorkflowTrigger.WorkflowTriggerType.DOCUMENT_ADDED,
+        )
+        action = WorkflowAction.objects.create()
+        action.assign_custom_fields.add(self.cf1)
+        action.assign_custom_fields_values = {
+            self.cf1.pk: "subject={{ mail.subject }}|sender={{ mail.sender }}",
+        }
+        action.save()
+        w = Workflow.objects.create(name="Workflow mail no-mail", order=0)
+        w.triggers.add(trigger)
+        w.actions.add(action)
+        w.save()
+
+        doc = Document.objects.create(
+            title="sample test",
+            correspondent=self.c,
+            original_filename="sample.pdf",
+        )
+        run_workflows(
+            WorkflowTrigger.WorkflowTriggerType.DOCUMENT_ADDED,
+            doc,
+        )
+        doc.refresh_from_db()
+        self.assertEqual(
+            doc.custom_fields.get(field=self.cf1).value,
+            "subject=|sender=",
+        )
+
+    def test_consumption_workflow_string_cf_template_mail(self) -> None:
+        """
+        GIVEN:
+            - Existing workflow with CONSUMPTION trigger assigning a STRING
+              custom field via a Jinja template referencing `mail.subject`
+              plus a non-string CF with a literal value
+            - Consumption overrides carry a populated mail_context
+        WHEN:
+            - run_workflows builds the CONSUMPTION overrides
+        THEN:
+            - overrides.custom_fields holds the rendered subject string for
+              the STRING field, and the literal value for the INT field
+        """
+        trigger = WorkflowTrigger.objects.create(
+            type=WorkflowTrigger.WorkflowTriggerType.CONSUMPTION,
+            sources=f"{DocumentSource.MailFetch}",
+            filter_mailrule=self.rule1,
+        )
+        action = WorkflowAction.objects.create()
+        action.assign_custom_fields.add(self.cf1)
+        action.assign_custom_fields.add(self.cf2)
+        action.assign_custom_fields_values = {
+            self.cf1.pk: "Re: {{ mail.subject }}",
+            self.cf2.pk: 7,
+        }
+        action.save()
+        w = Workflow.objects.create(name="Workflow mail cf", order=0)
+        w.triggers.add(trigger)
+        w.actions.add(action)
+        w.save()
+
+        overrides = DocumentMetadataOverrides(
+            mail_context={
+                "subject": "Invoice 42",
+                "sender": "Ann <ann@example.com>",
+                "recipients": ["me@example.com"],
+                "date": None,
+            },
+        )
+        input_doc = ConsumableDocument(
+            source=DocumentSource.MailFetch,
+            original_file=self.SAMPLE_DIR / "simple.pdf",
+            mailrule_id=self.rule1.pk,
+        )
+        result_overrides, _ = run_workflows(
+            trigger_type=WorkflowTrigger.WorkflowTriggerType.CONSUMPTION,
+            document=input_doc,
+            overrides=overrides,
+        )
+        self.assertEqual(
+            result_overrides.custom_fields[self.cf1.pk],
+            "Re: Invoice 42",
+        )
+        self.assertEqual(result_overrides.custom_fields[self.cf2.pk], 7)
+
+    def test_string_cf_bad_template_falls_back_to_raw(self) -> None:
+        """
+        GIVEN:
+            - Workflow with a malformed Jinja template on a STRING custom field
+        WHEN:
+            - Workflow builds CONSUMPTION overrides
+        THEN:
+            - The raw string is stored and no exception propagates
+        """
+        trigger = WorkflowTrigger.objects.create(
+            type=WorkflowTrigger.WorkflowTriggerType.CONSUMPTION,
+            sources=f"{DocumentSource.MailFetch}",
+            filter_mailrule=self.rule1,
+        )
+        action = WorkflowAction.objects.create()
+        action.assign_custom_fields.add(self.cf1)
+        action.assign_custom_fields_values = {
+            self.cf1.pk: "{{ mail.subject",  # unterminated
+        }
+        action.save()
+        w = Workflow.objects.create(name="Workflow bad tpl", order=0)
+        w.triggers.add(trigger)
+        w.actions.add(action)
+        w.save()
+
+        overrides = DocumentMetadataOverrides(
+            mail_context={"subject": "x", "sender": "", "recipients": [], "date": None},
+        )
+        input_doc = ConsumableDocument(
+            source=DocumentSource.MailFetch,
+            original_file=self.SAMPLE_DIR / "simple.pdf",
+            mailrule_id=self.rule1.pk,
+        )
+        result_overrides, _ = run_workflows(
+            trigger_type=WorkflowTrigger.WorkflowTriggerType.CONSUMPTION,
+            document=input_doc,
+            overrides=overrides,
+        )
+        self.assertEqual(
+            result_overrides.custom_fields[self.cf1.pk],
+            "{{ mail.subject",
+        )
+
+    def test_workflow_action_serializer_rejects_bad_cf_template(self) -> None:
+        """
+        GIVEN:
+            - Payload for a workflow action assigning a STRING custom field
+              with a syntactically invalid Jinja template
+        WHEN:
+            - The workflow API is called
+        THEN:
+            - The API returns a 400 with a per-field template error
+        """
+        superuser = User.objects.create_superuser("superuser2")
+        self.client.force_authenticate(user=superuser)
+        payload = {
+            "name": "Bad template workflow",
+            "order": 0,
+            "enabled": True,
+            "triggers": [
+                {
+                    "type": WorkflowTrigger.WorkflowTriggerType.CONSUMPTION,
+                    "sources": [DocumentSource.MailFetch.value],
+                    "filter_mailrule": self.rule1.pk,
+                },
+            ],
+            "actions": [
+                {
+                    "type": WorkflowAction.WorkflowActionType.ASSIGNMENT,
+                    "assign_custom_fields": [self.cf1.pk],
+                    "assign_custom_fields_values": {
+                        str(self.cf1.pk): "{{ mail.subject",
+                    },
+                },
+            ],
+        }
+        response = self.client.post("/api/workflows/", payload, format="json")
+        self.assertEqual(response.status_code, 400)
+
     def test_document_updated_workflow_merge_permissions(self) -> None:
         """
         GIVEN:

--- a/src/documents/workflows/mutations.py
+++ b/src/documents/workflows/mutations.py
@@ -1,16 +1,54 @@
 import logging
+import unicodedata
 
 from django.utils import timezone
 from guardian.shortcuts import remove_perm
 
 from documents.data_models import DocumentMetadataOverrides
+from documents.models import CustomField
 from documents.models import CustomFieldInstance
 from documents.models import Document
 from documents.models import WorkflowAction
 from documents.permissions import set_permissions_for_object
 from documents.templating.workflows import parse_w_workflow_placeholders
+from documents.templating.workflows import render_workflow_custom_field_string
 
 logger = logging.getLogger("paperless.workflows.mutations")
+
+
+def _render_string_cf_value(
+    field: CustomField,
+    raw_value,
+    mail_context: dict | None,
+    logging_group=None,
+):
+    """
+    If `field` is a STRING custom field and `raw_value` is a str carrying a
+    Jinja template ("{{" ), render it against the mail namespace, NFC-normalise
+    the result, and truncate to CustomFieldInstance.value_text.max_length.
+
+    Non-string types and plain (non-templated) strings pass through untouched.
+    On render failure a warning is logged and the raw value is returned so
+    consumption is not aborted by a bad template.
+    """
+    if field.data_type != CustomField.FieldDataType.STRING:
+        return raw_value
+    if not isinstance(raw_value, str) or "{{" not in raw_value:
+        return raw_value
+    try:
+        rendered = render_workflow_custom_field_string(raw_value, mail_context)
+    except Exception as e:
+        logger.warning(
+            f"Error rendering custom field '{field.name}' template "
+            f"'{raw_value}': {e}. Storing raw value instead.",
+            extra={"group": logging_group} if logging_group else {},
+        )
+        return raw_value
+    rendered = unicodedata.normalize("NFC", rendered)
+    max_length = CustomFieldInstance._meta.get_field("value_text").max_length
+    if max_length is not None and len(rendered) > max_length:
+        rendered = rendered[:max_length]
+    return rendered
 
 
 def apply_assignment_to_document(
@@ -94,10 +132,18 @@ def apply_assignment_to_document(
             value_field_name = CustomFieldInstance.get_value_field_name(
                 data_type=field.data_type,
             )
+            raw_value = action.assign_custom_fields_values.get(
+                str(field.pk),
+                None,
+            )
+            # DOCUMENT_ADDED/UPDATED triggers don't carry mail context; pass
+            # None so the render resolves `mail.*` to empty via defaults.
             args = {
-                value_field_name: action.assign_custom_fields_values.get(
-                    str(field.pk),
-                    None,
+                value_field_name: _render_string_cf_value(
+                    field,
+                    raw_value,
+                    mail_context=None,
+                    logging_group=logging_group,
                 ),
             }
             # for some reason update_or_create doesn't work here
@@ -187,15 +233,16 @@ def apply_assignment_to_overrides(
     if action.has_assign_custom_fields:
         if overrides.custom_fields is None:
             overrides.custom_fields = {}
-        overrides.custom_fields.update(
-            {
-                field.pk: action.assign_custom_fields_values.get(
-                    str(field.pk),
-                    None,
-                )
-                for field in action.assign_custom_fields.all()
-            },
-        )
+        for field in action.assign_custom_fields.all():
+            raw_value = action.assign_custom_fields_values.get(
+                str(field.pk),
+                None,
+            )
+            overrides.custom_fields[field.pk] = _render_string_cf_value(
+                field,
+                raw_value,
+                mail_context=overrides.mail_context,
+            )
 
 
 def apply_removal_to_document(

--- a/src/paperless_mail/mail.py
+++ b/src/paperless_mail/mail.py
@@ -508,6 +508,45 @@ class MailAccountHandler(LoggingMixin):
             self.log.error(f"Error while retrieving correspondent {name}: {e}")
             return None
 
+    @staticmethod
+    def _mail_context_from_message(message: MailMessage) -> dict:
+        """
+        Build the `mail` namespace exposed to workflow Jinja templates.
+
+        Keys:
+            subject:    str - message.subject or ""
+            sender:     str - full imap_tools address ("Name <addr>") or the
+                              raw From if from_values is unavailable
+            recipients: list[str] - full-form addresses from the To header
+            date:       datetime.date | None - sender-local calendar date of
+                              the Date header, or None if unparsable/absent
+        """
+        subject = message.subject or ""
+
+        from_values = getattr(message, "from_values", None)
+        if from_values is not None and getattr(from_values, "full", None):
+            sender = from_values.full
+        else:
+            sender = message.from_ or ""
+
+        to_values = getattr(message, "to_values", None) or ()
+        recipients = [addr.full for addr in to_values if getattr(addr, "full", None)]
+
+        msg_date = getattr(message, "date", None)
+        if isinstance(msg_date, datetime.datetime):
+            mail_date = msg_date.date()
+        elif isinstance(msg_date, date):
+            mail_date = msg_date
+        else:
+            mail_date = None
+
+        return {
+            "subject": subject,
+            "sender": sender,
+            "recipients": recipients,
+            "date": mail_date,
+        }
+
     def _get_title(
         self,
         message: MailMessage,
@@ -988,6 +1027,7 @@ class MailAccountHandler(LoggingMixin):
                         if (rule.assign_owner_from_rule and rule.owner)
                         else None
                     ),
+                    mail_context=self._mail_context_from_message(message),
                 )
 
                 consume_task = consume_file.s(
@@ -1079,6 +1119,7 @@ class MailAccountHandler(LoggingMixin):
             document_type_id=doc_type.id if doc_type else None,
             tag_ids=tag_ids,
             owner_id=rule.owner.id if rule.owner else None,
+            mail_context=self._mail_context_from_message(message),
         )
 
         consume_task = consume_file.s(

--- a/src/paperless_mail/tests/test_mail_workflow_templating.py
+++ b/src/paperless_mail/tests/test_mail_workflow_templating.py
@@ -1,0 +1,138 @@
+"""
+Tests that mail rule consumption populates the `mail_context` on
+DocumentMetadataOverrides so workflow Jinja templates can reference the
+originating mail's subject/sender/recipients/date.
+"""
+
+from unittest import mock
+
+import pytest
+
+from documents.tests.utils import remove_dirs
+from documents.tests.utils import setup_directories
+from paperless_mail.models import MailRule
+from paperless_mail.tests.factories import MailAccountFactory
+from paperless_mail.tests.test_mail import MessageBuilder
+from paperless_mail.tests.test_mail import _AttachmentDef
+from paperless_mail.tests.test_mail import fake_magic_from_buffer
+
+
+@pytest.fixture()
+def directories(settings):
+    dirs = setup_directories()
+    yield dirs
+    remove_dirs(dirs)
+
+
+@pytest.fixture()
+def queue_consumption_tasks_mock():
+    with mock.patch("paperless_mail.mail.queue_consumption_tasks") as m:
+        yield m
+
+
+@pytest.fixture()
+def mail_account(db):
+    return MailAccountFactory()
+
+
+@pytest.fixture()
+def attachment_rule(mail_account):
+    rule = MailRule(
+        name="attachment rule with templating",
+        account=mail_account,
+        assign_title_from=MailRule.TitleSource.FROM_SUBJECT,
+        consumption_scope=MailRule.ConsumptionScope.ATTACHMENTS_ONLY,
+        attachment_type=MailRule.AttachmentProcessing.ATTACHMENTS_ONLY,
+    )
+    rule.save()
+    return rule
+
+
+@pytest.fixture()
+def eml_rule(mail_account):
+    rule = MailRule(
+        name="eml rule with templating",
+        account=mail_account,
+        assign_title_from=MailRule.TitleSource.FROM_SUBJECT,
+        consumption_scope=MailRule.ConsumptionScope.EML_ONLY,
+        attachment_type=MailRule.AttachmentProcessing.ATTACHMENTS_ONLY,
+    )
+    rule.save()
+    return rule
+
+
+@pytest.fixture()
+def message_builder():
+    return MessageBuilder()
+
+
+@pytest.mark.django_db
+@mock.patch("paperless_mail.mail.magic.from_buffer", fake_magic_from_buffer)
+class TestMailContextOverrides:
+    """
+    GIVEN a mail rule ingests a message
+    WHEN attachment or EML overrides are built
+    THEN the resulting DocumentMetadataOverrides.mail_context exposes
+         subject, sender, recipients and date pulled from the message.
+    """
+
+    def test_attachment_overrides_carry_mail_context(
+        self,
+        directories,
+        queue_consumption_tasks_mock,
+        attachment_rule,
+        mail_account_handler,
+        message_builder,
+    ):
+        message = message_builder.create_message(
+            subject="Invoice 42",
+            from_="sender@example.com",
+            to=["me@example.com", "other@example.com"],
+            attachments=[
+                _AttachmentDef(filename="invoice.pdf", content=b"%PDF-1.4 test"),
+            ],
+        )
+
+        result = mail_account_handler._handle_message(message, attachment_rule)
+        assert result == 1
+
+        queue_consumption_tasks_mock.assert_called_once()
+        consume_tasks = queue_consumption_tasks_mock.call_args.kwargs["consume_tasks"]
+        overrides = consume_tasks[0].kwargs["overrides"]
+
+        assert overrides.mail_context is not None
+        assert overrides.mail_context["subject"] == "Invoice 42"
+        assert "sender@example.com" in overrides.mail_context["sender"]
+        assert any(
+            "me@example.com" in addr for addr in overrides.mail_context["recipients"]
+        )
+        # date key must exist even if None (unparsed test messages have no Date)
+        assert "date" in overrides.mail_context
+
+    def test_eml_overrides_carry_mail_context(
+        self,
+        directories,
+        queue_consumption_tasks_mock,
+        eml_rule,
+        mail_account_handler,
+        message_builder,
+    ):
+        message = message_builder.create_message(
+            subject="Meeting notes",
+            from_="boss@example.com",
+            to=["team@example.com"],
+            attachments=0,
+        )
+
+        mail_account_handler._handle_message(message, eml_rule)
+
+        queue_consumption_tasks_mock.assert_called_once()
+        consume_tasks = queue_consumption_tasks_mock.call_args.kwargs["consume_tasks"]
+        overrides = consume_tasks[0].kwargs["overrides"]
+
+        assert overrides.mail_context is not None
+        assert overrides.mail_context["subject"] == "Meeting notes"
+        assert "boss@example.com" in overrides.mail_context["sender"]
+        assert any(
+            "team@example.com" in addr for addr in overrides.mail_context["recipients"]
+        )


### PR DESCRIPTION
## Proposed change

Extends `WorkflowAction.assign_custom_fields_values` to support Jinja templates on STRING-type fields, and adds a `mail` template namespace exposing the source email's subject, sender, recipient list, and `Date` header when the document was consumed via a mail rule.

This is the workflow-based alternative to #13159's per-`MailRule` FKs. Same underlying use case (populate custom fields with email metadata during consumption), but the value flows through the existing workflow system rather than a new per-rule surface, so the same mechanism is available for non-mail future template sources. `WorkflowTrigger.filter_mailrule` already scopes assignments to a chosen rule.

Example workflow: trigger on _Consumption Started_ with `filter_mailrule = "Invoices"`, action _Assignment_ with `assign_custom_fields_values = {"5": "{{ mail.subject }}", "6": "{{ mail.sender }}", "7": "{{ mail.recipients | join(', ') }}", "8": "{{ mail.date }}"}`. The document ends up with the four `CustomFieldInstance` rows populated from the actual email.

## Behavior details

- Rendered values are NFC-normalized and truncated to `CustomFieldInstance.value_text.max_length` (128).
- Bad templates fall back to the raw value and log a warning. Consumption is never aborted by a template error.
- Non-STRING CF types (Date/Integer/Monetary/etc.) remain literal in v1.
- The `mail` namespace is populated only at the `CONSUMPTION` trigger for mail-sourced documents. Other trigger phases and non-mail documents see an empty namespace (`mail.subject = ""`, `mail.recipients = []`, `mail.date = None`), so a template like `{{ mail.subject }}` renders as an empty string rather than raising. Single workflows can target both mail and non-mail documents without a template guard.
- Template validation runs at serializer save. Bad templates return 400 on POST/PATCH `/api/workflows/`.
- **No schema migration.** `assign_custom_fields_values` stays a `JSONField(dict)`. Template detection happens at apply time via a `{{` heuristic. Existing rows are compatible.

## Placeholders

| Placeholder | Type | Populated when |
|---|---|---|
| `{{ mail.subject }}` | `str` | Doc consumed via mail rule |
| `{{ mail.sender }}` | `str` | Doc consumed via mail rule |
| `{{ mail.recipients }}` | `list[str]` | Doc consumed via mail rule (join with `\| join(', ')`) |
| `{{ mail.date }}` | `date \| None` | Doc consumed via mail rule + parsable Date header |

Related: #13159 (per-`MailRule` FK approach; this PR is the alternative discussed there).

## Type of change

- [ ] Bug fix: non-breaking change which fixes an issue.
- [x] New feature / Enhancement: non-breaking change which adds functionality.
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.

This PR was drafted with AI assistance.
