### PR TITLE
Performance: cut redundant per-document lookups in bulk `modify_custom_fields`

### DIFF
--- a/src/documents/bulk_edit.py
+++ b/src/documents/bulk_edit.py
@@ -310,8 +310,10 @@ def modify_custom_fields(
     custom_fields_by_id: dict[int, CustomField] = CustomField.objects.in_bulk(
         [field_id for field_id, _ in add_custom_fields],
     )
-    # Only doc link fields need the Document objects themselves, everything
-    # else works off the id alone. content is large and unused here.
+    # Passed to update_or_create() below rather than a bare id, so the FK is
+    # cached on the created instance and auditlog's post_save receiver does
+    # not reload it per row. Only needed for additions. content is deferred:
+    # the one field here that is both large and unused.
     docs_by_id: dict[int, Document] = (
         Document.objects.defer("content").in_bulk(affected_docs)
         if add_custom_fields

--- a/src/documents/bulk_edit.py
+++ b/src/documents/bulk_edit.py
@@ -299,53 +299,53 @@ def modify_custom_fields(
 ) -> Literal["OK"]:
     qs = Document.objects.filter(id__in=doc_ids).only("pk")
     affected_docs = list(qs.values_list("pk", flat=True))
-    # Ensure add_custom_fields is a list of tuples, supports old API
+    # Ensure add_custom_fields is a list of (int, value) tuples, supports old API
     add_custom_fields = (
-        add_custom_fields.items()
+        [(int(field), value) for field, value in add_custom_fields.items()]
         if isinstance(add_custom_fields, dict)
-        else [(field, None) for field in add_custom_fields]
+        else [(int(field), None) for field in add_custom_fields]
     )
 
-    custom_fields = CustomField.objects.filter(
-        id__in=[int(field) for field, _ in add_custom_fields],
-    ).distinct()
+    # Resolved once, instead of re-querying the same field for every document
+    custom_fields_by_id: dict[int, CustomField] = CustomField.objects.in_bulk(
+        [field_id for field_id, _ in add_custom_fields],
+    )
+    # Only doc link fields need the Document objects themselves, everything
+    # else works off the id alone. content is large and unused here.
+    docs_by_id: dict[int, Document] = (
+        Document.objects.defer("content").in_bulk(affected_docs)
+        if add_custom_fields
+        else {}
+    )
     for field_id, value in add_custom_fields:
+        custom_field = custom_fields_by_id[field_id]
+        value_field = CustomFieldInstance.TYPE_TO_DATA_STORE_NAME_MAP[
+            custom_field.data_type
+        ]
+        is_doclink = custom_field.data_type == CustomField.FieldDataType.DOCUMENTLINK
         for doc_id in affected_docs:
-            defaults = {}
-            custom_field = custom_fields.get(id=field_id)
-            if custom_field:
-                value_field = CustomFieldInstance.TYPE_TO_DATA_STORE_NAME_MAP[
-                    custom_field.data_type
-                ]
-                defaults[value_field] = value
-                if (
-                    custom_field.data_type == CustomField.FieldDataType.DOCUMENTLINK
-                    and value
-                    and doc_id in value
-                ):
-                    # Prevent self-linking
-                    continue
+            if is_doclink and value and doc_id in value:
+                # Prevent self-linking
+                continue
             CustomFieldInstance.objects.update_or_create(
-                document_id=doc_id,
-                field_id=field_id,
-                defaults=defaults,
+                document=docs_by_id[doc_id],
+                field=custom_field,
+                defaults={value_field: value},
             )
-            if custom_field.data_type == CustomField.FieldDataType.DOCUMENTLINK:
-                doc = Document.objects.get(id=doc_id)
-                reflect_doclinks(doc, custom_field, value)
+            if is_doclink:
+                reflect_doclinks(docs_by_id[doc_id], custom_field, value)
 
-    # For doc link fields that are being removed, remove symmetrical links
+    # For doc link fields that are being removed, remove symmetrical links.
+    # select_related avoids a per-instance reload of the document and field.
     for doclink_being_removed_instance in CustomFieldInstance.objects.filter(
         document_id__in=affected_docs,
         field__id__in=remove_custom_fields,
         field__data_type=CustomField.FieldDataType.DOCUMENTLINK,
         value_document_ids__isnull=False,
-    ):
+    ).select_related("field", "document"):
         for target_doc_id in doclink_being_removed_instance.value:
             remove_doclink(
-                document=Document.objects.get(
-                    id=doclink_being_removed_instance.document.id,
-                ),
+                document=doclink_being_removed_instance.document,
                 field=doclink_being_removed_instance.field,
                 target_doc_id=target_doc_id,
             )
@@ -1178,10 +1178,13 @@ def remove_doclink(
     """
     Removes a 'symmetrical' link to `document` from the target document's existing custom field instance
     """
-    target_doc_field_instance = CustomFieldInstance.objects.filter(
-        document_id=target_doc_id,
-        field=field,
-    ).first()
+    # select_related: a signal receiver (auditlog) touches .document/.field on
+    # the save() below, without this that is a per-call reload query
+    target_doc_field_instance = (
+        CustomFieldInstance.objects.filter(document_id=target_doc_id, field=field)
+        .select_related("document", "field")
+        .first()
+    )
     if (
         target_doc_field_instance is not None
         and document.id in target_doc_field_instance.value


### PR DESCRIPTION
## Proposed change

`modify_custom_fields()` re-resolved the same objects inside its per-document loop: a `CustomField` query per document, and a second `Document.objects.get()` for doc link fields.

Resolve both once with `in_bulk()` and pass the objects to `update_or_create()` instead of ids, which also caches the FKs so auditlog's `post_save` doesn't reload them. `select_related()` on the doc link removal pass and in `remove_doclink()`, for the same reason.

Query counts, 50 documents, sqlite, audit log enabled:

| | before | after |
|---|---|---|
| add 3 string fields | 1502 | 1054 |
| update 1 string field | 451 | 403 |
| add doc link | 851 | 653 |
| remove doc link | 604 | 354 |

Wall clock is unchanged. This is a round-trip reduction, worth more on a networked database than a local one.

Behaviour is unchanged and the existing tests cover these paths. An earlier revision also replaced `update_or_create()` with a hand-rolled loop; the extra statements that removed were its `transaction.atomic()` savepoints, which the `(document, field)` unique constraint needs, so that was dropped. The remaining per-document `update_or_create()` wants `bulk_create(update_conflicts=True)` and its own PR.

## Type of change

- [x] Other. Please explain: Performance, no behaviour or API change.

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR.
- [x] If applicable, I have checked that all tests pass.
- [x] I have run all Git `pre-commit` hooks.
- [x] I have made corresponding changes to the documentation as needed.
- [x] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.

AI disclosure: Claude reviewed the original revision, argued down the `update_or_create` rewrite, and ran the measurements above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
