### PR TITLE
Enhancement: prefill the IMAP port from the selected security setting

### DIFF
--- a/src-ui/src/app/components/common/edit-dialog/mail-account-edit-dialog/mail-account-edit-dialog.component.spec.ts
+++ b/src-ui/src/app/components/common/edit-dialog/mail-account-edit-dialog/mail-account-edit-dialog.component.spec.ts
@@ -7,7 +7,11 @@ import { ComponentFixture, TestBed } from '@angular/core/testing'
 import { FormsModule, ReactiveFormsModule } from '@angular/forms'
 import { NgbActiveModal, NgbModule } from '@ng-bootstrap/ng-bootstrap'
 import { NgSelectModule } from '@ng-select/ng-select'
-import { IMAPSecurity, MailAccountType } from 'src/app/data/mail-account'
+import {
+  IMAPSecurity,
+  MailAccount,
+  MailAccountType,
+} from 'src/app/data/mail-account'
 import { IfOwnerDirective } from 'src/app/directives/if-owner.directive'
 import { IfPermissionsDirective } from 'src/app/directives/if-permissions.directive'
 import { SettingsService } from 'src/app/services/settings.service'
@@ -116,5 +120,125 @@ describe('MailAccountEditDialogComponent', () => {
     expect(fixture.nativeElement.textContent).toContain('Unable to connect')
     jest.advanceTimersByTime(6000)
     jest.useRealTimers()
+  })
+
+  describe('IMAP port prefill', () => {
+    const createDialog = (
+      mode: EditDialogMode,
+      object?: MailAccount
+    ): MailAccountEditDialogComponent => {
+      const f = TestBed.createComponent(MailAccountEditDialogComponent)
+      f.componentInstance.dialogMode.set(mode)
+      if (object) {
+        f.componentInstance.object = object
+      }
+      f.detectChanges()
+      return f.componentInstance
+    }
+
+    const existingAccount = (overrides: Partial<MailAccount>): MailAccount =>
+      ({
+        id: 1,
+        name: 'example',
+        imap_server: 'imap.example.com',
+        imap_port: 993,
+        imap_security: IMAPSecurity.SSL,
+        username: 'user',
+        password: 'pass',
+        is_token: false,
+        account_type: MailAccountType.IMAP,
+        ...overrides,
+      }) as MailAccount
+
+    it('should prefill the port with the SSL default for a new account', () => {
+      const c = createDialog(EditDialogMode.CREATE)
+      expect(c.objectForm.get('imap_security').value).toEqual(IMAPSecurity.SSL)
+      expect(c.objectForm.get('imap_port').value).toEqual(993)
+    })
+
+    it('should update the port when the security setting changes', () => {
+      const c = createDialog(EditDialogMode.CREATE)
+      // Start on SSL/993, so moving to None has to change the value: landing on
+      // 143 from a security setting that already defaults to it would assert
+      // nothing about whether the handler ran.
+      c.objectForm.get('imap_security').setValue(IMAPSecurity.None)
+      expect(c.objectForm.get('imap_port').value).toEqual(143)
+      // None and STARTTLS do share a default, so this transition really is a
+      // no-op, and is here to pin that rather than to prove a change.
+      c.objectForm.get('imap_security').setValue(IMAPSecurity.STARTTLS)
+      expect(c.objectForm.get('imap_port').value).toEqual(143)
+      c.objectForm.get('imap_security').setValue(IMAPSecurity.SSL)
+      expect(c.objectForm.get('imap_port').value).toEqual(993)
+    })
+
+    it('should fill an empty port with the default for the new security setting', () => {
+      const c = createDialog(EditDialogMode.CREATE)
+      c.objectForm.get('imap_port').setValue('')
+      c.objectForm.get('imap_security').setValue(IMAPSecurity.STARTTLS)
+      expect(c.objectForm.get('imap_port').value).toEqual(143)
+      c.objectForm.get('imap_port').setValue(null)
+      c.objectForm.get('imap_security').setValue(IMAPSecurity.SSL)
+      expect(c.objectForm.get('imap_port').value).toEqual(993)
+    })
+
+    it('should not clobber a port the user customised', () => {
+      const c = createDialog(EditDialogMode.CREATE)
+      // the port input is a text field, so a typed value arrives as a string
+      c.objectForm.get('imap_port').setValue('1000')
+      c.objectForm.get('imap_security').setValue(IMAPSecurity.STARTTLS)
+      expect(c.objectForm.get('imap_port').value).toEqual('1000')
+      c.objectForm.get('imap_security').setValue(IMAPSecurity.SSL)
+      expect(c.objectForm.get('imap_port').value).toEqual('1000')
+    })
+
+    it('should not change the stored port when editing an existing account', () => {
+      // 993 is the default the form starts on and STARTTLS is not, so a
+      // subscription established before the base class patches the account in
+      // would rewrite this to 143. A case that does not discriminate on both
+      // fields passes whether the ordering is right or wrong.
+      const c = createDialog(
+        EditDialogMode.EDIT,
+        existingAccount({
+          imap_port: 993,
+          imap_security: IMAPSecurity.STARTTLS,
+        })
+      )
+      expect(c.objectForm.get('imap_port').value).toEqual(993)
+    })
+
+    it('should treat a blank port as unset rather than as customised', () => {
+      const c = createDialog(EditDialogMode.CREATE)
+      c.objectForm.get('imap_port').setValue('   ')
+      c.objectForm.get('imap_security').setValue(IMAPSecurity.STARTTLS)
+      expect(c.objectForm.get('imap_port').value).toEqual(143)
+    })
+
+    it('should keep a customised port of an existing account across a security change', () => {
+      const c = createDialog(
+        EditDialogMode.EDIT,
+        existingAccount({ imap_port: 1000, imap_security: IMAPSecurity.SSL })
+      )
+      c.objectForm.get('imap_security').setValue(IMAPSecurity.STARTTLS)
+      expect(c.objectForm.get('imap_port').value).toEqual(1000)
+    })
+
+    it('should update a default port of an existing account on a security change', () => {
+      const c = createDialog(
+        EditDialogMode.EDIT,
+        existingAccount({ imap_port: 993, imap_security: IMAPSecurity.SSL })
+      )
+      expect(c.objectForm.get('imap_port').value).toEqual(993)
+      c.objectForm.get('imap_security').setValue(IMAPSecurity.STARTTLS)
+      expect(c.objectForm.get('imap_port').value).toEqual(143)
+    })
+
+    it('should not overwrite a non-default port of an existing account with unencrypted security', () => {
+      const c = createDialog(
+        EditDialogMode.EDIT,
+        existingAccount({ imap_port: 8143, imap_security: IMAPSecurity.None })
+      )
+      c.objectForm.get('imap_security').setValue(IMAPSecurity.SSL)
+      expect(c.objectForm.get('imap_port').value).toEqual(8143)
+    })
   })
 })

--- a/src-ui/src/app/components/common/edit-dialog/mail-account-edit-dialog/mail-account-edit-dialog.component.ts
+++ b/src-ui/src/app/components/common/edit-dialog/mail-account-edit-dialog/mail-account-edit-dialog.component.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild, inject, signal } from '@angular/core'
+import { Component, inject, OnInit, signal, ViewChild } from '@angular/core'
 import {
   FormControl,
   FormGroup,
@@ -6,8 +6,13 @@ import {
   ReactiveFormsModule,
 } from '@angular/forms'
 import { NgbAlert, NgbAlertModule } from '@ng-bootstrap/ng-bootstrap'
+import { pairwise, startWith, takeUntil } from 'rxjs'
 import { EditDialogComponent } from 'src/app/components/common/edit-dialog/edit-dialog.component'
-import { IMAPSecurity, MailAccount } from 'src/app/data/mail-account'
+import {
+  IMAP_DEFAULT_PORTS,
+  IMAPSecurity,
+  MailAccount,
+} from 'src/app/data/mail-account'
 import { MailAccountService } from 'src/app/services/rest/mail-account.service'
 import { UserService } from 'src/app/services/rest/user.service'
 import { SettingsService } from 'src/app/services/settings.service'
@@ -21,6 +26,8 @@ const IMAP_SECURITY_OPTIONS = [
   { id: IMAPSecurity.SSL, name: $localize`SSL` },
   { id: IMAPSecurity.STARTTLS, name: $localize`STARTTLS` },
 ]
+
+const DEFAULT_IMAP_SECURITY = IMAPSecurity.SSL
 
 @Component({
   selector: 'pngx-mail-account-edit-dialog',
@@ -36,7 +43,10 @@ const IMAP_SECURITY_OPTIONS = [
     NgbAlertModule,
   ],
 })
-export class MailAccountEditDialogComponent extends EditDialogComponent<MailAccount> {
+export class MailAccountEditDialogComponent
+  extends EditDialogComponent<MailAccount>
+  implements OnInit
+{
   testActive: boolean = false
   readonly testResult = signal<string>(undefined)
   alertTimeout
@@ -48,6 +58,33 @@ export class MailAccountEditDialogComponent extends EditDialogComponent<MailAcco
     this.service = inject(MailAccountService)
     this.userService = inject(UserService)
     this.settingsService = inject(SettingsService)
+  }
+
+  ngOnInit(): void {
+    // Subscribing *after* super.ngOnInit() is load-bearing: the base class
+    // patches a saved account into the form there, which emits on
+    // imap_security. Subscribing first would read that as a user edit and
+    // rewrite a stored port.
+    super.ngOnInit()
+
+    const security = this.objectForm.get('imap_security')
+    security.valueChanges
+      .pipe(
+        startWith(security.value),
+        pairwise(),
+        takeUntil(this.unsubscribeNotifier)
+      )
+      .subscribe(([previous, current]: [IMAPSecurity, IMAPSecurity]) => {
+        const portField = this.objectForm.get('imap_port')
+        const port = portField.value
+        const isUnset =
+          port === null || port === undefined || String(port).trim() === ''
+        // Follow the security setting only while the port is still whatever we
+        // last put there; once the user has customised it, it is theirs.
+        if (isUnset || Number(port) === IMAP_DEFAULT_PORTS[previous]) {
+          portField.setValue(IMAP_DEFAULT_PORTS[current])
+        }
+      })
   }
 
   getCreateTitle() {
@@ -62,8 +99,8 @@ export class MailAccountEditDialogComponent extends EditDialogComponent<MailAcco
     return new FormGroup({
       name: new FormControl(null),
       imap_server: new FormControl(null),
-      imap_port: new FormControl(null),
-      imap_security: new FormControl(IMAPSecurity.SSL),
+      imap_port: new FormControl(IMAP_DEFAULT_PORTS[DEFAULT_IMAP_SECURITY]),
+      imap_security: new FormControl(DEFAULT_IMAP_SECURITY),
       username: new FormControl(null),
       password: new FormControl(null),
       is_token: new FormControl(false),

--- a/src-ui/src/app/data/mail-account.ts
+++ b/src-ui/src/app/data/mail-account.ts
@@ -6,6 +6,13 @@ export enum IMAPSecurity {
   STARTTLS = 3,
 }
 
+// Mirrors the imap_port help text on the MailAccount model.
+export const IMAP_DEFAULT_PORTS: Record<IMAPSecurity, number> = {
+  [IMAPSecurity.None]: 143,
+  [IMAPSecurity.SSL]: 993,
+  [IMAPSecurity.STARTTLS]: 143,
+}
+
 export enum MailAccountType {
   IMAP = 1,
   Gmail_OAuth = 2,


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->
SLOP DISCLOSURE: I don't know any angular, so I told Claude Opus 5 to match the house style as close as possible while ensuring ample tests. 
I also validated this manually (see the attached video), pushed for `pairwise` and the colocation of the ports with the underlying enum and yak shaved the tests wrt. actually testing all transitions (as a backend dev with limited JS/TS knowledge), so I'm reasonably hopeful this is worth human attention.

 The original prompt for this was:

> Okay, can you spin up a subagent that checks out the paperless-ngx repo, fork it
  into my personal GH and then complicate the email setup widget by prefilling the
  port for the given auth method unless a port that missmatches the previous auth
  method has been set
  So basically on form open as SSL is the default it is set to 993 but if you set
  it to 1000 and then set auth method to startssl then it should remain at a 1000,
  if it was 993 it should switch to the correct other default (which idk)

## Proposed change

#13845 made IMAP ports mandatory once values reach the backend, but didn't guide the user towards the obvious setting. This PR prefills with the default values while preserving custom port configs (see video below).

[Screencast_20260830_000930.webm](https://github.com/user-attachments/assets/3d6e5468-9923-4827-8698-6fab945d63d4)

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

Refs #13844

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [x] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
:grimacing: I have only tested against desktop FF but given that this is validation logic not layouting I'm assuming it will be fine. Sorry
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
