### PR TITLE
Fix: support Whoosh wildcard patterns in advanced search queries

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -945,11 +945,19 @@ added:yesterday
 modified:today
 ```
 
-Matching inexact words:
+Matching inexact words with wildcards:
 
 ```
-produ*name
+title:produ*name
+correspondent:acme*
+title:*202[0-4]
 ```
+
+`*` matches any number of characters, `?` matches exactly one and `[...]`
+matches a single character from a set or range (`[!...]` negates the set).
+A wildcard pattern is matched against whole indexed words and must be used
+with a field prefix, one of `title`, `content`, `correspondent`,
+`document_type`, `storage_path`, `original_filename` or `tag`.
 
 Matching natural date keywords:
 

--- a/src/documents/search/_query.py
+++ b/src/documents/search/_query.py
@@ -213,10 +213,13 @@ def parse_user_query(
         logger.warning("Query translation failed; using raw query", exc_info=True)
         query_str = raw_query
 
+    # allow_regexes lets Tantivy accept the ``field:/pattern/`` literals emitted
+    # by translate_query for Whoosh wildcard values (see _translate.WILDCARD_FIELDS).
     exact = index.parse_query(
         query_str,
         DEFAULT_SEARCH_FIELDS,
         field_boosts=_FIELD_BOOSTS,
+        allow_regexes=True,
     )
 
     # The standard analyzer keeps a whitespace-free CJK run as a single token,
@@ -241,6 +244,7 @@ def parse_user_query(
             field_boosts=_FIELD_BOOSTS,
             # (prefix=True, distance=1, transposition_cost_one=True) — edit-distance fuzziness
             fuzzy_fields={f: (True, 1, True) for f in DEFAULT_SEARCH_FIELDS},
+            allow_regexes=True,
         )
         # 0.1 boost keeps fuzzy hits ranked below exact matches (intentional)
         clauses.append((tantivy.Occur.Should, tantivy.Query.boost_query(fuzzy, 0.1)))

--- a/src/documents/search/_translate.py
+++ b/src/documents/search/_translate.py
@@ -5,6 +5,7 @@ from datetime import UTC
 from datetime import datetime
 from datetime import timedelta
 from typing import TYPE_CHECKING
+from typing import Final
 from typing import TypeAlias
 
 import regex
@@ -18,6 +19,7 @@ from documents.search._dates import _field_range_from_dates
 from documents.search._dates import _fmt
 from documents.search._dates import _precision_bounds
 from documents.search._dates import _utc_bounds_for_field
+from documents.search._tokenizer import ascii_fold
 
 # Compiled regex that matches any known multi-word (or single-word) date keyword
 # at the start of a match position, longest alternatives first so "previous week"
@@ -47,6 +49,26 @@ MULTI_VALUE_FIELDS = frozenset({"tag", "tag_id", "viewer_id"})
 
 # Date fields whose values/ranges get rewritten to RFC3339 Tantivy ranges.
 DATE_FIELDS = frozenset({"created", "modified", "added"})
+
+# Text fields (all tokenized with ``paperless_text``) whose values may carry
+# Whoosh wildcard patterns and can therefore be rewritten to a Tantivy regex
+# literal. Deliberately excludes:
+#   * date / numeric / ``*_id`` fields - a wildcard is meaningless there and the
+#     regex form would not match their non-text term encoding;
+#   * ``checksum`` - indexed with the ``raw`` tokenizer, so the case/ASCII
+#     folding applied below would not match the stored term;
+#   * ``notes`` / ``custom_fields`` - JSON fields, which regex terms don't address.
+WILDCARD_FIELDS = frozenset(
+    {
+        "title",
+        "content",
+        "correspondent",
+        "document_type",
+        "storage_path",
+        "original_filename",
+        "tag",
+    },
+)
 
 # Field aliases: Whoosh (v2) field names that were renamed in the Tantivy schema.
 # Preserved here so v2 queries using the old names continue to work without 400
@@ -514,6 +536,107 @@ def _bound_datetimes(
     return _utc_bounds_for_field(field, start, end, tz)
 
 
+# Characters that must be escaped to appear literally in a Rust ``regex`` crate
+# pattern. ``/`` is included because the rewritten value is emitted as a Tantivy
+# ``/.../`` regex literal, where an unescaped slash would close the literal early.
+_REGEX_SPECIAL: Final[frozenset[str]] = frozenset(".^$+(){}|\\/-[]?*")
+
+# Whoosh's ``Wildcard`` query translated its pattern with ``fnmatch.translate``,
+# so saved v2 queries can contain any fnmatch metacharacter: ``*``, ``?`` and
+# ``[seq]`` / ``[!seq]`` character classes. Tantivy's query parser understands
+# none of these - ``[`` in particular starts a range expression and makes the
+# whole query a syntax error - so such values are rewritten to a regex literal.
+_WILDCARD_META: Final[frozenset[str]] = frozenset("*?[")
+
+
+def _escape_literal(char: str) -> str:
+    """Escape a single character for literal use in a Rust regex pattern."""
+    return f"\\{char}" if char in _REGEX_SPECIAL else char
+
+
+def wildcard_to_regex(pattern: str) -> str | None:
+    """
+    Translate an fnmatch-style Whoosh wildcard into a Rust ``regex`` pattern.
+
+    Mirrors ``fnmatch.translate`` (what Whoosh's ``Wildcard`` query used), but
+    emits a bare fragment: Tantivy anchors regex term queries itself, and the
+    ``(?s:...)\\Z`` wrapper ``fnmatch`` produces uses ``\\Z``, which the Rust
+    ``regex`` crate does not accept.
+
+    Returns ``None`` when ``pattern`` holds no wildcard metacharacter, so plain
+    terms keep their existing term-query behaviour (and its stemming/scoring)
+    instead of silently becoming regex scans.
+    """
+    out: list[str] = []
+    i, length = 0, len(pattern)
+    saw_meta = False
+    while i < length:
+        char = pattern[i]
+        if char == "*":
+            out.append(".*")
+            saw_meta = True
+            i += 1
+        elif char == "?":
+            out.append(".")
+            saw_meta = True
+            i += 1
+        elif char == "[":
+            # fnmatch character class. Scan for the closing bracket, honouring
+            # the two positions where a literal is allowed inside the class:
+            # a leading negation (``!``/``^``) and a ``]`` immediately after it.
+            j = i + 1
+            if j < length and pattern[j] in "!^":
+                j += 1
+            if j < length and pattern[j] == "]":
+                j += 1
+            while j < length and pattern[j] != "]":
+                j += 1
+            saw_meta = True
+            if j >= length:
+                # Unterminated class: fnmatch treats the bracket as a literal.
+                # Still routed through the regex form so the value cannot reach
+                # Tantivy's parser and raise a syntax error.
+                out.append("\\[")
+                i += 1
+                continue
+            body = pattern[i + 1 : j]
+            if body[:1] in ("!", "^"):
+                body = f"^{body[1:]}"
+            # Inside a class only the backslash needs re-escaping; the rest is
+            # already valid Rust regex class syntax (ranges, literals, ``^``).
+            body = body.replace("\\", "\\\\")
+            out.append(f"[{body}]")
+            i = j + 1
+        else:
+            out.append(_escape_literal(char))
+            i += 1
+    return "".join(out) if saw_meta else None
+
+
+def _render_text_value(field: str, value: str) -> str:
+    """
+    Render one ``field:value`` clause, rewriting Whoosh wildcards to a regex.
+
+    Quoted phrases and values opening a group are passed through untouched: a
+    wildcard is literal inside a Whoosh phrase, and a ``(`` means the scanner
+    captured only the head of a grouped expression.
+    """
+    if (
+        field not in WILDCARD_FIELDS
+        or not value
+        or value[0] in "\"'("
+        or not (_WILDCARD_META & set(value))
+    ):
+        return f"{field}:{value}"
+    # Regex terms bypass the field analyzer, so fold the pattern exactly as
+    # ``paperless_text`` folds indexed terms (lowercase -> ascii_fold). Without
+    # this, ``title:Müll*`` would never match the indexed term ``muller``.
+    pattern = wildcard_to_regex(ascii_fold(value.lower()))
+    if pattern is None:  # pragma: no cover - guarded by the _WILDCARD_META check
+        return f"{field}:{value}"
+    return f"{field}:/{pattern}/"
+
+
 def _render(tok: Token, tz: tzinfo) -> str:
     """Render a single token back to a Tantivy query string fragment."""
     if isinstance(tok, Passthrough):
@@ -522,12 +645,12 @@ def _render(tok: Token, tz: tzinfo) -> str:
         return " AND "
     if isinstance(tok, FieldValueList):
         field = FIELD_ALIASES.get(tok.field, tok.field)
-        return " AND ".join(f"{field}:{v}" for v in tok.values)
+        return " AND ".join(_render_text_value(field, v) for v in tok.values)
     if isinstance(tok, FieldValue):
         field = FIELD_ALIASES.get(tok.field, tok.field)
         if field in DATE_FIELDS:
             return translate_scalar(field, tok.value, tz)
-        return f"{field}:{tok.value}"
+        return _render_text_value(field, tok.value)
     if isinstance(tok, FieldRange):
         field = FIELD_ALIASES.get(tok.field, tok.field)
         if field in DATE_FIELDS:

--- a/src/documents/tests/search/test_backend.py
+++ b/src/documents/tests/search/test_backend.py
@@ -1164,3 +1164,127 @@ class TestIndexDirectoryGarbageCollection:
             "Segment files present on disk but absent from Tantivy's "
             f".managed.json bookkeeping (permanently un-collectible): {orphans}"
         )
+
+
+class TestWildcardSearch:
+    """Whoosh-style wildcard values must parse and match (issue #13568).
+
+    Under Whoosh these were ``fnmatch``-translated ``Wildcard`` queries. Tantivy's
+    parser has no wildcard support: ``*`` was silently dropped (turning a prefix
+    search into an exact term match) and ``[`` raised a syntax error, breaking
+    saved views carried over from v2.
+    """
+
+    @pytest.fixture
+    def wildcard_docs(self, backend: TantivyBackend) -> dict[str, int]:
+        """Index documents whose titles exercise prefix/suffix/class matching."""
+        titles = {
+            "steuer_2024": "Steuer 2024",
+            "steuer_2019": "Steuer 2019",
+            "rechnung_2021": "Rechnung 2021",
+            "beleg_2024": "Beleg 2024 extra",
+            "steuerbescheid": "Steuerbescheid 2015",
+            "mueller": "Müller Rechnung 2022",
+        }
+        ids: dict[str, int] = {}
+        for pk, (key, title) in enumerate(titles.items(), start=100):
+            doc = Document.objects.create(
+                title=title,
+                content=title,
+                checksum=f"WC{pk}",
+                pk=pk,
+            )
+            backend.add_or_update(doc)
+            ids[key] = pk
+        return ids
+
+    def test_trailing_star_matches_prefix(
+        self,
+        backend: TantivyBackend,
+        wildcard_docs: dict[str, int],
+    ) -> None:
+        # Previously '*' was dropped, so this matched only the exact term
+        # "steuer" and missed "steuerbescheid".
+        found = set(backend.search_ids("title:steuer*", user=None))
+        assert wildcard_docs["steuerbescheid"] in found
+        assert wildcard_docs["steuer_2024"] in found
+        assert wildcard_docs["rechnung_2021"] not in found
+
+    def test_leading_star_matches_suffix(
+        self,
+        backend: TantivyBackend,
+        wildcard_docs: dict[str, int],
+    ) -> None:
+        found = set(backend.search_ids("title:*bescheid", user=None))
+        assert found == {wildcard_docs["steuerbescheid"]}
+
+    def test_question_mark_matches_single_character(
+        self,
+        backend: TantivyBackend,
+        wildcard_docs: dict[str, int],
+    ) -> None:
+        found = set(backend.search_ids("title:ste?er", user=None))
+        assert wildcard_docs["steuer_2024"] in found
+        assert wildcard_docs["steuerbescheid"] not in found
+
+    def test_character_class_does_not_raise_and_matches(
+        self,
+        backend: TantivyBackend,
+        wildcard_docs: dict[str, int],
+    ) -> None:
+        # '[0-4]' previously made the whole query a Tantivy syntax error.
+        found = set(backend.search_ids("title:*202[0-2]", user=None))
+        assert found == {
+            wildcard_docs["rechnung_2021"],
+            wildcard_docs["mueller"],
+        }
+
+    def test_pattern_matches_ascii_folded_terms(
+        self,
+        backend: TantivyBackend,
+        wildcard_docs: dict[str, int],
+    ) -> None:
+        # Regex terms bypass the analyzer; the pattern is folded to match the
+        # indexed term ("muller"), so an umlaut in the query still hits.
+        found = set(backend.search_ids("title:Müll*", user=None))
+        assert found == {wildcard_docs["mueller"]}
+
+    def test_reported_saved_view_query_returns_expected_documents(
+        self,
+        backend: TantivyBackend,
+        wildcard_docs: dict[str, int],
+    ) -> None:
+        """The v2 saved-view query from the report now runs and filters correctly."""
+        found = set(
+            backend.search_ids(
+                "title:*2024 OR (NOT title:*202[0-3] AND NOT title:*201[0-9])",
+                user=None,
+            ),
+        )
+        # 2024 titles match the positive clause; 2021/2022/2019/2015 titles are
+        # excluded by the negated classes.
+        assert wildcard_docs["steuer_2024"] in found
+        assert wildcard_docs["beleg_2024"] in found
+        assert wildcard_docs["rechnung_2021"] not in found
+        assert wildcard_docs["steuer_2019"] not in found
+        assert wildcard_docs["steuerbescheid"] not in found
+
+    def test_plain_query_without_wildcards_is_unaffected(
+        self,
+        backend: TantivyBackend,
+        wildcard_docs: dict[str, int],
+    ) -> None:
+        found = set(backend.search_ids("title:rechnung", user=None))
+        assert found == {wildcard_docs["rechnung_2021"], wildcard_docs["mueller"]}
+
+    def test_highlight_hits_survives_a_wildcard_query(
+        self,
+        backend: TantivyBackend,
+        wildcard_docs: dict[str, int],
+    ) -> None:
+        """A rewritten regex term must not break snippet generation."""
+        doc_id = wildcard_docs["steuerbescheid"]
+        hits = backend.highlight_hits("title:steuer*", [doc_id])
+
+        assert len(hits) == 1
+        assert hits[0]["id"] == doc_id

--- a/src/documents/tests/search/test_query.py
+++ b/src/documents/tests/search/test_query.py
@@ -437,6 +437,44 @@ class TestParseUserQuery:
         settings.ADVANCED_FUZZY_SEARCH_THRESHOLD = 0.5
         assert isinstance(parse_user_query(query_index, "invoice", UTC), tantivy.Query)
 
+    @pytest.mark.parametrize(
+        "raw_query",
+        [
+            pytest.param("title:*2024", id="leading_star"),
+            pytest.param("title:steuer*", id="trailing_star"),
+            pytest.param("title:ste?er", id="question_mark"),
+            pytest.param("title:*202[0-4]", id="character_class"),
+            pytest.param("title:*[!0-9]", id="negated_character_class"),
+            pytest.param("content:foo[bar", id="unterminated_class"),
+            pytest.param(
+                "tag:steuer AND (title:*2024 OR (NOT title:*202[0-3] "
+                "AND NOT title:*201[0-9] AND created:2024))",
+                id="reported_saved_view",
+            ),
+        ],
+    )
+    def test_wildcard_queries_parse(
+        self,
+        query_index: tantivy.Index,
+        raw_query: str,
+    ) -> None:
+        # Tantivy's parser rejects '*' semantics and reads '[' as a range, so
+        # these are rewritten to regex literals and parsed with allow_regexes.
+        assert isinstance(parse_user_query(query_index, raw_query, UTC), tantivy.Query)
+
+    def test_wildcard_query_parses_in_fuzzy_mode(
+        self,
+        query_index: tantivy.Index,
+        settings,
+    ) -> None:
+        # The fuzzy companion query parses the same rewritten string and must
+        # therefore also accept regex literals.
+        settings.ADVANCED_FUZZY_SEARCH_THRESHOLD = 0.5
+        assert isinstance(
+            parse_user_query(query_index, "title:*202[0-4]", UTC),
+            tantivy.Query,
+        )
+
     def test_date_rewriting_applied_before_tantivy_parse(
         self,
         query_index: tantivy.Index,

--- a/src/documents/tests/search/test_translate.py
+++ b/src/documents/tests/search/test_translate.py
@@ -27,6 +27,7 @@ from documents.search._translate import scan
 from documents.search._translate import translate_query
 from documents.search._translate import translate_range
 from documents.search._translate import translate_scalar
+from documents.search._translate import wildcard_to_regex
 
 
 @pytest.mark.search
@@ -808,3 +809,158 @@ class TestISODatetimeBounds:
         )
         translated = translate_query(q, UTC)
         index.parse_query(translated, DEFAULT_SEARCH_FIELDS, field_boosts=_FIELD_BOOSTS)
+
+
+@pytest.mark.search
+class TestWildcardToRegex:
+    """Whoosh wildcard values become Tantivy regex literals (fnmatch semantics)."""
+
+    @pytest.mark.parametrize(
+        ("pattern", "expected"),
+        [
+            pytest.param("*2024", ".*2024", id="leading_star"),
+            pytest.param("steuer*", "steuer.*", id="trailing_star"),
+            pytest.param("*2024*", ".*2024.*", id="both_stars"),
+            pytest.param("ste?er", "ste.er", id="question_mark"),
+            pytest.param("*202[0-4]", ".*202[0-4]", id="char_class_range"),
+            pytest.param("re[ck]hnung*", "re[ck]hnung.*", id="char_class_set"),
+            pytest.param("[!0-9]*", "[^0-9].*", id="negated_class_bang"),
+            pytest.param("[^0-9]*", "[^0-9].*", id="negated_class_caret"),
+            pytest.param("[]]*", "[]].*", id="class_leading_close_bracket"),
+            pytest.param("*", ".*", id="bare_star"),
+        ],
+    )
+    def test_translates_metacharacters(self, pattern: str, expected: str) -> None:
+        assert wildcard_to_regex(pattern) == expected
+
+    @pytest.mark.parametrize(
+        ("pattern", "expected"),
+        [
+            pytest.param("a.b*", r"a\.b.*", id="dot"),
+            pytest.param("a+b*", r"a\+b.*", id="plus"),
+            pytest.param("a/b*", r"a\/b.*", id="slash_would_close_literal"),
+            pytest.param("a(b)*", r"a\(b\).*", id="parens"),
+            pytest.param("a|b*", r"a\|b.*", id="alternation"),
+            pytest.param("a$b*", r"a\$b.*", id="dollar"),
+            pytest.param("a-b*", r"a\-b.*", id="dash"),
+        ],
+    )
+    def test_escapes_regex_metacharacters_in_literals(
+        self,
+        pattern: str,
+        expected: str,
+    ) -> None:
+        assert wildcard_to_regex(pattern) == expected
+
+    @pytest.mark.parametrize(
+        "pattern",
+        [
+            pytest.param("2024", id="digits"),
+            pytest.param("rechnung", id="word"),
+            pytest.param("a.b", id="dot_only"),
+            pytest.param("", id="empty"),
+        ],
+    )
+    def test_returns_none_without_metacharacters(self, pattern: str) -> None:
+        # Plain terms must keep their term-query behaviour (stemming, scoring)
+        # rather than silently degrading into a regex scan.
+        assert wildcard_to_regex(pattern) is None
+
+    def test_unterminated_class_is_literal(self) -> None:
+        # fnmatch treats an unterminated '[' as a literal bracket. It still takes
+        # the regex path so the value never reaches Tantivy's parser, which would
+        # otherwise read '[' as the start of a range expression and raise.
+        assert wildcard_to_regex("foo[bar") == r"foo\[bar"
+
+
+@pytest.mark.search
+class TestWildcardTranslation:
+    """translate_query rewrites wildcard values on text fields only."""
+
+    @pytest.mark.parametrize(
+        ("query", "expected"),
+        [
+            pytest.param("title:*2024", "title:/.*2024/", id="title"),
+            pytest.param("content:foo*", "content:/foo.*/", id="content"),
+            pytest.param(
+                "correspondent:ac*",
+                "correspondent:/ac.*/",
+                id="correspondent",
+            ),
+            pytest.param("tag:steu*", "tag:/steu.*/", id="tag"),
+            pytest.param(
+                "original_filename:scan*",
+                "original_filename:/scan.*/",
+                id="original_filename",
+            ),
+        ],
+    )
+    def test_text_fields_are_rewritten(self, query: str, expected: str) -> None:
+        assert translate_query(query, UTC) == expected
+
+    @pytest.mark.parametrize(
+        ("query", "expected"),
+        [
+            pytest.param("type:inv*", "document_type:/inv.*/", id="type_alias"),
+            pytest.param("path:arch*", "storage_path:/arch.*/", id="path_alias"),
+        ],
+    )
+    def test_v2_field_aliases_resolve_before_rewriting(
+        self,
+        query: str,
+        expected: str,
+    ) -> None:
+        assert translate_query(query, UTC) == expected
+
+    @pytest.mark.parametrize(
+        "query",
+        [
+            # 'raw' tokenizer: folding the pattern would not match the stored term.
+            pytest.param("checksum:abc*", id="checksum_raw_tokenizer"),
+            # Numeric fields: a regex term does not match their encoding.
+            pytest.param("asn:12*", id="asn"),
+            pytest.param("page_count:1*", id="page_count"),
+            pytest.param("correspondent_id:3*", id="correspondent_id"),
+            # JSON fields are not addressable by a regex term query.
+            pytest.param("notes:foo*", id="notes_json"),
+            pytest.param("custom_fields:bar*", id="custom_fields_json"),
+        ],
+    )
+    def test_excluded_fields_pass_through_unchanged(self, query: str) -> None:
+        assert translate_query(query, UTC) == query
+
+    def test_quoted_phrase_is_not_rewritten(self) -> None:
+        # A wildcard is a literal character inside a Whoosh phrase.
+        assert translate_query('title:"exact *phrase"', UTC) == 'title:"exact *phrase"'
+
+    def test_plain_value_unchanged(self) -> None:
+        assert translate_query("title:2024", UTC) == "title:2024"
+
+    def test_date_range_bracket_is_not_treated_as_a_class(self) -> None:
+        # '[' after a date field opens a range, and must keep doing so.
+        result = translate_query("created:[2020 TO 2021]", UTC)
+        assert result.startswith("created:[2020-01-01T00:00:00Z TO ")
+        assert "/" not in result
+
+    def test_pattern_is_lowercased_and_ascii_folded(self) -> None:
+        # Regex terms bypass the analyzer, so the pattern must be folded the same
+        # way paperless_text folds indexed terms, or it can never match.
+        assert translate_query("title:M\u00fcll*", UTC) == "title:/mull.*/"
+        assert translate_query("title:GRO\u00df*", UTC) == "title:/gross.*/"
+
+    def test_multi_value_tag_list_rewrites_each_value(self) -> None:
+        assert (
+            translate_query("tag:steu*,valentin", UTC)
+            == "tag:/steu.*/ AND tag:valentin"
+        )
+
+    def test_reported_saved_view_query(self) -> None:
+        # The query from the v2 -> v3 regression report (issue #13568).
+        result = translate_query(
+            "tag:steuer AND tag:valentin AND (title:*2024 OR "
+            "(NOT title:*202[0-3] AND NOT title:*201[0-9] AND created:2024))",
+            UTC,
+        )
+        assert "title:/.*2024/" in result
+        assert "NOT title:/.*202[0-3]/" in result
+        assert "NOT title:/.*201[0-9]/" in result


### PR DESCRIPTION
## Proposed change

Saved views created under the Whoosh backend can contain wildcard values such as `title:*202[0-4]`. Whoosh's `Wildcard` query translated its pattern with `fnmatch.translate`, so `*`, `?` and `[seq]` / `[!seq]` character classes were all valid. Tantivy's query parser supports none of them, and the two failure modes differ:

- `*` and `?` are not wildcards to Tantivy, they are simply dropped by the tokenizer. `title:steuer*` silently degrades into an exact term match for `steuer`, so `Steuerbescheid` is no longer found. This one fails quietly, with wrong results rather than an error.
- `[` starts a range expression. `title:*202[0-4]` therefore makes the whole query a syntax error, which surfaces as `Error listing search results, check logs for more detail.`

Both reported queries reproduce the second case on `dev`:

```
Syntax Error: tag:steuer AND tag:valentin AND (title:*2025 OR (NOT title:*202[0-4] AND NOT title:*201[0-9] AND created:[2025-01-01T00:00:00Z TO 2026-01-01T00:00:00Z}))
```

### Approach

`_translate.py` already tokenizes the query into field/value tokens before handing a string to Tantivy, so the rewrite fits there. A field-qualified value on a text field that contains an fnmatch metacharacter is converted to a Tantivy regex literal (`title:*202[0-4]` → `title:/.*202[0-4]/`), and `index.parse_query` is called with `allow_regexes=True` so those literals are accepted.

Details worth flagging for review:

- **Folding.** Regex terms bypass the field analyzer, so the pattern is lowercased and ASCII-folded with the same filter `paperless_text` uses at index time. Without this, `title:Müll*` would compile fine and never match the indexed term `muller`.
- **Field scope.** Only text fields tokenized with `paperless_text` are rewritten (`title`, `content`, `correspondent`, `document_type`, `storage_path`, `original_filename`, `tag`). `checksum` is excluded because it uses the `raw` tokenizer and folding would break it; date, numeric and `*_id` fields are excluded because a regex term does not match their encoding; `notes` and `custom_fields` are excluded because they are JSON fields. Existing tests already assert these pass through unchanged.
- **No change for plain terms.** `wildcard_to_regex` returns `None` when the value holds no metacharacter, so ordinary terms keep their existing term-query path, including stemming and scoring. Quoted phrases are also left alone, since a wildcard is a literal inside a Whoosh phrase.
- **Escaping.** Literal characters are escaped for the Rust `regex` crate. `/` is included, otherwise it would close the regex literal early. `fnmatch.translate`'s own output is not reusable here: it emits `(?s:...)\Z`, and the Rust crate does not accept `\Z`.
- **Unterminated `[`.** Treated as a literal bracket, as `fnmatch` does, but still routed through the regex form so the value can no longer reach Tantivy's parser and raise.

### Known limitation

This covers field-qualified values only. A bare, unqualified wildcard (`produ*name` with no `title:` prefix) is still not expanded, since that would mean rewriting free text into a disjunction across all default fields. `docs/usage.md` documented the bare form as working, which has not been true since the Tantivy migration, so I corrected that section to describe the field-qualified syntax that this PR makes work rather than leaving the example silently broken.

Enabling `allow_regexes` also means a user can now write a raw `field:/regex/` themselves. That seemed acceptable to me since the Rust `regex` crate has no backtracking, so there is no ReDoS exposure, but I wanted to call it out explicitly rather than slip it in.



## Type of change

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Testing

Both queries from the report, and the `title:200[1-9]` repro from the steps, now parse and return the expected documents.

Added coverage in three places:

- `test_translate.py` — `wildcard_to_regex` unit cases (metacharacters, escaping, negated classes, unterminated bracket, the "no metacharacter returns None" contract) and `translate_query` cases covering excluded fields, quoted phrases, v2 field aliases, ASCII folding and the reported query.
- `test_query.py` — parse-acceptance for wildcard forms, including the fuzzy path, which parses the same rewritten string and so also needed `allow_regexes`.
- `test_backend.py` — end-to-end matching against a real index: prefix, suffix, `?`, character class, ASCII-folded pattern, the reported saved-view query, a control case asserting non-wildcard queries are unaffected, and one asserting snippet generation still works for a rewritten query.

I confirmed the new backend tests fail without the source change, with exactly the reported `Syntax Error`, and pass with it.

Full runs:

- `pytest src/documents/tests/search/ src/documents/tests/test_api_search.py` — 451 passed.
- `pytest src/documents/tests/` — 235 failed / 2012 passed on this branch, against 236 failed / 1963 passed on a clean `dev` in the same environment. The passing count differs by exactly the tests added here, and the failures are pre-existing and confined to `test_workflows.py`, `test_classifier.py` and `test_management_consumer.py`, which fail identically without this change (they are local Windows environment issues — nltk, file watching, path globbing — not related to search).
- `ruff check` and `ruff format --check` clean on all changed files.

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.

### Use of AI

I used AI while writing this change, and I reviewed and refined the result myself. I verified the reported failure on `dev`, checked the behaviour of Tantivy's parser directly (that `*` is dropped rather than treated as a wildcard, that `[` is what actually raises, and that `allow_regexes` is the supported way to accept regex literals), decided the field scope and the folding behaviour, and confirmed the new tests fail without the fix and pass with it.
