### PR TITLE
Fix: adopt the request stream when pinning an outbound host

### DIFF
--- a/src/paperless/network.py
+++ b/src/paperless/network.py
@@ -129,7 +129,7 @@ def _rewrite_request_to_pinned_ip(
         method=request.method,
         url=new_url,
         headers=new_headers,
-        content=request.stream,
+        stream=request.stream,
         extensions=request.extensions,
     )
     rewritten_request.extensions["sni_hostname"] = hostname


### PR DESCRIPTION
ASLOP-PR-VERIFY (I worked together with AI on this issue and intentionally kept this label to not to "hide" my AI driven work)

## Proposed change

When an outbound request is rebuilt to pin its host, the body stream is re-encoded
rather than adopted. For an ordinary request — a bytes body, or no body at all — the
rebuilt stream loses its async capability, and the async transport rejects it with a
bare `AssertionError`. Adopting the stream keeps it usable by both transports; the
sync path and the headers are unchanged.

**When this matters:** the first time anything sends through the pinned transport
asynchronously — an async embedding or LLM call, or a switch of the index build or
the chat retriever to llama-index's async methods. Until then it is unreachable, so
this fixes no user-visible bug and only removes a trap.

Follow-up to #13887. The impact claim in that report was wrong: the traceback there
came from a manual probe of the transport, not from an index build.

**AI disclosure:** drafted with an AI assistant. Verified locally against a running
instance with a throwaway test that reproduces the `AssertionError` before the change
and passes after it; kept out of this PR to hold it to the single line, happy to add
it if you want the coverage.

## Type of change

- [x] Bug fix: non-breaking change which fixes an issue.

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR — deliberately omitted, see above.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices — n/a, backend only.
- [x] If applicable, I have checked that all tests pass.
- [x] I have run all Git `pre-commit` hooks.
- [ ] I have made corresponding changes to the documentation as needed — n/a.
- [x] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
