### PR TITLE
Fix: name the tool in the localization prompt so more models can localize suggestions

### DIFF
--- a/src/paperless_ai/ai_classifier.py
+++ b/src/paperless_ai/ai_classifier.py
@@ -7,6 +7,7 @@ from documents.models import Document
 from documents.permissions import get_objects_for_user_owner_aware
 from paperless.config import AIConfig
 from paperless_ai.base_model import ClassificationSuggestions
+from paperless_ai.base_model import DocumentClassifierSchema
 from paperless_ai.base_model import TaxonomyChoiceDict
 from paperless_ai.base_model import classification_suggestions_to_model
 from paperless_ai.client import AIClient
@@ -127,6 +128,9 @@ def build_localization_prompt(
         LocalizationPromptContext(
             language_name=language_name,
             suggestions_json=model_suggestions.model_dump_json(),
+            # Naming the tool is what keeps certain models from answering with a
+            # fenced JSON blob instead of calling it.
+            schema_name=DocumentClassifierSchema.__name__,
         ),
     )
 

--- a/src/paperless_ai/prompts/context.py
+++ b/src/paperless_ai/prompts/context.py
@@ -32,6 +32,7 @@ class LocalizationPromptContext(PromptContext):
     template_name: ClassVar[PromptName] = PromptName.LOCALIZATION
     language_name: str
     suggestions_json: str
+    schema_name: str
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/paperless_ai/prompts/localization.j2
+++ b/src/paperless_ai/prompts/localization.j2
@@ -4,7 +4,7 @@ Rewrite only the "title", "tags", "document_types", and "storage_paths" fields i
 
 Do not translate correspondents or dates.
 Preserve proper nouns, organization names, product names, and exact official document names. Translate generic category words when a {{ language_name }} equivalent exists.
-Return the same JSON schema with all fields present.
+Return the same JSON schema with all fields present by calling the {{ schema_name }} tool.
 
 Suggestions:
 {{ suggestions_json }}

--- a/src/paperless_ai/tests/test_ai_classifier.py
+++ b/src/paperless_ai/tests/test_ai_classifier.py
@@ -18,6 +18,7 @@ from paperless_ai.ai_classifier import build_prompt_without_rag
 from paperless_ai.ai_classifier import get_ai_document_classification
 from paperless_ai.ai_classifier import get_language_name
 from paperless_ai.ai_classifier import get_taxonomy_context
+from paperless_ai.base_model import DocumentClassifierSchema
 from paperless_ai.taxonomy import TaxonomyCandidate
 from paperless_ai.taxonomy import TaxonomyCandidates
 
@@ -292,6 +293,23 @@ def test_get_language_name_falls_back_to_language_code():
         - The original language code is returned unchanged
     """
     assert get_language_name("zz-zz") == "zz-zz"
+
+
+def test_build_localization_prompt_names_the_tool():
+    """
+    GIVEN:
+        - A localization prompt, which shows the model a JSON blob
+    WHEN:
+        - build_localization_prompt() is called
+    THEN:
+        - The prompt names the tool the model is meant to call, without which
+          models answer with a fenced JSON blob and no tool call at all
+        - The name is the one get_function_tool() derives from the schema
+          class, so the two cannot drift apart
+    """
+    prompt = build_localization_prompt(NESTED_SUGGESTIONS, output_language="de-de")
+
+    assert f"by calling the {DocumentClassifierSchema.__name__} tool" in prompt
 
 
 def test_build_localization_prompt_preserves_unicode_characters():

--- a/src/paperless_ai/tests/test_prompts.py
+++ b/src/paperless_ai/tests/test_prompts.py
@@ -43,6 +43,7 @@ _MINIMAL_CONTEXTS = {
     PromptName.LOCALIZATION: LocalizationPromptContext(
         language_name="German",
         suggestions_json="{}",
+        schema_name="DocumentClassifierSchema",
     ),
     PromptName.TAXONOMY_BLOCK: TaxonomyBlockPromptContext(
         candidate_payload_json="",


### PR DESCRIPTION
## Proposed change

The localization pass asks the model to "return the same JSON schema", but the call itself requires a tool call. Models that take the prompt at its word answer with a fenced JSON blob, never call the tool, and the request fails and runs into `PAPERLESS_AI_LLM_REQUEST_TIMEOUT`, because that generation does not terminate on its own. 

This is likely the ["not all models are compatible" case from #13596](https://github.com/paperless-ngx/paperless-ngx/issues/13596#issuecomment-5217651412). It is fixable I guess: the prompt is asking for the wrong thing, and the same model complies immediately once the tool is named.

Measured on `gemma-4-E4B-it-qat-GGUF` (llama.cpp, `openai-like` backend), replaying the request the code builds:

|localization prompt                     |runs|result                                           |
|----------------------------------------|----|-------------------------------------------------|
|current behavior                       |1/1 |no tool call, ran into timeout|
|current minus the "JSON schema" sentence|3/3 |no tool call at all                                     |
|**naming the tool**                     |**6/6**|tool call in 4–6 s, 81 tokens                    |

Deleting the JSON sentence is not enough — the model needs the positive instruction.

Gemma 4 would be a common local choice, so one line here buys a fair amount of compatibility without breaking nothing. Besides, I think that's the technically cleaner solution.

### Related

- Issue #13705 — AI suggestions timeout. Unfortunately AI generated novel but it sound similar.
- Discussion #13257 — the user-visible symptom (GPU pinned, multi-minute hangs)

### AI disclosure
I used AI to:
- onboard myself into the depths of the ai stack
- run (ai-speed) tests and verification of my work against repo conventions

## Type of change

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed. => not needed
- [x] In the description of the PR above I have disclosed the use of AI tools in the coding of this PR.
