### PR TITLE
Fix: localize datepicker week start

### DIFF
--- a/src-ui/src/app/utils/ngb-datepicker-config.spec.ts
+++ b/src-ui/src/app/utils/ngb-datepicker-config.spec.ts
@@ -1,0 +1,36 @@
+import { NgbInputDatepickerConfig } from '@ng-bootstrap/ng-bootstrap'
+import {
+  getLocaleFirstDayOfWeek,
+  localizedDatepickerConfigFactory,
+} from './ngb-datepicker-config'
+
+describe('localizedDatepickerConfigFactory', () => {
+  it.each([
+    ['en-US', 7],
+    ['en-GB', 1],
+  ])('sets the first day of the week for %s', (localeId, firstDay) => {
+    const config = localizedDatepickerConfigFactory(localeId)
+
+    expect(config).toBeInstanceOf(NgbInputDatepickerConfig)
+    expect(config.firstDayOfWeek).toBe(firstDay)
+  })
+})
+
+describe('getLocaleFirstDayOfWeek', () => {
+  it('falls back to Monday when week info is unavailable', () => {
+    const descriptor = Object.getOwnPropertyDescriptor(
+      Intl.Locale.prototype,
+      'getWeekInfo'
+    )!
+    Object.defineProperty(Intl.Locale.prototype, 'getWeekInfo', {
+      ...descriptor,
+      value: undefined,
+    })
+
+    try {
+      expect(getLocaleFirstDayOfWeek('en-US')).toBe(1)
+    } finally {
+      Object.defineProperty(Intl.Locale.prototype, 'getWeekInfo', descriptor)
+    }
+  })
+})

--- a/src-ui/src/app/utils/ngb-datepicker-config.ts
+++ b/src-ui/src/app/utils/ngb-datepicker-config.ts
@@ -1,0 +1,26 @@
+import { NgbInputDatepickerConfig } from '@ng-bootstrap/ng-bootstrap'
+
+interface LocaleWithWeekInfo extends Intl.Locale {
+  getWeekInfo?: () => { firstDay: number }
+}
+
+const ISO_FIRST_DAY_OF_WEEK = 1
+
+export function getLocaleFirstDayOfWeek(localeId: string): number {
+  try {
+    const locale = new Intl.Locale(localeId) as LocaleWithWeekInfo
+    const firstDay = locale.getWeekInfo?.().firstDay
+
+    return firstDay >= 1 && firstDay <= 7 ? firstDay : ISO_FIRST_DAY_OF_WEEK
+  } catch {
+    return ISO_FIRST_DAY_OF_WEEK
+  }
+}
+
+export function localizedDatepickerConfigFactory(
+  localeId: string
+): NgbInputDatepickerConfig {
+  const config = new NgbInputDatepickerConfig()
+  config.firstDayOfWeek = getLocaleFirstDayOfWeek(localeId)
+  return config
+}

--- a/src-ui/src/main.ts
+++ b/src-ui/src/main.ts
@@ -1,4 +1,5 @@
 import {
+  LOCALE_ID,
   importProvidersFrom,
   inject,
   provideAppInitializer,
@@ -18,6 +19,8 @@ import { BrowserModule, bootstrapApplication } from '@angular/platform-browser'
 import {
   NgbDateAdapter,
   NgbDateParserFormatter,
+  NgbDatepickerConfig,
+  NgbInputDatepickerConfig,
   NgbModule,
 } from '@ng-bootstrap/ng-bootstrap'
 import { NgSelectModule } from '@ng-select/ng-select'
@@ -186,6 +189,7 @@ import { FilterPipe } from './app/pipes/filter.pipe'
 import { UsernamePipe } from './app/pipes/username.pipe'
 import { SettingsService } from './app/services/settings.service'
 import { LocalizedDateParserFormatter } from './app/utils/ngb-date-parser-formatter'
+import { localizedDatepickerConfigFactory } from './app/utils/ngb-datepicker-config'
 import { ISODateAdapter } from './app/utils/ngb-iso-date-adapter'
 
 import localeAf from '@angular/common/locales/af'
@@ -441,6 +445,15 @@ bootstrapApplication(AppComponent, {
     DocumentTitlePipe,
     { provide: NgbDateAdapter, useClass: ISODateAdapter },
     { provide: NgbDateParserFormatter, useClass: LocalizedDateParserFormatter },
+    {
+      provide: NgbInputDatepickerConfig,
+      useFactory: localizedDatepickerConfigFactory,
+      deps: [LOCALE_ID],
+    },
+    {
+      provide: NgbDatepickerConfig,
+      useExisting: NgbInputDatepickerConfig,
+    },
     PermissionsGuard,
     DirtyDocGuard,
     DirtySavedViewGuard,


### PR DESCRIPTION
ASLOP-PR-VERIFY

AI disclosure: This pull request was prepared with assistance from OpenAI Codex. I reviewed and tested the resulting change locally.

## Proposed change

Configure ng-bootstrap datepickers globally from Angular's `LOCALE_ID` so their week layout follows the active Paperless locale.

- Derive `firstDayOfWeek` from `Intl.Locale(localeId).getWeekInfo().firstDay` when supported.
- Preserve ng-bootstrap's ISO/Monday default when locale week information is unavailable or invalid.
- Provide the localized `NgbInputDatepickerConfig` at the application root and alias `NgbDatepickerConfig` to the same instance. This covers all current popup datepicker usages and future inline datepickers without component-level overrides.
- Add coverage for Sunday-first `en-US`, Monday-first `en-GB`, and the unsupported-API fallback.

Addresses paperless-ngx/paperless-ngx#13997.

Related upstream decision: ng-bootstrap/ng-bootstrap#4685.

## Type of change

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Verification

- `npx jest src/app/utils/ngb-datepicker-config.spec.ts src/app/components/common/input/date/date.component.spec.ts src/app/components/common/dates-dropdown/dates-dropdown.component.spec.ts src/app/components/common/custom-fields-query-dropdown/custom-fields-query-dropdown.component.spec.ts --runInBand` (51 tests passed)
- `npm run lint -- --quiet`
- `npx ng build --configuration=production --localize=false`
- Manually verified `en-US` renders Sunday first in the datepicker.

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed (not applicable; no user-facing configuration changed).
- [x] In the description of the PR above I have clearly disclosed any use of AI tools or agents in the creation of this PR. I understand that failing to do so is a violation of the [Code of Conduct](https://github.com/paperless-ngx/paperless-ngx/blob/main/CODE_OF_CONDUCT.md).