### PR TITLE
Fix: assign random color when creating tags server-side

### DIFF
--- a/src/documents/barcodes.py
+++ b/src/documents/barcodes.py
@@ -14,6 +14,7 @@ from pikepdf import Page
 from pikepdf import PasswordError
 from pikepdf import Pdf
 
+from documents.colors import random_color
 from documents.converters import convert_from_tiff_to_pdf
 from documents.data_models import ConsumableDocument
 from documents.data_models import DocumentMetadataOverrides
@@ -428,7 +429,7 @@ class BarcodePlugin(ConsumeTaskPlugin):
                     if tag_str:
                         tag, _ = Tag.objects.get_or_create(
                             name__iexact=tag_str,
-                            defaults={"name": tag_str},
+                            defaults={"name": tag_str, "color": random_color()},
                         )
 
                         logger.debug(

--- a/src/documents/colors.py
+++ b/src/documents/colors.py
@@ -1,0 +1,60 @@
+"""Color helpers shared by server-side tag creation paths."""
+
+from __future__ import annotations
+
+import random
+
+
+def _hue2rgb(p: float, q: float, t: float) -> float:
+    if t < 0:
+        t += 1
+    if t > 1:
+        t -= 1
+    if t < 1 / 6:
+        return p + (q - p) * 6 * t
+    if t < 1 / 2:
+        return q
+    if t < 2 / 3:
+        return p + (q - p) * (2 / 3 - t) * 6
+    return p
+
+
+def _hsl_to_rgb(
+    hue: float,
+    saturation: float,
+    lightness: float,
+) -> tuple[float, float, float]:
+    """
+    Convert HSL in [0, 1] to RGB components in [0, 255].
+
+    Mirrors src-ui/src/app/utils/color.ts hslToRgb.
+    """
+    if saturation == 0:
+        r = g = b = lightness
+    else:
+        q = (
+            lightness * (1 + saturation)
+            if lightness < 0.5
+            else lightness + saturation - lightness * saturation
+        )
+        p = 2 * lightness - q
+        r = _hue2rgb(p, q, hue + 1 / 3)
+        g = _hue2rgb(p, q, hue)
+        b = _hue2rgb(p, q, hue - 1 / 3)
+    return r * 255, g * 255, b * 255
+
+
+def _component_to_hex(c: float) -> str:
+    """Mirror frontend componentToHex (Math.floor then zero-padded hex)."""
+    return f"{int(c):02x}"
+
+
+def random_color() -> str:
+    """
+    Random tag color matching the frontend randomColor() helper.
+
+    Uses HSL with random hue, fixed saturation 0.6, and lightness in
+    [0.4, 0.8), then converts to #rrggbb.
+    """
+    r, g, b = _hsl_to_rgb(random.random(), 0.6, random.random() * 0.4 + 0.4)
+    return f"#{_component_to_hex(r)}{_component_to_hex(g)}{_component_to_hex(b)}"

--- a/src/documents/management/commands/document_consumer.py
+++ b/src/documents/management/commands/document_consumer.py
@@ -24,6 +24,7 @@ from watchfiles import Change
 from watchfiles import DefaultFilter
 from watchfiles import watch
 
+from documents.colors import random_color
 from documents.data_models import ConsumableDocument
 from documents.data_models import DocumentMetadataOverrides
 from documents.data_models import DocumentSource
@@ -302,7 +303,7 @@ def _tags_from_path(filepath: Path, consumption_dir: Path) -> list[int]:
     for part in path_parts:
         tag, _ = Tag.objects.get_or_create(
             name__iexact=part,
-            defaults={"name": part},
+            defaults={"name": part, "color": random_color()},
         )
         tag_ids.add(tag.pk)
 

--- a/src/documents/tests/test_colors.py
+++ b/src/documents/tests/test_colors.py
@@ -1,0 +1,43 @@
+import re
+from unittest import mock
+
+from documents.colors import random_color
+
+
+class TestRandomColor:
+    def test_format_is_hex(self) -> None:
+        """
+        GIVEN:
+            - The server-side random_color helper
+        WHEN:
+            - It is called
+        THEN:
+            - The result is a lowercase #rrggbb hex string
+        """
+        color = random_color()
+        assert re.fullmatch(r"#[0-9a-f]{6}", color)
+
+    def test_does_not_use_model_default(self) -> None:
+        """
+        GIVEN:
+            - Controlled random values that cannot produce the model default
+        WHEN:
+            - random_color is called
+        THEN:
+            - The result is not the Tag model default #a6cee3
+        """
+        with mock.patch("documents.colors.random.random", side_effect=[0.0, 0.0]):
+            assert random_color() != "#a6cee3"
+
+    def test_matches_frontend_hsl_mapping(self) -> None:
+        """
+        GIVEN:
+            - Fixed hue and lightness inputs matching the frontend algorithm
+        WHEN:
+            - random_color is called
+        THEN:
+            - The hex matches the expected HSL→RGB conversion
+              (h=0, s=0.6, l=0.4 → #a32828)
+        """
+        with mock.patch("documents.colors.random.random", side_effect=[0.0, 0.0]):
+            assert random_color() == "#a32828"

--- a/src/documents/tests/test_workflows.py
+++ b/src/documents/tests/test_workflows.py
@@ -5873,6 +5873,34 @@ class TestApplyAISuggestionsWorkflowAction(
         self.assertFalse(StoragePath.objects.exists())
         self.assertNotIn("storage_path", changed)
 
+        suggested = Tag.objects.get(name="Suggested Tag", owner=self.user)
+        self.assertNotEqual(suggested.color, "#a6cee3")
+
+    def test_create_missing_tag_uses_random_color(self) -> None:
+        """
+        GIVEN:
+            - An action with create missing enabled
+            - random_color patched to a fixed non-default value
+        WHEN:
+            - A suggested tag that does not exist is created
+        THEN:
+            - The new tag receives that color rather than the model default
+        """
+        action = self.make_action(
+            ai_create_missing=True,
+            ai_overwrite_existing=True,
+            ai_suggestion_fields=[WorkflowAction.AISuggestionField.TAGS],
+        )
+
+        with mock.patch(
+            "documents.workflows.ai.random_color",
+            return_value="#abcdef",
+        ):
+            self.apply(action)
+
+        suggested = Tag.objects.get(name="Suggested Tag", owner=self.user)
+        self.assertEqual(suggested.color, "#abcdef")
+
     def test_overwrite_disabled_keeps_existing_values(self) -> None:
         """
         GIVEN:

--- a/src/documents/workflows/ai.py
+++ b/src/documents/workflows/ai.py
@@ -5,6 +5,7 @@ from typing import TypeVar
 
 from django.contrib.auth.models import User
 
+from documents.colors import random_color
 from documents.models import Correspondent
 from documents.models import Document
 from documents.models import DocumentType
@@ -103,6 +104,7 @@ def resolve_tags(
         tag, created = Tag.objects.get_or_create(
             name=name[:128],
             owner=owner,
+            defaults={"color": random_color()},
         )
         if created:
             logger.info("Created tag '%s' from AI suggestion", tag.name)


### PR DESCRIPTION
## Summary
- Tags created by Apply AI Suggestions (create-missing), consumer path-as-tags, and barcode tag creation now get a random color matching the UI `randomColor()` helper, instead of always using the model default `#a6cee3`.
- Adds a shared `documents.colors.random_color()` helper (HSL → hex) used by those server-side create paths.
- Existing tags are unchanged; no migration.

## Related
Fixes #14020

## Test plan
- [x] `pytest documents/tests/test_colors.py` (format, non-default, frontend HSL mapping)
- [x] `pytest` AI workflow tests for create-missing tag color (`test_create_missing_tag_uses_random_color`, assert on Suggested Tag in ownership test)
- [x] `ruff check` / `prek` on touched files
- [ ] Manual: Apply AI Suggestions with create-missing creates a tag with a non-default color
- [ ] Manual (optional): consume with path tags / barcode tags and confirm new tags are not all `#a6cee3`

## AI assistance
This change was assisted by Cursor/Composer for research, drafting, and scaffolding. The issue text, code, and tests were reviewed and verified by a human before submission. The PR is not mostly AI-derived; the contributor owns the change set.


Made with [Cursor](https://cursor.com)