### PR TITLE
Fix: fence LLM index updates after document deletion

### DIFF
--- a/src/documents/signals/handlers.py
+++ b/src/documents/signals/handlers.py
@@ -1422,7 +1422,7 @@ def add_or_update_document_in_llm_index(sender, document, **kwargs):
     if ai_config.llm_index_enabled:
         from documents.tasks import update_document_in_llm_index
 
-        update_document_in_llm_index.apply_async(kwargs={"document": document})
+        update_document_in_llm_index.delay_on_commit(document.pk)
 
 
 @receiver(models.signals.post_delete, sender=Document)
@@ -1438,4 +1438,4 @@ def delete_document_from_llm_index(
     if ai_config.llm_index_enabled:
         from documents.tasks import remove_document_from_llm_index
 
-        remove_document_from_llm_index.apply_async(kwargs={"document": instance})
+        remove_document_from_llm_index.delay_on_commit(instance.pk)

--- a/src/documents/tasks.py
+++ b/src/documents/tasks.py
@@ -459,7 +459,10 @@ def update_document_content_maybe_archive_file(
 
             ai_config = AIConfig()
             if ai_config.llm_index_enabled:
-                llm_index_add_or_update_document(document)
+                llm_index_add_or_update_document(
+                    document,
+                    expected_modified=document.modified.isoformat(),
+                )
 
             clear_document_caches(document.pk)
 
@@ -753,17 +756,50 @@ def apply_ai_suggestions(self, action_id: int, document_id: int) -> None:
 
     ai_config = AIConfig()
     if ai_config.llm_index_enabled:
-        update_document_in_llm_index.apply_async(kwargs={"document": document})
+        update_document_in_llm_index.delay_on_commit(document.pk)
+
+
+def _llm_index_document_id(
+    document_id: int | None,
+    document: Document | None,
+) -> int:
+    candidate = (
+        document_id if document_id is not None else getattr(document, "pk", None)
+    )
+    if isinstance(candidate, bool) or not isinstance(candidate, int) or candidate < 1:
+        raise ValueError("LLM index task requires a document id")
+    return candidate
 
 
 @shared_task
-def update_document_in_llm_index(document) -> None:
-    llm_index_add_or_update_document(document)
+def update_document_in_llm_index(
+    document_id: int | None = None,
+    *,
+    document: Document | None = None,
+) -> None:
+    document_id = _llm_index_document_id(document_id, document)
+    try:
+        document = Document.objects.get(pk=document_id)
+    except Document.DoesNotExist:
+        logger.info(
+            "Skipping stale LLM index update for document %s.",
+            document_id,
+        )
+        return
+    llm_index_add_or_update_document(
+        document,
+        expected_modified=document.modified.isoformat(),
+    )
 
 
 @shared_task
-def remove_document_from_llm_index(document) -> None:
-    llm_index_remove_document(document)
+def remove_document_from_llm_index(
+    document_id: int | None = None,
+    *,
+    document: Document | None = None,
+) -> None:
+    document_id = _llm_index_document_id(document_id, document)
+    llm_index_remove_document(document_id)
 
 
 @shared_task

--- a/src/documents/tests/test_tasks.py
+++ b/src/documents/tests/test_tasks.py
@@ -395,8 +395,27 @@ class TestAIIndex(DirectoriesMixin, TestCase):
         with mock.patch(
             "documents.tasks.llm_index_add_or_update_document",
         ) as llm_index_add_or_update_document:
-            tasks.update_document_in_llm_index(doc)
-            llm_index_add_or_update_document.assert_called_once_with(doc)
+            tasks.update_document_in_llm_index(doc.pk)
+            llm_index_add_or_update_document.assert_called_once_with(
+                doc,
+                expected_modified=doc.modified.isoformat(),
+            )
+
+    def test_legacy_stale_update_document_in_llm_index_is_a_noop(self) -> None:
+        doc = Document.objects.create(
+            title="test",
+            content="my document",
+            checksum="wow",
+        )
+        document_id = doc.pk
+        Document.global_objects.filter(pk=document_id).delete()
+
+        with mock.patch(
+            "documents.tasks.llm_index_add_or_update_document",
+        ) as llm_index_add_or_update_document:
+            tasks.update_document_in_llm_index(document=doc)
+
+        llm_index_add_or_update_document.assert_not_called()
 
     def test_remove_document_from_llm_index(self) -> None:
         """
@@ -407,6 +426,13 @@ class TestAIIndex(DirectoriesMixin, TestCase):
         THEN:
             - llm_index_remove_document is called
         """
+        with mock.patch(
+            "documents.tasks.llm_index_remove_document",
+        ) as llm_index_remove_document:
+            tasks.remove_document_from_llm_index(42)
+            llm_index_remove_document.assert_called_once_with(42)
+
+    def test_legacy_remove_document_from_llm_index_uses_only_id(self) -> None:
         doc = Document.objects.create(
             title="test",
             content="my document",
@@ -415,8 +441,9 @@ class TestAIIndex(DirectoriesMixin, TestCase):
         with mock.patch(
             "documents.tasks.llm_index_remove_document",
         ) as llm_index_remove_document:
-            tasks.remove_document_from_llm_index(doc)
-            llm_index_remove_document.assert_called_once_with(doc)
+            tasks.remove_document_from_llm_index(document=doc)
+
+        llm_index_remove_document.assert_called_once_with(doc.pk)
 
     @override_settings(AI_ENABLED=True, LLM_EMBEDDING_BACKEND="huggingface")
     def test_bulk_update_does_not_enqueue_per_doc_llm_tasks(self) -> None:
@@ -444,6 +471,7 @@ class TestAIIndex(DirectoriesMixin, TestCase):
             doc_ids = [doc.pk for doc in docs]
             tasks.bulk_update_documents(doc_ids)
             self.assertEqual(update_document_in_llm_index.apply_async.call_count, 0)
+            self.assertEqual(update_document_in_llm_index.delay_on_commit.call_count, 0)
             update_llm_index.assert_called_once_with(
                 rebuild=False,
                 document_ids=doc_ids,
@@ -533,7 +561,7 @@ class TestApplyAISuggestionsTask(DirectoriesMixin, TestCase):
         ):
             tasks.apply_ai_suggestions(self.action.pk, self.doc.pk)
 
-        update_in_llm_index.apply_async.assert_called_once()
+        update_in_llm_index.delay_on_commit.assert_called_once_with(self.doc.pk)
 
     def test_deleted_document_is_a_noop(self) -> None:
         """

--- a/src/paperless_ai/indexing.py
+++ b/src/paperless_ai/indexing.py
@@ -509,7 +509,11 @@ def update_llm_index(
     return msg
 
 
-def llm_index_add_or_update_document(document: Document):
+def llm_index_add_or_update_document(
+    document: Document,
+    *,
+    expected_modified: str | None = None,
+) -> None:
     """Add or atomically replace a document's chunks in the index."""
     config = AIConfig()
     new_nodes = build_document_node(
@@ -535,6 +539,18 @@ def llm_index_add_or_update_document(document: Document):
                 "migration check deferred while index readers are active; "
                 "will retry on the next write.",
                 document.id,
+            )
+            return
+        if (
+            expected_modified is not None
+            and not Document.objects.filter(
+                pk=document.pk,
+                modified=expected_modified,
+            ).exists()
+        ):
+            logger.info(
+                "Skipping stale LLM index update for document %s.",
+                document.pk,
             )
             return
         store.upsert_document(str(document.id), new_nodes)
@@ -576,7 +592,7 @@ def llm_index_compact() -> None:
         _with_exclusive_access("compaction", lambda: store.compact(force=True))
 
 
-def llm_index_remove_document(document: Document):
+def llm_index_remove_document(document_id: int) -> None:
     """Remove a document's chunks from the LLM index."""
     with write_store() as store:
         migration_result = _check_and_run_migrations(store)
@@ -585,7 +601,7 @@ def llm_index_remove_document(document: Document):
                 "Skipping removal of document %s from the LLM index: the "
                 "index requires re-embedding first. Run 'document_llmindex "
                 "rebuild' to resolve.",
-                document.id,
+                document_id,
             )
             return
         if migration_result is MigrationCheckResult.DEFERRED:
@@ -593,10 +609,10 @@ def llm_index_remove_document(document: Document):
                 "Skipping removal of document %s from the LLM index: "
                 "migration check deferred while index readers are active; "
                 "will retry on the next write.",
-                document.id,
+                document_id,
             )
             return
-        store.delete(str(document.id))
+        store.delete(str(document_id))
 
 
 def truncate_content(

--- a/src/paperless_ai/tests/test_ai_indexing.py
+++ b/src/paperless_ai/tests/test_ai_indexing.py
@@ -404,6 +404,38 @@ def test_add_or_update_document_updates_existing_entry(
 
 
 @pytest.mark.django_db
+def test_stale_update_cannot_recreate_removed_document(
+    temp_llm_index_dir: Path,
+    real_document: Document,
+    mock_embed_model: FakeEmbedding,
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    indexing.llm_index_add_or_update_document(real_document)
+    document_id = real_document.pk
+    expected_modified = real_document.modified.isoformat()
+    stale_document = Document.objects.get(pk=document_id)
+    embed_nodes = indexing._embed_nodes
+
+    def remove_document_before_update_write(nodes, embed_model) -> None:
+        embed_nodes(nodes, embed_model)
+        Document.global_objects.filter(pk=document_id).delete()
+        indexing.llm_index_remove_document(document_id)
+
+    mocker.patch(
+        "paperless_ai.indexing._embed_nodes",
+        side_effect=remove_document_before_update_write,
+    )
+
+    indexing.llm_index_add_or_update_document(
+        stale_document,
+        expected_modified=expected_modified,
+    )
+
+    with indexing.get_vector_store() as store:
+        assert str(document_id) not in store.get_modified_times()
+
+
+@pytest.mark.django_db
 def test_query_after_remove_does_not_raise_key_error(
     temp_llm_index_dir: Path,
     real_document: Document,
@@ -417,7 +449,7 @@ def test_query_after_remove_does_not_raise_key_error(
         added=timezone.now(),
     )
 
-    indexing.llm_index_remove_document(real_document)
+    indexing.llm_index_remove_document(real_document.pk)
 
     result = indexing.retrieve_similar_nodes(query_doc, top_k=5)
     assert isinstance(result, list)
@@ -584,13 +616,28 @@ class TestDocumentUpdatedSignalTriggersLlmReindex:
         self,
         mocker: pytest_mock.MockerFixture,
     ) -> None:
-        """Firing document_updated should call update_document_in_llm_index.apply_async."""
+        """Firing document_updated queues the document id on commit."""
         mock_task = mocker.patch("documents.tasks.update_document_in_llm_index")
 
         doc = DocumentFactory()
         document_updated.send(sender=object, document=doc)
 
-        mock_task.apply_async.assert_called_once_with(kwargs={"document": doc})
+        mock_task.delay_on_commit.assert_called_once_with(doc.pk)
+
+    @pytest.mark.django_db
+    @override_settings(AI_ENABLED=True, LLM_EMBEDDING_BACKEND="huggingface")
+    def test_document_delete_enqueues_llm_removal_by_id(
+        self,
+        mocker: pytest_mock.MockerFixture,
+    ) -> None:
+        from documents.signals.handlers import delete_document_from_llm_index
+
+        mock_task = mocker.patch("documents.tasks.remove_document_from_llm_index")
+        doc = DocumentFactory()
+
+        delete_document_from_llm_index(sender=Document, instance=doc)
+
+        mock_task.delay_on_commit.assert_called_once_with(doc.pk)
 
     @pytest.mark.django_db
     @override_settings(AI_ENABLED=True, LLM_EMBEDDING_BACKEND="huggingface")
@@ -611,7 +658,7 @@ class TestDocumentUpdatedSignalTriggersLlmReindex:
         )
         document_updated.send(sender=object, document=root_doc, skip_ai_index=True)
 
-        assert mock_task.apply_async.call_count == 1
+        mock_task.delay_on_commit.assert_called_once_with(root_doc.pk)
 
 
 @pytest.mark.django_db
@@ -784,9 +831,7 @@ class TestLlmIndexLocking:
             ),
         )
 
-        doc = MagicMock(spec=Document)
-        doc.id = 1
-        indexing.llm_index_remove_document(doc)
+        indexing.llm_index_remove_document(1)
 
         mock_store.delete.assert_called_once_with("1")
 
@@ -809,9 +854,7 @@ class TestLlmIndexLocking:
             ),
         )
 
-        doc = MagicMock(spec=Document)
-        doc.id = 1
-        indexing.llm_index_remove_document(doc)
+        indexing.llm_index_remove_document(1)
 
         mock_store.delete.assert_not_called()
 
@@ -837,9 +880,7 @@ class TestLlmIndexLocking:
             side_effect=Timeout("test"),
         )
 
-        doc = MagicMock(spec=Document)
-        doc.id = 1
-        indexing.llm_index_remove_document(doc)
+        indexing.llm_index_remove_document(1)
 
         mock_store.delete.assert_not_called()
 
@@ -919,7 +960,7 @@ class TestVectorStoreIndexing:
             count_sql = "SELECT count(*) FROM documents"
             assert store.client.execute(count_sql).fetchone()[0] >= 1
 
-            indexing.llm_index_remove_document(real_document)
+            indexing.llm_index_remove_document(real_document.pk)
             assert store.client.execute(count_sql).fetchone()[0] == 0
 
     def test_update_shrinks_chunks_without_orphans(

--- a/src/paperless_ai/tests/test_index_locking.py
+++ b/src/paperless_ai/tests/test_index_locking.py
@@ -2,7 +2,6 @@ import logging
 import sqlite3
 import threading
 from pathlib import Path
-from unittest.mock import MagicMock
 
 import pytest
 from django.conf import settings
@@ -106,7 +105,7 @@ class TestCompactionLock:
         done = threading.Event()
 
         def remove() -> None:
-            indexing.llm_index_remove_document(MagicMock(id=999))
+            indexing.llm_index_remove_document(999)
             done.set()
 
         holder = _reader_lock()


### PR DESCRIPTION
## Summary

- publish per-document LLM index updates and removals after transaction commit using scalar document IDs
- refetch the live document and recheck its ID and modified revision inside the existing writer lock before upsert
- preserve safe rolling-upgrade handling for already queued legacy document payloads by deriving only their primary key

## Bug

Update and delete work is currently queued as independent tasks carrying serialized Document objects. If removal finishes before an older updater runs, that updater can write stale embeddings back after the database row has been deleted. A task that begins embedding before deletion can produce the same outcome by writing after removal.

The new behavioral regression forces deletion and vector removal between embedding and the updater write, then verifies that the document cannot reappear in the vector store.

## Validation

- Ruff formatting and lint: passed
- Complete affected modules: 84 passed on Python 3.14 using the locked dependency set and declared CI system packages
- Independent race and compatibility review: no P0-P2 findings after correction

## AI assistance disclosure

Codex assisted with source analysis, implementation, test authoring, review, and this pull request text. The exact upstream source was inspected, the change was independently challenged, and the reported checks were run against the rebased branch.