### PR TITLE
Fix: chat answers are compressed and arrive in one piece

### DIFF
--- a/src/documents/tests/test_api_chat.py
+++ b/src/documents/tests/test_api_chat.py
@@ -38,6 +38,33 @@ class TestChatStreamingViewInputValidation(APITestCase):
             )
         assert resp.status_code == status.HTTP_400_BAD_REQUEST
 
+    def test_answer_is_exempt_from_compression(self) -> None:
+        """
+        A compressor buffers, so a compressed answer arrives in one piece
+        instead of streaming. The exemption has to land on the underlying
+        Django request, which is what the middleware sees.
+        """
+        with (
+            mock.patch(
+                "documents.views.AIConfig",
+                return_value=self._mock_ai_enabled(),
+            ),
+            mock.patch(
+                "documents.views.stream_chat_with_documents",
+                return_value=iter(["answer"]),
+            ),
+        ):
+            resp = self.client.post(
+                "/api/documents/chat/",
+                {"q": "What is in my archive?"},
+                format="json",
+                HTTP_ACCEPT_ENCODING="gzip, deflate, br",
+            )
+
+        assert resp.status_code == status.HTTP_200_OK
+        assert resp.wsgi_request.compress_exempt is True
+        assert not resp.has_header("Content-Encoding")
+
     def test_missing_question_is_rejected(self) -> None:
         with mock.patch(
             "documents.views.AIConfig",

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -243,6 +243,7 @@ from paperless.celery import app as celery_app
 from paperless.config import AIConfig
 from paperless.config import GeneralConfig
 from paperless.config import RemoteOCRConfig
+from paperless.middleware import compress_exempt
 from paperless.models import ApplicationConfiguration
 from paperless.parsers.registry import get_parser_registry
 from paperless.parsers.remote import RemoteEngineConfig
@@ -2303,6 +2304,7 @@ class ChatStreamingSerializer(serializers.Serializer[dict[str, Any]]):
     [
         ensure_csrf_cookie,
         cache_control(no_cache=True),
+        compress_exempt,
     ],
     name="dispatch",
 )
@@ -2311,7 +2313,6 @@ class ChatStreamingView(GenericAPIView[Any]):
     serializer_class = ChatStreamingSerializer
 
     def post(self, request, *args, **kwargs):
-        request.compress_exempt = True
         ai_config = AIConfig()
         if not ai_config.ai_enabled:
             return HttpResponseBadRequest("AI is required for this feature")
@@ -2353,6 +2354,9 @@ class ChatStreamingView(GenericAPIView[Any]):
             ),
             content_type="text/event-stream",
         )
+        # nginx buffers proxied responses by default, which holds the answer
+        # back until it is finished; this asks it not to.
+        response.headers["X-Accel-Buffering"] = "no"
         return response
 
 

--- a/src/paperless/middleware.py
+++ b/src/paperless/middleware.py
@@ -1,6 +1,26 @@
+from functools import wraps
+
 from django.conf import settings
 
 from paperless import version
+
+
+def compress_exempt(view_func):
+    """
+    Exempt a view's response from compression.
+
+    The compression middleware reads the flag off the Django request, so it
+    has to be set there: DRF's request wrapper proxies reads but keeps writes
+    to itself, and a flag set on it never arrives. Decorating dispatch runs
+    before that wrapper exists.
+    """
+
+    @wraps(view_func)
+    def wrapper(request, *args, **kwargs):
+        request.compress_exempt = True
+        return view_func(request, *args, **kwargs)
+
+    return wrapper
 
 
 class ApiVersionMiddleware:


### PR DESCRIPTION
> **AI disclosure:** I wrote this change with the help of an AI coding agent (Claude). I reviewed the diff, ran the tests, and checked the response headers in the browser myself.

## Proposed change

The chat endpoint streams its answer. The response is compressed on the way out. A compressor buffers, so the browser receives nothing until the answer is complete.

The symptom, on `dev`, during generation:

*(screenshot: `0-before-empty-bubble.png`)*

The view already asks to be exempt from compression. It sets the flag on the DRF request wrapper. The compression middleware reads the flag from the underlying Django request. The wrapper proxies reads but not writes, so the flag never arrives. This change moves the flag to a `compress_exempt` decorator on `dispatch`. That decorator runs before DRF wraps the request.

The change also sends `X-Accel-Buffering: no`. nginx buffers proxied responses by default, with the same effect one layer out.

Measured in Chrome on `dev`, same question and model:

| | `Content-Encoding` | XHR progress events |
|---|---|---|
| before | `br` | 1, carrying the whole answer |
| after | none | 1 |

The event count does not change with this fix alone. The response synthesizer above this layer also collapses the stream into one chunk. That is a separate problem in the llama-index library (run-llama/llama_index#22831). This fix is one of the two conditions for a streamed answer. It does not change behavior for users who do not use the chat.

How to test: enable AI chat, ask a question, and inspect the response headers of `/api/documents/chat/` in the browser. `Content-Encoding` is absent and `X-Accel-Buffering: no` is present. The new test asserts both the flag on the Django request and the absence of `Content-Encoding`.


## Type of change

- [x] Bug fix: non-breaking change which fixes an issue.

## Checklist:

- [x] I have read & agree with the contributing guidelines.
- [x] If applicable, I have included testing coverage for new code in this PR.
- [x] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass.
- [x] I have run all Git `pre-commit` hooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
