### PR TITLE
Enhancement: show that the model is working in the chat

### DIFF
--- a/src-ui/src/app/components/chat/chat/chat.component.html
+++ b/src-ui/src/app/components/chat/chat/chat.component.html
@@ -9,10 +9,17 @@
         @for (message of messages(); track message) {
           <div class="message d-flex flex-row small" [class.justify-content-end]="message.role === 'user'">
             <div class="p-2 m-2" [class.bg-body]="message.role === 'user'">
-              <span class="text-break">
-                {{ message.content }}
-                @if (message.isStreaming) { <span class="blinking-cursor">|</span> }
-              </span>
+              @if (message.role === 'assistant' && message.isStreaming && !message.content) {
+                <span class="d-flex align-items-center gap-2 text-muted">
+                  <output class="spinner-border spinner-border-sm" aria-hidden="true"></output>
+                  <ng-container i18n>Thinking...</ng-container>
+                </span>
+              } @else {
+                <span class="text-break">
+                  {{ message.content }}
+                  @if (message.isStreaming) { <span class="blinking-cursor">|</span> }
+                </span>
+              }
               @if (message.role === 'assistant' && message.references?.length) {
                 <div class="chat-references list-group mt-3">
                   @for (reference of message.references; track reference.id) {

--- a/src-ui/src/app/components/chat/chat/chat.component.spec.ts
+++ b/src-ui/src/app/components/chat/chat/chat.component.spec.ts
@@ -207,4 +207,20 @@ describe('ChatComponent', () => {
     component.searchInputKeyDown(event)
     expect(component.sendMessage).not.toHaveBeenCalled()
   })
+
+  it('should show a thinking indicator until the first response chunk arrives', async () => {
+    component.input.set('Hello')
+    component.sendMessage()
+    fixture.detectChanges()
+
+    const messages = fixture.nativeElement.querySelector('.chat-messages')
+    expect(messages.textContent).toContain('Thinking')
+    expect(messages.querySelector('.spinner-border')).not.toBeNull()
+
+    mockStream$.next('Hi there')
+    await jest.runAllTimersAsync()
+    fixture.detectChanges()
+    expect(messages.textContent).not.toContain('Thinking')
+    expect(messages.querySelector('.spinner-border')).toBeNull()
+  })
 })


### PR DESCRIPTION
> **AI disclosure:** I wrote this change with the help of an AI coding agent (Claude). I reviewed the diff, ran the tests, and checked the result in the browser myself.

## Proposed change

Between sending a question and the first token of the answer, the chat overlay shows an empty bubble with a blinking cursor. With a local model, that is up to a minute with no sign that anything happens.

This change shows a spinner and "Thinking..." in the assistant bubble until the assistant has streamed some text. After that, the answer renders as before. The change is two files: the template and one test. It does not touch the backend or the API.

Before (`dev`): empty bubble while the model works.

*(screenshot: `0-before-empty-bubble.png`)*

After: spinner and "Thinking..." in the same moment.

*(screenshot: `1-thinking-indicator.png`)*

This is a small enhancement without a feature request. If you prefer a feature request first, tell me and I will open one and close this PR.


## Type of change

- [x] New feature / Enhancement: non-breaking change which adds functionality.

## Checklist:

- [x] I have read & agree with the contributing guidelines.
- [x] If applicable, I have included testing coverage for new code in this PR.
- [x] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass.
- [x] I have run all Git `pre-commit` hooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
