### PR TITLE
Fix unsaved content loss when switching document versions

### DIFF
--- a/src-ui/src/app/components/document-detail/document-detail.component.spec.ts
+++ b/src-ui/src/app/components/document-detail/document-detail.component.spec.ts
@@ -1972,6 +1972,7 @@ describe('DocumentDetailComponent', () => {
       .spyOn(documentService, 'get')
       .mockReturnValue(of({ content: 'version-content' } as Document))
 
+    component.documentForm.get('content').markAsDirty()
     component.selectVersion(10)
     httpTestingController.expectOne('preview-version').flush('version text')
 
@@ -1979,6 +1980,7 @@ describe('DocumentDetailComponent', () => {
     expect(component.thumbUrl()).toBe('thumb-version')
     expect(component.previewText()).toBe('version text')
     expect(component.documentForm.get('content').value).toBe('version-content')
+    expect(component.documentForm.get('content').pristine).toBeTruthy()
     expect(component.pdfSource()).toBe('preview-version')
     expect(component.pdfPassword()).toBeUndefined()
 
@@ -2023,6 +2025,28 @@ describe('DocumentDetailComponent', () => {
       .mockImplementation(() => {})
 
     component.onVersionSelected(42)
+
+    expect(selectVersionSpy).toHaveBeenCalledWith(42)
+  })
+
+  it('onVersionSelected should confirm before replacing dirty content', async () => {
+    let openModal: NgbModalRef
+    modalService.activeInstances.subscribe((modals) => (openModal = modals[0]))
+    initNormally()
+    httpTestingController.expectOne(component.previewUrl()).flush('preview')
+    component.documentForm.get('content').markAsDirty()
+    const selectVersionSpy = jest
+      .spyOn(component, 'selectVersion')
+      .mockImplementation(() => {})
+
+    component.onVersionSelected(42)
+
+    expect(selectVersionSpy).not.toHaveBeenCalled()
+    const dialog = openModal.componentInstance as ConfirmDialogComponent
+    expect(dialog.message).toContain('replaces your unsaved document content')
+
+    dialog.confirmClicked.next()
+    await openModal.result
 
     expect(selectVersionSpy).toHaveBeenCalledWith(42)
   })

--- a/src-ui/src/app/components/document-detail/document-detail.component.ts
+++ b/src-ui/src/app/components/document-detail/document-detail.component.ts
@@ -98,8 +98,8 @@ import { ISODateAdapter } from 'src/app/utils/ngb-iso-date-adapter'
 import * as UTIF from 'utif'
 import { DocumentDetailFieldID } from '../admin/settings/settings.component'
 import { ConfirmDialogComponent } from '../common/confirm-dialog/confirm-dialog.component'
-import { ReprocessConfirmDialogComponent } from '../common/confirm-dialog/reprocess-confirm-dialog/reprocess-confirm-dialog.component'
 import { PasswordRemovalConfirmDialogComponent } from '../common/confirm-dialog/password-removal-confirm-dialog/password-removal-confirm-dialog.component'
+import { ReprocessConfirmDialogComponent } from '../common/confirm-dialog/reprocess-confirm-dialog/reprocess-confirm-dialog.component'
 import { CustomFieldsDropdownComponent } from '../common/custom-fields-dropdown/custom-fields-dropdown.component'
 import { CorrespondentEditDialogComponent } from '../common/edit-dialog/correspondent-edit-dialog/correspondent-edit-dialog.component'
 import { DocumentTypeEditDialogComponent } from '../common/edit-dialog/document-type-edit-dialog/document-type-edit-dialog.component'
@@ -977,6 +977,8 @@ export class DocumentDetailComponent
               emitEvent: false,
             }
           )
+          this.store.next({ ...this.store.value, content })
+          this.documentForm.get('content')?.markAsPristine()
         },
         error: (error) => {
           this.toastService.showError(
@@ -1005,7 +1007,23 @@ export class DocumentDetailComponent
   }
 
   onVersionSelected(versionId: number) {
-    this.selectVersion(versionId)
+    if (!this.documentForm.get('content')?.dirty) {
+      this.selectVersion(versionId)
+      return
+    }
+
+    const modal = this.modalService.open(ConfirmDialogComponent, {
+      backdrop: 'static',
+    })
+    modal.componentInstance.title = $localize`Discard unsaved content?`
+    modal.componentInstance.message = $localize`Switching versions replaces your unsaved document content.`
+    modal.componentInstance.btnClass = 'btn-warning'
+    modal.componentInstance.btnCaption = $localize`Discard and switch`
+    modal.componentInstance.cancelBtnCaption = $localize`Keep editing`
+    modal.componentInstance.confirmClicked.pipe(first()).subscribe(() => {
+      modal.close()
+      this.selectVersion(versionId)
+    })
   }
 
   onVersionsUpdated(versions: DocumentVersionInfo[]) {


### PR DESCRIPTION
ASLOP-PR-VERIFY

## Proposed change

Switching between document file versions can replace unsaved edits in the content field without warning.
This change asks for confirmation before replacing dirty content and keeps the current selection when canceled.
After an accepted switch, it updates the dirty-check baseline for content while preserving unrelated dirty fields.

Testing:

- `pnpm ng test --test-path-patterns=document-detail.component.spec.ts --watch=false`
- `pnpm lint`
- Chromium desktop against the disposable E2E backend: the confirmation rendered and canceling preserved unsaved content and the selected version.

This pull request was prepared with assistance from an AI coding agent under human direction.

## Type of change

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality not to work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [x] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for breaking changes & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all Git `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] In the description of the PR above I have clearly disclosed any use of AI tools or agents in the creation of this PR. I understand that failing to do so is a violation of the [Code of Conduct](https://github.com/paperless-ngx/paperless-ngx/blob/main/CODE_OF_CONDUCT.md).