### PR TITLE
Fix: expose PAPERLESS_MATCH_REGEX_TIMEOUT_SECONDS setting

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1527,6 +1527,19 @@ within your documents.
     second, and year last order. Characters D, M, or Y can be shuffled
     to meet the required order.
 
+#### [`PAPERLESS_MATCH_REGEX_TIMEOUT_SECONDS=<num>`](#PAPERLESS_MATCH_REGEX_TIMEOUT_SECONDS) {#PAPERLESS_MATCH_REGEX_TIMEOUT_SECONDS}
+
+: Regular expressions used for matching rules and for detecting dates within
+document content are each given this many seconds to complete before being
+aborted. This guards against pathologically slow patterns, but on very long
+documents (particularly on slower hardware) it can also abort date detection
+before it finds a match, silently falling back to the document's import date.
+
+    Raise this value if you notice documents with long extracted text are not
+    getting a `created` date detected from their content.
+
+    Defaults to 0.1 seconds.
+
 #### [`PAPERLESS_ENABLE_GPG_DECRYPTOR=<bool>`](#PAPERLESS_ENABLE_GPG_DECRYPTOR) {#PAPERLESS_ENABLE_GPG_DECRYPTOR}
 
 : Enable or disable the GPG decryptor for encrypted emails. See [GPG Decryptor](advanced_usage.md#gpg-decryptor) for more information.

--- a/src/documents/tests/test_regex.py
+++ b/src/documents/tests/test_regex.py
@@ -1,12 +1,25 @@
 import pytest
 import regex
+from django.conf import settings
 from pytest_mock import MockerFixture
 
+from documents.regex import REGEX_TIMEOUT_SECONDS
 from documents.regex import safe_regex_finditer
 from documents.regex import safe_regex_match
 from documents.regex import safe_regex_search
 from documents.regex import safe_regex_sub
 from documents.regex import validate_regex_pattern
+
+
+def test_regex_timeout_setting_is_wired_up() -> None:
+    """
+    MATCH_REGEX_TIMEOUT_SECONDS must actually be defined on Django settings.
+    Without it, PAPERLESS_MATCH_REGEX_TIMEOUT_SECONDS has no effect: the
+    getattr() fallback in documents.regex silently keeps the 0.1s default
+    no matter what a user configures.
+    """
+    assert hasattr(settings, "MATCH_REGEX_TIMEOUT_SECONDS")
+    assert REGEX_TIMEOUT_SECONDS == settings.MATCH_REGEX_TIMEOUT_SECONDS
 
 
 class TestValidateRegexPattern:

--- a/src/paperless/settings/__init__.py
+++ b/src/paperless/settings/__init__.py
@@ -996,6 +996,14 @@ POST_CONSUME_SCRIPT = os.getenv("PAPERLESS_POST_CONSUME_SCRIPT")
 DATE_ORDER = os.getenv("PAPERLESS_DATE_ORDER", "DMY")
 FILENAME_DATE_ORDER = os.getenv("PAPERLESS_FILENAME_DATE_ORDER")
 
+# Maximum time, in seconds, a single regex match/search/sub/finditer call may run
+# before being aborted. Guards against pathological matching rules and slow patterns
+# on long documents.
+MATCH_REGEX_TIMEOUT_SECONDS: Final[float] = get_float_from_env(
+    "PAPERLESS_MATCH_REGEX_TIMEOUT_SECONDS",
+    0.1,
+)
+
 
 # If not set, we will infer it at runtime
 DATE_PARSER_LANGUAGES = (


### PR DESCRIPTION
## Proposed change

I ran into this timeout while setting up paperless-ngx on some very old hardware.

`documents/regex.py` has always read the match-regex timeout via
`getattr(settings, "MATCH_REGEX_TIMEOUT_SECONDS", 0.1)`, but no such
Django setting was ever defined so the `getattr` default silently applied
no matter what.

This PR defines `MATCH_REGEX_TIMEOUT_SECONDS`, sourced from
`PAPERLESS_MATCH_REGEX_TIMEOUT_SECONDS` (default unchanged at 0.1s), so
the existing `getattr` actually has something to read, and documents
the new setting.

Fixes #13654

## Type of change

Bug fix: non-breaking change which fixes an issue.

## Checklist

- [x] I have read & agree with the contributing guidelines.
- [x] I have included testing coverage for this change (backend).
- [x] I have checked that all tests pass.
- [x] I have run ruff format/check.
- [x] I have made corresponding changes to the documentation.
- [x] AI disclosure: I used Claude to locate the code pointers for settings. I used that to create the full changes. I also used Claude to make sure this PR adheres to the contributing guide.